### PR TITLE
Fixes the width of the quirk pane

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
@@ -238,7 +238,7 @@ function QuirkPopper(props: QuirkPopperProps) {
                   onClick={(e) => {
                     e.stopPropagation();
                   }}
-                  maxWidth="400px"
+                  maxWidth="400px" // NOVA EDIT CHANGE - Original: 300px
                   backgroundColor="black"
                   px="5px"
                   py="3px"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
@@ -238,7 +238,7 @@ function QuirkPopper(props: QuirkPopperProps) {
                   onClick={(e) => {
                     e.stopPropagation();
                   }}
-                  maxWidth="300px"
+                  maxWidth="400px"
                   backgroundColor="black"
                   px="5px"
                   py="3px"


### PR DESCRIPTION
## About The Pull Request

Fixes the max width of the quirk pane so some quirks aren't cut off and render properly

## How This Contributes To The Nova Sector Roleplay Experience

UI bugs are no fun for anyone.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![PYWmUDAorE](https://github.com/NovaSector/NovaSector/assets/2568378/8d72f814-4f16-48e0-8493-2c4a498f3c68)

</details>

## Changelog

:cl:
fix: fixed the max width of the quirk UI so some quirks aren't cut off
/:cl:
