### PR TITLE
I See Clearly Now: customizable echolocation quirk

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -35,6 +35,7 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/light_drinker, /datum/quirk/drunkhealing),
 	list(/datum/quirk/oversized, /datum/quirk/freerunning),
 	list(/datum/quirk/oversized, /datum/quirk/item_quirk/settler),
+	list(/datum/quirk/echolocation, /datum/item_quirk/blindness, /datum/quirk/item_quirk/nearsighted, /datum/quirk/item_quirk/deafness)
 	//NOVA EDIT ADDITION END
 ))
 

--- a/code/datums/components/echolocation.dm
+++ b/code/datums/components/echolocation.dm
@@ -15,6 +15,10 @@
 	var/echo_group = null
 	/// This trait blocks us from receiving echolocation.
 	var/blocking_trait
+	// NOVA ADDITION START: echolocation
+	/// Should the mob see itself outlined?
+	var/show_own_outline = FALSE
+	// NOVA ADDITION END
 	/// Ref of the client color we give to the echolocator.
 	var/client_color
 	/// Associative list of receivers to lists of atoms they are rendering (those atoms are associated to data of the image and time they were rendered at).
@@ -32,7 +36,7 @@
 	/// Cooldown for the echolocation.
 	COOLDOWN_DECLARE(cooldown_last)
 
-/datum/component/echolocation/Initialize(echo_range, cooldown_time, image_expiry_time, fade_in_time, fade_out_time, images_are_static, blocking_trait, echo_group, echo_icon, color_path)
+/datum/component/echolocation/Initialize(echo_range, cooldown_time, image_expiry_time, fade_in_time, fade_out_time, images_are_static, blocking_trait, echo_group, echo_icon, color_path, use_echo = TRUE, show_own_outline = FALSE) // NOVA EDIT: echolocation (add use_echo and show_own_outline)
 	. = ..()
 	var/mob/living/echolocator = parent
 	if(!istype(echolocator))
@@ -55,12 +59,17 @@
 		src.images_are_static = images_are_static
 	if(!isnull(blocking_trait))
 		src.blocking_trait = blocking_trait
+	// NOVA ADDITION START: echolocation
+	if(!isnull(show_own_outline))
+		src.show_own_outline = show_own_outline
 	if(ispath(color_path))
 		client_color = echolocator.add_client_colour(color_path)
 	src.echo_group = echo_group || REF(src)
 	echolocator.add_traits(list(TRAIT_ECHOLOCATION_RECEIVER, TRAIT_TRUE_NIGHT_VISION), echo_group) //so they see all the tiles they echolocated, even if they are in the dark
 	echolocator.become_blind(ECHOLOCATION_TRAIT)
-	echolocator.overlay_fullscreen("echo", /atom/movable/screen/fullscreen/echo, echo_icon)
+	if (use_echo) // add constructor toggle to not use the eye overlay
+		echolocator.overlay_fullscreen("echo", /atom/movable/screen/fullscreen/echo, echo_icon)
+	// NOVA ADDITION END
 	START_PROCESSING(SSfastprocess, src)
 
 /datum/component/echolocation/Destroy(force)
@@ -121,12 +130,15 @@
 	if(images_are_static)
 		final_image.pixel_x = input.pixel_x
 		final_image.pixel_y = input.pixel_y
-	if(HAS_TRAIT_FROM(input, TRAIT_ECHOLOCATION_RECEIVER, echo_group)) //mark other echolocation with full white
+	// NOVA ADDITION START: echolocation (show outlines on self)
+	var/mob/living/echolocator = parent
+	if(HAS_TRAIT_FROM(input, TRAIT_ECHOLOCATION_RECEIVER, echo_group) && input != echolocator) //mark other echolocation with full white, except ourselves
 		final_image.color = white_matrix
 	var/list/fade_ins = list(final_image)
 	for(var/mob/living/echolocate_receiver as anything in receivers)
-		if(echolocate_receiver == input)
+		if(!show_own_outline && echolocate_receiver == input)
 			continue
+		// NOVA ADDITION END
 		if(receivers[echolocate_receiver][input])
 			var/previous_image = receivers[echolocate_receiver][input]["image"]
 			fade_ins |= previous_image

--- a/modular_nova/modules/echolocation_quirk/code/echolocation.dm
+++ b/modular_nova/modules/echolocation_quirk/code/echolocation.dm
@@ -1,0 +1,110 @@
+/datum/quirk/echolocation
+	name = "Echolocation"
+	desc = "Though your eyes no longer function, you accomodate for it by some means of extrasensory echolocation and sensitive hearing. Beware: if you're ever deafened, you'll also lose your echolocation until you recover!"
+	gain_text = span_notice("The slightest sounds map your surroundings.")
+	lose_text = span_notice("The world resolves into colour and clarity.")
+	value = 0
+	icon = FA_ICON_EAR_LISTEN
+	mob_trait = TRAIT_GOOD_HEARING
+	medical_record_text = "Patient's eyes are biologically nonfunctional. Hearing tests indicate almost supernatural acuity."
+	quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_CHANGES_APPEARANCE
+	mail_goodies = list(/obj/item/clothing/glasses/sunglasses, /obj/item/cane/white)
+	var/datum/component/echolocation/esp // where we store easy access to the character's echolocation component (for stuff like drugs)
+	var/datum/client_colour/esp_color // where we store access to the client colour we make
+
+/datum/quirk/echolocation/add(client/client_source)
+	// echolocation component handles blinding us already so we don't need to worry about that
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	// set up the desired echo group from our quirk preferences
+	var/client_echo_group = lowertext(client_source?.prefs.read_preference(/datum/preference/choiced/echolocation_key))
+	if (isnull(client_echo_group))
+		client_echo_group = "echolocation"
+	if (client_echo_group == "psychic")
+		client_echo_group = "psyker" // set this non-player-facing so they share echolocation with coded chaplain psykers/pirates and the like
+
+	var/client_use_echo = client_source?.prefs.read_preference(/datum/preference/toggle/echolocation_overlay)
+	if (isnull(client_use_echo))
+		client_use_echo = TRUE
+
+	///datum/client_colour/monochrome/blind
+	human_holder.AddComponent(/datum/component/echolocation, blocking_trait = TRAIT_DEAF, echo_range = 5, echo_group = client_echo_group, images_are_static = FALSE, use_echo = client_use_echo, show_own_outline = TRUE) //echolocation has now blinded us and added this on, so remove it
+	esp = human_holder.GetComponent(/datum/component/echolocation)
+
+	// the way this works is: client colours need a type path, a datum we make is not a type path.
+	// so we just take the colour we get from players and update the /datum/client_colour/monochrome/blind that the
+	// echolocation blinding gives us, thus applying the effect. it's jank but whatever
+	if (length(human_holder.client_colours))
+		// HEY! we probably need something to make sure they don't set a color that's too dark or their UI could be totally invisible.
+		// GOOD NEWS! we can re-use the runechat colour stuff for this (probably)
+		var/col = process_chat_color(client_source?.prefs.read_preference(/datum/preference/color/echolocation_outline))
+		human_holder.client_colours[1].priority = 1 // mirrors PRIORITY_ABSOLUTE def inside client_color.dm, stops pipes and stuff showing as different colours
+		human_holder.client_colours[1].update_colour(col)
+		esp_color = human_holder.client_colours[1]
+
+	// double the ear/hearing damage multiplier from any source.
+	var/obj/item/organ/internal/ears/echo_ears = human_holder.get_organ_slot(ORGAN_SLOT_EARS)
+	if (!istype(echo_ears))
+		return
+
+	echo_ears.damage_multiplier *= 2
+
+/datum/quirk/echolocation/remove()
+	esp.Destroy() // echolocation component removal handles graceful disposal of everything above except the ears
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	var/obj/item/organ/internal/ears/echo_ears = human_holder.get_organ_slot(ORGAN_SLOT_EARS)
+	if (!istype(echo_ears))
+		return
+	echo_ears.damage_multiplier = initial(echo_ears.damage_multiplier)
+
+/datum/quirk_constant_data/echolocation
+	associated_typepath = /datum/quirk/echolocation
+	customization_options = list(/datum/preference/color/echolocation_outline, /datum/preference/choiced/echolocation_key, /datum/preference/toggle/echolocation_overlay)
+
+// Client preference for echolocation outline colour
+/datum/preference/color/echolocation_outline
+	savefile_key = "echolocation_outline"
+	savefile_identifier = PREFERENCE_CHARACTER
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+
+/datum/preference/color/echolocation_outline/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	return "Echolocation" in preferences.all_quirks
+
+/datum/preference/color/echolocation_outline/apply_to_human(mob/living/carbon/human/target, value)
+	return
+
+// Client preference for echolocation key type
+/datum/preference/choiced/echolocation_key
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "echolocation_key"
+	savefile_identifier = PREFERENCE_CHARACTER
+
+/datum/preference/choiced/echolocation_key/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	return "Echolocation" in preferences.all_quirks
+
+/datum/preference/choiced/echolocation_key/init_possible_values()
+	var/list/values = list("Extrasensory", "Psychic", "Auditory/Vibrational")
+	return values
+
+/datum/preference/choiced/echolocation_key/apply_to_human(mob/living/carbon/human/target, value)
+	return
+
+// Client preference for whether we display the echolocation overlay or not
+/datum/preference/toggle/echolocation_overlay
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "echolocation_use_echo"
+	savefile_identifier = PREFERENCE_CHARACTER
+
+/datum/preference/toggle/echolocation_overlay/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	return "Echolocation" in preferences.all_quirks
+
+/datum/preference/toggle/echolocation_overlay/apply_to_human(mob/living/carbon/human/target, value)
+	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7198,6 +7198,7 @@
 #include "modular_nova\modules\drones_derelict\code\areas.dm"
 #include "modular_nova\modules\drones_derelict\code\space.dm"
 #include "modular_nova\modules\electric_welder\code\electric_welder.dm"
+#include "modular_nova\modules\echolocation_quirk\code\echolocation.dm"
 #include "modular_nova\modules\emergency_spacesuit\code\emergency_spacesuit.dm"
 #include "modular_nova\modules\emote_panel\code\emote_panel.dm"
 #include "modular_nova\modules\emotes\code\dna_screams.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/echolocation.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/echolocation.tsx
@@ -1,0 +1,24 @@
+// THIS IS A NOVA SECTOR UI FILE
+import {
+  CheckboxInput,
+  Feature,
+  FeatureChoiced,
+  FeatureColorInput,
+  FeatureDropdownInput,
+  FeatureToggle,
+} from '../../base';
+
+export const echolocation_outline: Feature<string> = {
+  name: 'Echo outline color',
+  component: FeatureColorInput,
+};
+
+export const echolocation_key: FeatureChoiced = {
+  name: 'Echolocation type',
+  component: FeatureDropdownInput,
+};
+
+export const echolocation_use_echo: FeatureToggle = {
+  name: 'Display echo overlay',
+  component: CheckboxInput,
+};


### PR DESCRIPTION
## About The Pull Request

This PR brought to you by NIP Studios. Thanks to @Nerev4r for a lot of R&D and brainstorming with this one!

This PR adds a functional and partly customizable echolocation quirk that basically gives you the pulsing visual overlay + blindness thing that psykers and psyker pirates get, with some minor changes made:

- Echolocation gives you *five* tiles of sight. Watch the videos in the testing header below to see how this works - it's way easier to see it in action than describe it in text.
- If you are ever rendered deaf from any source, echolocation turns off completely until you recover. If you don't recover, you remain blind for the rest of the round. Good luck!
- You cannot pick Echolocation with blindness, near-sighted or deafness.
- The color of the outline overlay can be customized in the quirk preferences dropdown, as can the "type", and whether you want the "echo overlay" on or not.
   - Echolocation users share the tiles they reveal via proximity with other users that have the same echolocation type. So if someone you know is on screen with the Extrasensory echolocation type and you pick that same one, you'll see their revealed tiles each tick as well as your own, and similarly, they'll see yours. This is innate echolocation functionality and isn't something I've added personally.
   - If you pick the "psychic" type, you will share your echolocation with nearby mechanical psykers both friendly and hostile.
   - The "echo overlay" refers to a full-black layer + particle effect which hides your character's sprite and the 1-tile radius immediately around them. By default, echolocation has this on. There's a slight mechanical advantage to having the overlay off since you can see like normal (as per the Blind quirk) in this radius, but I figured I'd leave it up to people whether they wanted that or not.
- The quirk also gives you the "good hearing" trait which allows you to hear whispers and a few other things from significantly further away.
- As a downside, echolocation *doubles* your susceptibility to hearing damage. If you pick felinid, you'll end up with x4 hearing damage.

I've made some minor constructor and cosmetic changes to the echolocation datum should have no effect anywhere else in order to facilitate some necessary QoL updates for full-round use.

## How This Contributes To The Nova Sector Roleplay Experience

This is a new spin on playing visually-impaired characters with a neat and themely mechanical system underlying it. Wanted to play an esper? You're a foot in the door. Are you a rehabilitated psyker trying to do a station job to recover from your crippling gore addiction? Turn the echo overlay on and set it to purple and go ham.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![Rv6D1UQc3y](https://github.com/NovaSector/NovaSector/assets/966289/f9dd33c1-e3ae-4885-b0d5-79ab84e84702)

White outlines with echo overlay disabled:

![dreamseeker_Vlr7EmYTp2](https://github.com/NovaSector/NovaSector/assets/966289/63e81416-edb5-4b42-b9e6-ce863aa59ec5)

Player-chosen outline with echo overlay enabled:

https://github.com/NovaSector/NovaSector/assets/966289/aae42a22-511d-49e4-8b2e-d5760ff28856

Moving around with white outlines and echo overlay disabled:

https://github.com/NovaSector/NovaSector/assets/966289/9ce1bcda-d02c-43f9-b7c4-45e489a60ebd


</details>

## Changelog

:cl: yooriss
add: The Echolocation quirk is now available with several levels of customization, granting 5 tiles of pulsing view distance and significantly enhanced hearing at the downside of being blind when deafened and twice as vulnerable to ear damage.
/:cl: