### PR TITLE
Increases PAI description and OOC notes limit

### DIFF
--- a/tgui/packages/tgui/interfaces/PaiSubmit.tsx
+++ b/tgui/packages/tgui/interfaces/PaiSubmit.tsx
@@ -86,7 +86,7 @@ const InputDisplay = (props) => {
           </Box>
           <Input
             fluid
-            maxLength={100}
+            maxLength={500} /* NOVA EDIT: ORIGINAL 100 */
             value={description}
             onChange={(e, value) => setInput({ ...input, description: value })}
           />
@@ -97,7 +97,7 @@ const InputDisplay = (props) => {
           </Box>
           <Input
             fluid
-            maxLength={100}
+            maxLength={500} /* NOVA EDIT: ORIGINAL 100 */
             value={comments}
             onChange={(e, value) => setInput({ ...input, comments: value })}
           />


### PR DESCRIPTION
## About The Pull Request

This increases the text limit for PAI's to use for their flavor text and for their OOC notes this is for the suggestion on the discord [To increase PAI text limit](https://discord.com/channels/1171566433923239977/1188597344183267348)

## How This Contributes To The Nova Sector Roleplay Experience

More descriptive characters is always good

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![xBrg7Je2lp](https://github.com/NovaSector/NovaSector/assets/2568378/4af63bfe-de1b-4e0b-9039-e02a695d7c0c)

</details>

## Changelog

:cl:
qol: PAI's now have a larger limit for their OOC notes and description, they can now put up to 500 characters for both
/:cl: