### PR TITLE
[MISSED MIRROR] Fixes Queen bee not working after being grown in a vat (#80766)

### DIFF
--- a/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
+++ b/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
@@ -652,7 +652,7 @@
 		/datum/reagent/drug/nicotine = -1)
 
 	virus_suspectibility = 0
-	resulting_atoms = list(/obj/item/queen_bee = 1)
+	resulting_atoms = list(/obj/item/queen_bee/bought = 1)
 
 /datum/micro_organism/cell_line/queen_bee/fuck_up_growing(obj/machinery/plumbing/growing_vat/vat) //we love job hazards
 	vat.visible_message(span_warning("You hear angry buzzing coming from the inside of the vat!"))


### PR DESCRIPTION
## ORIGINAL PR: https://github.com/tgstation/tgstation/pull/80766
## About The Pull Request

If you grow a queen bee using cytology, it will make the bee object but NOT the mob. I just changed the typepath to the one you get out of cargo.
## Why It's Good For The Game

If you want to make a bee paradise in charlie, its kind of hard to make one without a queen.
## Changelog
:cl:
fix: Queen bee's made with cytology now work
/:cl: