### PR TITLE
[MISSED MIRROR] Fixes morgue trays husking corpses, caps freezing burn damage (#80811)

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1502,6 +1502,10 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		// Apply the damage to all body parts
 		humi.apply_damage(burn_damage, BURN, spread_damage = TRUE)
 
+	// For cold damage, we cap at the threshold if you're dead
+	if(humi.getFireLoss() >= abs(HEALTH_THRESHOLD_DEAD) && humi.stat == DEAD)
+		return
+
 	// Apply some burn / brute damage to the body (Dependent if the person is hulk or not)
 	var/is_hulk = HAS_TRAIT(humi, TRAIT_HULK)
 

--- a/code/modules/surgery/organs/internal/_internal_organ.dm
+++ b/code/modules/surgery/organs/internal/_internal_organ.dm
@@ -46,12 +46,12 @@
 
 	if(owner)
 		if(owner.bodytemperature > T0C)
-			var/air_temperature_factor = min((owner.bodytemperature - T0C) / T20C, 1)
+			var/air_temperature_factor = min((owner.bodytemperature - T0C) / 20, 1)
 			apply_organ_damage(decay_factor * maxHealth * seconds_per_tick * air_temperature_factor)
 	else
 		var/datum/gas_mixture/exposed_air = return_air()
 		if(exposed_air && exposed_air.temperature > T0C)
-			var/air_temperature_factor = min((exposed_air.temperature - T0C) / T20C, 1)
+			var/air_temperature_factor = min((exposed_air.temperature - T0C) / 20, 1)
 			apply_organ_damage(decay_factor * maxHealth * seconds_per_tick * air_temperature_factor)
 
 /// Called once every life tick on every organ in a carbon's body


### PR DESCRIPTION
## About The Pull Request

Adds a limit to burn damage that can be caused by freezing temperatures.

## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/80302

## Changelog

:cl: LT3
fix: Morgue trays and freezing temperatures will no longer husk bodies fix: Organs outside bodies will properly receive cold damage /:cl:
