### PR TITLE
Revert "[MIRROR] Improves popper/dropdown performance"

### DIFF
--- a/tgui/docs/component-reference.md
+++ b/tgui/docs/component-reference.md
@@ -358,8 +358,9 @@ and displays selected entry.
 - See inherited props: [Box](#box)
 - See inherited props: [Icon](#icon)
 - `options: string[] | DropdownEntry[]` - An array of strings which will be displayed in the
-  dropdown when open. See Dropdown.tsx for more advanced usage with DropdownEntry
+  dropdown when open. See Dropdown.tsx for more adcanced usage with DropdownEntry
 - `selected: any` - Currently selected entry
+- `width: string` - Width of dropdown button and resulting menu; css width value
 - `over: boolean` - Dropdown renders over instead of below
 - `color: string` - Color of dropdown button
 - `noChevron: boolean` - Whether or not the arrow on the right hand side of the dropdown button is visible
@@ -735,7 +736,16 @@ to fine tune the value, or single click it to manually type a number.
 
 ### `Popper`
 
-Popper lets you position elements so that they don't go out of the bounds of the window. See [react-tiny-popover](https://github.com/alexkatz/react-tiny-popover) for more information.
+Popper lets you position elements so that they don't go out of the bounds of the window. See [popper.js](https://popper.js.org/) for more information.
+
+**Props:**
+
+- `popperContent: ReactNode` - The content that will be put inside the popper.
+- `options?: { ... }` - An object of options to pass to `createPopper`. See [https://popper.js.org/docs/v2/constructors/#options]
+- `isOpen: boolean` - Whether or not the popper is open.
+- `placement?: string` - The placement of the popper. See [https://popper.js.org/docs/v2/constructors/#placement]
+- `onClickOutside?: (e) => void` - A function that will be called when the user clicks outside of the popper.
+- `additionalStyles: { ... }` - A map of CSS styles to add to the element that will contain the popper.
 
 ### `ProgressBar`
 

--- a/tgui/packages/tgui/components/Dropdown.tsx
+++ b/tgui/packages/tgui/components/Dropdown.tsx
@@ -1,10 +1,10 @@
 import { classes } from 'common/react';
-import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
-import { Popover } from 'react-tiny-popover';
+import { ReactNode, useState } from 'react';
 
-import { BoxProps, unit } from './Box';
+import { Box, BoxProps } from './Box';
 import { Button } from './Button';
 import { Icon } from './Icon';
+import { Popper } from './Popper';
 
 type DropdownEntry = {
   displayText: ReactNode;
@@ -14,37 +14,21 @@ type DropdownEntry = {
 type DropdownOption = string | DropdownEntry;
 
 type Props = {
-  /** An array of strings which will be displayed in the
-  dropdown when open. See Dropdown.tsx for more advanced usage with DropdownEntry */
   options: DropdownOption[];
-  /** Called when a value is picked from the list, `value` is the value that was picked */
-  onSelected: (value: any) => void;
+  onSelected: (selected: any) => void;
 } & Partial<{
-  /** Whether to display previous / next buttons */
   buttons: boolean;
-  /** Whether to clip the selected text */
   clipSelectedText: boolean;
-  /** Color of dropdown button */
   color: string;
-  /** Disables the dropdown */
   disabled: boolean;
-  /** Text to always display in place of the selected text */
   displayText: ReactNode;
-  /** Icon to display in dropdown button */
   icon: string;
-  /** Angle of the icon */
   iconRotation: number;
-  /** Whether or not the icon should spin */
   iconSpin: boolean;
-  /** Width of the dropdown menu. Default: 15rem */
   menuWidth: string;
-  /** Whether or not the arrow on the right hand side of the dropdown button is visible */
   noChevron: boolean;
-  /** Called when dropdown button is clicked */
   onClick: (event) => void;
-  /** Dropdown renders over instead of below */
   over: boolean;
-  /** Currently selected entry */
   selected: string | number;
 }> &
   BoxProps;
@@ -74,73 +58,51 @@ export function Dropdown(props: Props) {
     width,
   } = props;
 
-  const [opacity, setOpacity] = useState(0);
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(false);
   const adjustedOpen = over ? !open : open;
-  const innerRef = useRef<HTMLDivElement>(null);
+
+  /** Get the index of the selected option */
+  function getSelectedIndex() {
+    return options.findIndex((option) => {
+      return getOptionValue(option) === selected;
+    });
+  }
 
   /** Update the selected value when clicking the left/right buttons */
-  const updateSelected = useCallback(
-    (direction: 'previous' | 'next') => {
-      if (options.length < 1 || disabled) {
-        return;
-      }
-      const startIndex = 0;
-      const endIndex = options.length - 1;
+  function updateSelected(direction: 'previous' | 'next') {
+    if (options.length < 1 || disabled) {
+      return;
+    }
 
-      let selectedIndex = options.findIndex(
-        (option) => getOptionValue(option) === selected,
-      );
+    let selectedIndex = getSelectedIndex();
+    const startIndex = 0;
+    const endIndex = options.length - 1;
 
-      if (selectedIndex < 0) {
-        selectedIndex = direction === 'next' ? endIndex : startIndex;
-      }
+    const hasSelected = selectedIndex >= 0;
+    if (!hasSelected) {
+      selectedIndex = direction === 'next' ? endIndex : startIndex;
+    }
 
-      let newIndex = selectedIndex;
-      if (direction === 'next') {
-        newIndex = selectedIndex === endIndex ? startIndex : selectedIndex++;
-      } else {
-        newIndex = selectedIndex === startIndex ? endIndex : selectedIndex--;
-      }
+    const newIndex =
+      direction === 'next'
+        ? selectedIndex === endIndex
+          ? startIndex
+          : selectedIndex + 1
+        : selectedIndex === startIndex
+          ? endIndex
+          : selectedIndex - 1;
 
-      onSelected?.(getOptionValue(options[newIndex]));
-    },
-    [disabled, onSelected, options, selected],
-  );
-
-  /**
-   * HACK: Just like the original dropdown,
-   * the menu does not propagate correctly on the first event.
-   * This tricks it into getting the parent component's position
-   * so there is no flickering on open.
-   */
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setOpen(false);
-      setOpacity(1);
-    }, 1);
-
-    return () => clearTimeout(timer);
-  }, []);
-
-  /** Allows the menu to be scrollable on open */
-  useEffect(() => {
-    if (!open) return;
-
-    innerRef.current?.focus();
-  }, [open]);
+    onSelected?.(getOptionValue(options[newIndex]));
+  }
 
   return (
-    <Popover
+    <Popper
+      autoFocus
       isOpen={open}
       onClickOutside={() => setOpen(false)}
-      positions={over ? 'top' : 'bottom'}
-      content={
-        <div
-          className="Layout Dropdown__menu"
-          style={{ minWidth: menuWidth, opacity }}
-          ref={innerRef}
-        >
+      placement={over ? 'top-start' : 'bottom-start'}
+      popperContent={
+        <div className="Layout Dropdown__menu" style={{ minWidth: menuWidth }}>
           {options.length === 0 && (
             <div className="Dropdown__menuentry">No options</div>
           )}
@@ -154,7 +116,8 @@ export function Dropdown(props: Props) {
                   'Dropdown__menuentry',
                   selected === value && 'selected',
                 ])}
-                key={index}
+                id="dropdown-item"
+                key={value}
                 onClick={() => {
                   setOpen(false);
                   onSelected?.(value);
@@ -167,70 +130,64 @@ export function Dropdown(props: Props) {
         </div>
       }
     >
-      <div>
-        <div className="Dropdown" style={{ width: unit(width) }}>
-          <div
-            className={classes([
-              'Dropdown__control',
-              'Button',
-              'Button--dropdown',
-              'Button--color--' + color,
-              disabled && 'Button--disabled',
-              className,
-            ])}
-            onClick={(event) => {
-              if (disabled && !open) {
-                return;
-              }
-              setOpen(!open);
-              onClick?.(event);
+      <Box className="Dropdown" width={width}>
+        <div
+          className={classes([
+            'Dropdown__control',
+            'Button',
+            'Button--dropdown',
+            'Button--color--' + color,
+            disabled && 'Button--disabled',
+            className,
+          ])}
+          onClick={(event) => {
+            if (disabled && !open) {
+              return;
+            }
+            setOpen(!open);
+            onClick?.(event);
+          }}
+        >
+          {icon && (
+            <Icon mr={1} name={icon} rotation={iconRotation} spin={iconSpin} />
+          )}
+          <span
+            className="Dropdown__selected-text"
+            style={{
+              overflow: clipSelectedText ? 'hidden' : 'visible',
             }}
           >
-            {icon && (
-              <Icon
-                mr={1}
-                name={icon}
-                rotation={iconRotation}
-                spin={iconSpin}
-              />
-            )}
-            <span
-              className="Dropdown__selected-text"
-              style={{
-                overflow: clipSelectedText ? 'hidden' : 'visible',
-              }}
-            >
-              {displayText || selected}
+            {displayText || selected}
+          </span>
+          {!noChevron && (
+            <span className="Dropdown__arrow-button">
+              <Icon name={adjustedOpen ? 'chevron-up' : 'chevron-down'} />
             </span>
-            {!noChevron && (
-              <span className="Dropdown__arrow-button">
-                <Icon name={adjustedOpen ? 'chevron-up' : 'chevron-down'} />
-              </span>
-            )}
-          </div>
-          {buttons && (
-            <>
-              <Button
-                disabled={disabled}
-                height={1.8}
-                icon="chevron-left"
-                onClick={() => {
-                  updateSelected('previous');
-                }}
-              />
-
-              <Button
-                disabled={disabled}
-                height={1.8}
-                icon="chevron-right"
-                onClick={() => {
-                  updateSelected('next');
-                }}
-              />
-            </>
           )}
         </div>
-      </div>
-    </Popover>
+
+        {buttons && (
+          <>
+            <Button
+              disabled={disabled}
+              height={1.8}
+              icon="chevron-left"
+              onClick={() => {
+                updateSelected('previous');
+              }}
+            />
+
+            <Button
+              disabled={disabled}
+              height={1.8}
+              icon="chevron-right"
+              onClick={() => {
+                updateSelected('next');
+              }}
+            />
+          </>
+        )}
+      </Box>
+    </Popper>
   );
 }

--- a/tgui/packages/tgui/components/Popper.tsx
+++ b/tgui/packages/tgui/components/Popper.tsx
@@ -1,0 +1,101 @@
+import { createPopper, Placement } from '@popperjs/core';
+import { ArgumentsOf } from 'common/types';
+import {
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
+import { CSSProperties, JSXElementConstructor, ReactElement } from 'react';
+import { createPortal } from 'react-dom';
+
+type Props = {
+  isOpen: boolean;
+  popperContent: ReactElement<any, string | JSXElementConstructor<any>> | null;
+} & Partial<{
+  additionalStyles: CSSProperties;
+  autoFocus: boolean;
+  onClickOutside: () => void;
+  options: ArgumentsOf<typeof createPopper>[2];
+  placement: Placement;
+}> &
+  PropsWithChildren;
+
+export function Popper(props: Props) {
+  const {
+    additionalStyles,
+    autoFocus,
+    children,
+    isOpen,
+    placement,
+    popperContent,
+    options = {},
+    onClickOutside,
+  } = props;
+
+  const parentRef = useRef<HTMLDivElement | null>(null);
+  const popperRef = useRef<HTMLDivElement | null>(null);
+
+  const handleClickOutside = useCallback((event: MouseEvent) => {
+    if (
+      !parentRef.current?.contains(event.target as Node) &&
+      !popperRef.current?.contains(event.target as Node)
+    ) {
+      onClickOutside?.();
+    }
+  }, []);
+
+  /** Create the popper instance when the component mounts */
+  useEffect(() => {
+    if (!parentRef.current || !popperRef.current) return;
+    if (placement) options.placement = placement;
+
+    const instance = createPopper(
+      parentRef.current,
+      popperRef.current,
+      options,
+    );
+
+    return () => {
+      instance.destroy();
+    };
+  }, [options]);
+
+  /** Focus when opened, adds click outside listener */
+  useEffect(() => {
+    if (!isOpen) return;
+
+    if (autoFocus) {
+      const focusable = popperRef.current?.firstChild as HTMLElement | null;
+      focusable?.focus();
+    }
+
+    if (!onClickOutside) return;
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen]);
+
+  const contentStyle = useMemo(() => {
+    return {
+      ...additionalStyles,
+      position: 'absolute',
+      zIndex: 1000,
+    } as CSSProperties;
+  }, [additionalStyles]);
+
+  return (
+    <>
+      <div ref={parentRef}>{children}</div>
+      {createPortal(
+        <div ref={popperRef} style={isOpen ? contentStyle : {}}>
+          {isOpen && popperContent}
+        </div>,
+        document.body,
+      )}
+    </>
+  );
+}

--- a/tgui/packages/tgui/components/index.ts
+++ b/tgui/packages/tgui/components/index.ts
@@ -34,6 +34,7 @@ export { MenuBar } from './MenuBar';
 export { Modal } from './Modal';
 export { NoticeBox } from './NoticeBox';
 export { NumberInput } from './NumberInput';
+export { Popper } from './Popper';
 export { ProgressBar } from './ProgressBar';
 export { RestrictedInput } from './RestrictedInput';
 export { RoundGauge } from './RoundGauge';

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/MainPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/MainPage.tsx
@@ -1,7 +1,6 @@
 import { filterMap, sortBy } from 'common/collections';
 import { classes } from 'common/react';
 import { useState } from 'react';
-import { Popover } from 'react-tiny-popover';
 
 import { sendAct, useBackend } from '../../backend';
 import {
@@ -11,6 +10,7 @@ import {
   Dropdown, // NOVA EDIT ADDITION
   Flex,
   LabeledList,
+  Popper,
   Stack,
 } from '../../components';
 import { CharacterPreview } from '../common/CharacterPreview';
@@ -207,11 +207,10 @@ const GenderButton = (props: {
   const [genderMenuOpen, setGenderMenuOpen] = useState(false);
 
   return (
-    <Popover
+    <Popper
       isOpen={genderMenuOpen}
-      onClickOutside={() => setGenderMenuOpen(false)}
-      positions="right"
-      content={
+      placement="right-end"
+      popperContent={
         <Stack backgroundColor="white" ml={0.5} p={0.3}>
           {[Gender.Male, Gender.Female, Gender.Other, Gender.Other2].map(
             (gender) => {
@@ -244,7 +243,7 @@ const GenderButton = (props: {
         tooltip="Gender"
         tooltipPosition="top"
       />
-    </Popover>
+    </Popper>
   );
 };
 
@@ -277,11 +276,11 @@ const MainFeature = (props: {
   const supplementalFeature = catalog.supplemental_feature;
 
   return (
-    <Popover
-      positions="bottom"
+    <Popper
+      placement="bottom-start"
       onClickOutside={() => handleClose()}
       isOpen={isOpen}
-      content={
+      popperContent={
         <ChoicedSelection
           name={catalog.name}
           catalog={catalog}
@@ -349,7 +348,7 @@ const MainFeature = (props: {
           />
         )}
       </Button>
-    </Popover>
+    </Popper>
   );
 };
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
@@ -1,9 +1,16 @@
 import { filterMap } from 'common/collections';
 import { useState } from 'react';
-import { Popover } from 'react-tiny-popover';
 
 import { useBackend } from '../../backend';
-import { Box, Button, Icon, Stack, Tooltip } from '../../components';
+import {
+  Box,
+  Button,
+  Icon,
+  Popper,
+  Stack,
+  Tooltip,
+  TrackOutsideClicks,
+} from '../../components';
 import { PreferencesMenuData, Quirk, RandomSetting, ServerData } from './data';
 import { getRandomization, PreferenceList } from './MainPage';
 import { ServerPreferencesFetcher } from './ServerPreferencesFetcher';
@@ -212,69 +219,70 @@ function QuirkPopper(props: QuirkPopperProps) {
     Object.entries(customization_options).length > 0;
 
   return (
-    <Popover
-      positions="bottom"
-      onClickOutside={() => setCustomizationExpanded(false)}
+    <Popper
+      placement="bottom-end"
       isOpen={customizationExpanded}
-      content={
-        <div>
-          {!!customization_options && hasExpandableCustomization && (
-            <Box
-              mt="1px"
-              style={{
-                boxShadow: '0px 4px 8px 3px rgba(0, 0, 0, 0.7)',
-              }}
-            >
-              <Stack
-                onClick={(e) => {
-                  e.stopPropagation();
+      popperContent={
+        <TrackOutsideClicks
+          onOutsideClick={() => setCustomizationExpanded(false)}
+        >
+          <Box>
+            {!!customization_options && hasExpandableCustomization && (
+              <Box
+                mt="1px"
+                style={{
+                  boxShadow: '0px 4px 8px 3px rgba(0, 0, 0, 0.7)',
                 }}
-                maxWidth="400px" // NOVA EDIT CHANGE - Original: 300px - Prevents Quirks like Death Degradation from being cut off
-                backgroundColor="black"
-                px="5px"
-                py="3px"
               >
-                <Stack.Item>
-                  <PreferenceList
-                    act={act}
-                    preferences={getCorrespondingPreferences(
-                      customization_options,
-                      character_preferences.manually_rendered_features,
-                    )}
-                    randomizations={getRandomization(
-                      getCorrespondingPreferences(
+                <Stack
+                  onClick={(e) => {
+                    e.stopPropagation();
+                  }}
+                  maxWidth="400px" // NOVA EDIT CHANGE - Original: 300px - Prevents Quirks like Death Degradation from being cut off
+                  backgroundColor="black"
+                  px="5px"
+                  py="3px"
+                >
+                  <Stack.Item>
+                    <PreferenceList
+                      act={act}
+                      preferences={getCorrespondingPreferences(
                         customization_options,
                         character_preferences.manually_rendered_features,
-                      ),
-                      serverData,
-                      randomBodyEnabled,
-                    )}
-                    maxHeight="100px"
-                  />
-                </Stack.Item>
-              </Stack>
-            </Box>
-          )}
-        </div>
+                      )}
+                      randomizations={getRandomization(
+                        getCorrespondingPreferences(
+                          customization_options,
+                          character_preferences.manually_rendered_features,
+                        ),
+                        serverData,
+                        randomBodyEnabled,
+                      )}
+                      maxHeight="100px"
+                    />
+                  </Stack.Item>
+                </Stack>
+              </Box>
+            )}
+          </Box>
+        </TrackOutsideClicks>
       }
     >
-      <div>
-        {selected && (
-          <Button
-            selected={customizationExpanded}
-            icon="cog"
-            tooltip="Customize"
-            onClick={(e) => {
-              e.stopPropagation();
-              setCustomizationExpanded(!customizationExpanded);
-            }}
-            style={{
-              float: 'right',
-            }}
-          />
-        )}
-      </div>
-    </Popover>
+      {selected && (
+        <Button
+          selected={customizationExpanded}
+          icon="cog"
+          tooltip="Customize"
+          onClick={(e) => {
+            e.stopPropagation();
+            setCustomizationExpanded(!customizationExpanded);
+          }}
+          style={{
+            float: 'right',
+          }}
+        />
+      )}
+    </Popper>
   );
 }
 

--- a/tgui/packages/tgui/interfaces/RequestManager.jsx
+++ b/tgui/packages/tgui/interfaces/RequestManager.jsx
@@ -3,12 +3,13 @@
  * @copyright 2021 bobbahbrown (https://github.com/bobbahbrown)
  * @license MIT
  */
+
 import { decodeHtmlEntities } from 'common/string';
 import { useState } from 'react';
-import { Popover } from 'react-tiny-popover';
 
 import { useBackend, useLocalState } from '../backend';
 import { Button, Input, Section, Table } from '../components';
+import { Popper } from '../components/Popper';
 import { Window } from '../layouts';
 
 export const RequestManager = (props) => {
@@ -140,9 +141,9 @@ const FilterPanel = (props) => {
   );
 
   return (
-    <Popover
-      positions="bottom"
-      content={
+    <Popper
+      placement="bottom-start"
+      popperContent={
         <div
           className="RequestManager__filterPanel"
           style={{
@@ -173,11 +174,9 @@ const FilterPanel = (props) => {
         </div>
       }
     >
-      <div>
-        <Button icon="cog" onClick={() => setFilterVisible(!filterVisible)}>
-          Type Filter
-        </Button>
-      </div>
-    </Popover>
+      <Button icon="cog" onClick={() => setFilterVisible(!filterVisible)}>
+        Type Filter
+      </Button>
+    </Popper>
   );
 };

--- a/tgui/packages/tgui/package.json
+++ b/tgui/packages/tgui/package.json
@@ -15,7 +15,6 @@
     "marked": "^4.2.12",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-tiny-popover": "^8.0.4",
     "tgui-dev-server": "workspace:*",
     "tgui-polyfill": "workspace:*"
   }

--- a/tgui/packages/tgui/stories/Popper.stories.jsx
+++ b/tgui/packages/tgui/stories/Popper.stories.jsx
@@ -1,0 +1,60 @@
+import { Box, Popper } from '../components';
+
+export const meta = {
+  title: 'Popper',
+  render: () => <Story />,
+};
+
+const Story = () => {
+  return (
+    <>
+      <Popper
+        popperContent={
+          <Box
+            style={{
+              background: 'white',
+              border: '2px solid blue',
+            }}
+          >
+            Loogatme!
+          </Box>
+        }
+        options={{
+          placement: 'bottom',
+        }}
+      >
+        <Box
+          style={{
+            border: '5px solid white',
+            height: '300px',
+            width: '200px',
+          }}
+        />
+      </Popper>
+
+      <Popper
+        popperContent={
+          <Box
+            style={{
+              background: 'white',
+              border: '2px solid blue',
+            }}
+          >
+            I am on the right!
+          </Box>
+        }
+        options={{
+          placement: 'right',
+        }}
+      >
+        <Box
+          style={{
+            border: '5px solid white',
+            height: '500px',
+            width: '100px',
+          }}
+        />
+      </Popper>
+    </>
+  );
+};

--- a/tgui/yarn.lock
+++ b/tgui/yarn.lock
@@ -7765,16 +7765,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-tiny-popover@npm:^8.0.4":
-  version: 8.0.4
-  resolution: "react-tiny-popover@npm:8.0.4"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 1c7bcd0227e616326240cc97f112def0cd6e6edc94a56f763b20e82bf9ef1efdcc3e9bfff4bc9417a16e948aa3f2cfb960504135760b8f9e55fc73851d177bc3
-  languageName: node
-  linkType: hard
-
 "react@npm:^18.2.0":
   version: 18.2.0
   resolution: "react@npm:18.2.0"
@@ -9151,7 +9141,6 @@ resolve@^1.20.0:
     marked: ^4.2.12
     react: ^18.2.0
     react-dom: ^18.2.0
-    react-tiny-popover: ^8.0.4
     tgui-dev-server: "workspace:*"
     tgui-polyfill: "workspace:*"
   languageName: unknown


### PR DESCRIPTION
Reverts NovaSector/NovaSector#424

Fixes https://github.com/NovaSector/NovaSector/issues/434
Fixes https://github.com/NovaSector/NovaSector/issues/435

https://github.com/tgstation/tgstation/pull/80883 was causing serious issues with the char prefs menu (see linked issues) and I don't have the time to fully fix it right now so we're just reverting it for the time being. 

Offhand, looks like the new replacement popper component is not always going in the right spot, and it also looks like the dropdowns need to not expand past the ui when one gets opened near the bottom of the window.

On a related note: https://github.com/NovaSector/NovaSector/issues/347

