### PR TITLE
Fix BYOND membership status available to non-members

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -109,8 +109,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		load_path(parent.ckey)
 		if(load_and_save && !fexists(path))
 			try_savefile_type_migration()
-		unlock_content = !!parent.IsByondMember() || GLOB.donator_list[parent.ckey] //NOVA EDIT - ADDED DONATOR CHECK
-		if(unlock_content)
+		unlock_content = !!parent.IsByondMember()
+		donator_status = !!SSplayer_ranks.is_donator(parent) //NOVA EDIT ADD - DONATOR CHECK
+		if(unlock_content || donator_status) //NOVA EDIT CHANGE - ADD DONATOR CHECK
 			max_save_slots = 50 //NOVA EDIT - ORIGINAL 8
 	else
 		CRASH("attempted to create a preferences datum without a client or mock!")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -110,7 +110,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		if(load_and_save && !fexists(path))
 			try_savefile_type_migration()
 		unlock_content = !!parent.IsByondMember()
-		donator_status = !!SSplayer_ranks.is_donator(parent) //NOVA EDIT ADD - DONATOR CHECK
+		donator_status = !!GLOB.donator_list[parent.ckey] //NOVA EDIT ADD - DONATOR CHECK
 		if(unlock_content || donator_status) //NOVA EDIT CHANGE - ADD DONATOR CHECK
 			max_save_slots = 50 //NOVA EDIT - ORIGINAL 8
 	else

--- a/modular_nova/master_files/code/modules/mob/login.dm
+++ b/modular_nova/master_files/code/modules/mob/login.dm
@@ -5,6 +5,6 @@
 		return FALSE
 
 	if(SSplayer_ranks.initialized)
-		SSplayer_ranks.update_prefs_unlock_content(client?.prefs)
+		SSplayer_ranks.update_prefs_donator_status(client?.prefs)
 
 	return TRUE

--- a/modular_nova/modules/player_ranks/code/preferences.dm
+++ b/modular_nova/modules/player_ranks/code/preferences.dm
@@ -1,0 +1,3 @@
+/datum/preferences
+	/// Does this member have donator status on the server
+	var/donator_status = FALSE

--- a/modular_nova/modules/player_ranks/code/subsystem/player_ranks.dm
+++ b/modular_nova/modules/player_ranks/code/subsystem/player_ranks.dm
@@ -111,7 +111,7 @@ SUBSYSTEM_DEF(player_ranks)
 
 	if(CONFIG_GET(flag/donator_legacy_system))
 		donator_controller.load_legacy()
-		update_all_prefs_unlock_contents()
+		update_all_prefs_donator_status()
 		return
 
 	if(!SSdbcore.Connect())
@@ -124,30 +124,31 @@ SUBSYSTEM_DEF(player_ranks)
 		return
 
 	load_player_rank_sql(donator_controller)
-	update_all_prefs_unlock_contents()
+	update_all_prefs_donator_status()
 
 
 /**
  * Handles updating all of the preferences datums to have the appropriate
- * `unlock_content` and `max_save_slots` once donators are loaded.
+ * `donator_status` and `max_save_slots` once donators are loaded.
  */
-/datum/controller/subsystem/player_ranks/proc/update_all_prefs_unlock_contents()
+/datum/controller/subsystem/player_ranks/proc/update_all_prefs_donator_status()
 	for(var/ckey as anything in GLOB.preferences_datums)
-		update_prefs_unlock_content(GLOB.preferences_datums[ckey])
+		update_prefs_donator_status(GLOB.preferences_datums[ckey])
 
 
 /**
- * Updates the `unlock_contents` and the `max_save_slots`
+ * Updates the `donator_status` and the `max_save_slots`
  *
  * Arguments:
- * * prefs - The preferences datum to check the unlock_content eligibility.
+ * * prefs - The preferences datum to check the donator_status eligibility.
  */
-/datum/controller/subsystem/player_ranks/proc/update_prefs_unlock_content(datum/preferences/prefs)
+/datum/controller/subsystem/player_ranks/proc/update_prefs_donator_status(datum/preferences/prefs)
 	if(!prefs)
 		return
 
-	prefs.unlock_content = !!prefs.parent.IsByondMember() || is_donator(prefs.parent)
-	if(prefs.unlock_content)
+	prefs.unlock_content = !!prefs.parent.IsByondMember()
+	prefs.donator_status = is_donator(prefs.parent)
+	if(prefs.unlock_content || prefs.donator_status)
 		prefs.max_save_slots = 50
 
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7789,6 +7789,7 @@
 #include "modular_nova\modules\pixel_shift\code\pixel_shift_component.dm"
 #include "modular_nova\modules\pixel_shift\code\pixel_shift_keybind.dm"
 #include "modular_nova\modules\pixel_shift\code\pixel_shift_mob.dm"
+#include "modular_nova\modules\player_ranks\code\preferences.dm"
 #include "modular_nova\modules\player_ranks\code\world_topic.dm"
 #include "modular_nova\modules\player_ranks\code\player_rank_controller\_player_rank_controller.dm"
 #include "modular_nova\modules\player_ranks\code\player_rank_controller\donator_controller.dm"


### PR DESCRIPTION
## About The Pull Request

Fixes an issue introduced by https://github.com/Skyrat-SS13/Skyrat-tg/pull/18946 where players on the server donator list are marked as BYOND membership holders.

This adds a variable, donator_status that correctly holds a player's donator status to the server and unlocks the associated content.

## How This Contributes To The Nova Sector Roleplay Experience

We're all thankful for the work Lummox puts in to keep BYOND alive and he doesn't ask for much. Circumventing the BYOND membership check in exchange for a donation to the server instead is hopefully not intended behavior.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/83487515/2878b6cd-2d72-4b4c-b119-76140a4fd469)

</details>

## Changelog

:cl: LT3
fix: Fixed BYOND membership status being available to non-BYOND members
/:cl: