### PR TITLE
Ghost cafe turf fixes

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -13417,8 +13417,8 @@
 /turf/open/floor/iron/white,
 /area/centcom/interlink)
 "qGA" = (
-/obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/iron/dark,
 /area/centcom/holding/cafe)
 "qGW" = (

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -310,12 +310,7 @@
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "ahk" = (
-/turf/open/indestructible/hotelwood{
-	desc = "It's really cozy! Great for soft paws!";
-	icon = 'modular_skyrat/modules/ghostcafe/icons/carpet_royalblack.dmi';
-	icon_state = "carpet";
-	name = "soft carpet"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/centcom/holding/cafepark)
 "ahs" = (
 /obj/structure/flora/bush/leavy/style_2,
@@ -475,12 +470,7 @@
 	color = "#B22222";
 	name = "Curtain"
 	},
-/turf/open/indestructible/hotelwood{
-	desc = "It's really cozy! Great for soft paws!";
-	icon = 'modular_skyrat/modules/ghostcafe/icons/carpet_royalblack.dmi';
-	icon_state = "carpet";
-	name = "soft carpet"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/centcom/holding/cafe)
 "ajK" = (
 /obj/structure/flora/rock/pile{
@@ -592,12 +582,7 @@
 "alk" = (
 /obj/item/bedsheet/dorms_double,
 /obj/structure/bed/double,
-/turf/open/indestructible/hotelwood{
-	desc = "It's really cozy! Great for soft paws!";
-	icon = 'modular_skyrat/modules/ghostcafe/icons/carpet_royalblack.dmi';
-	icon_state = "carpet";
-	name = "soft carpet"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/centcom/holding/cafe)
 "alm" = (
 /obj/effect/turf_decal/tile/blue{
@@ -1221,12 +1206,7 @@
 "asz" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/machinery/light/directional/north,
-/turf/open/indestructible/hotelwood{
-	desc = "It's really cozy! Great for soft paws!";
-	icon = 'modular_skyrat/modules/ghostcafe/icons/carpet_royalblack.dmi';
-	icon_state = "carpet";
-	name = "soft carpet"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/centcom/holding/cafepark)
 "asC" = (
 /obj/effect/turf_decal/tile/blue{
@@ -1645,11 +1625,7 @@
 	light_range = 10;
 	nightshift_light_power = 10
 	},
-/turf/open/indestructible/hoteltile{
-	icon = 'modular_skyrat/modules/ghostcafe/icons/floors.dmi';
-	icon_state = "titanium_blue_old";
-	name = "bathroom floor"
-	},
+/turf/open/indestructible/bathroom,
 /area/centcom/holding/cafe)
 "axF" = (
 /obj/structure/bed/dogbed,
@@ -2064,12 +2040,7 @@
 /obj/structure/mirror{
 	pixel_y = 32
 	},
-/turf/open/indestructible/hotelwood{
-	desc = "It's really cozy! Great for soft paws!";
-	icon = 'modular_skyrat/modules/ghostcafe/icons/carpet_royalblack.dmi';
-	icon_state = "carpet";
-	name = "soft carpet"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/centcom/holding/cafe)
 "aAY" = (
 /obj/effect/turf_decal/tile/blue{
@@ -3260,11 +3231,7 @@
 	light_range = 10;
 	nightshift_light_power = 10
 	},
-/turf/open/indestructible/hoteltile{
-	icon = 'modular_skyrat/modules/ghostcafe/icons/floors.dmi';
-	icon_state = "titanium_blue_old";
-	name = "bathroom floor"
-	},
+/turf/open/indestructible/bathroom,
 /area/centcom/holding/cafedorms)
 "aOZ" = (
 /obj/machinery/light/directional/north,
@@ -3284,14 +3251,6 @@
 "aPo" = (
 /obj/structure/sink/directional/west,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafe)
-"aPx" = (
-/turf/open/indestructible/hotelwood{
-	desc = "It's really cozy! Great for soft paws!";
-	icon = 'modular_skyrat/modules/ghostcafe/icons/carpet_royalblack.dmi';
-	icon_state = "carpet";
-	name = "soft carpet"
-	},
 /area/centcom/holding/cafe)
 "aPC" = (
 /obj/structure/railing{
@@ -3434,12 +3393,7 @@
 /obj/structure/fireplace{
 	dir = 4
 	},
-/turf/open/indestructible/hotelwood{
-	desc = "It's really cozy! Great for soft paws!";
-	icon = 'modular_skyrat/modules/ghostcafe/icons/carpet_royalblack.dmi';
-	icon_state = "carpet";
-	name = "soft carpet"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/centcom/holding/cafe)
 "aQR" = (
 /obj/effect/turf_decal/stripes/line{
@@ -3540,11 +3494,7 @@
 /obj/structure/toilet{
 	pixel_y = 14
 	},
-/turf/open/indestructible/hoteltile{
-	icon = 'modular_skyrat/modules/ghostcafe/icons/floors.dmi';
-	icon_state = "titanium_blue_old";
-	name = "bathroom floor"
-	},
+/turf/open/indestructible/bathroom,
 /area/centcom/holding/cafe)
 "aRC" = (
 /obj/machinery/light/directional/north,
@@ -3926,11 +3876,7 @@
 /area/centcom/holding/cafepark)
 "aVC" = (
 /obj/machinery/shower/directional/west,
-/turf/open/indestructible/hoteltile{
-	icon = 'modular_skyrat/modules/ghostcafe/icons/floors.dmi';
-	icon_state = "titanium_blue_old";
-	name = "bathroom floor"
-	},
+/turf/open/indestructible/bathroom,
 /area/centcom/holding/cafedorms)
 "aVI" = (
 /obj/structure/fake_stairs/directional/east,
@@ -4858,12 +4804,7 @@
 /obj/structure/fireplace{
 	dir = 8
 	},
-/turf/open/indestructible/hotelwood{
-	desc = "It's really cozy! Great for soft paws!";
-	icon = 'modular_skyrat/modules/ghostcafe/icons/carpet_royalblack.dmi';
-	icon_state = "carpet";
-	name = "soft carpet"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/centcom/holding/cafe)
 "bTR" = (
 /obj/structure/table/reinforced,
@@ -5584,11 +5525,7 @@
 /obj/structure/toilet{
 	pixel_y = 14
 	},
-/turf/open/indestructible/hoteltile{
-	icon = 'modular_skyrat/modules/ghostcafe/icons/floors.dmi';
-	icon_state = "titanium_blue_old";
-	name = "bathroom floor"
-	},
+/turf/open/indestructible/bathroom,
 /area/centcom/holding/cafe)
 "dbZ" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -7647,12 +7584,7 @@
 /obj/structure/dresser{
 	pixel_y = 7
 	},
-/turf/open/indestructible/hotelwood{
-	desc = "It's really cozy! Great for soft paws!";
-	icon = 'modular_skyrat/modules/ghostcafe/icons/carpet_royalblack.dmi';
-	icon_state = "carpet";
-	name = "soft carpet"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/centcom/holding/cafe)
 "hbE" = (
 /obj/structure/fence/interlink{
@@ -8598,11 +8530,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/thinplating_new/end,
-/turf/open/indestructible/hoteltile{
-	icon = 'modular_skyrat/modules/ghostcafe/icons/floors.dmi';
-	icon_state = "titanium_blue_old";
-	name = "bathroom floor"
-	},
+/turf/open/indestructible/bathroom,
 /area/centcom/holding/cafe)
 "iCz" = (
 /obj/structure/fans/tiny/invisible,
@@ -11267,12 +11195,7 @@
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
 	},
-/turf/open/indestructible/hotelwood{
-	desc = "It's really cozy! Great for soft paws!";
-	icon = 'modular_skyrat/modules/ghostcafe/icons/carpet_royalblack.dmi';
-	icon_state = "carpet";
-	name = "soft carpet"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/centcom/holding/cafepark)
 "nii" = (
 /obj/structure/fireplace,
@@ -11429,12 +11352,7 @@
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
 	},
-/turf/open/indestructible/hotelwood{
-	desc = "It's really cozy! Great for soft paws!";
-	icon = 'modular_skyrat/modules/ghostcafe/icons/carpet_royalblack.dmi';
-	icon_state = "carpet";
-	name = "soft carpet"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/centcom/holding/cafepark)
 "npe" = (
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
@@ -13017,12 +12935,7 @@
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
 	},
-/turf/open/indestructible/hotelwood{
-	desc = "It's really cozy! Great for soft paws!";
-	icon = 'modular_skyrat/modules/ghostcafe/icons/carpet_royalblack.dmi';
-	icon_state = "carpet";
-	name = "soft carpet"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/centcom/holding/cafepark)
 "pTO" = (
 /obj/structure/table/reinforced,
@@ -13192,12 +13105,7 @@
 /area/centcom/interlink)
 "qfy" = (
 /obj/structure/table/wood/fancy/blue,
-/turf/open/indestructible/hotelwood{
-	desc = "It's really cozy! Great for soft paws!";
-	icon = 'modular_skyrat/modules/ghostcafe/icons/carpet_royalblack.dmi';
-	icon_state = "carpet";
-	name = "soft carpet"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/centcom/holding/cafepark)
 "qgh" = (
 /obj/structure/stone_tile/surrounding,
@@ -13522,12 +13430,7 @@
 /obj/item/stack/sheet/mineral/wood/fifty,
 /obj/item/stack/sheet/mineral/wood/fifty,
 /obj/item/lighter,
-/turf/open/indestructible/hotelwood{
-	desc = "It's really cozy! Great for soft paws!";
-	icon = 'modular_skyrat/modules/ghostcafe/icons/carpet_royalblack.dmi';
-	icon_state = "carpet";
-	name = "soft carpet"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/centcom/holding/cafe)
 "qHJ" = (
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -13711,11 +13614,7 @@
 /area/centcom/holding/cafepark)
 "qWc" = (
 /obj/machinery/shower/directional/west,
-/turf/open/indestructible/hoteltile{
-	icon = 'modular_skyrat/modules/ghostcafe/icons/floors.dmi';
-	icon_state = "titanium_blue_old";
-	name = "bathroom floor"
-	},
+/turf/open/indestructible/bathroom,
 /area/centcom/holding/cafe)
 "qWv" = (
 /obj/effect/turf_decal/tile/blue{
@@ -14589,12 +14488,7 @@
 	},
 /obj/structure/bed/double,
 /obj/item/bedsheet/dorms_double,
-/turf/open/indestructible/hotelwood{
-	desc = "It's really cozy! Great for soft paws!";
-	icon = 'modular_skyrat/modules/ghostcafe/icons/carpet_royalblack.dmi';
-	icon_state = "carpet";
-	name = "soft carpet"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/centcom/holding/cafepark)
 "ssn" = (
 /obj/machinery/status_display/shuttle{
@@ -14665,11 +14559,7 @@
 "sys" = (
 /obj/machinery/shower/directional/west,
 /obj/structure/sink/directional/south,
-/turf/open/indestructible/hoteltile{
-	icon = 'modular_skyrat/modules/ghostcafe/icons/floors.dmi';
-	icon_state = "titanium_blue_old";
-	name = "bathroom floor"
-	},
+/turf/open/indestructible/bathroom,
 /area/centcom/holding/cafe)
 "sAC" = (
 /obj/effect/turf_decal/box,
@@ -15164,11 +15054,7 @@
 /turf/open/floor/fakebasalt,
 /area/centcom/holding/cafepark)
 "tky" = (
-/turf/open/indestructible/hoteltile{
-	icon = 'modular_skyrat/modules/ghostcafe/icons/floors.dmi';
-	icon_state = "titanium_blue_old";
-	name = "bathroom floor"
-	},
+/turf/open/indestructible/bathroom,
 /area/centcom/holding/cafe)
 "tlu" = (
 /obj/effect/turf_decal/siding/wood{
@@ -16262,11 +16148,7 @@
 /obj/structure/mirror{
 	pixel_y = 32
 	},
-/turf/open/indestructible/hoteltile{
-	icon = 'modular_skyrat/modules/ghostcafe/icons/floors.dmi';
-	icon_state = "titanium_blue_old";
-	name = "bathroom floor"
-	},
+/turf/open/indestructible/bathroom,
 /area/centcom/holding/cafedorms)
 "vui" = (
 /obj/effect/turf_decal/siding/wood{
@@ -16589,12 +16471,7 @@
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
 	},
-/turf/open/indestructible/hotelwood{
-	desc = "It's really cozy! Great for soft paws!";
-	icon = 'modular_skyrat/modules/ghostcafe/icons/carpet_royalblack.dmi';
-	icon_state = "carpet";
-	name = "soft carpet"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/centcom/holding/cafepark)
 "vZv" = (
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -16896,11 +16773,7 @@
 /area/centcom/holding/cafepark)
 "wBX" = (
 /obj/structure/sink/directional/south,
-/turf/open/indestructible/hoteltile{
-	icon = 'modular_skyrat/modules/ghostcafe/icons/floors.dmi';
-	icon_state = "titanium_blue_old";
-	name = "bathroom floor"
-	},
+/turf/open/indestructible/bathroom,
 /area/centcom/holding/cafedorms)
 "wCl" = (
 /obj/item/kirbyplants/random,
@@ -17634,12 +17507,7 @@
 /obj/structure/sign/painting/library_secure{
 	pixel_y = -32
 	},
-/turf/open/indestructible/hotelwood{
-	desc = "It's really cozy! Great for soft paws!";
-	icon = 'modular_skyrat/modules/ghostcafe/icons/carpet_royalblack.dmi';
-	icon_state = "carpet";
-	name = "soft carpet"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/centcom/holding/cafe)
 "xRx" = (
 /obj/item/stack/sheet/mineral/wood/fifty,
@@ -57613,8 +57481,8 @@ aFP
 aqf
 qWc
 axD
-aPx
-aPx
+amF
+amF
 alk
 sQj
 atp
@@ -64559,8 +64427,8 @@ lwv
 aqf
 aRx
 axD
-aPx
-aPx
+amF
+amF
 qHc
 aqf
 tgU
@@ -64816,7 +64684,7 @@ tzR
 aqf
 qWc
 aqf
-aPx
+amF
 bTK
 xQK
 aqf

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -7522,7 +7522,7 @@
 /area/centcom/holding/cafepark)
 "gPD" = (
 /obj/structure/rack/shelf{
-	icon = 'modular_skyrat/modules/mapping/icons/unique/furniture.dmi';
+	icon = 'modular_nova/modules/mapping/icons/unique/furniture.dmi';
 	icon_state = "empty_shelf_1"
 	},
 /obj/item/reagent_containers/cup/bucket/wooden,
@@ -10037,7 +10037,7 @@
 /area/centcom/holding/cafepark)
 "lgm" = (
 /obj/structure/rack/shelf{
-	icon = 'modular_skyrat/modules/mapping/icons/unique/furniture.dmi';
+	icon = 'modular_nova/modules/mapping/icons/unique/furniture.dmi';
 	icon_state = "empty_shelf_1"
 	},
 /obj/structure/stone_tile/slab,
@@ -12299,7 +12299,7 @@
 /area/centcom/interlink)
 "oSG" = (
 /obj/structure/rack/shelf{
-	icon = 'modular_skyrat/modules/mapping/icons/unique/furniture.dmi';
+	icon = 'modular_nova/modules/mapping/icons/unique/furniture.dmi';
 	icon_state = "empty_shelf_1"
 	},
 /obj/item/bedsheet/black{
@@ -15330,7 +15330,7 @@
 /area/centcom/interlink)
 "tDj" = (
 /obj/structure/rack/shelf{
-	icon = 'modular_skyrat/modules/mapping/icons/unique/furniture.dmi';
+	icon = 'modular_nova/modules/mapping/icons/unique/furniture.dmi';
 	icon_state = "empty_shelf_1"
 	},
 /obj/structure/wall_torch/spawns_lit/directional/west,

--- a/modular_nova/modules/ghostcafe/code/ghostcafeturf.dm
+++ b/modular_nova/modules/ghostcafe/code/ghostcafeturf.dm
@@ -13,3 +13,11 @@
 	name = "nitrogen-filled plating"
 	desc = "Vox box certified."
 	initial_gas_mix = "n2=104;TEMP=293.15"
+
+/turf/open/indestructible/bathroom
+	icon = 'modular_nova/modules/ghostcafe/icons/floors.dmi';
+	icon_state = "titanium_blue_old";
+	name = "bathroom floor"
+	footstep = FOOTSTEP_FLOOR
+	tiled_dirt = FALSE
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Three different fixes:

Some of the cabins had turfs that were just edited to have icon paths and those icon paths were pointing to old skyrat folders. 
These were the black carpet and the bathroom floor tile.
The black carpet I just replaced with normal black carpet, because half of the cabins already had normal black carpet anyway
With the bathroom floor I made a subtype for it that should be effectively the same as what it was before. (Except referencing Nova so that the turf icon actually shows up - there wasn't really an equivalent turf already in existence)

Also, when I remodeled the ghost cafe I accidentally removed the only sec drobe and never put it back, so I added it back to the security section. 

And some of the shelves were referencing icons in a modular_skyrat folder that didnt exist.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Currently the bathrooms in the ghost cafe and unusable, and I've heard multiple complains about that sec drobe disappearing. 

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/102194057/a40578c1-0270-4bdc-a4fe-1bdf504a62fa)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: ghost cafe bathroom turfs are no longer solid black blocks of missing icon-ness
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
