### PR TITLE
Custom say emote formatting fixes: no title case and trim whitespaces

### DIFF
--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -169,8 +169,8 @@
 		return message
 	if (is_banned_from(ckey, "Emote"))
 		return copytext(message, customsaypos + 1)
-	mods[MODE_CUSTOM_SAY_EMOTE] = copytext(message, 1, customsaypos)
-	message = copytext(message, customsaypos + 1)
+	mods[MODE_CUSTOM_SAY_EMOTE] = lowercase_title(copytext(message, 1, customsaypos)) // NOVA EDIT: ORIGINAL: mods[MODE_CUSTOM_SAY_EMOTE] = copytext(message, 1, customsaypos)
+	message = trim(copytext(message, customsaypos + 1)) //NOVA EDIT: ORIGINAL: message = copytext(message, customsaypos + 1)
 	if (!message)
 		mods[MODE_CUSTOM_SAY_ERASE_INPUT] = TRUE
 		message = "an interesting thing to say"

--- a/modular_nova/master_files/code/_globalvars/text.dm
+++ b/modular_nova/master_files/code/_globalvars/text.dm
@@ -7,3 +7,8 @@
 
 	input_text = replacetext(input_text, GLOB.noncapital_i, "I")
 	return input_text
+
+/// Ensures text does not start with capital letters.
+/proc/lowercase_title(input_text)
+	var/start = lowertext(input_text[1])
+	return start + copytext(input_text, 2, length(input_text)+1)


### PR DESCRIPTION
## About The Pull Request

Very simple PR: this adjusts custom say emote texts (IE: `confusedly asks* what the heck is up with airplane food?`) to be appropriately lowercased at the start and also trims any excess whitespace so that they don't have random spaces at the start.

Example before:
`Cybernetics Man Confusedly asks, " What the heck is up with airplane food?"`

Example after:
`Cybernetics man confusedly asks, "What the heck is up with airplane food?"`

## How This Contributes To The Nova Sector Roleplay Experience

Enhances readability (especially for ESL speakers who may rely more heavily on capitalization for proper noun context, etc) and is generally a silent improvement that shouldn't affect anybody's characterization in any way.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
https://github.com/NovaSector/NovaSector/assets/966289/473d49f9-90e8-4c8c-9e8d-80db1a402f7d

![dreamseeker_1vv9jBlnKL](https://github.com/NovaSector/NovaSector/assets/966289/f3228c2f-29f0-4db7-b82e-3e4e4cf94f46)

</details>

## Changelog

:cl: yooriss
fix: Custom say emotes now properly apply lowercase at the start where appropriate and also trim excess whitespace. Cleaner and easier for everyone!
/:cl: