### PR TITLE
[MISSED MIRROR] Fixes security batons reporting to cyborgs that they're stunning them (#80781)

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -625,7 +625,7 @@
 	. = list()
 
 	.["visible"] = span_danger("[user] tries to stun [target] with [src], and predictably fails!")
-	.["local"] = span_userdanger("[target] tries to... stun you with [src]?")
+	.["local"] = span_userdanger("[user] tries to... stun you with [src]?")
 
 /obj/item/melee/baton/security/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()


### PR DESCRIPTION
## ORIGINAL PR: https://github.com/tgstation/tgstation/pull/80781

## About The Pull Request
Fixes security batons reporting to cyborgs that they're stunning themselves
## Why It's Good For The Game

![image](https://github.com/tgstation/tgstation/assets/93492992/f481dc13-bd96-47ce-9b1d-36703425533d) Funny! But a bug I think.
## Changelog
:cl:
fix: Cyborgs no longer think they're hitting themselves when stunned with a stun baton
/:cl:
