### PR TITLE
Jetpack Joyride | Makes Wyloms throw small users back when shot

### DIFF
--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/rifle.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/rifle.dm
@@ -112,6 +112,7 @@
 
 /obj/item/gun/ballistic/automatic/wylom/give_manufacturer_examine()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_SZOT)
+	AddElement(/datum/element/gun_launches_little_guys, throwing_force = 3, throwing_range = 5)
 
 /obj/item/gun/ballistic/automatic/wylom/examine(mob/user)
 	. = ..()

--- a/modular_nova/modules/modular_weapons/code/gun_launches_little_guys_element.dm
+++ b/modular_nova/modules/modular_weapons/code/gun_launches_little_guys_element.dm
@@ -38,6 +38,6 @@
 		return
 
 	var/fling_direction = REVERSE_DIR(get_dir(user, target))
-	var/atom/throw_target = get_edge_target_turf(PBT, fling_direction)
+	var/atom/throw_target = get_edge_target_turf(user, fling_direction)
 	user.Knockdown(1 SECONDS)
 	user.throw_at(throw_target, throwing_range, throwing_force)

--- a/modular_nova/modules/modular_weapons/code/gun_launches_little_guys_element.dm
+++ b/modular_nova/modules/modular_weapons/code/gun_launches_little_guys_element.dm
@@ -34,7 +34,7 @@
 /datum/element/gun_launches_little_guys/proc/throw_it_back(mob/living/carbon/user, obj/item/gun/gun_fired, target, params, zone_override, list/bonus_spread_values)
 	SIGNAL_HANDLER
 
-	if(!isteshari(user) || !isdwarf(user) || !HAS_TRAIT(user, TRAIT_DWARF))
+	if(!isteshari(user) && !isdwarf(user) && !HAS_TRAIT(user, TRAIT_DWARF))
 		return
 
 	var/fling_direction = REVERSE_DIR(get_dir(user, target))

--- a/modular_nova/modules/modular_weapons/code/gun_launches_little_guys_element.dm
+++ b/modular_nova/modules/modular_weapons/code/gun_launches_little_guys_element.dm
@@ -17,12 +17,12 @@
 	src.throwing_range = throwing_range
 
 	RegisterSignal(target, COMSIG_ATOM_EXAMINE, PROC_REF(examine))
-	RegisterSignal(target, COMSIG_MOB_FIRED_GUN, PROC_REF(throw_it_back))
+	RegisterSignal(target, COMSIG_GUN_FIRED, PROC_REF(throw_it_back))
 
 /datum/element/gun_launches_little_guys/Detach(datum/target)
 	. = ..()
 	UnregisterSignal(target, COMSIG_ATOM_EXAMINE)
-	UnregisterSignal(target, COMSIG_MOB_FIRED_GUN)
+	UnregisterSignal(target, COMSIG_GUN_FIRED)
 
 /// Warns that this gun might throw you away really hard
 /datum/element/gun_launches_little_guys/proc/examine(datum/source, mob/user, list/examine_list)
@@ -31,13 +31,13 @@
 	examine_list += span_notice("It has some serious kick to it, smaller users should take caution while firing.")
 
 /// Checks if the shooter is just a little guy. If so? Throw it back.
-/datum/element/gun_launches_little_guys/proc/throw_it_back(mob/living/carbon/user, obj/item/gun/gun_fired, target, params, zone_override, list/bonus_spread_values)
+/datum/element/gun_launches_little_guys/proc/throw_it_back(obj/item/gun/weapon, mob/living/user, atom/target, params, zone_override)
 	SIGNAL_HANDLER
 
 	if(!isteshari(user) && !isdwarf(user) && !HAS_TRAIT(user, TRAIT_DWARF))
 		return
 
-	var/fling_direction = REVERSE_DIR(get_dir(user, target))
+	var/fling_direction = REVERSE_DIR(user.dir)
 	var/atom/throw_target = get_edge_target_turf(user, fling_direction)
 	user.Knockdown(1 SECONDS)
 	user.throw_at(throw_target, throwing_range, throwing_force)

--- a/modular_nova/modules/modular_weapons/code/gun_launches_little_guys_element.dm
+++ b/modular_nova/modules/modular_weapons/code/gun_launches_little_guys_element.dm
@@ -1,0 +1,43 @@
+/// An element that makes guns throw their user back if they are just a little guy
+/datum/element/gun_launches_little_guys
+	element_flags = ELEMENT_BESPOKE
+	argument_hash_start_idx = 2
+
+	/// The throwing force applied to the gun's user
+	var/throwing_force
+	/// The throwing range applied to the gun's user
+	var/throwing_range
+
+/datum/element/gun_launches_little_guys/Attach(datum/target, throwing_force = 2, throwing_range = 3)
+	. = ..()
+	if(!isgun(target))
+		return ELEMENT_INCOMPATIBLE
+
+	src.throwing_force = throwing_force
+	src.throwing_range = throwing_range
+
+	RegisterSignal(target, COMSIG_ATOM_EXAMINE, PROC_REF(examine))
+	RegisterSignal(target, COMSIG_MOB_FIRED_GUN, PROC_REF(throw_it_back))
+
+/datum/element/gun_launches_little_guys/Detach(datum/target)
+	. = ..()
+	UnregisterSignal(target, COMSIG_ATOM_EXAMINE)
+	UnregisterSignal(target, COMSIG_MOB_FIRED_GUN)
+
+/// Warns that this gun might throw you away really hard
+/datum/element/gun_launches_little_guys/proc/examine(datum/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+
+	examine_list += span_notice("It has some serious kick to it, smaller users should take caution while firing.")
+
+/// Checks if the shooter is just a little guy. If so? Throw it back.
+/datum/element/gun_launches_little_guys/proc/throw_it_back(mob/living/carbon/user, obj/item/gun/gun_fired, target, params, zone_override, list/bonus_spread_values)
+	SIGNAL_HANDLER
+
+	if(!isteshari(user) || !isdwarf(user) || !HAS_TRAIT(user, TRAIT_DWARF))
+		return
+
+	var/fling_direction = REVERSE_DIR(get_dir(user, target))
+	var/atom/throw_target = get_edge_target_turf(PBT, fling_direction)
+	user.Knockdown(1 SECONDS)
+	user.throw_at(throw_target, throwing_range, throwing_force)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7673,6 +7673,7 @@
 #include "modular_nova\modules\modular_weapons\code\ballistic_master.dm"
 #include "modular_nova\modules\modular_weapons\code\conversion_kits.dm"
 #include "modular_nova\modules\modular_weapons\code\energy.dm"
+#include "modular_nova\modules\modular_weapons\code\gun_launches_little_guys_element.dm"
 #include "modular_nova\modules\modular_weapons\code\gunsets.dm"
 #include "modular_nova\modules\modular_weapons\code\melee.dm"
 #include "modular_nova\modules\modular_weapons\code\modular_projectiles.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

see title

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Have you ever seen a teshari use a giant anti materiel cannon before? And be completely fine after?

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  

https://github.com/NovaSector/NovaSector/assets/82386923/1c52dca5-9869-42af-a17d-8530dca8716e


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds a new element that makes guns throw small users backwards when shot, which has been added to the wylom
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
