### PR TITLE
[MISSED MIRROR] Input changes take XII: Responsive small lists (#80720)

### DIFF
--- a/tgui/docs/component-reference.md
+++ b/tgui/docs/component-reference.md
@@ -556,6 +556,8 @@ A basic text input, which allow users to enter text into a UI.
 - `onEnter: (e, value) => void` - Fires when the user hits enter.
 - `onEscape: (e) => void` - Fires when the user hits escape.
 - `onInput: (e, value) => void` - Fires when the user types into the input.
+- `expensive: boolean` - Introduces a delay before updating the input. Useful for large filters,
+  where you don't want to update on every keystroke.
 
 ### `Knob`
 

--- a/tgui/packages/tgui/interfaces/CameraConsole.tsx
+++ b/tgui/packages/tgui/interfaces/CameraConsole.tsx
@@ -115,10 +115,12 @@ const CameraSelector = (props) => {
       <Stack.Item>
         <Input
           autoFocus
+          expensive
           fluid
           mt={1}
           placeholder="Search for a camera"
           onInput={(e, value) => setSearchText(value)}
+          value={searchText}
         />
       </Stack.Item>
       <Stack.Item grow>

--- a/tgui/packages/tgui/interfaces/common/SearchBar.tsx
+++ b/tgui/packages/tgui/interfaces/common/SearchBar.tsx
@@ -40,6 +40,7 @@ export function SearchBar(props: Props) {
       <Stack.Item grow>
         <Input
           autoFocus={autoFocus}
+          expensive
           fluid
           onInput={(e, value) => onSearch(value)}
           placeholder={placeholder}


### PR DESCRIPTION
## ORIGINAL PR: https://github.com/tgstation/tgstation/pull/80720

## About The Pull Request

Admittedly it's been tough to find a sweet spot that will let us handle large lists and basic inputs. This PR aims to address this by adding the `expensive` prop on Input. This introduces the debounce that #80688 without compromising the responsiveness of smaller filters like those in orbit, giving the author the keys to monitor performance of their UIs. On a more human note inputs just feel better with this PR.

Along with this change I've expanded documentation for the typescript types and included a discriminating union to let contributors know that the `expensive` prop requires `onInput` to work.
## Why It's Good For The Game
Bug fixes, responsiveness, etc
## Changelog
:cl:
fix: Search bars for smaller lists should return to their former responsiveness.
/:cl:

