### PR TITLE
Chitter emote is the TG chitter sound unless you're a moth

### DIFF
--- a/modular_nova/modules/emotes/code/emotes.dm
+++ b/modular_nova/modules/emotes/code/emotes.dm
@@ -193,7 +193,12 @@
 	emote_type = EMOTE_AUDIBLE
 	mob_type_allowed_typecache = list(/mob/living/carbon, /mob/living/silicon/pai)
 	vary = TRUE
-	sound = 'modular_nova/modules/emotes/sound/emotes/mothchitter.ogg'
+
+/datum/emote/living/chitter/get_sound(mob/living/user)
+	if(ismoth(user))
+		return 'modular_nova/modules/emotes/sound/emotes/mothchitter.ogg'
+	else
+		return'sound/creatures/chitter.ogg'
 
 /datum/emote/living/sigh/get_sound(mob/living/user)
 	if(iscarbon(user))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the *chitter emote to play the standard TG chitter sfx, unless you're a moth, then it plays the moth chitter.

## How This Contributes To The Nova Sector Roleplay Experience

TG chitter is cute.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  

https://github.com/NovaSector/NovaSector/assets/77534246/eae4fc45-d104-4588-8537-394da9304151


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Chitter emote has a different sound effect, unless you're a moth
/:cl:
