### PR TITLE
[MISSED MIRROR] russian mobsters are no longer ridicilously fast (#80788)

### DIFF
--- a/code/modules/mob/living/basic/trooper/abductor.dm
+++ b/code/modules/mob/living/basic/trooper/abductor.dm
@@ -2,7 +2,6 @@
 /mob/living/basic/trooper/abductor
 	name = "Abductor Agent"
 	desc = "Mezaflorp?"
-	speed = 1.1
 	faction = list(ROLE_SYNDICATE)
 	loot = list(/obj/effect/mob_spawn/corpse/human/abductor)
 	mob_spawner = /obj/effect/mob_spawn/corpse/human/abductor

--- a/code/modules/mob/living/basic/trooper/nanotrasen.dm
+++ b/code/modules/mob/living/basic/trooper/nanotrasen.dm
@@ -2,7 +2,6 @@
 /mob/living/basic/trooper/nanotrasen
 	name = "\improper Nanotrasen Private Security Officer"
 	desc = "An officer of Nanotrasen's private security force. Seems rather unpleased to meet you."
-	speed = 0
 	melee_damage_lower = 10
 	melee_damage_upper = 15
 	faction = list(ROLE_DEATHSQUAD)

--- a/code/modules/mob/living/basic/trooper/pirate.dm
+++ b/code/modules/mob/living/basic/trooper/pirate.dm
@@ -4,7 +4,6 @@
 	desc = "Does what he wants cause a pirate is free."
 	response_help_continuous = "pushes"
 	response_help_simple = "push"
-	speed = 0
 	speak_emote = list("yarrs")
 	faction = list(FACTION_PIRATE)
 	loot = list(/obj/effect/mob_spawn/corpse/human/pirate)
@@ -42,7 +41,6 @@
 	name = "Space Pirate Swashbuckler"
 	unsuitable_atmos_damage = 0
 	minimum_survivable_temperature = 0
-	speed = 1
 	loot = list(/obj/effect/mob_spawn/corpse/human/pirate/melee/space)
 	mob_spawner = /obj/effect/mob_spawn/corpse/human/pirate/melee/space
 
@@ -79,7 +77,6 @@
 	name = "Space Pirate Gunner"
 	unsuitable_atmos_damage = 0
 	minimum_survivable_temperature = 0
-	speed = 1
 	loot = list(/obj/effect/mob_spawn/corpse/human/pirate/ranged/space)
 	mob_spawner = /obj/effect/mob_spawn/corpse/human/pirate/ranged/space
 	r_hand = /obj/item/gun/energy/e_gun/lethal

--- a/code/modules/mob/living/basic/trooper/russian.dm
+++ b/code/modules/mob/living/basic/trooper/russian.dm
@@ -2,7 +2,7 @@
 /mob/living/basic/trooper/russian
 	name = "Russian Mobster"
 	desc = "For the Motherland!"
-	speed = 0
+	speed = 1.2
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	unsuitable_cold_damage = 1

--- a/code/modules/mob/living/basic/trooper/syndicate.dm
+++ b/code/modules/mob/living/basic/trooper/syndicate.dm
@@ -2,7 +2,6 @@
 /mob/living/basic/trooper/syndicate
 	name = "Syndicate Operative"
 	desc = "Death to Nanotrasen."
-	speed = 1.1
 	faction = list(ROLE_SYNDICATE)
 	loot = list(/obj/effect/mob_spawn/corpse/human/syndicatesoldier)
 	mob_spawner = /obj/effect/mob_spawn/corpse/human/syndicatesoldier
@@ -192,7 +191,6 @@
 	health = 170
 	unsuitable_atmos_damage = 0
 	minimum_survivable_temperature = 0
-	speed = 1
 	mob_spawner = /obj/effect/mob_spawn/corpse/human/syndicatecommando
 
 /mob/living/basic/trooper/syndicate/ranged/shotgun/space/Initialize(mapload)


### PR DESCRIPTION
## ORIGINAL PR: https://github.com/tgstation/tgstation/pull/80788

## About The Pull Request

instead of 0 additive slowdown now they have 1.2, moving at a comfortable pace now
previously if you did not react fast enough and they hit you even once you could not outrun them because damage slowdown and they moved ridicilously fast like an assistant on crack

## Why It's Good For The Game

fixes #79799

## Changelog
:cl:
fix: After a raid on the local drug mafia in the sector by TerraGov, the Russian Mobsters no longer have access to easy drugs and as a result are no longer 24/7 running faster than the average spaceman. /:cl: