### PR TITLE
Fixes Compile Changelog by making it use GITHUB_TOKEN instead of a secret token

### DIFF
--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -51,4 +51,4 @@ jobs:
         if: steps.value_holder.outputs.ACTIONS_ENABLED
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.SKYRATBOT_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## About The Pull Request
Uses the right kind of access token so that the Compile Changelogs action can work properly.

## Changelog
Not player-facing.