### PR TITLE
Nerfs the ore thumper x2

### DIFF
--- a/modular_nova/modules/kahraman_equipment/code/ore_thumper.dm
+++ b/modular_nova/modules/kahraman_equipment/code/ore_thumper.dm
@@ -10,7 +10,7 @@
 	density = TRUE
 	max_integrity = 250
 	idle_power_usage = 0
-	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 25 // Should be 25 kw or half of a SOFIE generator
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 50 // Should be 50 kw or an entire SOFIE generator's power production
 	anchored = TRUE
 	can_change_cable_layer = FALSE
 	circuit = null
@@ -22,7 +22,7 @@
 	/// How many times we've slammed, counts up until the number is high enough to make a box of materials
 	var/slam_jams = 0
 	/// How many times we need to slam in order to produce a box of materials
-	var/slam_jams_needed = 15
+	var/slam_jams_needed = 30
 	/// List of the thumping sounds we can choose from
 	var/static/list/list_of_thumper_sounds = list(
 		'modular_nova/modules/kahraman_equipment/sound/thumper_thump/punch_press_1.wav',
@@ -55,7 +55,7 @@
 		/obj/item/stack/ore/bluespace_crystal = 1,
 	)
 	/// What's the limit for ore near us? Counts by stacks, not individual amounts of ore
-	var/nearby_ore_limit = 10
+	var/nearby_ore_limit = 5
 	/// How far away does ore spawn?
 	var/ore_spawn_range = 2
 	/// What do we undeploy into
@@ -88,7 +88,7 @@
 		. += span_notice("Its must be constructed <b>outdoors</b> to function.")
 	if(!istype(get_turf(src), /turf/open/misc))
 		. += span_notice("It must be constructed on <b>suitable terrain</b>, like ash, snow, or sand.")
-	. += span_notice("It must have a powered, <b>wired connection</b> running beneath it with <b>25 kW</b> of excess power to function.")
+	. += span_notice("It must have a powered, <b>wired connection</b> running beneath it with <b>[active_power_usage / BASE_MACHINE_ACTIVE_CONSUMPTION] kW</b> of excess power to function.")
 	. += span_notice("It will produce a box of materials after it has slammed [slam_jams_needed] times.")
 	. += span_notice("Currently, it has slammed [slam_jams] / [slam_jams_needed] times needed.")
 	. += span_notice("It will stop producing resources if there are too many piles of ore near it.")
@@ -111,8 +111,6 @@
 		else
 			balloon_alert_to_viewers("not enough power!")
 			cut_that_out()
-	else if(avail(idle_power_usage))
-		add_load(idle_power_usage)
 
 
 /// Checks the turf we are on to make sure we are outdoors and on a misc turf


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ore thumpers now take twice as long to make ore, consume twice the power, and can have half as many ores sitting around them total before they stop working.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Ore thumpers are almost fine they just produce way too much too fast at the moment

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

Trust me bro

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Ore thumpers require twice as much power (50 kW), take twice as long to make ore, and can have half as many ores around them before they stop producing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
