### PR TITLE
Voidraptor: Swaps Russian mobs with lore-friendly looter simplemobs

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -3995,6 +3995,11 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/station/security/lockers)
+"bfi" = (
+/obj/structure/table/wood,
+/obj/item/documents/syndicate,
+/turf/open/floor/wood,
+/area/station/maintenance/rus_gambling)
 "bfB" = (
 /obj/effect/turf_decal/tile/red/anticorner{
 	dir = 1
@@ -19465,7 +19470,7 @@
 /area/station/command/cc_dock)
 "fFf" = (
 /obj/effect/mapping_helpers/broken_floor,
-/mob/living/simple_animal/hostile/looter,
+/mob/living/basic/trooper/syndicate/melee,
 /turf/open/floor/wood,
 /area/station/maintenance/rus_gambling)
 "fFg" = (
@@ -28492,7 +28497,6 @@
 /obj/structure/chair/sofa/left/brown{
 	dir = 8
 	},
-/mob/living/simple_animal/hostile/vox/melee,
 /turf/open/floor/wood,
 /area/station/maintenance/rus_gambling)
 "ila" = (
@@ -44088,6 +44092,7 @@
 	pixel_y = 24
 	},
 /obj/effect/mapping_helpers/broken_floor,
+/mob/living/basic/trooper/syndicate/melee,
 /turf/open/floor/wood,
 /area/station/maintenance/rus_gambling)
 "muZ" = (
@@ -50868,6 +50873,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/rus_gambling)
 "omT" = (
@@ -60224,7 +60230,7 @@
 /area/station/medical/virology)
 "qLu" = (
 /obj/effect/decal/cleanable/blood/old,
-/mob/living/simple_animal/hostile/looter/big,
+/mob/living/basic/trooper/syndicate/melee/sword,
 /turf/open/floor/wood,
 /area/station/maintenance/rus_gambling)
 "qLy" = (
@@ -65985,7 +65991,7 @@
 /obj/structure/chair/stool/directional/north{
 	pixel_y = 6
 	},
-/mob/living/simple_animal/hostile/looter,
+/mob/living/basic/trooper/syndicate/melee,
 /turf/open/floor/wood,
 /area/station/maintenance/rus_gambling)
 "svC" = (
@@ -75327,6 +75333,11 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/central)
+"uQI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/pod,
+/turf/open/floor/wood,
+/area/station/maintenance/rus_gambling)
 "uQV" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/service)
@@ -128065,7 +128076,7 @@ tDO
 wkm
 gDf
 djz
-iAj
+uQI
 ykh
 wtQ
 yep
@@ -128320,7 +128331,7 @@ pzh
 ykh
 fop
 qLu
-gDf
+bfi
 pBo
 aWR
 ykh


### PR DESCRIPTION
## About The Pull Request
Replaces the 'Space Russian' simplemobs in Voidraptor with some of the looter simplemobs from the cargo freighter ghost role.

## How This Contributes To The Nova Sector Roleplay Experience

"Space Russians" have no connection to the NRI and have no lore-reason for being onstation. Additionally, they're a bit of a caricature that's in poor taste. The looter mobs are a similar power level to the Russians, and come with the benefit of being both lore friendly, and dissolving into maint loot when killed - this prevent situations in Voidraptor such as 4 human corpses appearing in the main hallway five minutes into the round which everyone ignores for some reason.

## Proof of Testing

![image](https://github.com/NovaSector/NovaSector/assets/50682821/41f8eb89-e9d9-47b6-ae33-63d2a461ae5b)

![image](https://github.com/NovaSector/NovaSector/assets/50682821/595a92f8-5939-4c16-9dc2-5e43843442e6)


<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl:
add: The 'Space Russians' located on Void Raptor station have been replaced with something a bit more lore friendly. Why not go meet them yourself? 
del: Removed space russians from Void Raptor. 
/:cl:
