### PR TITLE
Loadout additions: basic DeForest medkits, Kahraman frontier drip, heelys and holobadge fixes

### DIFF
--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_accessory.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_accessory.dm
@@ -75,6 +75,16 @@ GLOBAL_LIST_INIT(loadout_accessory, generate_loadout_items(/datum/loadout_item/a
 	item_path = /obj/item/clothing/accessory/armband/deputy/lopland
 	restricted_roles = list(JOB_HEAD_OF_SECURITY, JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_DETECTIVE)
 
+/datum/loadout_item/accessory/holobadge
+	name = "Holobadge"
+	item_path = /obj/item/clothing/accessory/badge/holo
+	restricted_roles = list(JOB_SECURITY_OFFICER, JOB_DETECTIVE, JOB_WARDEN, JOB_HEAD_OF_SECURITY)
+
+/datum/loadout_item/accessory/holobadge/lanyard
+	name = "Holobadge with Lanyard"
+	item_path = /obj/item/clothing/accessory/badge/holo/cord
+	restricted_roles = list(JOB_SECURITY_OFFICER, JOB_DETECTIVE, JOB_WARDEN, JOB_HEAD_OF_SECURITY)
+
 /datum/loadout_item/accessory/armband_security_deputy
 	name = "Security Deputy Armband"
 	item_path = /obj/item/clothing/accessory/armband/deputy

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_heads.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_heads.dm
@@ -129,6 +129,14 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	name = "Mothic Softcap"
 	item_path = /obj/item/clothing/head/mothcap
 
+/datum/loadout_item/head/frontiercap
+	name = "Frontier Cap"
+	item_path = /obj/item/clothing/head/soft/frontier_colonist
+
+/datum/loadout_item/head/frontiercap/medic
+	name = "Frontier Medical Cap"
+	item_path = /obj/item/clothing/head/soft/frontier_colonist/medic
+
 /*
 *	FEDORAS
 */

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_pocket.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_pocket.dm
@@ -201,6 +201,14 @@ GLOBAL_LIST_INIT(loadout_pocket_items, generate_loadout_items(/datum/loadout_ite
 	name = "First-Aid Kit"
 	item_path = /obj/item/storage/medkit/regular
 
+/datum/loadout_item/pocket_items/deforest_cheesekit
+	name = "Civil Defense Medical Kit"
+	item_path = /obj/item/storage/medkit/civil_defense/stocked
+
+/datum/loadout_item/pocket_items/deforest_frontiermedkit
+	name = "Frontier Medical Kit"
+	item_path = /obj/item/storage/medkit/frontier/stocked
+
 /datum/loadout_item/pocket_items/ingredients
 	name = "Wildcard Ingredient Box"
 	item_path = /obj/item/storage/box/ingredients/wildcard

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_shoes.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_shoes.dm
@@ -42,6 +42,10 @@ GLOBAL_LIST_INIT(loadout_shoes, generate_loadout_items(/datum/loadout_item/shoes
 	name = "Recolorable Jackboots"
 	item_path = /obj/item/clothing/shoes/jackboots/recolorable
 
+/datum/loadout_item/shoes/jackboots/frontier
+	name = "Heavy Frontier Boots"
+	item_path = /obj/item/clothing/shoes/jackboots/frontier_colonist
+
 /*
 *	MISC BOOTS
 */
@@ -214,6 +218,10 @@ GLOBAL_LIST_INIT(loadout_shoes, generate_loadout_items(/datum/loadout_item/shoes
 /datum/loadout_item/shoes/rollerskates
 	name = "Roller Skates"
 	item_path = /obj/item/clothing/shoes/wheelys/rollerskates
+
+/datum/loadout_item/shoes/wheelys
+	name = "Wheely-Heels"
+	item_path = /obj/item/clothing/shoes/wheelys
 
 /*
 *	SEASONAL

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_suit.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_suit.dm
@@ -391,6 +391,10 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	name = "Blue Trenchcoat"
 	item_path = /obj/item/clothing/suit/frenchtrench
 
+/datum/loadout_item/suit/frontiertrench
+	name = "Frontier Trenchcoat"
+	item_path = /obj/item/clothing/suit/jacket/frontier_colonist
+
 /datum/loadout_item/suit/cossak
 	name = "Ukrainian Coat"
 	item_path = /obj/item/clothing/suit/cossack
@@ -430,6 +434,14 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 /datum/loadout_item/suit/colourable_leather_jacket
 	name = "Colourable Leather Jacket"
 	item_path = /obj/item/clothing/suit/jacket/leather/colourable
+
+/datum/loadout_item/suit/frontierjacket/short
+	name = "Frontier Jacket (Short)"
+	item_path = /obj/item/clothing/suit/jacket/frontier_colonist/short
+
+/datum/loadout_item/suit/frontierjacket/short/medical
+	name = "Frontier Medical Jacket (Short)"
+	item_path = /obj/item/clothing/suit/jacket/frontier_colonist/medical
 
 /datum/loadout_item/suit/woolcoat
 	name = "Leather Overcoat"

--- a/modular_nova/modules/loadouts/loadout_items/under/loadout_datum_under.dm
+++ b/modular_nova/modules/loadouts/loadout_items/under/loadout_datum_under.dm
@@ -51,6 +51,10 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 	item_path = /obj/item/clothing/under/color/jumpskirt/random
 	additional_tooltip_contents = list(TOOLTIP_RANDOM_COLOR)
 
+/datum/loadout_item/under/jumpsuit/frontier
+	name = "Frontier Jumpsuit"
+	item_path = /obj/item/clothing/under/frontier_colonist
+
 /datum/loadout_item/under/jumpsuit/rainbow
 	name = "Rainbow Jumpsuit"
 	item_path = /obj/item/clothing/under/color/rainbow


### PR DESCRIPTION
## About The Pull Request

I am currently afflicted by a weird version of the Mandela Effect where I **SWEAR** we had DeForest civil defense kits and frontier medkits available as loadout options. I swear we had these. I remember taking them. Everybody I've spoken to says this isn't the case, so I've decided to make this terrible reality real, as well as adding a few other things.

This PR adds the following to the loadout selection:

- Civil Defense and Frontier medkits (the cheese kits and definitely-not-salewa). Standard first aid kits remain superior in terms of total overall healing compared to these two. If we had some way to make these things distinct (aka you pick 1 of the medkit options), I'd probably do that, but we don't, so I haven't.
- As much of the Kahraman frontier clothing I could reasonably add from Paxil's awesome stuff that didn't have direct mechanical stuff. The flak jackets, gloves and gas masks are noticeably absent from this list.
- Wheely-Heels, the base item rollerskates are skinned off (but aren't available regularly for some reason)
- Holobadges (normal and w/ lanyard) in the accessory category, since they're also accessories that can be attached to suits in the event that you still want some secofficer drip.

## How This Contributes To The Nova Sector Roleplay Experience

More drip is never a bad thing. Live out your frontiersman dreams with Kahraman clothing your character printed off seven years ago and hasn't replaced yet. Start the round with an assortment of minor DeForest medical solutions and menace anyone on the station with allergies. Zip around on your wheely-heels while public service cadets smile fondly upon you.

## Proof of Testing

It compiles.

## Changelog

:cl: yooriss
add: A bunch of new stuff has been added to the loadout tab, such as civil defense & frontier medkits, a ton of Kahraman frontier clothing and wheely-heels!
fix: Holobadges are now accessible from both the neck and accessory loadout slots (since they fit in both).
/:cl:
