### PR TITLE
Fixes there being 3 progressbars when welding self as a synth

### DIFF
--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -150,12 +150,10 @@
 	if(user == attacked_humanoid)
 		user.visible_message(span_notice("[user] starts to fix some of the dents on [attacked_humanoid]'s [affecting.name]."),
 			span_notice("You start fixing some of the dents on [attacked_humanoid == user ? "your" : "[attacked_humanoid]'s"] [affecting.name]."))
-		if(!do_after(user, self_delay, attacked_humanoid)) // NOVA EDIT CHANGE - ORIGINAL: if(!do_after(user, 5 SECONDS, attacked_humanoid))
-			return ITEM_INTERACT_BLOCKING
-		use_delay = 5 SECONDS
+		use_delay = self_delay // NOVA EDIT CHANGE - ORIGINAL: use_delay = 5 SECONDS
 	// NOVA EDIT ADDITION START
-	if(!do_after(user, other_delay, attacked_humanoid))
-		return ITEM_INTERACT_BLOCKING
+	else
+		use_delay = other_delay
 	// NOVA EDIT ADDITION END
 
 	if(!use_tool(attacked_humanoid, user, use_delay, volume=50, amount=1))

--- a/modular_nova/master_files/code/game/objects/items/tools/weldingtool.dm
+++ b/modular_nova/master_files/code/game/objects/items/tools/weldingtool.dm
@@ -1,7 +1,7 @@
 /obj/item/weldingtool
-	/// How long it takes to weld someone else's robotic limbs.
-	var/self_delay = 5 SECONDS
 	/// How long it takes to weld your own robotic limbs.
+	var/self_delay = 5 SECONDS
+	/// How long it takes to weld someone else's robotic limbs.
 	var/other_delay = 1 SECONDS
 
 /obj/item/weldingtool/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

Now there is only one.

Fixes https://github.com/NovaSector/NovaSector/issues/430

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![dreamseeker_OjpcYCTh5x](https://github.com/NovaSector/NovaSector/assets/13398309/c148de04-eddc-4392-9a1f-7f5c77347ca9)

</details>

## Changelog

:cl:
fix: welding self as synth no longer makes you suffer through 3 progressbars
/:cl:
