### PR TITLE
Fixes a bug with the basic panties.

### DIFF
--- a/modular_nova/master_files/code/modules/client/preferences_savefile.dm
+++ b/modular_nova/master_files/code/modules/client/preferences_savefile.dm
@@ -169,7 +169,6 @@
 
 	if(current_version < VERSION_UNDERSHIRT_BRA_SPLIT)
 		var/static/list/underwear_to_underwear_bra = list(
-			"Panties" = list("Panties - Basic", null), // Just a rename
 			"Bikini" = list("Panties - Slim", "Bra"),
 			"Lace Bikini" = list("Panties - Thin", "Bra - Thin"),
 			"Bralette w/ Boyshorts" = list("Boyshorts (Alt)", "Bra, Sports"),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This, as the title suggests, fixes an annoying bug with the basic panties.

Back when the bras and underwear were split up, the panties in question, aptly named "Panties", were renamed to "Panties - Basic", and an entry was added to the underwear replacement list to replace all instances of the old panties to the new ones.

When the underwear updates were merged recently, they were renamed back to "Panties", but the replacement entry wasn't removed. Since "Panties - Basic" no longer exists, this just results in them getting changed to a random article of underwear in the list. As you can imagine, this can get annoying.

This removes the replacement entry, so the issue is resolved.

I haven't tested this yet, so i'm marking this as draft.

## How This Contributes To The Nova Sector Roleplay Experience

You should be able to pick an article of underwear in the underwear selection, and not have it change to something else for no reason.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The "Panties" option in the underwear menu no longer changes itself to something else.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
