### PR TITLE
Disable medical/security record deletion & mass purging

### DIFF
--- a/code/game/machinery/computer/records/records.dm
+++ b/code/game/machinery/computer/records/records.dm
@@ -40,6 +40,10 @@
 			return TRUE
 
 		if("expunge_record")
+			//NOVA EDIT BEGIN: disable record purging/expunging to stop people messing around with the AI effortlessly
+			balloon_alert(usr, "access denied!")
+			return TRUE
+			/*
 			if(!target)
 				return FALSE
 			// Don't let people off station futz with the station network.
@@ -53,6 +57,7 @@
 			investigate_log("[key_name(usr)] expunged the record of [target.name].", INVESTIGATE_RECORDS)
 
 			return TRUE
+			*/
 
 		if("login")
 			authenticated = secure_login(usr)
@@ -67,6 +72,10 @@
 
 		if("purge_records")
 			// Don't let people off station futz with the station network.
+			//NOVA EDIT BEGIN: disable record purging/expunging to stop people messing around with the AI effortlessly
+			balloon_alert(usr, "access denied!")
+			return TRUE
+			/*
 			if(!is_station_level(z))
 				balloon_alert(usr, "out of range!")
 				return TRUE
@@ -86,6 +95,8 @@
 				balloon_alert(usr, "interrupted!")
 
 			return TRUE
+			*/
+			//NOVA EDIT END
 
 		if("view_record")
 			if(!target)


### PR DESCRIPTION
## About The Pull Request

At the moment, anyone with access to a security or medical records console/laptop can completely change the course of the round by clicking the 'purge' records button. This deletes *all* records and wipes the crew manifest. There is no real counterplay. These consoles are often not guarded and are in many cases, strewn throughout maintenance in laptop form in decent numbers.

No less than four times in the past month, I've been personally playing in rounds where the silicon players immediately interpret that the absence of records means the crew is suddenly not crew anymore. Deleting everyone's records can be done by a dozen or more players each round, every cyborg, every AI, and anyone who otherwise comes into possession of a medical/sec ID or just a laptop somebody forgot to log out of.

I've asked three people about whether silicons are even allowed to act on a cleared manifest as a matter of policy and have received three different answers. In light of all the confusion, I present the nuclear option: disabling it entirely.

## How This Contributes To The Nova Sector Roleplay Experience

Prevents clicking one button in a UI console potentially setting all silicon players into quasi-antagonist status with the remainder of the crew.

## Proof of Testing

It compiles.

## Changelog

:cl: yooriss
del: Security and medical records can no longer be expunged or mass-purged from their respective consoles.
/:cl:
