### PR TITLE
cuffbusters - wirecutter-mode powered drivers can snip cablecuffs/zipties

### DIFF
--- a/modular_nova/modules/colony_fabricator/code/tools/tools.dm
+++ b/modular_nova/modules/colony_fabricator/code/tools/tools.dm
@@ -32,6 +32,10 @@
 	greyscale_config_belt = null
 	greyscale_config_inhand_left = null
 	greyscale_config_inhand_right = null
+	/// Used on Initialize, how much time to cut cable restraints and zipties.
+	var/snap_time_weak_handcuffs = 0 SECONDS
+	/// Used on Initialize, how much time to cut real handcuffs. Null means it can't.
+	var/snap_time_strong_handcuffs = null
 
 /obj/item/screwdriver/omni_drill/Initialize(mapload)
 	. = ..()
@@ -67,6 +71,7 @@
 	var/tool_result = show_radial_menu(user, src, tool_list, custom_check = CALLBACK(src, PROC_REF(check_menu), user), require_near = TRUE, tooltips = TRUE)
 	if(!check_menu(user) || !tool_result)
 		return
+	RemoveElement(/datum/element/cuffsnapping, snap_time_weak_handcuffs, snap_time_strong_handcuffs)
 	switch(tool_result)
 		if("Wrench")
 			tool_behaviour = TOOL_WRENCH
@@ -74,6 +79,7 @@
 		if("Wirecutters")
 			tool_behaviour = TOOL_WIRECUTTER
 			sharpness = NONE
+			AddElement(/datum/element/cuffsnapping, snap_time_weak_handcuffs, snap_time_strong_handcuffs)
 		if("Screwdriver")
 			tool_behaviour = TOOL_SCREWDRIVER
 			sharpness = SHARP_POINTY


### PR DESCRIPTION
## About The Pull Request
see title - powered drivers on wirecutter mode can snip cablecuffs

## How This Contributes To The Nova Sector Roleplay Experience
parity with wirecutters/jaws

## Changelog

:cl:
qol: Much like their non-powertool counterpart, powered drivers on wirecutter mode can now snip cablecuffs.
/:cl: