### PR TITLE
[MISSED MIRROR] [NO GBP] Fix hub shuttle time (#80819)

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -382,6 +382,8 @@ GLOBAL_VAR(restart_counter)
 		new_status += ": [jointext(features, ", ")]"
 
 	new_status += "<br>Time: <b>[gameTimestamp("hh:mm")]</b>"
+	if(SSshuttle?.emergency && SSshuttle?.emergency?.mode != (SHUTTLE_IDLE || SHUTTLE_ENDGAME))
+		new_status += " | Shuttle: <b>[SSshuttle.emergency.getModeStr()] [SSshuttle.emergency.getTimerStr()]</b>"
 	if(SSmapping.config)
 		new_status += "<br>Map: <b>[SSmapping.config.map_path == CUSTOM_MAP_PATH ? "Uncharted Territory" : SSmapping.config.map_name]</b>"
 	var/alert_text = SSsecurity_level.get_current_level_as_text()


### PR DESCRIPTION
# Original: https://github.com/tgstation/tgstation/pull/80819

Was showing a constant "Shuttle: 00:10" in hub
hopefully should no longer show shuttle info if it hasn't actually been called yet

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Hub shuttle time works correctly
/:cl:
