### PR TITLE
[MODULAR] Adds a new reagent meant for cooling synthetic burns: Dinitrogen Plasmide

### DIFF
--- a/modular_nova/master_files/code/modules/jobs/job_types/roboticist.dm
+++ b/modular_nova/master_files/code/modules/jobs/job_types/roboticist.dm
@@ -23,4 +23,5 @@
 		/obj/item/storage/pill_bottle/system_cleaner = 6,
 		/obj/item/storage/pill_bottle/nanite_slurry = 6,
 		/obj/item/reagent_containers/spray/hercuri/chilled = 8,
+		/obj/item/reagent_containers/spray/dinitrogen_plasmide = 8,
 	)

--- a/modular_nova/modules/medical/code/cargo/packs.dm
+++ b/modular_nova/modules/medical/code/cargo/packs.dm
@@ -1,8 +1,8 @@
-/datum/supply_pack/science/chilled_hercuri
-	name = "Chilled Hercuri Pack"
-	desc = "Contains 2 pre-chilled bottles of hercuri, 100u each. Useful for dealing with severely burnt synthetics!"
+/datum/supply_pack/science/synthetic_burns
+	name = "Synthetic Burns Kit"
+	desc = "Contains a bottle of pre-chilled hercuri and a bottle of dinitrogen plasmide, perfect for treating synthetic burns!"
 	cost = CARGO_CRATE_VALUE * 2.5
-	contains = list(/obj/item/reagent_containers/spray/hercuri/chilled = 2)
+	contains = list(/obj/item/reagent_containers/spray/hercuri/chilled = 1, /obj/item/reagent_containers/spray/dinitrogen_plasmide = 1)
 	crate_name = "chilled hercuri crate"
 
 	access_view = FALSE

--- a/modular_nova/modules/medical/code/medkit.dm
+++ b/modular_nova/modules/medical/code/medkit.dm
@@ -12,7 +12,6 @@
 	// Slash/Pierce wound tools - can reduce intensity of electrical damage (wires can fix generic burn damage)
 	new /obj/item/stack/cable_coil(src)
 	new /obj/item/stack/cable_coil(src)
-	new /obj/item/stack/cable_coil(src)
 	new /obj/item/wirecutters(src)
 	// Blunt/Brute tools
 	new /obj/item/weldingtool/largetank(src) // Used for repairing blunt damage or heating metal at T3 blunt
@@ -24,6 +23,7 @@
 	new /obj/item/clothing/glasses/hud/diagnostic(src) // When worn, generally improves wound treatment quality
 	// Reagent containers
 	new /obj/item/reagent_containers/spray/hercuri/chilled(src) // Highly effective (specifically coded to be) against burn wounds
+	new /obj/item/reagent_containers/spray/dinitrogen_plasmide(src) // same
 	// Generic medical items
 	new /obj/item/stack/medical/gauze/twelve(src)
 	new /obj/item/healthanalyzer(src)
@@ -41,8 +41,8 @@
 
 /datum/storage/duffel/synth_trauma_kit
 	exception_max = 6
-	max_slots = 27
-	max_total_storage = 35
+	max_slots = 28
+	max_total_storage = 36
 
 /datum/storage/duffel/synth_trauma_kit/New(atom/parent, max_slots, max_specific_storage, max_total_storage, numerical_stacking, allow_quick_gather, allow_quick_empty, collection_mode, attack_hand_interact)
 	. = ..()
@@ -121,6 +121,7 @@
 	new /obj/item/clothing/glasses/hud/diagnostic(src) // When worn, generally improves wound treatment quality
 	// Reagent containers
 	new /obj/item/reagent_containers/spray/hercuri/chilled(src) // Highly effective (specifically coded to be) against burn wounds
+	new /obj/item/reagent_containers/spray/dinitrogen_plasmide(src) // same
 	// Generic medical items
 	new /obj/item/stack/medical/gauze/twelve(src)
 	new /obj/item/healthanalyzer(src)
@@ -140,8 +141,8 @@
 
 /datum/storage/duffel/synth_trauma_kit/advanced
 	exception_max = 10
-	max_slots = 31
-	max_total_storage = 48
+	max_slots = 33
+	max_total_storage = 50
 
 /obj/item/storage/backpack/duffelbag/synth_treatment_kit/trauma/advanced/PopulateContents() // yes, this is all within the storage capacity
 	// Slash/Pierce wound tools - can reduce intensity of electrical damage (wires can fix generic burn damage)
@@ -162,6 +163,8 @@
 	// Reagent containers
 	new /obj/item/reagent_containers/spray/hercuri/chilled(src) // Highly effective (specifically coded to be) against burn wounds
 	new /obj/item/reagent_containers/spray/hercuri/chilled(src) // 2 of them
+	new /obj/item/reagent_containers/spray/dinitrogen_plasmide(src) // same
+	new /obj/item/reagent_containers/spray/dinitrogen_plasmide(src)
 	new /obj/item/storage/pill_bottle/nanite_slurry(src) // Heals blunt/burn
 	new /obj/item/storage/pill_bottle/liquid_solder(src) // Heals brain damage
 	new /obj/item/storage/pill_bottle/system_cleaner(src) // Heals toxin damage and purges chems

--- a/modular_nova/modules/medical/code/wounds/synth/medicine_reagents.dm
+++ b/modular_nova/modules/medical/code/wounds/synth/medicine_reagents.dm
@@ -1,0 +1,65 @@
+// a potent coolant that treats synthetic burns at decent efficiency. compared to hercuri its worse, but without
+// the lethal side effects, opting for a movement speed decrease instead
+/datum/reagent/dinitrogen_plasmide
+	name = "Dinitrogen Plasmide"
+	description = "A compound of nitrogen and stabilized plasma, this substance has the ability to flash-cool overheated metals \
+	while avoiding excessive damage. Being a heavy compound, it has the effect of slowing anything that metabolizes it."
+	ph = 4.8
+	specific_heat = SPECIFIC_HEAT_PLASMA * 1.2
+	color = "#b779cc"
+	taste_description = "dull plasma"
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	process_flags = REAGENT_ORGANIC | REAGENT_SYNTHETIC
+	metabolization_rate = 0.5 // fast
+	overdose_threshold = 60 // it takes a lot, if youre really messed up you CAN hit this but its unlikely
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+
+/datum/reagent/dinitrogen_plasmide/on_mob_metabolize(mob/living/affected_mob)
+	. = ..()
+
+	affected_mob.add_movespeed_modifier(/datum/movespeed_modifier/dinitrogen_plasmide)
+	to_chat(affected_mob, span_warning("Your joints suddenly feel stiff."))
+
+/datum/reagent/dinitrogen_plasmide/on_mob_end_metabolize(mob/living/affected_mob)
+	. = ..()
+
+	affected_mob.remove_movespeed_modifier(/datum/movespeed_modifier/dinitrogen_plasmide)
+	affected_mob.remove_movespeed_modifier(/datum/movespeed_modifier/dinitrogen_plasmide_overdose)
+	to_chat(affected_mob, span_warning("Your joints no longer feel stiff!"))
+
+/datum/reagent/dinitrogen_plasmide/overdose_start(mob/living/affected_mob)
+	. = ..()
+
+	to_chat(affected_mob, span_danger("You feel like your joints are filling with some viscous fluid!"))
+	affected_mob.add_movespeed_modifier(/datum/movespeed_modifier/dinitrogen_plasmide_overdose)
+
+/datum/reagent/dinitrogen_plasmide/overdose_process(mob/living/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+
+	holder.remove_reagent(type, 1.2 * seconds_per_tick) // decays
+	holder.add_reagent(/datum/reagent/stable_plasma, 0.4 * seconds_per_tick)
+	holder.add_reagent(/datum/reagent/nitrogen, 0.8 * seconds_per_tick)
+
+/datum/movespeed_modifier/dinitrogen_plasmide
+	multiplicative_slowdown = 0.3
+
+/datum/movespeed_modifier/dinitrogen_plasmide_overdose
+	multiplicative_slowdown = 1.3
+
+/datum/chemical_reaction/dinitrogen_plasmide_formation
+	results = list(/datum/reagent/dinitrogen_plasmide = 3)
+	required_reagents = list(/datum/reagent/stable_plasma = 1, /datum/reagent/nitrogen = 2)
+	required_catalysts = list(/datum/reagent/acetone = 0.1)
+	required_temp = 400
+	optimal_temp = 550
+	overheat_temp = 590
+
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_HEALING
+
+/obj/item/reagent_containers/spray/dinitrogen_plasmide
+	name = "coolant spray"
+	desc = "A medical spray bottle. This one contains dinitrogen plasmide, a potent coolant commonly used to treat synthetic burns. \
+	Has the side effect of causing movement slowdown."
+	icon = 'icons/obj/medical/chemical.dmi'
+	icon_state = "sprayer_med_yellow"
+	list_reagents = list(/datum/reagent/dinitrogen_plasmide = 100)

--- a/modular_nova/modules/medical/code/wounds/synth/robotic_burns.dm
+++ b/modular_nova/modules/medical/code/wounds/synth/robotic_burns.dm
@@ -1,8 +1,4 @@
 #define OVERHEAT_ON_STASIS_HEAT_MULT 0.25
-/// At 100% hercuri composition, a spray of reagents will have its effective chem temp reduced by this. 50%, reduced by half this, etc.
-#define ROBOTIC_BURN_REAGENT_EXPOSURE_HERCURI_MAX_HEAT_DECREMENT 60
-/// At 100% hercuri composition, a spray of reagents will have its heat shock damage reduced by this. 50%, reduced by half this, etc.
-#define ROBOTIC_BURN_REAGENT_EXPOSURE_HERCURI_HEAT_SHOCK_MULT_DECREMENT 0.3
 
 /datum/wound_pregen_data/burnt_metal
 	abstract = TRUE
@@ -88,6 +84,18 @@
 
 	/// The glow we have attached to our victim, to simulate our limb glowing.
 	var/obj/effect/dummy/lighting_obj/moblight/mob_glow
+
+	/// A assoc list of (reagent typepath -> cooling), where cooling is how much its presence will reduce the effective temperature of a reagent spray for cooling us.
+	var/static/list/reagent_types_to_extra_cooling = list(
+		/datum/reagent/medicine/c2/hercuri = 60,
+		/datum/reagent/dinitrogen_plasmide = 50,
+	)
+
+	/// A assoc list of (reagent typepath -> damage mult), where the mult will be multiplied against the thermal shock damage.
+	var/static/list/reagent_types_to_thermal_shock_mult = list(
+		/datum/reagent/medicine/c2/hercuri = 0.3,
+		/datum/reagent/dinitrogen_plasmide = 0.6,
+	)
 
 /datum/wound/burn/robotic/overheat/New(temperature)
 	chassis_temperature = (isnull(temperature) ? get_random_starting_temperature() : temperature)
@@ -195,20 +203,18 @@
 		return
 
 	var/total_reagent_amount = 0
-	var/hercuri_amount = 0
+	var/chem_temp_increment = 0
+	var/thermal_shock_mult = 1
+	// imperfect, this means you can microdose hercuri/plasmide in a huge tank of water and have the entire effect.
+	// really not a big deal, though, they arent really limited by availability
 	for (var/datum/reagent/iterated_reagent as anything in reagents)
 		total_reagent_amount += reagents[iterated_reagent]
-		if (iterated_reagent.type == /datum/reagent/medicine/c2/hercuri)
-			hercuri_amount = reagents[iterated_reagent]
+		chem_temp_increment += reagent_types_to_extra_cooling[iterated_reagent.type]
+		thermal_shock_mult *= reagent_types_to_thermal_shock_mult[iterated_reagent.type]
 
-	var/hercuri_percent = (hercuri_amount / total_reagent_amount)
+	var/local_chem_temp = max(source.chem_temp - chem_temp_increment, 0)
 
-	var/hercuri_chem_temp_increment = (ROBOTIC_BURN_REAGENT_EXPOSURE_HERCURI_MAX_HEAT_DECREMENT * hercuri_percent)
-	var/local_chem_temp = max(source.chem_temp - hercuri_chem_temp_increment, 0)
-
-	var/heat_shock_damage_mult = 1 - (ROBOTIC_BURN_REAGENT_EXPOSURE_HERCURI_HEAT_SHOCK_MULT_DECREMENT * hercuri_percent)
-
-	expose_temperature(local_chem_temp, (reagent_coeff * volume_modifier * total_reagent_amount), TRUE, heat_shock_damage_mult = heat_shock_damage_mult)
+	expose_temperature(local_chem_temp, (reagent_coeff * volume_modifier * total_reagent_amount), TRUE, heat_shock_damage_mult = thermal_shock_mult)
 
 /// Adjusts chassis_temperature by the delta between temperature and itself, multiplied by coeff.
 /// If heat_shock is TRUE, limb will receive brute damage based on the delta.
@@ -438,4 +444,3 @@
 	threshold_minimum = 140
 
 #undef OVERHEAT_ON_STASIS_HEAT_MULT
-#undef ROBOTIC_BURN_REAGENT_EXPOSURE_HERCURI_MAX_HEAT_DECREMENT

--- a/modular_nova/modules/modular_vending/code/wardrobes.dm
+++ b/modular_nova/modules/modular_vending/code/wardrobes.dm
@@ -62,6 +62,7 @@
 		/obj/item/reagent_containers/cup/bottle/morphine = 2,
 		/obj/item/reagent_containers/syringe = 2,
 		/obj/item/reagent_containers/spray/hercuri/chilled = 2,
+		/obj/item/reagent_containers/spray/dinitrogen_plasmide = 2,
 		/obj/item/clothing/gloves/color/black = 2, // fire resistant, allows the robo to painlessly mold metal. also its down here because its a treatment item
 		/obj/item/bonesetter = 2, // for dislocations
 		/obj/item/stack/medical/gauze = 4, // for ALL wounds

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7447,6 +7447,7 @@
 #include "modular_nova\modules\medical\code\wounds\medical.dm"
 #include "modular_nova\modules\medical\code\wounds\muscle.dm"
 #include "modular_nova\modules\medical\code\wounds\wound_effects.dm"
+#include "modular_nova\modules\medical\code\wounds\synth\medicine_reagents.dm"
 #include "modular_nova\modules\medical\code\wounds\synth\robotic_burns.dm"
 #include "modular_nova\modules\medical\code\wounds\synth\robotic_muscle.dm"
 #include "modular_nova\modules\medical\code\wounds\synth\robotic_pierce.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

Compared to hercuri, dinitrogen plasmide is a worse coolant, but it doesnt cool the bodytemp of the target, meaning its much more useful in situations where you really dont want that.

Added this to all synth treatment kits, and the robodrobe.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

I realized a while ago that hercuri is not the best thing to use for synthetic burns. It often caused more problems than it solved, especially since we dont have many good ways to purge chems on a synth. Take a synth who took a lava bath, theyll be coming into robo with multiple critical burns and the rest severe. Youll want to use a good coolant for that, as not to destroy them, but hercuri will just build up in their systems, and when theyre revived, theyll immediately overdose and die again.

Plasmide, in this scenario, will simply slow them down a lot and give them a hefty movespeed malice for about a minute.

Keeping hercuri's ability to cool burns is important, IMO, for ghetto treatment, as hercuri is in burn kits and in medical. Plus, if that aformentioned synth was alive, the hercuri might be able to fight off the bodytemp caused by the burn wounds.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/59709059/8848cf80-dde7-42fe-9449-699998f35fe4)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Dinitrogen Plasmide, a chem used to cool synthetic burns. Does not have the side effects of hercuri, making it safer to use.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
