### PR TITLE
Make holobadges accessory-only in loadout categories

### DIFF
--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_neck.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_neck.dm
@@ -287,16 +287,6 @@ GLOBAL_LIST_INIT(loadout_necks, generate_loadout_items(/datum/loadout_item/neck)
 	name = "MODlink Scryer"
 	item_path = /obj/item/clothing/neck/link_scryer/loaded
 
-/datum/loadout_item/neck/holobadge
-	name = "Holobadge"
-	item_path = /obj/item/clothing/accessory/badge/holo
-	restricted_roles = list(JOB_HEAD_OF_SECURITY, JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_DETECTIVE, JOB_CORRECTIONS_OFFICER)
-
-/datum/loadout_item/neck/holobadge_cord
-	name = "Holobadge with Lanyard"
-	item_path = /obj/item/clothing/accessory/badge/holo/cord
-	restricted_roles = list(JOB_HEAD_OF_SECURITY, JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_DETECTIVE, JOB_CORRECTIONS_OFFICER)
-
 /*
 *	DONATOR
 */


### PR DESCRIPTION
## About The Pull Request

It appears that the loadout system doesn't like the same item being in multiple categories - if you have an accessory holobadge equipped, it will clear your neck slot (since it seems to think the holobadge is a neck slot *first*). 

This PR just removes holobadges from the neck slot category and keeps them purely in accessory to make concurrency between holobadge+neck slot choices possible.

## How This Contributes To The Nova Sector Roleplay Experience

You should be able to wear a scarf AND your holobadge, especially when the latter attaches to your uniform!

## Proof of Testing

It compiles!

## Changelog

:cl: yooriss
fix: Loadout holobadges are now considered accessory category only, meaning they can be paired up with neck slot loadout items without occupying both slots. Wear a scarf and a holobadge together!
/:cl:
