### PR TITLE
Updates the "Slim" belt reskin and code cleanup of no longer used "peacekeeper" belts

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -334,23 +334,6 @@
 	inhand_icon_state = "security"//Could likely use a better one.
 	worn_icon_state = "security"
 	content_overlays = TRUE
-	// NOVA EDIT ADDITION START
-	uses_advanced_reskins = TRUE
-	unique_reskin = list(
-		"Basic Security" = list(
-			RESKIN_ICON = 'icons/obj/clothing/belts.dmi',
-			RESKIN_ICON_STATE = "security",
-			RESKIN_WORN_ICON = 'icons/mob/clothing/belt.dmi',
-			RESKIN_WORN_ICON_STATE = "security"
-		),
-		"Peacekeeper" = list(
-			RESKIN_ICON = 'modular_nova/master_files/icons/obj/clothing/belts.dmi',
-			RESKIN_ICON_STATE = "peacekeeperbelt",
-			RESKIN_WORN_ICON = 'modular_nova/master_files/icons/mob/clothing/belt.dmi',
-			RESKIN_WORN_ICON_STATE = "peacekeeperbelt"
-		)
-	)
-	// NOVA EDIT ADDITION END
 
 /obj/item/storage/belt/security/Initialize(mapload)
 	. = ..()

--- a/modular_nova/modules/goofsec/code/sec_clothing_overrides.dm
+++ b/modular_nova/modules/goofsec/code/sec_clothing_overrides.dm
@@ -133,9 +133,11 @@
 			RESKIN_ICON_STATE = "belt_white",
 			RESKIN_WORN_ICON_STATE = "belt_white"
 		),
-		"Slim Variant" = list(
-			RESKIN_ICON_STATE = "belt_slim",
-			RESKIN_WORN_ICON_STATE = "belt_slim"
+		"Basic Variant" = list(
+			RESKIN_ICON = 'icons/obj/clothing/belts.dmi',
+			RESKIN_ICON_STATE = "security",
+			RESKIN_WORN_ICON = 'icons/mob/clothing/belt.dmi',
+			RESKIN_WORN_ICON_STATE = "security"
 		),
 	)
 

--- a/modular_nova/modules/goofsec/code/sec_clothing_overrides.dm
+++ b/modular_nova/modules/goofsec/code/sec_clothing_overrides.dm
@@ -149,7 +149,7 @@
 /obj/item/storage/belt/security/webbing/peacekeeper //did I mention this codebase is fucking awful
 	current_skin = "peacekeeper_webbing"
 
-/obj/item/storage/belt/security/webbing/peacekeeper/armadyne
+/obj/item/storage/belt/security/webbing/armadyne
 	current_skin = "armadyne_webbing"
 
 ///Enables you to quickdraw weapons from security holsters

--- a/modular_nova/modules/sec_haul/code/peacekeeper/armadyne_clothing.dm
+++ b/modular_nova/modules/sec_haul/code/peacekeeper/armadyne_clothing.dm
@@ -73,22 +73,20 @@
 	inhand_icon_state = "jackboots"
 	worn_icon_state = "armadyne_boots"
 
-
-/obj/item/storage/belt/security/webbing/peacekeeper/armadyne
-	name = "armadyne webbing"
-	desc = "Unique and versatile chest rig, can hold security gear."
-	icon = 'modular_nova/master_files/icons/obj/clothing/belts.dmi'
-	worn_icon = 'modular_nova/master_files/icons/mob/clothing/belt.dmi'
-	icon_state = "armadyne_webbing"
-	worn_icon_state = "armadyne_webbing"
-
-/obj/item/storage/belt/security/peacekeeper/armadyne
+/obj/item/storage/belt/security/armadyne
 	name = "armadyne belt"
 	desc = "Can hold security gear like handcuffs and flashes. Has a holster for a gun."
 	icon = 'modular_nova/master_files/icons/obj/clothing/belts.dmi'
 	worn_icon = 'modular_nova/master_files/icons/mob/clothing/belt.dmi'
 	icon_state = "armadyne_belt"
 	worn_icon_state = "armadyne_belt"
+
+/obj/item/storage/belt/security/webbing/armadyne
+	name = "armadyne webbing"
+	icon = 'modular_nova/master_files/icons/obj/clothing/belts.dmi'
+	worn_icon = 'modular_nova/master_files/icons/mob/clothing/belt.dmi'
+	icon_state = "armadyne_webbing"
+	worn_icon_state = "armadyne_webbing"
 
 /datum/outfit/armadyne_rep
 	name = "Armadyne Corporate Representative"
@@ -102,7 +100,7 @@
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/peacekeeper/armadyne
 	suit = /obj/item/clothing/suit/armor/vest/peacekeeper/armadyne
 	shoes = /obj/item/clothing/shoes/jackboots/peacekeeper/armadyne
-	belt = /obj/item/storage/belt/security/peacekeeper/armadyne
+	belt = /obj/item/storage/belt/security/armadyne
 	r_pocket = /obj/item/assembly/flash/handheld
 	backpack_contents = list(
 		/obj/item/melee/baton/telescopic,
@@ -149,7 +147,7 @@
 	suit = /obj/item/clothing/suit/armor/vest/peacekeeper/armadyne/armor
 	suit_store = /obj/item/gun/ballistic/automatic/sol_rifle
 	shoes = /obj/item/clothing/shoes/jackboots/peacekeeper/armadyne
-	belt = /obj/item/storage/belt/security/webbing/peacekeeper/armadyne
+	belt = /obj/item/storage/belt/security/webbing/armadyne
 	backpack_contents = list(
 		/obj/item/storage/toolbox/guncase/nova/pistol/trappiste_small_case/wespe,
 		/obj/item/storage/box/handcuffs,
@@ -164,7 +162,7 @@
 
 /datum/outfit/armadyne_security/high_alert
 	name = "Armadyne Corporate Security (High Alert)"
-	belt = /obj/item/storage/belt/security/webbing/peacekeeper/armadyne
+	belt = /obj/item/storage/belt/security/webbing/armadyne
 	suit_store = /obj/item/gun/ballistic/automatic/sol_rifle
 	backpack_contents = list(
 		/obj/item/melee/baton/telescopic,

--- a/modular_nova/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
+++ b/modular_nova/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
@@ -157,49 +157,7 @@
 	worn_icon = 'modular_nova/master_files/icons/mob/clothing/hands.dmi'
 	icon_state = "peacekeeper_gripper_gloves"
 
-//PEACEKEEPER BELTS
-/obj/item/storage/belt/security/peacekeeper
-	name = "peacekeeper belt"
-	desc = "This belt can hold security gear like handcuffs and flashes. It has a holster for a gun."
-	icon = 'modular_nova/master_files/icons/obj/clothing/belts.dmi'
-	worn_icon = 'modular_nova/master_files/icons/mob/clothing/belt.dmi'
-	icon_state = "peacekeeperbelt"
-	worn_icon_state = "peacekeeperbelt"
-	content_overlays = FALSE
-
-/obj/item/storage/belt/security/peacekeeper/Initialize(mapload)
-	. = ..()
-	atom_storage.max_slots = 5
-	atom_storage.set_holdable(list(
-		/obj/item/gun/ballistic/automatic/pistol,
-		/obj/item/gun/ballistic/revolver,
-		/obj/item/gun/energy/disabler,
-		/obj/item/melee/baton,
-		/obj/item/melee/baton,
-		/obj/item/grenade,
-		/obj/item/reagent_containers/spray/pepper,
-		/obj/item/restraints/handcuffs,
-		/obj/item/assembly/flash/handheld,
-		/obj/item/clothing/glasses,
-		/obj/item/ammo_casing/shotgun,
-		/obj/item/ammo_box,
-		/obj/item/food/donut,
-		/obj/item/knife/combat,
-		/obj/item/flashlight/seclite,
-		/obj/item/melee/baton/telescopic,
-		/obj/item/radio,
-		/obj/item/clothing/gloves,
-		/obj/item/restraints/legcuffs/bola,
-		/obj/item/holosign_creator/security
-		))
-
-/obj/item/storage/belt/security/peacekeeper/full/PopulateContents()
-	new /obj/item/reagent_containers/spray/pepper(src)
-	new /obj/item/restraints/handcuffs(src)
-	new /obj/item/grenade/flashbang(src)
-	new /obj/item/assembly/flash/handheld(src)
-	update_icon()
-
+//PEACEKEEPER WEBBING
 /obj/item/storage/belt/security/webbing/peacekeeper
 	name = "peacekeeper webbing"
 	desc = "A tactical chest rig issued to peacekeepers; slow is smooth, smooth is fast. Has a notable lack of a holster that fits energy-based weapons."

--- a/modular_nova/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
+++ b/modular_nova/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
@@ -160,39 +160,10 @@
 //PEACEKEEPER WEBBING
 /obj/item/storage/belt/security/webbing/peacekeeper
 	name = "peacekeeper webbing"
-	desc = "A tactical chest rig issued to peacekeepers; slow is smooth, smooth is fast. Has a notable lack of a holster that fits energy-based weapons."
 	icon = 'modular_nova/master_files/icons/obj/clothing/belts.dmi'
 	worn_icon = 'modular_nova/master_files/icons/mob/clothing/belt.dmi'
 	icon_state = "peacekeeper_webbing"
 	worn_icon_state = "peacekeeper_webbing"
-	content_overlays = FALSE
-	custom_premium_price = PAYCHECK_CREW * 3
-
-/obj/item/storage/belt/security/webbing/peacekeeper/Initialize(mapload)
-	. = ..()
-	atom_storage.max_slots = 7
-	atom_storage.set_holdable(list(
-		/obj/item/gun/ballistic/automatic/pistol,
-		/obj/item/gun/ballistic/revolver,
-		/obj/item/melee/baton,
-		/obj/item/melee/baton,
-		/obj/item/grenade,
-		/obj/item/reagent_containers/spray/pepper,
-		/obj/item/restraints/handcuffs,
-		/obj/item/assembly/flash/handheld,
-		/obj/item/clothing/glasses,
-		/obj/item/ammo_casing/shotgun,
-		/obj/item/ammo_box,
-		/obj/item/food/donut,
-		/obj/item/knife/combat,
-		/obj/item/flashlight/seclite,
-		/obj/item/melee/baton/telescopic,
-		/obj/item/radio,
-		/obj/item/clothing/gloves,
-		/obj/item/restraints/legcuffs/bola,
-		/obj/item/holosign_creator/security
-		))
-
 
 //BOOTS
 /obj/item/clothing/shoes/jackboots/peacekeeper


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Saw the screenshot of the current belts included a very outdated sprite. Found out it's not even linking to TG's file so now its doing that.

While here I did a few other things:
- Removed a nonmodular edit adding reskins to secbelts... which we then override with the reskins we ACTUALLY have available right now. This code was not in use.
- Removed the Peacekeeper belt. Item not in use.
- Repathed the Armadyne belt/webbing to be their own unique subtypes instead of subtypes of /peacekeeper
- Removed lots of the redefined code on Peacekeeper webbing, bringing it in line with TG sec webbing (This may sound like a nerf, and it DOES remove one slot, but it actually makes it so that _any_ subtype of /gun/ can be put in as long as its small enough. So might qualify as a buff.) (The hope is that whenever TG resprites the sec webbing we can just throw this item out entirely but right now its our "bluesec webbing"
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Sprite that isnt years out of date, other related cleanup
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
WIP
<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed unused "Peacekeeper Belt" and put the remaining "Peacekeeper Webbing" in-line with TG Sec Webbing
image: updated the icon used for the "Slim" variant of sec belts (now called "Basic")
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
