### PR TITLE
[MODULAR] Fixes colonial cloaks not being able to hold any suit storage items

### DIFF
--- a/modular_nova/modules/food_replicator/code/clothing.dm
+++ b/modular_nova/modules/food_replicator/code/clothing.dm
@@ -37,7 +37,7 @@
 	worn_icon = 'modular_nova/modules/food_replicator/icons/clothing_worn.dmi'
 	worn_icon_digi = 'modular_nova/modules/food_replicator/icons/clothing_digi.dmi'
 	icon_state = "cloak_colonial"
-	var/allowed = /obj/item/clothing/suit/jacket/leather::allowed // these are special and can be worn in the suit slot, so we need this var to be defined
+	allowed = /obj/item/clothing/suit/jacket/leather::allowed // these are special and can be worn in the suit slot, so we need this var to be defined
 
 /obj/item/clothing/neck/cloak/colonial/mob_can_equip(mob/living/equipper, slot, disable_warning, bypass_equip_delay_self, ignore_equipped, indirect_action)
 	if(is_species(equipper, /datum/species/teshari))

--- a/modular_nova/modules/food_replicator/code/clothing.dm
+++ b/modular_nova/modules/food_replicator/code/clothing.dm
@@ -39,15 +39,6 @@
 	icon_state = "cloak_colonial"
 	var/allowed = /obj/item/clothing/suit/jacket/leather::allowed // these are special and can be worn in the suit slot, so we need this var to be defined
 
-// Just some extra police equipment
-/obj/item/clothing/neck/cloak/colonial/Initialize()
-	allowed += list(
-		/obj/item/restraints/handcuffs,
-		/obj/item/ammo_box,
-		/obj/item/ammo_casing,
-	)
-	return ..()
-
 /obj/item/clothing/neck/cloak/colonial/mob_can_equip(mob/living/equipper, slot, disable_warning, bypass_equip_delay_self, ignore_equipped, indirect_action)
 	if(is_species(equipper, /datum/species/teshari))
 		to_chat(equipper, span_warning("[src] is far too big for you!"))

--- a/modular_nova/modules/food_replicator/code/clothing.dm
+++ b/modular_nova/modules/food_replicator/code/clothing.dm
@@ -37,6 +37,16 @@
 	worn_icon = 'modular_nova/modules/food_replicator/icons/clothing_worn.dmi'
 	worn_icon_digi = 'modular_nova/modules/food_replicator/icons/clothing_digi.dmi'
 	icon_state = "cloak_colonial"
+	var/allowed = /obj/item/clothing/suit/jacket/leather::allowed // these are special and can be worn in the suit slot, so we need this var to be defined
+
+// Just some extra police equipment
+/obj/item/clothing/neck/cloak/colonial/Initialize()
+	allowed += list(
+		/obj/item/restraints/handcuffs,
+		/obj/item/ammo_box,
+		/obj/item/ammo_casing,
+	)
+	return ..()
 
 /obj/item/clothing/neck/cloak/colonial/mob_can_equip(mob/living/equipper, slot, disable_warning, bypass_equip_delay_self, ignore_equipped, indirect_action)
 	if(is_species(equipper, /datum/species/teshari))

--- a/modular_nova/modules/novaya_ert/code/police_outfit.dm
+++ b/modular_nova/modules/novaya_ert/code/police_outfit.dm
@@ -47,3 +47,12 @@
 	icon_state = "police_vest"
 	icon = 'modular_nova/modules/novaya_ert/icons/armor.dmi'
 	worn_icon = 'modular_nova/modules/novaya_ert/icons/wornarmor.dmi'
+
+// Just some extra police equipment
+/obj/item/clothing/neck/cloak/colonial/nri_police/Initialize()
+	allowed += list(
+		/obj/item/restraints/handcuffs,
+		/obj/item/ammo_box,
+		/obj/item/ammo_casing,
+	)
+	return ..()

--- a/modular_nova/modules/novaya_ert/code/police_outfit.dm
+++ b/modular_nova/modules/novaya_ert/code/police_outfit.dm
@@ -14,6 +14,14 @@
 	desc = "A cloak made from heavy tarpaulin. Nigh wind- and waterproof thanks to its design. The signature white rectangle of the NRI police covers the garment's back."
 	icon_state = "cloak_police"
 
+// Just some extra police equipment
+/obj/item/clothing/neck/cloak/colonial/nri_police/Initialize()
+	allowed += list(
+		/obj/item/restraints/handcuffs,
+		/obj/item/ammo_box,
+		/obj/item/ammo_casing,
+	)
+	return ..()
 /obj/item/clothing/head/hats/colonial/nri_police
 	name = "imperial police cap"
 	desc = "A puffy cap made out of tarpaulin covered by some textile. It is sturdy and comfortable, and seems to retain its form very well. <br>\
@@ -47,12 +55,3 @@
 	icon_state = "police_vest"
 	icon = 'modular_nova/modules/novaya_ert/icons/armor.dmi'
 	worn_icon = 'modular_nova/modules/novaya_ert/icons/wornarmor.dmi'
-
-// Just some extra police equipment
-/obj/item/clothing/neck/cloak/colonial/nri_police/Initialize()
-	allowed += list(
-		/obj/item/restraints/handcuffs,
-		/obj/item/ammo_box,
-		/obj/item/ammo_casing,
-	)
-	return ..()

--- a/modular_nova/modules/novaya_ert/code/police_outfit.dm
+++ b/modular_nova/modules/novaya_ert/code/police_outfit.dm
@@ -22,6 +22,7 @@
 		/obj/item/ammo_casing,
 	)
 	return ..()
+
 /obj/item/clothing/head/hats/colonial/nri_police
 	name = "imperial police cap"
 	desc = "A puffy cap made out of tarpaulin covered by some textile. It is sturdy and comfortable, and seems to retain its form very well. <br>\


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/120

These for some reason are a cloak that is wearable in both the neck slot and suit slot. The issue is that cloaks don't have an `allowed` var set to anything.

Defines the allowed items for this specific type of cloak, the only one of its kind. It can hold the same things as a leather jacket.
The NRI version is able to hold some extra police items (ammo and restraints). 

## How This Contributes To The Nova Sector Roleplay Experience

Fixes a special case oversight

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![dreamseeker_mxPeQ3pnIm](https://github.com/NovaSector/NovaSector/assets/13398309/458b716e-aa3d-45a8-96fd-9d8e87565f5d)

![image](https://github.com/NovaSector/NovaSector/assets/13398309/2f6f236f-0eb4-4048-8173-9b634571adab)

![image](https://github.com/NovaSector/NovaSector/assets/13398309/2e7c7c42-db8c-42e6-8ced-b0712986baed)

</details>

## Changelog
:cl:
fix: colonial cloaks and imperial police cloaks can now carry suit storage items when worn in the suit slot.
/:cl:

