### PR TITLE
Lowpop W: Removes population limit from Void Raptor and Blueshift

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -61,11 +61,9 @@ endmap
 ##NOVA SECTOR MAPS##
 
 map voidraptor
-	maxplayers 100
 	votable
 endmap
 
 map blueshift
-	minplayers 70
 	votable
 endmap


### PR DESCRIPTION
## About The Pull Request
This PR removes the population limit from our Nova Sector maps, Void Raptor and Blueshift.

## How This Contributes To The Nova Sector Roleplay Experience
Map variety and timezone accessibility. Removing the population limit means players of all timezones can access these maps without having to depend on NA players to wake up and boost server population to trigger the minimum for these maps to appear on a vote. As it stands, the only maps Europeans are exposed to on a constant loop is the CBT brothers of Icebox, Birdshot and Tram. If they want to experience the rest of the roster, they have to stay up for it past midnight. We have a decently sized EU playerbase that can manage playing on bigger maps.

To reference a personal experience, I only get to play either of these maps less than five times a week, and that's if I stay up for them.

## Proof of Testing
![cascsacas](https://github.com/NovaSector/NovaSector/assets/136726218/ed1cab4e-f037-444a-9794-9ce7928ffa32)
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Void Raptor and Blueshift can now be voted on lowpop.
/:cl:
