### PR TITLE
Saving Private Oversized: Quirk balancing adjustments

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -32,6 +32,9 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/spacer_born, /datum/quirk/oversized),
 	list(/datum/quirk/feline_aspect, /datum/quirk/item_quirk/canine, /datum/quirk/item_quirk/avian),
 	list(/datum/quirk/all_nighter, /datum/quirk/heavy_sleeper),
+	list(/datum/quirk/light_drinker, /datum/quirk/drunkhealing),
+	list(/datum/quirk/oversized, /datum/quirk/freerunning),
+	list(/datum/quirk/oversized, /datum/quirk/item_quirk/settler),
 	//NOVA EDIT ADDITION END
 ))
 


### PR DESCRIPTION
## About The Pull Request

Ongoing discussion on Discord regarding the Oversized quirk has revealed that a selection of unscrupulous players are quite flagrantly taking advantages of oversights in quirk "balancing" for rather severe gameplay advantages. This PR aims to address this somewhat with the following changes:

- Light Drinker can no longer be taken with Drunken Resilience. This prevents (especially sec players) people from taking a boot flask loadout item and carrying around 60u of quadsec or bastion bourbon, swigging three sips and benefitting from on-demand giga healing. It can scale as high as like 8 brute/burn per tick with some drink combos.
- Oversized can no longer be taken with Freerunning. You're huge and the point of Oversized is to introduce mobility limitations, not have someone who struggles to fit in airlocks be partially immune to falling damage.
- Oversized can no longer be taken with Settler. Settler and Oversized contest one another for a hunger rate adjustment at exact opposite ends of the spectrum, with Settler reducing hunger to 50% of normal and Oversized increasing it to 150% of normal. In some circumstances, Settler would apply second in this list and entirely negate one of the principle downsides of Oversized. This is almost certainly a bug/oversight.

## How This Contributes To The Nova Sector Roleplay Experience

It stops gremlins from doing gremlin things and allows us to potentially keep Oversized's other bonuses untouched for those doing the right thing.

## Proof of Testing

trust me bro

## Changelog

:cl: yooriss
balance: Light Drinker and Drunken Resilience quirks can no longer be chosen together.
balance: Oversized and Freerunning quirks can no longer be chosen together.
fix: Oversized and Settler can now no longer be chosen together to negate the Oversized hunger mod penalty.
/:cl: