### PR TITLE
Over(sized) and Under: Oversized combat adjustments

### DIFF
--- a/code/__DEFINES/~skyrat_defines/combat.dm
+++ b/code/__DEFINES/~skyrat_defines/combat.dm
@@ -23,6 +23,7 @@
 
 // Damage modifiers
 #define OVERSIZED_HARM_DAMAGE_BONUS 5 /// Those with the oversized trait do 5 more damage.
+#define OVERSIZED_KICK_EFFECTIVENESS_BONUS 5 /// Increased unarmed_effectiveness/stun threshold on oversized kicks.
 
 #define FILTER_STAMINACRIT filter(type="drop_shadow", x=0, y=0, size=-3, color="#04080F")
 

--- a/modular_nova/modules/oversized/code/oversized_quirk.dm
+++ b/modular_nova/modules/oversized/code/oversized_quirk.dm
@@ -23,13 +23,22 @@
 	human_holder.mob_size = MOB_SIZE_LARGE
 	var/obj/item/bodypart/arm/left/left_arm = human_holder.get_bodypart(BODY_ZONE_L_ARM)
 	if(left_arm)
-		left_arm.unarmed_damage_low += OVERSIZED_HARM_DAMAGE_BONUS
 		left_arm.unarmed_damage_high += OVERSIZED_HARM_DAMAGE_BONUS
 
 	var/obj/item/bodypart/arm/right/right_arm = human_holder.get_bodypart(BODY_ZONE_R_ARM)
 	if(right_arm)
-		right_arm.unarmed_damage_low += OVERSIZED_HARM_DAMAGE_BONUS
 		right_arm.unarmed_damage_high += OVERSIZED_HARM_DAMAGE_BONUS
+
+	// Before this, we never actually did anything with Oversized legs.
+	// This brings their unarmed_effectiveness up to 20 from 15, which is on par with mushroom legs.
+	// Functionally, this makes their prone kicks more accurate and increases the chance of extending prone knockdown... but only while the victim is already prone.
+	var/obj/item/bodypart/leg/left/left_leg = human_holder.get_bodypart(BODY_ZONE_L_LEG)
+	if(left_leg)
+		left_leg.unarmed_effectiveness += OVERSIZED_KICK_EFFECTIVENESS_BONUS
+
+	var/obj/item/bodypart/leg/right/right_leg = human_holder.get_bodypart(BODY_ZONE_R_LEG)
+	if(right_leg)
+		right_leg.unarmed_effectiveness += OVERSIZED_KICK_EFFECTIVENESS_BONUS
 
 	human_holder.blood_volume_normal = BLOOD_VOLUME_OVERSIZED
 	human_holder.physiology.hunger_mod *= OVERSIZED_HUNGER_MOD //50% hungrier


### PR DESCRIPTION
## About The Pull Request

Post Brawlening (https://github.com/tgstation/tgstation/pull/79362), Oversized characters have been in a bit of a weird spot. Previously, the quirk added a flat +5 damage to their punches and did little else. Unarmed combat works by dealing 1.5x the brute damage your punches do as stamina damage, meaning a maxrolled Oversized punch does a minimum of *20* stamina damage every single time.

To help illustrate the problem, knockdown works in two ways:
- If your limb's `unarmed_effectiveness` is rolled as a probability percentage, you knock your target down. *Oversized does not directly affect this.*
OR:
- If your target is staggered from being shoved (right-clicked) and they have a combined **stamina and brute** value of **>40**, you knock your target down. *Oversized definitely directly affects this since it increases flat damage.*

Thus, you are punched once by an oversized aggressor. Assuming no armor, you take 10 brute damage and 20 stamina damage. You are punched again. You now have 20 brute damage and 40 stamina damage, putting you firmly over the 40 combined damage threshold for knockdown. On Nova, we have a 20 damage stamina knockdown instead of /tg/station's 4 second hard stun. This also adds 20 extra stamina damage as part of the knockdown, leaving you at 60 stamina damage and on the floor. The oversized character hits you another time. You have now taken 30 brute damage and 100 stamina damage. You are now stamcrit with 120+ stamina damage, because going stamcrit also deals another 20 damage. This works out across the course of 3-4 hits, on average.

This PR thus reworks things as follows:
- The Oversized harm damage bonus is applied to unarmed damage *ceiling* instead of as a flat value. This means oversized punches roll from 5-15 instead of 10-15 like before. This lets them get lucky and continue the 3-4 hit pain train as described above, but increases the number of hits required to 5-6 on average.
- Oversized characters receive a +5 bonus to `unarmed_effectiveness` on their legs, bringing them up to Mushroom-levels of stompage without actually increasing any damage. This increases their base prone kicking accuracy by 5% and improves their ability to keep you down on the ground once they get you there.

## How This Contributes To The Nova Sector Roleplay Experience

Addresses mechanical oversized cheese to make fights more interesting while still giving characters that take the quirk a unique bruiser spin on combat.

## Proof of Testing

also trust me bro

## Changelog

:cl: yooriss
balance: Oversized characters no longer receive a flat +5 damage to all unarmed attacks, and instead gain a +5 bonus to the  maximum possible damage. In addition, the unarmed effectiveness value of their legs has increased by +5, making them better at keeping people on the ground once they get them there, without doing any extra damage with their kicks.
/:cl: