### PR TITLE
Tweaks ration printer pixel shift, and colony fabricator design printing times

### DIFF
--- a/modular_nova/modules/colony_fabricator/code/appliances/foodricator.dm
+++ b/modular_nova/modules/colony_fabricator/code/appliances/foodricator.dm
@@ -10,7 +10,7 @@
 	pass_flags = PASSTABLE
 	efficiency = 1
 	productivity = 2.5
-	anchored_tabletop_offset = 8
+	anchored_tabletop_offset = 6
 	show_categories = list(
 		RND_CATEGORY_AKHTER_FOODRICATOR_INGREDIENTS,
 		RND_CATEGORY_AKHTER_FOODRICATOR_BAGS,

--- a/modular_nova/modules/colony_fabricator/code/design_datums/appliances.dm
+++ b/modular_nova/modules/colony_fabricator/code/design_datums/appliances.dm
@@ -100,7 +100,7 @@
 		RND_CATEGORY_INITIAL,
 		FABRICATOR_CATEGORY_APPLIANCES + FABRICATOR_SUBCATEGORY_ATMOS,
 	)
-	construction_time = 30 SECONDS
+	construction_time = 15 SECONDS
 
 // Plumbable chem machine that makes nothing but water
 
@@ -117,7 +117,7 @@
 		RND_CATEGORY_INITIAL,
 		FABRICATOR_CATEGORY_APPLIANCES + FABRICATOR_SUBCATEGORY_FLUIDS,
 	)
-	construction_time = 10 SECONDS
+	construction_time = 30 SECONDS
 
 // Plumbable chem machine that makes nothing but water
 
@@ -134,7 +134,7 @@
 		RND_CATEGORY_INITIAL,
 		FABRICATOR_CATEGORY_APPLIANCES + FABRICATOR_SUBCATEGORY_FLUIDS,
 	)
-	construction_time = 10 SECONDS
+	construction_time = 30 SECONDS
 
 // Chem dispenser that dispenses various flavored beverages and nutrislop, yum!
 

--- a/modular_nova/modules/colony_fabricator/code/design_datums/construction.dm
+++ b/modular_nova/modules/colony_fabricator/code/design_datums/construction.dm
@@ -36,7 +36,7 @@
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_CONSTRUCTION + FABRICATOR_SUBCATEGORY_STRUCTURES,
 	)
-	construction_time = 30 SECONDS
+	construction_time = 10 SECONDS
 
 // Manul Airlock kit
 
@@ -53,7 +53,7 @@
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_CONSTRUCTION + FABRICATOR_SUBCATEGORY_STRUCTURES,
 	)
-	construction_time = 30 SECONDS
+	construction_time = 5 SECONDS
 
 // Shutters kit
 
@@ -70,7 +70,7 @@
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_CONSTRUCTION + FABRICATOR_SUBCATEGORY_STRUCTURES,
 	)
-	construction_time = 30 SECONDS
+	construction_time = 10 SECONDS
 
 // Fancy floor tiles
 
@@ -86,7 +86,7 @@
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_CONSTRUCTION + FABRICATOR_SUBCATEGORY_STRUCTURES,
 	)
-	construction_time = 15 SECONDS
+	construction_time = 0.5 SECONDS
 
 // Fancy catwalk floor tiles
 
@@ -102,7 +102,7 @@
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_CONSTRUCTION + FABRICATOR_SUBCATEGORY_STRUCTURES,
 	)
-	construction_time = 15 SECONDS
+	construction_time = 0.5 SECONDS
 
 // Plastic wall panels, twice the wall for the same price in plastic, efficient!
 
@@ -119,6 +119,6 @@
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_CONSTRUCTION + FABRICATOR_SUBCATEGORY_STRUCTURES,
 	)
-	construction_time = 15 SECONDS
+	construction_time = 1 SECONDS
 
 #undef FABRICATOR_SUBCATEGORY_STRUCTURES

--- a/modular_nova/modules/colony_fabricator/code/design_datums/flatpack_machines.dm
+++ b/modular_nova/modules/colony_fabricator/code/design_datums/flatpack_machines.dm
@@ -51,7 +51,7 @@
 		RND_CATEGORY_INITIAL,
 		FABRICATOR_CATEGORY_FLATPACK_MACHINES + FABRICATOR_SUBCATEGORY_MANUFACTURING,
 	)
-	construction_time = 30 SECONDS
+	construction_time = 2 MINUTES
 
 // Solar panels and trackers
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The ration printer's on-table pixel shift has been lowered by 2 so it doesn't come up too far off the table.

The times of many colony fabricator designs have been changed to take into account the fact that lathes now actually take the entire time listed to print the item.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

The ration printer didn't look so good next to the other machines while shifted up so high.

Some items would take 1000 years to print when they didn't need to, and some things would be too short to print for what they give you.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

yeah

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The times that many colony lathe designs take to print have been changed to better reflect what the resulting items are
fix: Ration printers are no longer pixel shifted way too high up
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
