### PR TITLE
Fix for text input boxes not resetting upon switching characters

### DIFF
--- a/modular_nova/modules/gunhud/code/gun_hud_component.dm
+++ b/modular_nova/modules/gunhud/code/gun_hud_component.dm
@@ -1,5 +1,4 @@
 /datum/component/ammo_hud
-	/// The ammo counter screen object itself
 	var/atom/movable/screen/ammo_counter/hud
 
 /datum/component/ammo_hud/Initialize()
@@ -20,6 +19,7 @@
 		if(H.is_holding(parent))
 			if(H.hud_used)
 				hud = H.hud_used.ammo_counter
+				RegisterSignal(user, COMSIG_QDELETING, PROC_REF(turn_off))
 				turn_on()
 		else
 			UnregisterSignal(user, COMSIG_QDELETING)
@@ -42,8 +42,6 @@
 	if(hud)
 		hud.turn_off()
 		hud = null
-
-	current_hud_owner = null
 
 /// Returns get_ammo() with the appropriate args passed to it - some guns like the revolver and bow are special cases
 /datum/component/ammo_hud/proc/get_accurate_ammo_count(obj/item/gun/ballistic/the_gun)


### PR DESCRIPTION
## About The Pull Request

This needs to use the old hook because of the key that differentiates each slot.

## How This Contributes To The Nova Sector Roleplay Experience

Fixes a serious issue with the flavor text input box.
