### PR TITLE
Remove implants from prisoner role on join

### DIFF
--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -66,6 +66,17 @@
 /datum/outfit/job/prisoner/post_equip(mob/living/carbon/human/new_prisoner, visualsOnly)
 	. = ..()
 
+	//NOVA ADDITION BEGIN - remove prisoner implants on join
+	var/implants_removed = 0
+	for(var/organ in new_prisoner.organs)
+		if (istype(organ, /obj/item/organ/internal/cyberimp))
+			QDEL_NULL(organ)
+			implants_removed += 1
+
+	if (implants_removed >= 1)
+		to_chat(new_prisoner, span_warning("Your implants have been removed as part of your sentence."))
+	//NOVA ADDITION END
+
 	var/crime_name = new_prisoner.client?.prefs?.read_preference(/datum/preference/choiced/prisoner_crime)
 	if(!crime_name)
 		return


### PR DESCRIPTION
## About The Pull Request

Really simple: this removes any roundstart implants you might have if you decide to join as a prisoner.

## How This Contributes To The Nova Sector Roleplay Experience

I've been told this is necessary given the recent toolset implants basically allowing someone to hack to permabrig doors at roundstart, if they wanted to (and risk breaking policy in the process).

## Proof of Testing

It compiles!

## Changelog

:cl: yooriss
fix: Prisoners joining a round now properly have their implants removed as intended.
/:cl:
