### PR TITLE
[MODULAR] Fixes synth burn wounds not applying scars, rewrites synth wounds to be better

### DIFF
--- a/modular_nova/modules/medical/code/wounds/synth/robotic_burns.dm
+++ b/modular_nova/modules/medical/code/wounds/synth/robotic_burns.dm
@@ -89,13 +89,49 @@
 	/// The glow we have attached to our victim, to simulate our limb glowing.
 	var/obj/effect/dummy/lighting_obj/moblight/mob_glow
 
+	/// A bad system I'm using to track the worst scar we earned (since we can demote, we want the biggest our wound has been, not what it was when it was cured (probably moderate))
+	var/datum/scar/highest_scar
+
 /datum/wound/burn/robotic/overheat/New(temperature)
 	chassis_temperature = (isnull(temperature) ? get_random_starting_temperature() : temperature)
 
 	return ..()
 
+/datum/wound/burn/robotic/overheat/wound_injury(datum/wound/old_wound, attack_direction)
+	. = ..()
+
+	if (old_wound && old_wound.severity > severity && istype(old_wound, /datum/wound/burn/robotic/overheat))
+		var/datum/wound/burn/robotic/overheat/overheat_wound = old_wound
+		if(overheat_wound.highest_scar)
+			set_highest_scar(overheat_wound.highest_scar)
+			overheat_wound.clear_highest_scar()
+
+	if(!highest_scar && can_scar)
+		var/datum/scar/new_scar = new
+		set_highest_scar(new_scar)
+		new_scar.generate(limb, src, add_to_scars = FALSE)
+
+/datum/wound/burn/robotic/overheat/proc/set_highest_scar(datum/scar/new_scar)
+	if(highest_scar)
+		UnregisterSignal(highest_scar, COMSIG_QDELETING)
+	if(new_scar)
+		RegisterSignal(new_scar, COMSIG_QDELETING, PROC_REF(clear_highest_scar))
+	highest_scar = new_scar
+
+/datum/wound/burn/robotic/overheat/proc/clear_highest_scar(datum/source)
+	SIGNAL_HANDLER
+	set_highest_scar(null)
+
+/datum/wound/burn/robotic/overheat/remove_wound(ignore_limb, replaced)
+	if(!replaced && highest_scar)
+		already_scarred = TRUE
+		highest_scar.lazy_attach(limb)
+	return ..()
+
 /datum/wound/burn/robotic/overheat/Destroy()
 	QDEL_NULL(mob_glow)
+
+	highest_scar = null
 	return ..()
 
 /datum/wound/burn/robotic/overheat/set_victim(mob/living/new_victim)

--- a/strings/wounds/metal_scar_desc.json
+++ b/strings/wounds/metal_scar_desc.json
@@ -7,7 +7,7 @@
 
 	"bluntsevere": [
 		"an area of slightly crumpled metal",
-		"some faded cracks on some screws"
+		"some misaligned plates"
 	],
 
 	"bluntcritical": [
@@ -21,30 +21,30 @@
 	],
 
 	"slashsevere": [
-		"a pair of soldered, straight cracks",
-		"an area of freshly replaced metal",
-        "has some deep welded scratches on the metal"
+		"a pair of soldered cracks",
+		"an line of freshly replaced metal",
+        "some deep welds on the metal"
 	],
 
 	"slashcritical": [
-		"a matrix of desperately soldered wide cracks",
+		"a matrix of desperately soldered cracks",
 		"some gruesome welding lines",
 		"a series of deep and wide welded gashes"
 	],
 
 	"piercemoderate": [
 		"a dot of hardened solder",
-		"a dot of fresh metal in a small hole"
+		"a dot of fresh metal"
 	],
 
 	"piercesevere": [
-		"a wad of hardened solder",
-		"a small patch of fresh metal in a small hole"
+		"a large wad of hardened solder",
+		"a few cracks originating from a small hole"
 	],
 
 	"piercecritical": [
 		"a large splot of hardened solder",
-		"an inward caving hole leading to fresh metal"
+		"a spiderweb of cracks crawling from a sealed hole"
 	],
 
 	"burnsevere": [
@@ -54,14 +54,14 @@
 	],
 
 	"burncritical": [
-		"lots of polychromatic metal on it",
-		"some heat-warped plating",
-		"melting marks"
+		"streaks of polychromatic metal",
+		"gruesomely heat-warped plating",
+		"huge melting marks"
 	],
 
 	"dismember": [
-		"has some fresh metal around various joints",
+		"has fresh metal around various joints",
 		"has some solder marks securing various joints",
-		"has clear re-seating welding marks"
+		"has clear re-seating marks"
 	]
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Bugs bad, writing good.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Synth burn wounds now apply scars
spellcheck: Certain synth wounds have been rewritten
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
