### PR TITLE
Makes headset sounds not insane (WHY DO THEY HAVE A RANGE OF 17 TI:LES?)

### DIFF
--- a/modular_nova/modules/radiosound/code/headset.dm
+++ b/modular_nova/modules/radiosound/code/headset.dm
@@ -1,5 +1,8 @@
 /obj/item/radio/headset
+	/// The sound that plays when someone uses the headset
 	var/radiosound = 'modular_nova/modules/radiosound/sound/radio/common.ogg'
+	/// The volume of the radio sound we make
+	var/radio_sound_volume = 25
 
 /obj/item/radio/headset/syndicate //disguised to look like a normal headset for stealth ops
 	radiosound = 'modular_nova/modules/radiosound/sound/radio/syndie.ogg'
@@ -7,7 +10,7 @@
 /obj/item/radio/headset/headset_sec
 	radiosound = 'modular_nova/modules/radiosound/sound/radio/security.ogg'
 
-/obj/item/radio/headset/talk_into(mob/living/M, message, channel, list/spans, datum/language/language, list/message_mods, direct = TRUE)
+/obj/item/radio/headset/talk_into(mob/living/mob_in_question, message, channel, list/spans, datum/language/language, list/message_mods, direct = TRUE)
 	if(radiosound && listening)
-		playsound(M, radiosound, rand(20, 30), 0, 0, SOUND_FALLOFF_EXPONENT)
+		playsound(mob_in_question, radiosound, radio_sound_volume, TRUE, -12, SOUND_FALLOFF_EXPONENT)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Cleans up headset sound code and reduces the range that the sounds can be heard at severely.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

1. The code in this place had some problems (single letter variables, normal skyrat code activity)
2. The headset sounds could reach **17** tiles out and you just never heard them because they fell off, and now that I've added a headset sound that doesn't fall off as well it sounds insane.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

Nah I'd win

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
sound: The headset radio sound no longer reaches 17 entire tiles away from you
code: Some of the code around headset sounds has been improved a bit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
