### PR TITLE
[REMIRROR] Fixing a runtime with H.A.R.S. (#80772)

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -190,36 +190,44 @@
 		return dismembering.apply_dismember(src, wounding_type)
 
 /obj/item/organ/internal/eyes/on_bodypart_insert(obj/item/bodypart/head/head)
-	head.eyes = src
-	..()
+	if(istype(head))
+		head.eyes = src
+	return ..()
 
 /obj/item/organ/internal/ears/on_bodypart_insert(obj/item/bodypart/head/head)
-	head.ears = src
-	..()
+	if(istype(head))
+		head.ears = src
+	return ..()
 
 /obj/item/organ/internal/tongue/on_bodypart_insert(obj/item/bodypart/head/head)
-	head.tongue = src
-	..()
+	if(istype(head))
+		head.tongue = src
+	return ..()
 
 /obj/item/organ/internal/brain/on_bodypart_insert(obj/item/bodypart/head/head)
-	head.brain = src
-	..()
+	if(istype(head))
+		head.brain = src
+	return ..()
 
 /obj/item/organ/internal/eyes/on_bodypart_remove(obj/item/bodypart/head/head)
-	head.eyes = null
-	..()
+	if(istype(head))
+		head.eyes = null
+	return ..()
 
 /obj/item/organ/internal/ears/on_bodypart_remove(obj/item/bodypart/head/head)
-	head.ears = null
-	..()
+	if(istype(head))
+		head.ears = null
+	return ..()
 
 /obj/item/organ/internal/tongue/on_bodypart_remove(obj/item/bodypart/head/head)
-	head.tongue = null
-	..()
+	if(istype(head))
+		head.tongue = null
+	return ..()
 
 /obj/item/organ/internal/brain/on_bodypart_remove(obj/item/bodypart/head/head)
-	head.brain = null
-	..()
+	if(istype(head))
+		head.brain = null
+	return ..()
 
 /obj/item/bodypart/chest/drop_limb(special, dismembered, move_to_floor = TRUE)
 	if(special)


### PR DESCRIPTION
## About The Pull Request
The brain gets moved into the chest with H.A.R.S. now, but the bodypart insertion and removal procs for it still asume it can only be found in the head. This should fix it. For the sake of preventing similar issues in the future, I've also updated the pretty-much-identical versions for ears, eyes and tongue.

I've checked, and the brain var is only used by the head for visuals and examine strings.

---

The first time had no changed files..