### PR TITLE
[MODULAR] Changes opfor 'approve/deny' objective buttons, opfor chat qol

### DIFF
--- a/modular_nova/modules/opposing_force/code/opposing_force_datum.dm
+++ b/modular_nova/modules/opposing_force/code/opposing_force_datum.dm
@@ -243,6 +243,8 @@
 			submit_to_subsystem(usr)
 		if("send_message")
 			send_message(usr, params["message"])
+			if(!handling_admin && check_rights_for(usr.client, R_ADMIN) && usr != mind_reference)
+				handle(usr) // if an admin sends a message and it's not being handled, assign them as handling it
 		// Objective control
 		if("add_objective")
 			add_objective(usr)

--- a/tgui/packages/tgui/interfaces/OpposingForcePanel.jsx
+++ b/tgui/packages/tgui/interfaces/OpposingForcePanel.jsx
@@ -770,63 +770,70 @@ export const AdminTab = (props) => {
               <Section
                 title={index + 1 + '. ' + objective.title}
                 key={objective.id}
-                buttons={
-                  <>
-                    <Button
-                      icon="check"
-                      color="good"
-                      disabled={
-                        objective.approved &&
-                        objective.status_text !== 'Not Reviewed'
-                      }
-                      content="Approve Objective"
-                      onClick={() =>
-                        act('approve_objective', {
-                          objective_ref: objective.ref,
-                        })
-                      }
-                    />
-                    <Button
-                      icon="times"
-                      color="bad"
-                      disabled={
-                        !objective.approved &&
-                        objective.status_text !== 'Not Reviewed'
-                      }
-                      content="Deny Objective"
-                      onClick={() =>
-                        act('deny_objective', {
-                          objective_ref: objective.ref,
-                        })
-                      }
-                    />
-                  </>
-                }
               >
-                <LabeledList key={objective.id}>
-                  <LabeledList.Item label="Description">
-                    {objective.description}
-                  </LabeledList.Item>
-                  <LabeledList.Item label="Justification">
-                    {objective.justification}
-                  </LabeledList.Item>
-                  <LabeledList.Item label="Intensity">
-                    {'(' +
-                      objective.intensity +
-                      ') ' +
-                      objective.text_intensity}
-                  </LabeledList.Item>
-                  <LabeledList.Item label="Status">
-                    {objective.status_text === 'Not Reviewed'
-                      ? 'Objective Not Reviewed'
-                      : objective.approved
-                        ? 'Objective Approved'
-                        : objective.denied_text
-                          ? 'Objective Denied - Reason: ' +
-                            objective.denied_text
-                          : 'Objective Denied'}
-                  </LabeledList.Item>
-                </LabeledList>
+                <Stack vertical>
+                  <Stack.Item>
+                    <LabeledList key={objective.id}>
+                      <LabeledList.Item label="Description">
+                        {objective.description}
+                      </LabeledList.Item>
+                      <LabeledList.Item label="Justification">
+                        {objective.justification}
+                      </LabeledList.Item>
+                      <LabeledList.Item label="Intensity">
+                        {'(' +
+                          objective.intensity +
+                          ') ' +
+                          objective.text_intensity}
+                      </LabeledList.Item>
+                      <LabeledList.Item label="Status">
+                        {objective.status_text === 'Not Reviewed'
+                          ? 'Objective Not Reviewed'
+                          : objective.approved
+                            ? 'Objective Approved'
+                            : objective.denied_text
+                              ? 'Objective Denied - Reason: ' +
+                                objective.denied_text
+                              : 'Objective Denied'}
+                      </LabeledList.Item>
+                    </LabeledList>
+                  </Stack.Item>
+                  <Stack mb={-1.5}>
+                    <Stack.Divider hidden grow width="50%" />
+                    <Stack.Item>
+                      <Button
+                        icon="check"
+                        color="good"
+                        disabled={
+                          objective.approved &&
+                          objective.status_text !== 'Not Reviewed'
+                        }
+                        content="Approve Objective"
+                        onClick={() =>
+                          act('approve_objective', {
+                            objective_ref: objective.ref,
+                          })
+                        }
+                      />
+                    </Stack.Item>
+                    <Stack.Item>
+                      <Button
+                        icon="times"
+                        color="bad"
+                        disabled={
+                          !objective.approved &&
+                          objective.status_text !== 'Not Reviewed'
+                        }
+                        content="Deny Objective"
+                        onClick={() =>
+                          act('deny_objective', {
+                            objective_ref: objective.ref,
+                          })
+                        }
+                      />
+                    </Stack.Item>
+                  </Stack>
+                </Stack>
               </Section>
             ))
           )}


### PR DESCRIPTION
## About The Pull Request

See screenshots for the before/after. Also per request makes it so that when you send a chat message to a player as an admin using the opfor panel, it will consider you as handling the opfor (if no one else is).

## How This Contributes To The Nova Sector Roleplay Experience

## Proof of Testing

<details>
<summary>Before</summary>
  
![Cd7xhMHEQb](https://github.com/NovaSector/NovaSector/assets/13398309/485a4e94-5dfa-4e3f-9abc-44fc172e7e49)

</details>

<details>
<summary>After</summary>
  
![KA3mxqE9S5](https://github.com/NovaSector/NovaSector/assets/13398309/8e559999-e1c3-412f-a0bc-8357548155b3)

</details>

## Changelog

:cl:
admin: opfor panel 'approve objective' button is no longer annoyingly in the way of the objective title text
qol: when you send a message as an admin via the opfor panel and no one is handling the opfor, it will automatically mark you as handling it
/:cl:
