### PR TITLE
Makes the bluespace miner unorderable (and removes it from the raptor qm closet)

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -43218,7 +43218,6 @@
 "mgS" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/closet/secure_closet/quartermaster,
-/obj/item/circuitboard/machine/bluespace_miner,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1

--- a/modular_nova/modules/bluespace_miner/code/bluespace_miner.dm
+++ b/modular_nova/modules/bluespace_miner/code/bluespace_miner.dm
@@ -188,43 +188,6 @@
 	)
 	needs_anchored = TRUE
 
-/datum/supply_pack/misc/bluespace_miner
-	name = "Bluespace Miner"
-	desc = "Nanotrasen has revolutionized the procuring of materials with bluespace-- featuring the Bluespace Miner!"
-	cost = CARGO_CRATE_VALUE * 50 // 10,000
-	contains = list(/obj/item/circuitboard/machine/bluespace_miner)
-	crate_name = "Bluespace Miner Circuitboard Crate"
-	crate_type = /obj/structure/closet/crate
-
-/* if we were going to go research based
-/datum/design/board/bluespace_miner
-	name = "Machine Design (Bluespace Miner)"
-	desc = "Allows for the construction of circuit boards used to build a bluespace miner."
-	id = "bluespace_miner"
-	build_path = /obj/item/circuitboard/machine/bluespace_miner
-	category = list(RND_CATEGORY_MISC_MACHINERY)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO | DEPARTMENT_BITFLAG_ENGINEERING
-
-/datum/experiment/scanning/points/bluespace_miner
-	name = "Bluespace Miner"
-	description = "We can learn from the past technology and create a better future-- with bluespace miners."
-	required_points = 5
-	required_atoms = list(
-		/obj/item/xenoarch/broken_item/tech = 1,
-	)
-
-/datum/techweb_node/bluespace_miner
-	id = "bluespace_miner"
-	display_name = "Bluespace Miner"
-	description = "The future is here, where we can mine ores from the great bluespace sea."
-	prereq_ids = list("anomaly_research", "bluespace_power")
-	design_ids = list(
-		"bluespace_miner",
-	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
-	discount_experiments = list(/datum/experiment/scanning/points/bluespace_miner = 5000)
-*/
-
 #undef BLUESPACE_MINER_TOO_HOT
 #undef BLUESPACE_MINER_LOW_PRESSURE
 #undef BLUESPACE_MINER_HIGH_PRESSURE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

We have arcmining now which literally teleports resources from lavaland to the station, we don't need the BS miner to entirely overstep that whole system anymore.

I'm not deleting the entire thing *yet* because tarkon still uses it.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

If all the checkmarks below are green then there's not much else I could prove to you.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Bluespace miner boards can no longer be bought
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
