### PR TITLE
Autopunctuation regex fix: don't consider underscores a word character

### DIFF
--- a/modular_nova/master_files/code/_globalvars/regexes.dm
+++ b/modular_nova/master_files/code/_globalvars/regexes.dm
@@ -1,5 +1,5 @@
 //Any EOL char that isn't appropriate punctuation
-GLOBAL_DATUM_INIT(has_no_eol_punctuation, /regex, regex(@"\w$"))
+GLOBAL_DATUM_INIT(has_no_eol_punctuation, /regex, regex(@"[a-zA-Z0-9]$"))
 
 //All non-capitalized 'i' surrounded with whitespace (aka, 'hello >i< am a cat')
 GLOBAL_DATUM_INIT(noncapital_i, /regex, regex(@"\b[i]\b", "g"))


### PR DESCRIPTION
## About The Pull Request

felinid in Discord reported that ending sentences in an underscore caused autopunctuation to apply periods. For reasons unknown to science, `\w` is aliased to `[a-zA-Z0-9_]` which as you can see, carries an underscore in its matching list. This change replicates `\w` without this match.

At some point we'll probably need to broaden the matching to check for chat markdown (`+, |, _`) but that can happen later.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

https://github.com/NovaSector/NovaSector/assets/966289/9bcc193f-da1a-4189-bccb-c1d87a7f071e

Before:

![image](https://github.com/NovaSector/NovaSector/assets/966289/09e53154-801c-4356-a965-b717e2736e6b)

After:

![dreamseeker_W1DjKuI3mw](https://github.com/NovaSector/NovaSector/assets/966289/d8ef4c89-ea8a-48a0-81e7-e78c2e0cc4a8)

</details>

## Changelog

:cl:
fix: Autopunctuation no longer checks for underscores at the end of messages.
/:cl:
