### PR TITLE
[MISSED MIRROR] fixes touching minebots not changing combat mode (#80789)

### DIFF
--- a/code/modules/mob/living/basic/minebots/minebot.dm
+++ b/code/modules/mob/living/basic/minebots/minebot.dm
@@ -118,10 +118,8 @@
 	return ..()
 
 /mob/living/basic/mining_drone/attack_hand(mob/living/carbon/human/user, list/modifiers)
-	. = ..()
-
-	if(. || user.combat_mode)
-		return
+	if(user.combat_mode)
+		return ..()
 	set_combat_mode(!combat_mode)
 	balloon_alert(user, "now [combat_mode ? "attacking wildlife" : "collecting loose ore"]")
 


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/80789

## About The Pull Request

uhh touch with empty hand and off combat mode and they change combat mode now

## Why It's Good For The Game

fixes #80584

## Changelog
:cl:
fix: you can use your hand to make minebots go into combat mode again /:cl:
