### PR TITLE
Various nerfs and tweaks and fixes to synth wounds

### DIFF
--- a/modular_nova/modules/medical/code/wounds/synth/blunt/robotic_blunt.dm
+++ b/modular_nova/modules/medical/code/wounds/synth/blunt/robotic_blunt.dm
@@ -53,6 +53,10 @@
 	var/base_movement_stagger_score = 30
 	/// The base chance of moving to trigger stagger().
 	var/chest_movement_stagger_chance = 1
+	/// The minimum amount of time between movement staggers, to prevent really annoying scenarios.
+	var/time_between_movement_staggers = 3 SECONDS
+	/// The last world.time that we triggered a movement stagger.
+	var/last_movement_stagger_time = 0
 
 	/// The base duration of a stagger()'s sprite shaking.
 	var/base_stagger_shake_duration = 1.5 SECONDS
@@ -249,7 +253,7 @@
 	message += "!"
 	self_message += "! You might be able to avoid an aftershock by stopping and waiting..."
 
-	if (isnull(attack_direction))
+	if (isnull(attack_direction) && !isnull(attacking_item))
 		attack_direction = get_dir(victim, attacking_item)
 
 	if (!isnull(attack_direction) && prob(stagger_score * stagger_movement_chance_ratio))
@@ -359,9 +363,10 @@
 
 	overall_mult *= get_buckled_movement_consequence_mult(victim.buckled)
 
-	if (limb.body_zone == BODY_ZONE_CHEST)
+	if (limb.body_zone == BODY_ZONE_CHEST && (world.time >= (last_movement_stagger_time + time_between_movement_staggers)))
 		var/stagger_chance = chest_movement_stagger_chance * overall_mult
 		if (prob(stagger_chance))
+			last_movement_stagger_time = world.time
 			stagger(base_movement_stagger_score, shake_duration = base_stagger_movement_shake_duration, from_movement = TRUE, shift = movement_stagger_shift, knockdown_ratio = stagger_aftershock_knockdown_movement_ratio)
 
 	last_time_victim_moved = world.time

--- a/modular_nova/modules/medical/code/wounds/synth/blunt/robotic_blunt_T1.dm
+++ b/modular_nova/modules/medical/code/wounds/synth/blunt/robotic_blunt_T1.dm
@@ -43,7 +43,7 @@
 	var/delay_mult = 1
 
 	if (user == victim)
-		delay_mult *= 3
+		delay_mult *= 2
 
 	if (HAS_TRAIT(user, TRAIT_DIAGNOSTIC_HUD))
 		delay_mult *= 0.5
@@ -56,7 +56,7 @@
 	victim.visible_message(span_notice("[user] begins fastening the screws of [their_or_other] [limb.plaintext_zone]..."), \
 		span_notice("You begin fastening the screws of [your_or_other] [limb.plaintext_zone]..."))
 
-	if (!screwdriver_tool.use_tool(target = victim, user = user, delay = (10 SECONDS * delay_mult), volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
+	if (!screwdriver_tool.use_tool(target = victim, user = user, delay = (6 SECONDS * delay_mult), volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
 		return
 
 	victim.visible_message(span_green("[user] finishes fastening [their_or_other] [limb.plaintext_zone]!"), \

--- a/modular_nova/modules/medical/code/wounds/synth/blunt/robotic_blunt_T2.dm
+++ b/modular_nova/modules/medical/code/wounds/synth/blunt/robotic_blunt_T2.dm
@@ -32,7 +32,7 @@
 	chest_attacked_stagger_chance_ratio = 5
 	chest_attacked_stagger_mult = 3
 
-	chest_movement_stagger_chance = 3
+	chest_movement_stagger_chance = 2
 
 	stagger_aftershock_knockdown_ratio = 0.3
 	stagger_aftershock_knockdown_movement_ratio = 0.2

--- a/modular_nova/modules/medical/code/wounds/synth/blunt/robotic_blunt_T3.dm
+++ b/modular_nova/modules/medical/code/wounds/synth/blunt/robotic_blunt_T3.dm
@@ -38,7 +38,7 @@
 	status_effect_type = /datum/status_effect/wound/blunt/robotic/critical
 	treatable_tools = list(TOOL_WELDER, TOOL_CROWBAR)
 
-	base_movement_stagger_score = 55
+	base_movement_stagger_score = 50
 
 	base_aftershock_camera_shake_duration = 1.75 SECONDS
 	base_aftershock_camera_shake_strength = 1
@@ -46,7 +46,7 @@
 	chest_attacked_stagger_chance_ratio = 6.5
 	chest_attacked_stagger_mult = 4
 
-	chest_movement_stagger_chance = 14
+	chest_movement_stagger_chance = 8
 
 	aftershock_stopped_moving_score_mult = 0.3
 
@@ -117,7 +117,7 @@
 	if (HAS_TRAIT(src, TRAIT_WOUND_SCANNED))
 		delay_mult *= 0.75
 
-	if(!do_after(user, 8 SECONDS, target = victim, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
+	if(!do_after(user, 4 SECONDS, target = victim, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
 		return
 	mold_metal(user)
 	return TRUE
@@ -213,7 +213,7 @@
 	if (HAS_TRAIT(src, TRAIT_WOUND_SCANNED))
 		delay_mult *= 0.75
 
-	if (!welder.use_tool(target = victim, user = user, delay = 10 SECONDS * delay_mult, volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
+	if (!welder.use_tool(target = victim, user = user, delay = 7 SECONDS * delay_mult, volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
 		return TRUE
 
 	var/wound_path = /datum/wound/burn/robotic/overheat/severe
@@ -249,11 +249,11 @@
 	var/their_or_other = (user == victim ? "[user.p_their()]" : "[victim]'s")
 	var/your_or_other = (user == victim ? "your" : "[victim]'s")
 
-	var/base_time = 10 SECONDS
+	var/base_time = 7 SECONDS
 	var/delay_mult = 1
 	var/knows_wires = FALSE
 	if (victim == user)
-		delay_mult *= 3 // real slow
+		delay_mult *= 2
 	if (HAS_TRAIT(src, TRAIT_WOUND_SCANNED))
 		delay_mult *= 0.75
 	if (HAS_TRAIT(user, TRAIT_KNOW_ROBO_WIRES))
@@ -335,7 +335,7 @@
 
 	delay_mult /= treating_plunger.plunge_mod
 
-	if (!treating_plunger.use_tool(target = victim, user = user, delay = 8 SECONDS * delay_mult, volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
+	if (!treating_plunger.use_tool(target = victim, user = user, delay = 6 SECONDS * delay_mult, volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
 		return TRUE
 
 	var/success_chance = 80

--- a/modular_nova/modules/medical/code/wounds/synth/blunt/secures_internals.dm
+++ b/modular_nova/modules/medical/code/wounds/synth/blunt/secures_internals.dm
@@ -340,14 +340,14 @@
 
 	var/delay_mult = 1
 	if (victim == user)
-		delay_mult *= 0.5
+		delay_mult *= 1.5
 
 	if (HAS_TRAIT(src, TRAIT_WOUND_SCANNED))
 		delay_mult *= 0.75
 
 	user.visible_message(span_danger("[user] begins hastily applying [gel] to [victim]'s [limb.plaintext_zone]..."), span_warning("You begin hastily applying [gel] to [user == victim ? "your" : "[victim]'s"] [limb.plaintext_zone], disregarding the acidic effect it seems to have on the metal..."))
 
-	if (!do_after(user, (8 SECONDS * delay_mult), target = victim, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
+	if (!do_after(user, (6 SECONDS * delay_mult), target = victim, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
 		return TRUE
 
 	gel.use(1)

--- a/modular_nova/modules/medical/code/wounds/synth/robotic_pierce.dm
+++ b/modular_nova/modules/medical/code/wounds/synth/robotic_pierce.dm
@@ -41,7 +41,7 @@
 	process_shock_spark_count_max = 1
 	process_shock_spark_count_min = 1
 
-	wirecut_repair_percent = 0.065 // not even faster at this point
+	wirecut_repair_percent = 0.104
 	wire_repair_percent = 0.026
 
 	initial_sparks_amount = 1
@@ -84,7 +84,7 @@
 	process_shock_spark_count_max = 2
 	process_shock_spark_count_min = 1
 
-	wirecut_repair_percent = 0.068
+	wirecut_repair_percent = 0.08
 	wire_repair_percent = 0.02
 
 	initial_sparks_amount = 3
@@ -129,7 +129,7 @@
 	process_shock_spark_count_max = 3
 	process_shock_spark_count_min = 2
 
-	wirecut_repair_percent = 0.067
+	wirecut_repair_percent = 0.072
 	wire_repair_percent = 0.018
 
 	initial_sparks_amount = 8

--- a/modular_nova/modules/medical/code/wounds/synth/robotic_slash.dm
+++ b/modular_nova/modules/medical/code/wounds/synth/robotic_slash.dm
@@ -326,12 +326,12 @@
 	var/change = (processing_full_shock_threshold * wire_repair_percent) * ELECTRICAL_DAMAGE_SUTURE_WIRE_HEALING_AMOUNT_MULT
 	var/delay_mult = 1
 	if (user == victim)
-		delay_mult *= 1.5
+		delay_mult *= 1.4
 	if (is_suture)
-		delay_mult *= 2
+		delay_mult *= 1.5
 		var/obj/item/stack/medical/suture/suture_item = suturing_item
 		var/obj/item/stack/medical/suture/base_suture = /obj/item/stack/medical/suture
-		change += (suture_item.heal_brute - initial(base_suture.heal_brute))
+		change = max(change - (suture_item.heal_brute - initial(base_suture.heal_brute)), 0.00001)
 
 	// as this is the trauma treatment, there are less bonuses
 	// if youre doing this, youre probably doing this on-the-spot
@@ -342,7 +342,7 @@
 	if (HAS_TRAIT(user, TRAIT_DIAGNOSTIC_HUD))
 		delay_mult *= 0.8
 	if (HAS_TRAIT(src, TRAIT_WOUND_SCANNED))
-		change *= 1.2
+		change *= 1.5
 
 	var/their_or_other = (user == victim ? "[user.p_their()]" : "[victim]'s")
 	var/your_or_other = (user == victim ? "your" : "[victim]'s")
@@ -385,17 +385,15 @@
 	var/change = (processing_full_shock_threshold * wirecut_repair_percent)
 	var/delay_mult = 1
 	if (user == victim)
-		delay_mult *= 2.5
+		delay_mult *= 2
 	if (is_retractor)
 		delay_mult *= 2
-		change *= 0.8
 	var/knows_wires = FALSE
 	if (HAS_TRAIT(user, TRAIT_KNOW_ROBO_WIRES))
-		delay_mult *= 0.9
-		change *= 1.7
+		delay_mult *= 0.3
 		knows_wires = TRUE
 	else if (HAS_TRAIT(user, TRAIT_KNOW_ENGI_WIRES))
-		change *= 1.35
+		delay_mult *= 0.6
 		knows_wires = TRUE
 	if (HAS_TRAIT(user, TRAIT_DIAGNOSTIC_HUD))
 		if (knows_wires)
@@ -403,7 +401,7 @@
 		else
 			delay_mult *= 0.75
 	if (HAS_TRAIT(src, TRAIT_WOUND_SCANNED))
-		delay_mult *= 0.8
+		change *= 1.5
 
 	var/their_or_other = (user == victim ? "[user.p_their()]" : "[victim]'s")
 	var/your_or_other = (user == victim ? "your" : "[victim]'s")
@@ -518,7 +516,7 @@
 	process_shock_spark_count_max = 1
 	process_shock_spark_count_min = 1
 
-	wirecut_repair_percent = 0.085 // not even faster at this point
+	wirecut_repair_percent = 0.14
 	wire_repair_percent = 0.035
 
 	initial_sparks_amount = 1
@@ -561,7 +559,7 @@
 	process_shock_spark_count_max = 2
 	process_shock_spark_count_min = 1
 
-	wirecut_repair_percent = 0.1
+	wirecut_repair_percent = 0.128
 	wire_repair_percent = 0.032
 
 	initial_sparks_amount = 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes movement oscillations causing a "You reel from the impact!" message

Standardizes wirecut treatment on electrical damage - now heals 4x as much as wire replacing all the time. Reasoning: Its a lot slower, and I cant remember why I even had it be more effective on more severity.

Movement staggers now have a minimum of 3 seconds before they can happen after one, to avoid really annoying circumstances

Streamlined some bits of blunt treatment
Generally just made blunt treatment a lot faster

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

I've heard that some people have some real issues with synth wounds, and I agree. They take too long to treat, electrical damage is too punishing, and oscillations are annoying. This should help.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/59709059/700896f3-90d9-47c0-9a8e-48ce37f430b2)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Synth wound oscillations will no longer cause you to reel from impacts if there were no impacts
balance: Synth blunt wounds are now faster to treat
balance: Wirecutters on electrical damage have been streamlined and are always fix 4x more than suturing
balance: Synth wound oscillations now have a minimum of 3 seconds between each oscillation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
