### PR TITLE
[MISSED MIRROR] Fixes Cameras views on clients 515.1615 or greater (#80818)

### DIFF
--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -13,6 +13,9 @@
 	var/active_offset = 0
 	/// What, if any, submap we render onto
 	var/map = ""
+	/// Controls the screen_loc that owned plane masters will use when generating relays. Due to a Byond bug, relays using the CENTER positional loc
+	/// Will be improperly offset
+	var/relay_loc = "CENTER"
 
 /datum/plane_master_group/New(key, map = "")
 	. = ..()
@@ -51,10 +54,14 @@
 /// Fully regenerate our group, resetting our planes to their compile time values
 /datum/plane_master_group/proc/rebuild_hud()
 	hide_hud()
-	QDEL_LIST_ASSOC_VAL(plane_masters)
-	build_plane_masters(0, SSmapping.max_plane_offset)
+	rebuild_plane_masters()
 	show_hud()
 	transform_lower_turfs(our_hud, active_offset)
+
+/// Regenerate our plane masters, this is useful if we don't have a mob but still want to rebuild. Such in the case of changing the screen_loc of relays
+/datum/plane_master_group/proc/rebuild_plane_masters()
+	QDEL_LIST_ASSOC_VAL(plane_masters)
+	build_plane_masters(0, SSmapping.max_plane_offset)
 
 /datum/plane_master_group/proc/hide_hud()
 	for(var/thing in plane_masters)
@@ -169,6 +176,20 @@
 /// This is because it's annoying to get turfs to position inside it correctly
 /// If you wanna try someday feel free, but I can't manage it
 /datum/plane_master_group/popup
+
+/// This is janky as hell but since something changed with CENTER positioning after build 1614 we have to switch to the bandaid LEFT,TOP positioning
+/// using LEFT,TOP *at* or *before* 1614 will result in another broken offset for cameras
+#define MAX_CLIENT_BUILD_WITH_WORKING_SECONDARY_MAPS 1614
+
+/datum/plane_master_group/popup/attach_to(datum/hud/viewing_hud)
+	// If we're about to display this group to a mob who's client is more recent than the last known version with working CENTER, then we need to remake the relays
+	// with the correct screen_loc using the relay override
+	if(viewing_hud.mymob?.client?.byond_build > MAX_CLIENT_BUILD_WITH_WORKING_SECONDARY_MAPS)
+		relay_loc = "LEFT,TOP"
+		rebuild_plane_masters()
+	return ..()
+
+#undef MAX_CLIENT_BUILD_WITH_WORKING_SECONDARY_MAPS
 
 /datum/plane_master_group/popup/transform_lower_turfs(datum/hud/source, new_offset, use_scale = TRUE)
 	return ..(source, new_offset, FALSE)

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -396,7 +396,7 @@
  * Other vars such as alpha will automatically be applied with the render source
  */
 /atom/movable/screen/plane_master/proc/generate_render_relays()
-	var/relay_loc = "CENTER"
+	var/relay_loc = home?.relay_loc || "CENTER"
 	// If we're using a submap (say for a popup window) make sure we draw onto it
 	if(home?.map)
 		relay_loc = "[home.map]:[relay_loc]"


### PR DESCRIPTION
# [tgstation/80818](https://github.com/tgstation/tgstation/pull/80818)

## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/79954

Turns out the cause of cameras breaking was something weird with how
Byond determined the CENTER location for screen_locs on secondary popup
maps like cameras and the spyglass. This can be remedied by manually
using the LEFT,TOP position for the plane relays. However LEFT,TOP
breaks the views for clients 1614 and below so I included a jank
solution that should allow any client up to this point have the screen
displayed correctly

### 515.1609 views working

![dreamseeker_nolb8BLgRb](https://github.com/tgstation/tgstation/assets/46236974/e155c9c3-12c0-4eb5-a4a6-4e3f09dc456d)

### 515.1623 views working

![dreamseeker_I37Z4X04Hf](https://github.com/tgstation/tgstation/assets/46236974/e91b3bd8-ea05-40e7-ab20-6c48810f9879)
## Why It's Good For The Game

Cameras working passed 1614 means you can update the server. At some
point I suspect Lummox will fix the CENTER position on secondary maps
and when that happens it will likely break the current fix.


## Changelog
:cl:
fix: popup screen locs will work on clients >1614. Security cameras and
Spyglass will work
/:cl: