### PR TITLE
[MISSED MIRROR] Hub Entry shows Next Map and Shuttle Time, removes Alert #80705 

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -348,7 +348,7 @@ GLOBAL_VAR(restart_counter)
 	auxcleanup()
 	. = ..()
 
-/* NOVA EDIT REMOVAL - OVERRIDEN
+/* NOVA EDIT REMOVAL - OVERRIDDEN
 /world/proc/update_status()
 
 	var/list/features = list()
@@ -382,7 +382,7 @@ GLOBAL_VAR(restart_counter)
 		new_status += ": [jointext(features, ", ")]"
 
 	new_status += "<br>Time: <b>[gameTimestamp("hh:mm")]</b>"
-	if(SSshuttle.emergency)
+	if(SSshuttle?.emergency && SSshuttle?.emergency?.mode != (SHUTTLE_IDLE || SHUTTLE_ENDGAME))
 		new_status += " | Shuttle: <b>[SSshuttle.emergency.getModeStr()] [SSshuttle.emergency.getTimerStr()]</b>"
 	if(SSmapping.config)
 		new_status += "<br>Map: <b>[SSmapping.config.map_path == CUSTOM_MAP_PATH ? "Uncharted Territory" : SSmapping.config.map_name]</b>"


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/80705

## About The Pull Request

If there is a next map and if shuttle is called, show them in the hub entry

Removes the alert from the hub entry cuz it's useless, 99% of the time it's blue, generally not useful to those in the hub

## How This Contributes To The Nova Sector Roleplay Experience

More info is good, so players know "ok round's about to end i'll join up"
Or if players dislike a certain map like Birdshot/Northstar, they may join up and play anyway since they can see "alright Meta's coming up soon so i might as well jump in"

## Changelog

:cl:
qol: The hub entry shows the next map and shuttle time, and no longer shows the alert
/:cl:
