### PR TITLE
[MODULAR] ICSpawning Module: Quirks, Loadout, and BST RPED buff

### DIFF
--- a/modular_nova/modules/icspawning/code/observer.dm
+++ b/modular_nova/modules/icspawning/code/observer.dm
@@ -35,6 +35,12 @@
 			give_return = tgui_alert(usr, "Do you want to give them the power to return? Not recommended for non-admins.", "Give power?", list("Yes", "No"))
 			if(!give_return)
 				return
+		
+		var/addquirks = FALSE
+		if(character_option == "Selected Character")
+			addquirks = tgui_input_list(src, "Include quirks?", "Quirky", list("Quirks & Loadout", "Quirks Only", "Loadout Only", "Neither", "Cancel"))
+			if (addquirks == "Cancel")
+				return
 
 
 		var/turf/current_turf = get_turf(user)
@@ -46,8 +52,18 @@
 
 			var/mob/living/carbon/human/H = spawned_player
 			user.client?.prefs.safe_transfer_prefs_to(H)
+			if(addquirks == "Quirks & Loadout" || addquirks == "Quirks Only")
+				SSquirks.AssignQuirks(H, user.client)
+			if(addquirks == "Quirks & Loadout" || addquirks == "Loadout Only")
+				if(dresscode == "Naked")
+					H.equip_outfit_and_loadout(new /datum/outfit(), user.client?.prefs)
+				else
+					H.equip_outfit_and_loadout(dresscode, user.client?.prefs)
+			else if(dresscode != "Naked")
+				spawned_player.equipOutfit(dresscode)
 			H.dna.update_dna_identity()
-
+		else if(dresscode != "Naked")
+			spawned_player.equipOutfit(dresscode)
 		QDEL_IN(user, 1)
 
 		if (teleport_option == "Bluespace")
@@ -61,9 +77,6 @@
 		if(give_return != "No")
 			var/datum/action/cooldown/spell/return_back/return_spell = new(spawned_player)
 			return_spell.Grant(spawned_player)
-
-		if(dresscode != "Naked")
-			spawned_player.equipOutfit(dresscode)
 
 		switch(teleport_option)
 			if("Bluespace")

--- a/modular_nova/modules/icspawning/code/observer.dm
+++ b/modular_nova/modules/icspawning/code/observer.dm
@@ -36,10 +36,10 @@
 			if(!give_return)
 				return
 		
-		var/addquirks = FALSE
+		var/addquirks
 		if(character_option == "Selected Character")
-			addquirks = tgui_input_list(src, "Include quirks?", "Quirky", list("Quirks & Loadout", "Quirks Only", "Loadout Only", "Neither", "Cancel"))
-			if (addquirks == "Cancel")
+			addquirks = tgui_input_list(src, "Include quirks?", "Quirky", list("Quirks & Loadout", "Quirks Only", "Loadout Only", "Neither"))
+			if(!addquirks)
 				return
 
 

--- a/modular_nova/modules/icspawning/code/standard.dm
+++ b/modular_nova/modules/icspawning/code/standard.dm
@@ -66,18 +66,18 @@
 
 /obj/item/storage/part_replacer/bluespace/tier4_bst/Initialize(mapload)
 	. = ..()
-	atom_storage.max_slots = 800
-	atom_storage.max_total_storage = 16000
+	atom_storage.max_slots = 1000
+	atom_storage.max_total_storage = 20000
 
 /obj/item/storage/part_replacer/bluespace/tier4_bst/PopulateContents()
-	for(var/i in 1 to 50)
+	for(var/i in 1 to 30)
 		new /obj/item/stock_parts/capacitor/quadratic(src)
 		new /obj/item/stock_parts/scanning_module/triphasic(src)
 		new /obj/item/stock_parts/servo/femto(src)
 		new /obj/item/stock_parts/micro_laser/quadultra(src)
 		new /obj/item/stock_parts/matter_bin/bluespace(src)
 		new /obj/item/stock_parts/cell/bluespace(src)
-	for(var/i in 1 to 100)
+	for(var/i in 1 to 70)
 		new /obj/item/stock_parts/capacitor/quadratic(src)
 		new /obj/item/stock_parts/servo/femto(src)
 		new /obj/item/stock_parts/micro_laser/quadultra(src)

--- a/modular_nova/modules/icspawning/code/standard.dm
+++ b/modular_nova/modules/icspawning/code/standard.dm
@@ -36,6 +36,14 @@
 	shoes = /obj/item/clothing/shoes/combat/debug
 	id = /obj/item/card/id/advanced/debug/bst
 	box = /obj/item/storage/box/debugtools
+	backpack_contents = list(
+		/obj/item/melee/energy/axe = 1,
+		/obj/item/storage/part_replacer/bluespace/tier4_bst = 1,
+		/obj/item/gun/magic/wand/resurrection/debug = 1,
+		/obj/item/gun/magic/wand/death/debug = 1,
+		/obj/item/debug/human_spawner = 1,
+		/obj/item/debug/omnitool = 1,
+	)
 
 /datum/outfit/admin/bst //Debug objs plus modsuit
 	name = "Bluespace Tech (MODsuit)"
@@ -44,3 +52,34 @@
 	shoes = /obj/item/clothing/shoes/combat/debug
 	id = /obj/item/card/id/advanced/debug/bst
 	box = /obj/item/storage/box/debugtools
+	backpack_contents = list(
+		/obj/item/melee/energy/axe = 1,
+		/obj/item/storage/part_replacer/bluespace/tier4_bst = 1,
+		/obj/item/gun/magic/wand/resurrection/debug = 1,
+		/obj/item/gun/magic/wand/death/debug = 1,
+		/obj/item/debug/human_spawner = 1,
+		/obj/item/debug/omnitool = 1,
+	)
+
+/obj/item/storage/part_replacer/bluespace/tier4_bst
+	name = "BST's RPED"
+
+/obj/item/storage/part_replacer/bluespace/tier4_bst/Initialize(mapload)
+	. = ..()
+	atom_storage.max_slots = 800
+	atom_storage.max_total_storage = 16000
+
+/obj/item/storage/part_replacer/bluespace/tier4_bst/PopulateContents()
+	for(var/i in 1 to 50)
+		new /obj/item/stock_parts/capacitor/quadratic(src)
+		new /obj/item/stock_parts/scanning_module/triphasic(src)
+		new /obj/item/stock_parts/servo/femto(src)
+		new /obj/item/stock_parts/micro_laser/quadultra(src)
+		new /obj/item/stock_parts/matter_bin/bluespace(src)
+		new /obj/item/stock_parts/cell/bluespace(src)
+	for(var/i in 1 to 100)
+		new /obj/item/stock_parts/capacitor/quadratic(src)
+		new /obj/item/stock_parts/servo/femto(src)
+		new /obj/item/stock_parts/micro_laser/quadultra(src)
+		new /obj/item/stock_parts/matter_bin/bluespace(src)
+		new /obj/item/stock_parts/cell/bluespace(src)


### PR DESCRIPTION
## About The Pull Request

This PR adds a new option to the admin ICSpawning module to include the target player's *quirks* and/or *loadout items* when they spawn in.  The option is only made available when loading their selected character; for randomly-generated characters it won't be shown.

It also includes a small QOL buff to the default Bluespace Technician loadout; you get an expanded Bluespace RPED that comes preloaded with significantly more T4 parts (30x T4 scanners, 100x of all other T4 parts, with significantly higher max storage to allow for materials, boards ,etc) - should be helpful for event setup and similar.

## How This Contributes To The Nova Sector Roleplay Experience

This is primarily a debugging & QOL feature for admins, GAs, and coders - it lets you get a character more or less identical to how they would be on actual job or ghostrole spawn-in, without having to know all the procs to load their prefs/loadout/etc by hand.  Shouldn't be player-facing beyond events or thunderdome shenanigans.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
 
![image](https://github.com/NovaSector/NovaSector/assets/2958111/2fbd5443-be6e-46ef-9ba1-497fdde375ed)

https://github.com/NovaSector/NovaSector/assets/2958111/d6ddce1c-1918-43ff-a52c-1c91e09ef3ad

![image](https://github.com/NovaSector/NovaSector/assets/2958111/e7b0691a-816f-4dd4-9bf0-0699d3d4c006)

</details>

## Changelog

:cl:
admin: icspawning supports quirks & loadout items now
qol: bluespace technicians got an upgrade to their RPED
/:cl:
