### PR TITLE
Hotfix for Upstream Merge 81033

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -487,10 +487,6 @@
 #define FLASH_PROTECTION_FLASH 1
 #define FLASH_PROTECTION_WELDER 2
 
-// Roundstart trait system
-
-#define MAX_QUIRKS 6 //The maximum amount of quirks one character can have at roundstart
-
 // AI Toggles
 #define AI_CAMERA_LUMINOSITY 5
 #define AI_VOX // Comment out if you don't want VOX to be enabled and have players download the voice sounds.

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -430,3 +430,30 @@
 /datum/config_entry/flag/give_tutorials_without_db
 
 /datum/config_entry/string/new_player_alert_role_id
+<<<<<<< HEAD
+=======
+
+/datum/config_entry/keyed_list/positive_station_traits
+	default = list("0" = 8, "1" = 4, "2" = 2, "3" = 1)
+	key_mode = KEY_MODE_TEXT
+	value_mode = VALUE_MODE_NUM
+
+/datum/config_entry/keyed_list/negative_station_traits
+	default = list("0" = 8, "1" = 4, "2" = 2, "3" = 1)
+	key_mode = KEY_MODE_TEXT
+	value_mode = VALUE_MODE_NUM
+
+/datum/config_entry/keyed_list/neutral_station_traits
+	default = list("0" = 10, "1" = 10, "2" = 3, "2.5" = 1)
+	key_mode = KEY_MODE_TEXT
+	value_mode = VALUE_MODE_NUM
+
+// Configs for the Quirk system
+/// Disables Quirk point balancing for the server and clients.
+/datum/config_entry/flag/disable_quirk_points
+
+/// The maximum amount of positive quirks one character can have at roundstart.
+/datum/config_entry/number/max_positive_quirks
+	default = 6
+	min_val = -1
+>>>>>>> 495fde6a2c1 (Add: 2 Quirks Configs (#81033))

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -430,8 +430,6 @@
 /datum/config_entry/flag/give_tutorials_without_db
 
 /datum/config_entry/string/new_player_alert_role_id
-<<<<<<< HEAD
-=======
 
 /datum/config_entry/keyed_list/positive_station_traits
 	default = list("0" = 8, "1" = 4, "2" = 2, "3" = 1)
@@ -456,4 +454,3 @@
 /datum/config_entry/number/max_positive_quirks
 	default = 6
 	min_val = -1
->>>>>>> 495fde6a2c1 (Add: 2 Quirks Configs (#81033))

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -124,10 +124,15 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	var/bonus_quirks = max((length(user.quirks) + rand(-RANDOM_QUIRK_BONUS, RANDOM_QUIRK_BONUS)), MINIMUM_RANDOM_QUIRKS)
 	var/added_quirk_count = 0 //How many we've added
 	var/list/quirks_to_add = list() //Quirks we're adding
-	var/good_count = 0 //Maximum of 6 good perks
+	var/good_count = 0
 	var/score //What point score we're at
 	///Cached list of possible quirks
 	var/list/possible_quirks = quirks.Copy()
+
+	var/max_positive_quirks = CONFIG_GET(number/max_positive_quirks)
+	if(max_positive_quirks < 0)
+		max_positive_quirks = 6
+
 	//Create a random list of stuff to start with
 	while(bonus_quirks > added_quirk_count)
 		var/quirk = pick(possible_quirks) //quirk is a string
@@ -157,19 +162,20 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		quirks_to_add += quirk
 
 	//And have benefits too
-	while(score < 0 && good_count <= MAX_QUIRKS)
-		if(!length(possible_quirks))//Lets not get stuck
-			break
-		var/quirk = pick(quirks)
-		if(quirk in GLOB.quirk_blacklist) //prevent blacklisted
-			possible_quirks -= quirk
-			continue
-		if(!quirk_points[quirk] > 0) //positive only
-			possible_quirks -= quirk
-			continue
-		good_count++
-		score += quirk_points[quirk]
-		quirks_to_add += quirk
+	if(max_positive_quirks > 0)
+		while(score < 0 && good_count <= max_positive_quirks)
+			if(!length(possible_quirks))//Lets not get stuck
+				break
+			var/quirk = pick(quirks)
+			if(quirk in GLOB.quirk_blacklist) //prevent blacklisted
+				possible_quirks -= quirk
+				continue
+			if(!(quirk_points[quirk] > 0)) //positive only
+				possible_quirks -= quirk
+				continue
+			good_count++
+			score += quirk_points[quirk]
+			quirks_to_add += quirk
 
 	for(var/datum/quirk/quirk as anything in user.quirks)
 		if(quirk.name in quirks_to_add) //Don't delete ones we keep
@@ -187,6 +193,8 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 /datum/controller/subsystem/processing/quirks/proc/filter_invalid_quirks(list/quirks, list/augments) // NOVA EDIT - AUGMENTS+
 	var/list/new_quirks = list()
 	var/list/positive_quirks = list()
+	var/points_enabled = !CONFIG_GET(flag/disable_quirk_points)
+	var/max_positive_quirks = CONFIG_GET(number/max_positive_quirks)
 	var/balance = 0
 
 	var/list/all_quirks = get_quirks()
@@ -223,7 +231,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 
 		var/value = initial(quirk.value)
 		if (value > 0)
-			if (positive_quirks.len == MAX_QUIRKS)
+			if (max_positive_quirks >= 0 && positive_quirks.len == max_positive_quirks)
 				continue
 
 			positive_quirks[quirk_name] = value
@@ -231,7 +239,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		balance += value
 		new_quirks += quirk_name
 
-	if (balance > 0)
+	if (points_enabled && balance > 0)
 		var/balance_left_to_remove = balance
 
 		for (var/positive_quirk in positive_quirks)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -540,6 +540,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			.++
 
 /datum/preferences/proc/validate_quirks()
+	if(CONFIG_GET(flag/disable_quirk_points))
+		return
 	if(GetQuirkBalance() < 0)
 		all_quirks = list()
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -178,6 +178,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	//NOVA EDIT BEGIN
 	data["preview_selection"] = preview_pref
 
+	data["quirk_points_enabled"] = !CONFIG_GET(flag/disable_quirk_points)
 	data["quirks_balance"] = GetQuirkBalance()
 	data["positive_quirk_count"] = GetPositiveQuirkCount()
 	//NOVA EDIT END

--- a/code/modules/client/preferences/middleware/quirks.dm
+++ b/code/modules/client/preferences/middleware/quirks.dm
@@ -31,8 +31,13 @@
 
 	var/list/quirks = SSquirks.get_quirks()
 
+	var/max_positive_quirks = CONFIG_GET(number/max_positive_quirks)
+	var/positive_quirks_disabled = max_positive_quirks == 0
 	for (var/quirk_name in quirks)
 		var/datum/quirk/quirk = quirks[quirk_name]
+		if(positive_quirks_disabled && initial(quirk.value) > 0)
+			continue
+
 		var/datum/quirk_constant_data/constant_data = GLOB.all_quirk_constant_data[quirk]
 		var/list/datum/preference/customization_options = constant_data?.get_customization_data()
 
@@ -47,9 +52,10 @@
 		)
 
 	return list(
-		"max_positive_quirks" = MAX_QUIRKS,
+		"max_positive_quirks" = max_positive_quirks,
 		"quirk_info" = quirk_info,
 		"quirk_blacklist" = GLOB.quirk_string_blacklist,
+		"points_enabled" = !CONFIG_GET(flag/disable_quirk_points),
 	)
 
 /datum/preference_middleware/quirks/on_new_character(mob/user)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -563,3 +563,35 @@ DISALLOW_TITLE_MUSIC
 ## This is primarily useful for developing tutorials. If you have a proper DB setup, you
 ## don't need (or want) this.
 #GIVE_TUTORIALS_WITHOUT_DB
+<<<<<<< HEAD
+=======
+
+## Configuration for station traits of each type.
+## The first value (key) is the budget, or the space available to use for station traits of that type. Some take more space than others.
+## The second value (assoc) is the weight associated with said budget compared to the rest for that type.
+POSITIVE_STATION_TRAITS 0 8
+POSITIVE_STATION_TRAITS 1 4
+POSITIVE_STATION_TRAITS 2 2
+POSITIVE_STATION_TRAITS 3 1
+
+NEUTRAL_STATION_TRAITS 0 10
+NEUTRAL_STATION_TRAITS 1 10
+NEUTRAL_STATION_TRAITS 2 3
+NEUTRAL_STATION_TRAITS 2.5 1
+
+NEGATIVE_STATION_TRAITS 0 8
+NEGATIVE_STATION_TRAITS 1 4
+NEGATIVE_STATION_TRAITS 2 2
+NEGATIVE_STATION_TRAITS 3 1
+
+# Uncomment to disable Quirk point balancing for the server and clients.
+# If enabled, players will be able to select positive quirks without first selecting negative quirks.
+# If enabled, randomized Quirks will still use points internally, in order to maintain balance.
+#DISABLE_QUIRK_POINTS
+
+# The maximum amount of positive quirks one character can have at roundstart.
+# If set to -1, then players will be able to select any quantity of positive quirks.
+# If set to 0, then players won't be able to select any positive quirks.
+# If commented-out or undefined, the maximum default is 6.
+MAX_POSITIVE_QUIRKS 6
+>>>>>>> 495fde6a2c1 (Add: 2 Quirks Configs (#81033))

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -563,8 +563,6 @@ DISALLOW_TITLE_MUSIC
 ## This is primarily useful for developing tutorials. If you have a proper DB setup, you
 ## don't need (or want) this.
 #GIVE_TUTORIALS_WITHOUT_DB
-<<<<<<< HEAD
-=======
 
 ## Configuration for station traits of each type.
 ## The first value (key) is the budget, or the space available to use for station traits of that type. Some take more space than others.
@@ -594,4 +592,3 @@ NEGATIVE_STATION_TRAITS 3 1
 # If set to 0, then players won't be able to select any positive quirks.
 # If commented-out or undefined, the maximum default is 6.
 MAX_POSITIVE_QUIRKS 6
->>>>>>> 495fde6a2c1 (Add: 2 Quirks Configs (#81033))

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/LimbsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/LimbsPage.tsx
@@ -145,7 +145,10 @@ export const AugmentationPage = (props) => {
                     onSelected={(value) => {
                       // Since the costs are positive,
                       // it's added and not substracted
-                      if (balance + props.limb.costs[value] > 0) {
+                      if (
+                        data.quirk_points_enabled &&
+                        balance + props.limb.costs[value] > 0
+                      ) {
                         return;
                       }
                       act('set_limb_aug', {
@@ -198,7 +201,10 @@ export const OrganPage = (props) => {
             displayText={props.organ.chosen_organ}
             onSelected={(value) => {
               // Since the costs are positive, it's added and not substracted
-              if (balance + props.organ.costs[value] > 0) {
+              if (
+                data.quirk_points_enabled &&
+                balance + props.organ.costs[value] > 0
+              ) {
                 return;
               }
               act('set_organ_aug', {
@@ -245,27 +251,32 @@ export const LimbsPage = (props) => {
             width="100%"
           />
           <RotateCharacterButtons />
-          <Box
-            style={{
-              marginTop: '3em',
-            }}
-          >
-            <Section title="Quirk Points Balance" />
-          </Box>
-
-          <Box
-            backgroundColor="#eee"
-            bold
-            color="black"
-            fontSize="1.2em"
-            py={0.5}
-            style={{
-              width: '20%',
-              alignItems: 'center',
-            }}
-          >
-            {balance}
-          </Box>
+          {data.quirk_points_enabled ? (
+            <Section
+              fill
+              align="center"
+              title="Quirk Points Balance"
+              style={{ marginTop: '3em' }}
+            >
+              <Stack justify="center">
+                <Box
+                  backgroundColor="#eee"
+                  bold
+                  color="black"
+                  fontSize="1.2em"
+                  py={0.5}
+                  style={{
+                    width: '20%',
+                    alignItems: 'center',
+                  }}
+                >
+                  {balance}
+                </Box>
+              </Stack>
+            </Section>
+          ) : (
+            ''
+          )}
         </Section>
       </Stack.Item>
       <Stack.Item minWidth="33%">

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
@@ -318,7 +318,12 @@ export function QuirksPage(props) {
           max_positive_quirks: maxPositiveQuirks,
           quirk_blacklist: quirkBlacklist,
           quirk_info: quirkInfo,
+<<<<<<< HEAD
         } = quirks_data.quirks; // NOVA EDIT - Quirks balance refactor
+=======
+          points_enabled: pointsEnabled,
+        } = server_data.quirks;
+>>>>>>> 495fde6a2c1 (Add: 2 Quirks Configs (#81033))
 
         const quirks = Object.entries(quirkInfo);
         quirks.sort(([_, quirkA], [__, quirkB]) => {
@@ -338,9 +343,12 @@ export function QuirksPage(props) {
           const quirk = quirkInfo[quirkName];
 
           if (quirk.value > 0) {
-            if (positiveQuirks >= maxPositiveQuirks) {
+            if (
+              maxPositiveQuirks !== -1 &&
+              positiveQuirks >= maxPositiveQuirks
+            ) {
               return "You can't have any more positive quirks!";
-            } else if (balance + quirk.value > 0) {
+            } else if (pointsEnabled && balance + quirk.value > 0) {
               return 'You need a negative quirk to balance this out!';
             }
           }
@@ -376,7 +384,7 @@ export function QuirksPage(props) {
         const getReasonToNotRemove = (quirkName: string) => {
           const quirk = quirkInfo[quirkName];
 
-          if (balance - quirk.value > 0) {
+          if (pointsEnabled && balance - quirk.value > 0) {
             return 'You need to remove a positive quirk first!';
           }
 
@@ -388,13 +396,21 @@ export function QuirksPage(props) {
             <Stack.Item basis="50%">
               <Stack vertical fill align="center">
                 <Stack.Item>
-                  <Box fontSize="1.3em">Positive Quirks</Box>
+                  {maxPositiveQuirks > 0 ? (
+                    <Box fontSize="1.3em">Positive Quirks</Box>
+                  ) : (
+                    <Box mt={pointsEnabled ? 3.4 : 0} />
+                  )}
                 </Stack.Item>
 
                 <Stack.Item>
-                  <StatDisplay>
-                    {positiveQuirks} / {maxPositiveQuirks}
-                  </StatDisplay>
+                  {maxPositiveQuirks > 0 ? (
+                    <StatDisplay>
+                      {positiveQuirks} / {maxPositiveQuirks}
+                    </StatDisplay>
+                  ) : (
+                    <Box mt={pointsEnabled ? 3.4 : 0} />
+                  )}
                 </Stack.Item>
 
                 <Stack.Item>
@@ -442,11 +458,19 @@ export function QuirksPage(props) {
             <Stack.Item basis="50%">
               <Stack vertical fill align="center">
                 <Stack.Item>
-                  <Box fontSize="1.3em">Quirk Balance</Box>
+                  {pointsEnabled ? (
+                    <Box fontSize="1.3em">Quirk Balance</Box>
+                  ) : (
+                    <Box mt={maxPositiveQuirks > 0 ? 3.4 : 0} />
+                  )}
                 </Stack.Item>
 
                 <Stack.Item>
-                  <StatDisplay>{balance}</StatDisplay>
+                  {pointsEnabled ? (
+                    <StatDisplay>{balance}</StatDisplay>
+                  ) : (
+                    <Box mt={maxPositiveQuirks > 0 ? 3.4 : 0} />
+                  )}
                 </Stack.Item>
 
                 <Stack.Item>

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
@@ -318,12 +318,8 @@ export function QuirksPage(props) {
           max_positive_quirks: maxPositiveQuirks,
           quirk_blacklist: quirkBlacklist,
           quirk_info: quirkInfo,
-<<<<<<< HEAD
-        } = quirks_data.quirks; // NOVA EDIT - Quirks balance refactor
-=======
           points_enabled: pointsEnabled,
-        } = server_data.quirks;
->>>>>>> 495fde6a2c1 (Add: 2 Quirks Configs (#81033))
+        } = quirks_data.quirks; // NOVA EDIT - Quirks balance refactor
 
         const quirks = Object.entries(quirkInfo);
         quirks.sort(([_, quirkA], [__, quirkB]) => {

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
@@ -137,6 +137,7 @@ export type QuirkInfo = {
   max_positive_quirks: number;
   quirk_info: Record<string, Quirk>;
   quirk_blacklist: string[][];
+  points_enabled: boolean;
 };
 
 export enum RandomSetting {

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
@@ -227,6 +227,7 @@ export type PreferencesMenuData = {
   selected_languages: Language[];
   unselected_languages: Language[];
   total_language_points: number;
+  quirk_points_enabled: number;
   quirks_balance: number;
   positive_quirk_count: number;
   species_restricted_jobs?: string[];


### PR DESCRIPTION
## About The Pull Request

This PR fixes #549 to allow it to work nicely with our Augments+ system.

## How This Contributes To The Nova Sector Roleplay Experience

Makes #549 mergeable which should allow us to use the new quirk configs fully. Without the changes in this PR, the Augments+ page may not function as expected.

## Proof of Testing

Tested with default settings OK. Also tested with quirk points disabled.

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl:
fix: Fixed config DISABLE_QUIRK_POINTS so it works with the Augments+ page.
fix: Fixed the alignment of the Quirk Points Balance section on the Augments+ page.
/:cl:
