### PR TITLE
Fixes interaction menu

### DIFF
--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_arousal/status_effects/climax.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_arousal/status_effects/climax.dm
@@ -50,8 +50,8 @@
 /datum/status_effect/climax_cooldown/tick(seconds_between_ticks)
 	var/obj/item/organ/external/genital/vagina/vagina = owner.get_organ_slot(ORGAN_SLOT_VAGINA)
 	var/obj/item/organ/external/genital/testicles/balls = owner.get_organ_slot(ORGAN_SLOT_TESTICLES)
-	var/obj/item/organ/external/genital/testicles/penis = owner.get_organ_slot(ORGAN_SLOT_PENIS)
-	var/obj/item/organ/external/genital/testicles/anus = owner.get_organ_slot(ORGAN_SLOT_ANUS)
+	var/obj/item/organ/external/genital/penis/penis = owner.get_organ_slot(ORGAN_SLOT_PENIS)
+	var/obj/item/organ/external/genital/anus/anus = owner.get_organ_slot(ORGAN_SLOT_ANUS)
 
 	if(penis)
 		penis.aroused = AROUSAL_NONE

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_items/fleshlight.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_items/fleshlight.dm
@@ -53,9 +53,8 @@
 	color_changed = TRUE
 
 /obj/item/clothing/sextoy/fleshlight/attack(mob/living/carbon/human/target, mob/living/carbon/human/user)
-	. = ..()
-	if(!istype(target))
-		return
+	if(user.combat_mode || !istype(target))
+		return ..()
 
 	var/message = ""
 	if(!target.check_erp_prefs(/datum/preference/toggle/erp/sex_toy, user, src))
@@ -83,3 +82,4 @@
 								'modular_nova/modules/modular_items/lewd_items/sounds/bang4.ogg',
 								'modular_nova/modules/modular_items/lewd_items/sounds/bang5.ogg',
 								'modular_nova/modules/modular_items/lewd_items/sounds/bang6.ogg'), 70, 1, -1)
+	return ..()

--- a/tgui/packages/tgui/interfaces/InteractionMenu.tsx
+++ b/tgui/packages/tgui/interfaces/InteractionMenu.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   Collapsible,
   Icon,
+  Image,
   NoticeBox,
   Section,
   Stack,
@@ -23,10 +24,10 @@ class Interaction {
   block_interact;
 }
 
-class LewdSlot {
-  img;
-  name;
-}
+type LewdSlot = {
+  img: string;
+  name: string;
+};
 
 export const InteractionMenu = (props) => {
   const { act, data } = useBackend<Interaction>();
@@ -48,38 +49,36 @@ export const InteractionMenu = (props) => {
         {(block_interact && <NoticeBox>Unable to Interact</NoticeBox>) || (
           <NoticeBox>Able to Interact</NoticeBox>
         )}
-        <Stack fill vertical>
-          <Section key="interactions">
-            {categories.map((category) => (
-              <Collapsible key={category} title={category}>
-                <Section fill>
-                  <Box mt={0.2}>
-                    {interactions[category].map((interaction) => (
-                      <Button
-                        key={interaction}
-                        width="150.5px"
-                        lineHeight={1.75}
-                        disabled={block_interact}
-                        color={block_interact ? 'grey' : colors[interaction]}
-                        tooltip={descriptions[interaction]}
-                        icon="exclamation-circle"
-                        onClick={() =>
-                          act('interact', {
-                            interaction: interaction,
-                            selfref: ref_self,
-                            userref: ref_user,
-                          })
-                        }
-                      >
-                        {interaction}
-                      </Button>
-                    ))}
-                  </Box>
-                </Section>
-              </Collapsible>
-            ))}
-          </Section>
-        </Stack>
+        <Section key="interactions">
+          {categories.map((category) => (
+            <Collapsible key={category} title={category}>
+              <Section fill>
+                <Box mt={0.2}>
+                  {interactions[category].map((interaction) => (
+                    <Button
+                      key={interaction}
+                      width="150.5px"
+                      lineHeight={1.75}
+                      disabled={block_interact}
+                      color={block_interact ? 'grey' : colors[interaction]}
+                      tooltip={descriptions[interaction]}
+                      icon="exclamation-circle"
+                      onClick={() =>
+                        act('interact', {
+                          interaction: interaction,
+                          selfref: ref_self,
+                          userref: ref_user,
+                        })
+                      }
+                    >
+                      {interaction}
+                    </Button>
+                  ))}
+                </Box>
+              </Section>
+            </Collapsible>
+          ))}
+        </Section>
         {lewd_slots.length > 0 ? (
           <Section key="item_slots" title={'Lewd Slots'}>
             <Stack fill>
@@ -104,8 +103,8 @@ export const InteractionMenu = (props) => {
                         }}
                       >
                         {element.img ? (
-                          <img
-                            src={'data:image/png;base64,' + element.img}
+                          <Image
+                            src={`data:image/jpeg;base64,${element.img}`}
                             style={{
                               width: '100%',
                               height: '100%',


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/151

The interaction menu was rending the slots portion waaay at the bottom of the page and it wasn't visible unless you scrolled. It will shot up correctly now.

## How This Contributes To The Nova Sector Roleplay Experience

Fixes a bug

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![1k96qMaVSo](https://github.com/NovaSector/NovaSector/assets/13398309/9a1d168f-84d8-4389-ad97-d04d44310909)

</details>

## Changelog

:cl:
fix: fixes interaction menu UI displaying the slots portion waaay at the bottom, to the point where you had to scroll to view it
/:cl: