### PR TITLE
Fix: Robotic Factory Cooldowns

### DIFF
--- a/modular_nova/modules/SiliconQoL/code/countdown.dm
+++ b/modular_nova/modules/SiliconQoL/code/countdown.dm
@@ -1,0 +1,12 @@
+/obj/effect/countdown/transformer_rp
+	name = "transformer countdown"
+	color = "#4C5866"
+
+/obj/effect/countdown/transformer_rp/get_value()
+	var/obj/machinery/transformer_rp/T = attached_to
+	if(!istype(T))
+		return
+	if(T.cooldown || (T.stored_cyborgs > 0))
+		return "[round(max(0, (T.cooldown_timer - world.time) / 10))]"
+	if(T.stored_cyborgs == 0)
+		return "[round(max(0, (T.stored_timer - world.time) / 10))]"

--- a/modular_nova/modules/SiliconQoL/code/robotic_factory.dm
+++ b/modular_nova/modules/SiliconQoL/code/robotic_factory.dm
@@ -10,12 +10,18 @@
 	var/stored_cyborgs = 1
 	/// How many cyborgs can we store?
 	var/max_stored_cyborgs = 4
-	/// How much between the construction of a cyborg?
-	var/cooldown_duration = 5 MINUTES
-	/// Handles the timer , shouldn't touch.
+	// How much time between the spawning of new cyborgs?
+	var/cooldown_duration = 1 MINUTES
+	/// Whether we're on spawn cooldown.
+	var/cooldown = FALSE
+	/// Handles the Cyborg spawner timer.
 	var/cooldown_timer
+	/// How much time between the storing of cyborgs?
+	var/stored_duration = 5 MINUTES
+	/// Handles the stored Cyborg timer.
+	var/stored_timer
 	/// The countdown itself
-	var/obj/effect/countdown/transformer/countdown
+	var/obj/effect/countdown/transformer_rp/countdown
 	/// The master AI , assigned when placed down with the ability.
 	var/mob/living/silicon/ai/master_ai
 
@@ -23,13 +29,19 @@
 	// On us
 	. = ..()
 	new /obj/machinery/conveyor/auto(loc, WEST)
+	stored_timer = world.time + stored_duration
 	countdown = new(src)
 	countdown.start()
 
 /obj/machinery/transformer_rp/examine(mob/user)
 	. = ..()
 	if(issilicon(user) || isobserver(user))
-		. += "It will create a new cyborg in [DisplayTimeText(cooldown_timer - world.time)]."
+		. += "<br>It has [stored_cyborgs] cyborgs stored."
+		if(cooldown && cooldown_timer)
+			. += "<br>It will be ready to deploy a stored cyborg in [DisplayTimeText(max(0, cooldown_timer - world.time))]."
+		if(stored_cyborgs >= max_stored_cyborgs)
+			return
+		. += "<br>It will store a new cyborg in [DisplayTimeText(max(0, stored_timer - world.time))]."
 
 /obj/machinery/transformer_rp/Destroy()
 	QDEL_NULL(countdown)
@@ -47,29 +59,42 @@
 	create_a_cyborg(target_ghost)
 
 /obj/machinery/transformer_rp/process()
-	if(cooldown_timer <= world.time)
-		cooldown_timer = world.time + cooldown_duration
-		update_icon()
-		if(stored_cyborgs > max_stored_cyborgs)
-			return
-		stored_cyborgs++
-		notify_ghosts("A new cyborg shell has been created at the [src]",
-			source = src,
-			notify_flags = NOTIFY_CATEGORY_NOFLASH,
-			header = "New malfunctioning cyborg created!",
-		)
+	if(cooldown_timer < world.time)
+		cooldown = FALSE
+
+	if(stored_timer > world.time)
+		return
+
+	stored_timer = world.time + stored_duration
+
+	if(stored_cyborgs >= max_stored_cyborgs)
+		return
+
+	stored_cyborgs++
+	notify_ghosts("A new cyborg shell has been created at the [src]",
+		source = src,
+		notify_flags = NOTIFY_CATEGORY_NOFLASH,
+		header = "New malfunctioning cyborg created!",
+	)
 
 /obj/machinery/transformer_rp/proc/create_a_cyborg(mob/dead/observer/target_ghost)
 	if(machine_stat & (BROKEN|NOPOWER))
 		return
-	if(stored_cyborgs<1)
+	if(stored_cyborgs < 1)
 		return
+	if(cooldown)
+		return
+
 	var/cyborg_ask = tgui_alert(target_ghost, "Become a cyborg?", "Are you a terminator?", list("Yes", "No"))
 	if(cyborg_ask == "No" || !src || QDELETED(src))
 		return FALSE
+
 	var/mob/living/silicon/robot/cyborg = new /mob/living/silicon/robot(loc)
 	cyborg.key = target_ghost.key
 	cyborg.set_connected_ai(master_ai)
 	cyborg.lawsync()
 	cyborg.lawupdate = TRUE
 	stored_cyborgs--
+
+	cooldown = TRUE
+	cooldown_timer = world.time + cooldown_duration

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7906,6 +7906,7 @@
 #include "modular_nova\modules\shotgunrebalance\code\autolathe_design.dm"
 #include "modular_nova\modules\shotgunrebalance\code\shotgun.dm"
 #include "modular_nova\modules\SiliconQoL\code\_onclick.dm"
+#include "modular_nova\modules\SiliconQoL\code\countdown.dm"
 #include "modular_nova\modules\SiliconQoL\code\robotic_factory.dm"
 #include "modular_nova\modules\skyrat-uplinks\code\categories\bundles.dm"
 #include "modular_nova\modules\skyrat-uplinks\code\categories\dangerous.dm"


### PR DESCRIPTION
## About The Pull Request

Fixes Skyrat-SS13/Skyrat-tg#25524

This PR includes a minor bug fix and re-balance for the Automatic Robotic Factory and its cooldown timer.

- The countdown timer effect was invisible to ghosts due to a failing type check, so I modularly replaced it.
- I have added a new cooldown timer which introduces a 60 second delay between cyborg spawns.
- Both cooldown timers are visible to ghosts, and they disappear if the machine is ready for a ghost to use it.

## How This Contributes To The Nova Sector Roleplay Experience

The issue was described in Skyrat-SS13/Skyrat-tg#25524 in which a malfunctioning cyborg accumulated spawns, got killed by other players, and then instantly respawned multiple times in order to continue combat. I myself witnessed the cyborg players abuse the lack of a spawn cooldown in order to powergame, albeit while in a permanent mechanical state, and so I'm certain that my PR corrects this imbalance.

It's my opinion that malfunctioning cyborgs/AIs should be strategic and not have any instant respawn mechanic, because as we can see it is abused to forestall a nearly-inevitable loss and powergame. It's my opinion that when a factory is found by the crew of the station, the silicon players should have a tactic other than "abuse instant respawns".

## Proof of Testing

Draft status. Please wait.

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl: A.C.M.O.
fix: Fixed the Automatic Robotic Factory cooldown timer, which was invisible to ghosts.
balance: Balanced the Automatic Robotic Factory by adding a 60 second cooldown for spawning cyborgs.
/:cl:
