### PR TITLE
Spacer fixes: anti gravity harness now applies appropriate buffs/debuffs & improved wellness messaging

### DIFF
--- a/modular_nova/master_files/code/datums/quirks/positive_quirks/spacer.dm
+++ b/modular_nova/master_files/code/datums/quirks/positive_quirks/spacer.dm
@@ -1,0 +1,8 @@
+// Make spacer's gravity wellness effect visible so players know something is happening.
+/datum/status_effect/spacer/gravity_wellness
+	alert_type = /atom/movable/screen/alert/status_effect/gravity_wellness
+
+/atom/movable/screen/alert/status_effect/gravity_wellness
+	name = "Gravity Wellness"
+	desc = "Your physiology thrives in low-gravity conditions: you catch your breath quicker and are more mobile."
+	icon_state = "negative"

--- a/modular_nova/master_files/code/modules/clothing/back/antigravityharness.dm
+++ b/modular_nova/master_files/code/modules/clothing/back/antigravityharness.dm
@@ -101,6 +101,7 @@
 	user.RemoveElement(/datum/element/forced_gravity, 0)
 	REMOVE_TRAIT(user, TRAIT_NEGATES_GRAVITY, CLOTHING_TRAIT)
 
+	var/datum/quirk/spacer_born/spacer = user.get_quirk(/datum/quirk/spacer_born)
 	switch(target_mode)
 		if(MODE_ANTIGRAVITY)
 			mode = MODE_ANTIGRAVITY
@@ -115,6 +116,10 @@
 			icon_state = ANTIGRAVITY_STATE
 			worn_icon_state = ANTIGRAVITY_STATE
 
+			//are we a spacer? if so, let the quirk know we're back in low gravity conditions
+			if (!isnull(spacer))
+				spacer.in_space(user)
+
 		if(MODE_EXTRAGRAVITY)
 			mode = MODE_EXTRAGRAVITY
 
@@ -127,6 +132,10 @@
 			gravity_on = TRUE
 			icon_state = EXTRAGRAVITY_STATE
 			worn_icon_state = EXTRAGRAVITY_STATE
+
+			//are we a spacer? if so, let the quirk know we're in extremely uncomfortable extragrav
+			if (!isnull(spacer))
+				spacer.on_planet(user)
 
 		if(MODE_GRAVOFF)
 			if(!user.has_gravity() && mode != MODE_GRAVOFF)
@@ -144,6 +153,10 @@
 
 			icon_state = OFF_STATE
 			worn_icon_state = OFF_STATE
+
+			//are we a spacer? if so, make the quirk assert the correct condition based on where we are
+			if (!isnull(spacer))
+				spacer.check_z(user)
 
 		else
 			return FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6210,6 +6210,7 @@
 #include "modular_nova\master_files\code\datums\quirks\negative_quirks\nerve_staple.dm"
 #include "modular_nova\master_files\code\datums\quirks\neutral_quirks\equipping.dm"
 #include "modular_nova\master_files\code\datums\quirks\neutral_quirks\lungs.dm"
+#include "modular_nova\master_files\code\datums\quirks\positive_quirks\spacer.dm"
 #include "modular_nova\master_files\code\datums\records\record.dm"
 #include "modular_nova\master_files\code\datums\station_traits\negative_traits.dm"
 #include "modular_nova\master_files\code\datums\storage\storage.dm"


### PR DESCRIPTION
## About The Pull Request

Simple fix PR: gravity harness local gravity changes were not causing spacer buff/debuff routines to run, since the upstream spacer quirk isn't signalled for changes in gravity for whatever reason. This is a modular solution to that particular issue (the alternate involves rewriting most of the quirk upstream), and I've also thrown in a modular messaging improvement to let spacer players know when they're benefitting from gravity wellness.

## How This Contributes To The Nova Sector Roleplay Experience

Fixes a long-standing annoyance with what should have been (and now is) the premier spacer comfort device on station. At a stonking 1200 credits, the harness is a fairly hefty purchase, after all.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_w5ySd0QhpC](https://github.com/NovaSector/NovaSector/assets/966289/ef5cbfd2-b689-49ab-ba7d-95cc5d493535)

![dreamseeker_Y2VPgwkdQm](https://github.com/NovaSector/NovaSector/assets/966289/ef78d883-a1bc-4d1c-a534-c483de5a30e6)

</details>

## Changelog

:cl: yooriss
fix: Anti-gravity harnesses now properly apply various interactions with the Spacer quirk.
fix: Players now receive a visible status effect alert when benefitting from the gravity wellness buff given by the Spacer quirk.
/:cl: