### PR TITLE
Space Ruin - Space hotel Pipenet, Powernet and disposal fixes

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/spacehotel_skyrat.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel_skyrat.dmm
@@ -243,6 +243,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hotel/bar)
 "bb" = (
@@ -324,7 +327,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
 	name = "Hotel Maintenance"
 	},
@@ -397,6 +399,14 @@
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/hotel)
+"cC" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/sink/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/pool)
 "cE" = (
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/carpet/black,
@@ -515,6 +525,7 @@
 "dv" = (
 /obj/item/reagent_containers/cup/rag,
 /obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel/bar)
 "dx" = (
@@ -536,6 +547,19 @@
 	dir = 9
 	},
 /turf/open/floor/carpet/black,
+/area/ruin/space/has_grav/hotel)
+"dF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
 /area/ruin/space/has_grav/hotel)
 "dH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -701,6 +725,14 @@
 /obj/effect/turf_decal/tile/dark/diagonal_edge,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/hotel)
+"ev" = (
+/obj/structure/chair/stool/bar,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/black,
+/area/ruin/space/has_grav/hotel/bar)
 "ex" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet/green,
@@ -719,14 +751,10 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/hotel)
 "ez" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/hotel/bar)
 "eA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -1337,6 +1365,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/ruin/space/has_grav/hotel/pool)
 "ho" = (
@@ -1411,13 +1440,9 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel/bar)
 "hv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/coffeemaker,
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/mug/nanotrasen{
@@ -1443,9 +1468,6 @@
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/light_switch{
 	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/hotel/guestroom/room_6)
@@ -1644,6 +1666,12 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/twin_nexus_staff,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/bar)
 "il" = (
@@ -1681,9 +1709,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -1735,14 +1760,12 @@
 /turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/hotel/guestroom/room_6)
 "iz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/indestructible/hoteltile,
-/area/ruin/space/has_grav/hotel/guestroom)
+/turf/open/floor/iron/cafeteria,
+/area/ruin/space/has_grav/hotel/bar)
 "iA" = (
 /turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/hotel/bar)
@@ -1759,9 +1782,6 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Power Storage"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/airlock/access/all/twin_nexus_staff,
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/hotel/power)
@@ -1770,9 +1790,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/hotel)
 "iM" = (
@@ -1900,7 +1918,6 @@
 /area/ruin/space/has_grav/hotel/bar)
 "jm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/neon/simple/black/nodots,
 /area/ruin/space/has_grav/hotel/guestroom/room_1)
 "jo" = (
@@ -1951,11 +1968,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/hotel)
@@ -2009,10 +2026,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/wood,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/hotel)
 "jL" = (
@@ -2067,19 +2084,17 @@
 "kb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/workroom)
 "kc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/carpet/green,
-/area/ruin/space/has_grav/hotel/guestroom/room_4)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/carpet/orange,
+/area/ruin/space/has_grav/hotel)
 "ke" = (
 /obj/machinery/gibber,
 /obj/effect/decal/cleanable/blood/old,
@@ -2164,7 +2179,7 @@
 /area/ruin/space/has_grav/hotel/power)
 "kw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/carpet/green,
 /area/ruin/space/has_grav/hotel/guestroom/room_4)
@@ -2285,6 +2300,9 @@
 /obj/machinery/airalarm/directional/north{
 	pixel_y = 24
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/hotel)
 "kR" = (
@@ -2363,6 +2381,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/dark_green/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/hotel/bar)
 "lc" = (
@@ -2618,6 +2639,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/hotel/dock)
+"mq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/hotel/bar)
 "mr" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -2711,12 +2738,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/hotel)
@@ -2842,6 +2869,9 @@
 /area/ruin/space/has_grav/hotel)
 "ni" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/cafeteria,
@@ -3053,6 +3083,13 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/hotel)
+"os" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/carpet/black,
+/area/ruin/space/has_grav/hotel/bar)
 "ov" = (
 /turf/open/floor/iron/dark/diagonal,
 /area/ruin/space/has_grav/hotel/dock)
@@ -3073,6 +3110,9 @@
 "oH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hotel/bar)
@@ -3108,14 +3148,11 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/ruin/space/has_grav/hotel/bar)
 "oV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/indestructible/hoteltile,
-/area/ruin/space/has_grav/hotel/guestroom)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor,
+/area/ruin/space/has_grav/hotel)
 "oW" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/flashlight/lamp/green,
@@ -3494,11 +3531,11 @@
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/hotel)
 "rp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/effect/turf_decal/siding/green{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hotel/bar)
@@ -3609,7 +3646,6 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Hotel Medical Storage"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -3713,15 +3749,9 @@
 /turf/open/floor/carpet/executive,
 /area/ruin/space/has_grav/hotel/workroom)
 "sh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/has_grav/hotel)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/hotel/bar)
 "sj" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -3758,6 +3788,12 @@
 	},
 /turf/open/floor/carpet/neon/simple/teal/nodots,
 /area/ruin/space/has_grav/hotel/guestroom/room_3)
+"sA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/carpet/neon/simple/pink/nodots,
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "sC" = (
 /obj/machinery/light{
 	dir = 1
@@ -3822,6 +3858,9 @@
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/siding/dark_green{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/hotel/bar)
@@ -4107,6 +4146,10 @@
 	},
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/hotel/guestroom/room_4)
+"ve" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "vn" = (
 /obj/structure/table/glass,
 /obj/item/flashlight/flare/candle/infinite{
@@ -4156,6 +4199,9 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 6
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hotel/bar)
 "vu" = (
@@ -4172,9 +4218,6 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel/bar)
 "vB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -4183,6 +4226,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/hotel)
 "vG" = (
@@ -4285,7 +4331,7 @@
 /area/ruin/space/has_grav/hotel/custodial)
 "wB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/carpet/green,
 /area/ruin/space/has_grav/hotel/guestroom/room_4)
@@ -4432,9 +4478,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
@@ -4542,6 +4585,16 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hotel/power)
+"yi" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/catwalk_floor,
+/area/ruin/space/has_grav/hotel)
 "yk" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Changing"
@@ -4688,6 +4741,9 @@
 /area/ruin/space/has_grav/hotel/pool)
 "zo" = (
 /obj/structure/decorative/shelf/alcohol_assortment,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel/bar)
 "zp" = (
@@ -4745,6 +4801,9 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/twin_nexus_staff,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel)
 "zP" = (
@@ -4830,7 +4889,6 @@
 /area/ruin/space/has_grav/hotel/guestroom)
 "Ao" = (
 /obj/structure/table/wood,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/item/flashlight/lamp/green{
 	pixel_x = 1;
 	pixel_y = 5
@@ -5097,6 +5155,9 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hotel/bar)
 "Cb" = (
@@ -5345,7 +5406,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/workroom)
 "DH" = (
@@ -5666,6 +5726,9 @@
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/siding/dark_green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/hotel/bar)
 "Ga" = (
@@ -5815,12 +5878,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/hotel/bar)
 "GN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/indestructible/hoteltile,
 /area/ruin/space/has_grav/hotel/guestroom)
 "GO" = (
@@ -5883,11 +5944,12 @@
 /turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/hotel/guestroom/room_6)
 "Hp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/turf/open/indestructible/hoteltile,
-/area/ruin/space/has_grav/hotel/guestroom)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/orange,
+/area/ruin/space/has_grav/hotel)
 "Hq" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -5901,9 +5963,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/hotel)
@@ -5936,6 +5995,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/dark_green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/hotel/bar)
 "HG" = (
@@ -5968,10 +6030,9 @@
 	pixel_x = 6;
 	pixel_y = 5
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/hotel/bar)
 "HS" = (
@@ -6067,8 +6128,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/hotel)
@@ -6383,6 +6444,9 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/turf_decal/siding/dark_green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/hotel/bar)
 "KY" = (
@@ -6416,6 +6480,9 @@
 /obj/effect/turf_decal/siding/dark_green{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/hotel/bar)
 "Lh" = (
@@ -6441,6 +6508,14 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel/bar)
+"Lk" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/orange,
+/area/ruin/space/has_grav/hotel)
 "Lm" = (
 /obj/structure/chair/pew/right{
 	dir = 8;
@@ -6458,8 +6533,6 @@
 	pixel_y = -24
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel/guestroom/room_5)
 "Lp" = (
@@ -6569,6 +6642,9 @@
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/hotel)
@@ -6696,9 +6772,6 @@
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/hotel)
 "MV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -6734,6 +6807,9 @@
 	},
 /obj/effect/turf_decal/siding/dark_green{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/hotel/bar)
@@ -6825,9 +6901,6 @@
 /turf/open/floor/carpet/neon/simple/pink/nodots,
 /area/ruin/space/has_grav/hotel/guestroom/room_2)
 "NV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/machinery/light{
 	dir = 8
@@ -6882,6 +6955,9 @@
 	},
 /obj/structure/sign/poster/contraband/random/directional/north,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/hotel)
 "Om" = (
@@ -6938,6 +7014,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/hotel)
 "OB" = (
@@ -7139,9 +7218,6 @@
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/hotel)
 "PN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -30
@@ -7300,9 +7376,6 @@
 "QR" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/machinery/light_switch{
 	pixel_y = -24
 	},
@@ -7346,14 +7419,19 @@
 /turf/closed/wall,
 /area/ruin/space/has_grav/hotel/workroom)
 "Rm" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/carpet/green,
-/area/ruin/space/has_grav/hotel/guestroom/room_4)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/turf/open/floor/catwalk_floor,
+/area/ruin/space/has_grav/hotel)
 "Rn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -7363,9 +7441,6 @@
 	},
 /obj/item/kirbyplants/random,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/hotel)
 "Rq" = (
@@ -7381,6 +7456,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/dark_green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/hotel/bar)
 "Rv" = (
@@ -7484,6 +7562,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/hotel)
 "RS" = (
@@ -7505,11 +7584,17 @@
 /turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/hotel/guestroom/room_6)
 "RX" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/ruin/space/has_grav/hotel/guestroom/room_1)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/orange,
+/area/ruin/space/has_grav/hotel)
 "RY" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
@@ -7585,7 +7670,7 @@
 /area/ruin/space/has_grav/hotel/sauna)
 "SH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+	dir = 1
 	},
 /turf/open/indestructible/hoteltile,
 /area/ruin/space/has_grav/hotel/guestroom)
@@ -7611,6 +7696,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/hotel)
 "SU" = (
@@ -7655,6 +7743,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/hotel)
 "Tj" = (
@@ -7703,18 +7794,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
 	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/hotel)
 "Tz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/turf/open/floor/carpet/green,
-/area/ruin/space/has_grav/hotel/guestroom/room_4)
+/turf/open/floor/carpet/orange,
+/area/ruin/space/has_grav/hotel)
 "TA" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Disposals Access"
@@ -7879,6 +7970,9 @@
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/siding/dark_green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/hotel/bar)
 "UW" = (
@@ -7934,8 +8028,6 @@
 /turf/open/floor/engine/n2,
 /area/ruin/space/has_grav/hotel/power)
 "Vn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -30
@@ -8030,8 +8122,10 @@
 /turf/open/floor/carpet/neon/simple/black/nodots,
 /area/ruin/space/has_grav/hotel/guestroom/room_1)
 "VX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/hotel/guestroom/room_6)
 "VY" = (
@@ -8260,7 +8354,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/power)
 "XB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
 	},
@@ -8839,12 +8932,12 @@ OA
 RO
 mH
 cd
-ed
-ed
-ed
-ed
-ed
-or
+oV
+oV
+oV
+oV
+oV
+yi
 am
 aa
 aa
@@ -8902,7 +8995,7 @@ YK
 xe
 ww
 Qv
-Zc
+sA
 aw
 kL
 vB
@@ -9261,7 +9354,7 @@ Ba
 cl
 DR
 bq
-RX
+bV
 mT
 cl
 Oh
@@ -9327,7 +9420,7 @@ Qe
 bN
 dl
 yE
-uN
+RX
 cl
 YP
 Bn
@@ -9483,7 +9576,7 @@ ZI
 wc
 RH
 ni
-RH
+iz
 HF
 VI
 hw
@@ -9491,7 +9584,7 @@ hw
 Lj
 hw
 hw
-hw
+sh
 rD
 fi
 bE
@@ -9561,7 +9654,7 @@ hw
 Lj
 hw
 hw
-hw
+sh
 hw
 HV
 hS
@@ -9701,7 +9794,7 @@ AA
 sT
 AA
 AA
-AA
+ev
 AA
 AI
 fo
@@ -9902,7 +9995,7 @@ qA
 qA
 qA
 qA
-oH
+mq
 oD
 fi
 iA
@@ -9971,7 +10064,7 @@ IZ
 AG
 IZ
 IZ
-ez
+AG
 rp
 vt
 fi
@@ -10198,7 +10291,7 @@ Wo
 Wo
 ye
 fi
-RL
+Rm
 jO
 jO
 gM
@@ -10229,7 +10322,7 @@ aa
 xH
 qd
 xD
-Tz
+sj
 kw
 ql
 rr
@@ -10258,7 +10351,7 @@ fi
 iA
 gd
 gb
-ZM
+ez
 ud
 pe
 qU
@@ -10299,7 +10392,7 @@ aa
 xH
 gV
 xD
-kc
+sj
 sm
 FQ
 vK
@@ -10328,7 +10421,7 @@ fi
 iA
 Mh
 ur
-ZM
+ez
 bb
 ya
 qU
@@ -10369,7 +10462,7 @@ aa
 xH
 rG
 UI
-Rm
+sj
 wB
 av
 YI
@@ -10455,7 +10548,7 @@ tC
 lL
 am
 Rn
-LN
+dF
 LN
 LN
 LN
@@ -10467,8 +10560,8 @@ iC
 fi
 iA
 gd
-gb
-iA
+os
+ez
 ud
 pe
 qU
@@ -10524,7 +10617,7 @@ Fc
 bW
 bW
 SU
-lO
+nh
 nh
 lO
 nh
@@ -10602,7 +10695,7 @@ am
 am
 DL
 ey
-so
+UX
 qq
 fi
 fi
@@ -10791,13 +10884,13 @@ OL
 OL
 OL
 hE
-OL
-OL
+zQ
+zQ
 kO
 YO
 fE
 yE
-MU
+Hp
 di
 JZ
 fC
@@ -10830,7 +10923,7 @@ vo
 am
 iZ
 jQ
-jU
+cC
 Xs
 Jy
 qr
@@ -10862,12 +10955,12 @@ OL
 OL
 em
 zQ
-zQ
+OL
 hv
 aC
 xR
 yE
-MU
+Hp
 di
 UW
 fY
@@ -10937,7 +11030,7 @@ rP
 aC
 xR
 yE
-MU
+Hp
 di
 WH
 fC
@@ -10952,7 +11045,7 @@ Nq
 am
 IK
 ey
-UX
+so
 ET
 am
 Ln
@@ -11007,7 +11100,7 @@ cf
 cf
 xR
 yE
-MU
+Hp
 di
 di
 fC
@@ -11077,7 +11170,7 @@ OZ
 cf
 xR
 yE
-MU
+Hp
 di
 cc
 lh
@@ -11147,7 +11240,7 @@ DN
 cf
 xR
 yE
-MU
+Hp
 di
 cb
 xX
@@ -11162,7 +11255,7 @@ bP
 am
 fq
 ey
-so
+UX
 Xu
 am
 Ln
@@ -11217,7 +11310,7 @@ HM
 cf
 xR
 yE
-MU
+Hp
 di
 Sf
 bZ
@@ -11287,7 +11380,7 @@ cf
 cf
 xR
 yE
-MU
+Hp
 di
 di
 di
@@ -11300,7 +11393,7 @@ Tj
 sE
 Pq
 rU
-sh
+sE
 ey
 eA
 Xu
@@ -11357,7 +11450,7 @@ hx
 cf
 iQ
 yE
-JW
+Lk
 am
 ac
 di
@@ -11421,13 +11514,13 @@ uR
 uR
 uR
 uR
-uR
+ve
 VX
 kA
 lF
 UQ
 yE
-MU
+Hp
 qI
 ac
 Ml
@@ -11497,7 +11590,7 @@ MV
 cf
 xR
 yE
-MU
+Hp
 qI
 ac
 Ml
@@ -11567,7 +11660,7 @@ UF
 cf
 xR
 yE
-MU
+Hp
 qI
 ac
 Ml
@@ -11637,7 +11730,7 @@ cf
 cf
 xR
 yE
-MU
+Hp
 am
 ac
 di
@@ -11707,7 +11800,7 @@ Cw
 dN
 GF
 yE
-MU
+Hp
 di
 di
 di
@@ -11777,7 +11870,7 @@ Hd
 Al
 EP
 yE
-MU
+Hp
 di
 LQ
 xd
@@ -11845,9 +11938,9 @@ Cj
 Cj
 KY
 dN
-Dt
+Tz
 yE
-MU
+kc
 di
 GC
 xN
@@ -12191,9 +12284,9 @@ dN
 dN
 dN
 dN
-oV
-iz
-Hp
+vH
+vH
+vH
 dN
 sD
 sD


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Not entirely sure how it got this bad over time but this fixes many disposal breaks and ... frankly VERY WEIRD pipe behavior to where it actually works now. Fixes all the disconnected atmos pipes and reroutes some to get rid of a number of dead-ends.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
disposals working and the rest of the map loaded without issue
  
![image](https://github.com/NovaSector/NovaSector/assets/22140677/cce67006-dd25-4cb1-be0b-4570bfb3a10e)

  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Ruins - Space Hotel should now run without runtimes for atmos
fix: Ruins - Space Hotel disposals actually works
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
