### PR TITLE
Chronic Break: psifinil DeForest medkits for spacers & other disease sufferers

### DIFF
--- a/code/datums/quirks/positive_quirks/spacer.dm
+++ b/code/datums/quirks/positive_quirks/spacer.dm
@@ -13,7 +13,7 @@
 	quirk_flags = QUIRK_CHANGES_APPEARANCE //NOVA EDIT CHANGE - ORIGINAL: quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_CHANGES_APPEARANCE
 	medical_record_text = "Patient is well-adapted to non-terrestrial environments."
 	mail_goodies = list(
-		/obj/item/storage/pill_bottle/ondansetron,
+		/obj/item/reagent_containers/hypospray/medipen/deforest/psifinil, // NOVA EDIT: change the terrible patches to DeForest pens
 		/obj/item/reagent_containers/pill/gravitum,
 	)
 	/// How high spacers get bumped up to
@@ -63,10 +63,10 @@
 			you are awarded with a 25% hazard pay bonus due to your [on_a_planet ?  "station" : "occupational"] assignment."))
 
 	// Supply them with some patches to help out on their new assignment
-	var/obj/item/storage/pill_bottle/ondansetron/disgust_killers = new()
-	disgust_killers.desc += " Best to take one when travelling to a planet's surface."
+	var/obj/item/storage/medkit/civil_defense/comfort/stocked/disgust_killers = new() // NOVA EDIT: replaces /obj/item/storage/pill_bottle/ondansetron/ with a custom deforest cheesekit filled with much better meds
+	//disgust_killers.desc += " Best to take one when travelling to a planet's surface." NOVA EDIT: remove extra blurb, unneeded
 	if(quirk_holder.equip_to_slot_if_possible(disgust_killers, ITEM_SLOT_BACKPACK, qdel_on_fail = TRUE, initial = TRUE, indirect_action = TRUE))
-		to_chat(quirk_holder, span_info("You have[isnull(spacer_account) ? " " : " also "]been given some anti-emetic patches to assist in adjusting to planetary gravity."))
+		to_chat(quirk_holder, span_info("You have[isnull(spacer_account) ? " " : " also "]been given a kit of symptom-alleviating autoinjectors to aid in adjusting to planetary gravity.")) //NOVA EDIT: rewords to make sense
 
 /datum/quirk/spacer_born/remove()
 	UnregisterSignal(quirk_holder, COMSIG_MOVABLE_Z_CHANGED)

--- a/modular_nova/modules/company_imports/code/armament_datums/deforest_medical.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/deforest_medical.dm
@@ -7,6 +7,10 @@
 /datum/armament_entry/company_import/deforest/first_aid_kit
 	subcategory = "First-Aid Kits"
 
+/datum/armament_entry/deforest/first_aid_kit/civil_defense/comfort
+	item_type = /obj/item/storage/medkit/civil_defense/comfort/stocked
+	cost = PAYCHECK_COMMAND * 2
+
 /datum/armament_entry/company_import/deforest/first_aid_kit/civil_defense
 	item_type = /obj/item/storage/medkit/civil_defense/stocked
 	cost = PAYCHECK_COMMAND * 4

--- a/modular_nova/modules/deforest_medical_items/code/cargo_packs.dm
+++ b/modular_nova/modules/deforest_medical_items/code/cargo_packs.dm
@@ -8,6 +8,16 @@
 		/obj/item/storage/medkit/civil_defense/stocked = 5,
 	)
 
+/datum/supply_pack/medical/civil_defense/comfort
+	name = "Civil Defense Symptom Support Kit Crate"
+	crate_name = "civil defense symptom support kit crate"
+	desc = "Contains five civil defense symptom support kits stocked with four pens of psifinil each, a proprietary DeForest mix designed to provide long-lasting relief from chronic disease and syndromes like gravity sickness."
+	access = ACCESS_MEDICAL
+	cost = CARGO_CRATE_VALUE * 5 // 2000
+	contains = list(
+		/obj/item/storage/medkit/civil_defense/comfort/stocked = 5,
+	)
+
 /datum/supply_pack/medical/frontier_first_aid
 	name = "Frontier First Aid Crate"
 	crate_name = "frontier first aid crate"

--- a/modular_nova/modules/deforest_medical_items/code/storage_items.dm
+++ b/modular_nova/modules/deforest_medical_items/code/storage_items.dm
@@ -50,6 +50,19 @@
 	)
 	generate_items_inside(items_inside,src)
 
+// Variant on the civil defense medkit for spacer planetside personnel (or other people suffering from chronic illnesses)
+/obj/item/storage/medkit/civil_defense/comfort
+	name = "civil defense symptom support kit"
+	desc = "A small, pocket-sized kit that can typically only fit autoinjectors in it. This variant on the classic 'cheese' civil defense kit contains supplies to address hindering symptomatic burden associated with common chronic diseases or adaptation syndromes, such as gravity sickness."
+
+/obj/item/storage/medkit/civil_defense/comfort/stocked
+
+/obj/item/storage/medkit/civil_defense/comfort/stocked/PopulateContents()
+	var/static/items_inside = list(
+		/obj/item/reagent_containers/hypospray/medipen/deforest/psifinil = 4,
+	)
+	generate_items_inside(items_inside,src)
+
 // Pre-packed frontier medkit, with supplies to repair most common frontier health issues
 /obj/item/storage/medkit/frontier
 	name = "frontier medical kit"


### PR DESCRIPTION
## About The Pull Request

Have you ever played a spacer (quirk) on Icemoon and thought to yourself: "wow, these ondansetron patches the game gives me are absolutely fucking useless?" If so, you're not alone! Ondansetron is possibly the worst chem in the entire codebase, and it is better off gone for the good of mankind.

The hardworking chemists at DeForest have had a solution for spacer-related gravity sickness and other forms of chronic sickness, stuttering or sleepiness this whole time: the mighty psifinil pen. And as the pen is mightier than the sword, I've decided to bundle up the following changes:

- A new civil defense medical kit variant titled the "civil defense symptom support kit" has been added. It is filled with *four* psifinil pens (which are 10u modafinil, 10u psicodine and 5u leporazine) perfectly positioned towards helping crew with conditions that involve jitteriness, stuttering, drowsiness, confusion, disgust, and sudden inexplicable swings in temperature.
- The civil defense symptom support kit (SSK from now on) is available at cargo for half the price of an ordinary civil defense kit given it only contains 1 type of autoinjector and doesn't actually heal anything.
- The SSK is also available as a medical department order, again at half price compared to a CDK.
- Spacers now spawn in with a free SSK instead of a USELESS bottle of ondansetron patches.

Astute chemical enthusiasts may note that modafinil is the "funny always-adjusting overdose" drug, a feature that tends to manifest itself when *used often across the course of a shift*. People playing temperature sensitive characters may appreciate a quick and themely fix to accidental exposure in the form of an autoinjector instead of mainlining a chocolate drink (did you know coco is almost as good as leporazine?).

## How This Contributes To The Nova Sector Roleplay Experience

This gives characters with mechanical chronic illnesses the means to reliably find some kind of symptomatic relief from their conditions if a chemist willing to make psicodine or modafinil is not available. On top of that, it eliminates the offensively useless stop-gap meds given to people with the Spacer quirk that were probably putting them off from playing the quirk entirely.

Even better, it continues the DeForest trend of Side Effects(tm) by introducing potentially large groups of people to the funny wonder that is modafinil's random overdose threshold! Medbay characters, rejoice!

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_ggdAVaXcoH](https://github.com/NovaSector/NovaSector/assets/966289/60b416ee-7ec8-4ab8-b5f0-da6997cc4a74)

</details>

## Changelog

:cl: yooriss
add: A new variant of the DeForest civil defense medical kit is now available: the civil defense symptom support kit. Loaded with four pens of psifinil, this little thing'll fit in your pocket and give your characters guaranteed relief from sleepiness, stuttering and sickliness. Some side effects may occur. Consult your doctor before use. This new kit is available cheaply from cargo and from medical's departmental orders, too.
balance: People with the Spacer quirk now start with a civil defense symptom support kit instead of a bottle of atrociously, unbelievably useless ondansetron patches.
/:cl: