### PR TITLE
Makes SMES deconstructible normally again | Adds pre-charged variants of the stationary batteries for mappers

### DIFF
--- a/modular_nova/modules/colony_fabricator/code/machines/power_storage_unit.dm
+++ b/modular_nova/modules/colony_fabricator/code/machines/power_storage_unit.dm
@@ -5,9 +5,9 @@
 		<b>higher maximum output</b> than some larger units. Most commonly seen being used not for their ability to store \
 		power, but rather for use in regulating power input and output."
 	icon = 'modular_nova/modules/colony_fabricator/icons/power_storage_unit/small_battery.dmi'
-	capacity = 75e4
-	input_level_max = 4e5
-	output_level_max = 4e5
+	capacity = 750 * 1000
+	input_level_max = 400 * 1000
+	output_level_max = 400 * 1000
 	circuit = null
 	obj_flags = CAN_BE_HIT | NO_DECONSTRUCTION
 	/// The item we turn into when repacked
@@ -39,8 +39,16 @@
 	return
 
 // We also don't need to bother with fuddling with charging power cells, there are none to remove
-/obj/machinery/power/smes/on_deconstruction()
+/obj/machinery/power/smes/battery_pack/on_deconstruction()
 	return
+
+// Automatically set themselves to be completely charged on init
+
+/obj/machinery/power/smes/battery_pack/precharged
+
+/obj/machinery/power/smes/battery_pack/precharged/Initialize(mapload)
+	. = ..()
+	charge = capacity
 
 // Item for creating the small battery and carrying it around
 
@@ -58,10 +66,18 @@
 		<b>low maximum output</b> compared to smaller units. Most commonly seen as large backup batteries, or simply \
 		for large power storage where throughput is not a concern."
 	icon = 'modular_nova/modules/colony_fabricator/icons/power_storage_unit/large_battery.dmi'
-	capacity = 1e7
-	input_level_max = 5e4
-	output_level_max = 5e4
+	capacity = 10000 * 1000
+	input_level_max = 50 * 1000
+	output_level_max = 50 * 1000
 	repacked_type = /obj/item/flatpacked_machine/large_station_battery
+
+// Automatically set themselves to be completely charged on init
+
+/obj/machinery/power/smes/battery_pack/large/precharged
+
+/obj/machinery/power/smes/battery_pack/large/precharged/Initialize(mapload)
+	. = ..()
+	charge = capacity
 
 /obj/item/flatpacked_machine/large_station_battery
 	name = "flat-packed large stationary battery"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

The smes deconstruction thing was a bug, oops!
Mappers might want to have these batteries and let them have charge without having to use var edits, so why not?
Oh and uh a last thing, the numbers for the charge that the machines have is MUCH nicer looking and more readable now.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

Yeah

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: For all the mappers out there, stationary batteries come with pre-charged variants now for mapping use
fix: SMES can now be deconstructed normally again
code: The flatpacked stationary batteries have much more readable power amounts now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
