### PR TITLE
Allows Spraypainting Synth Limbs | Also moves their ears

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -936,7 +936,7 @@
 		var/obj/item/bodypart/limb = target
 		if(!IS_ORGANIC_LIMB(limb))
 			var/list/skins = list()
-			var/static/list/style_list_icons = list("standard" = 'icons/mob/augmentation/augments.dmi', "engineer" = 'icons/mob/augmentation/augments_engineer.dmi', "security" = 'icons/mob/augmentation/augments_security.dmi', "mining" = 'icons/mob/augmentation/augments_mining.dmi')
+			var/static/list/style_list_icons = GLOB.robotic_styles_list //NOVA EDIT CHANGE - Original: var/static/list/style_list_icons = list("standard" = 'icons/mob/augmentation/augments.dmi', "engineer" = 'icons/mob/augmentation/augments_engineer.dmi', "security" = 'icons/mob/augmentation/augments_security.dmi', "mining" = 'icons/mob/augmentation/augments_mining.dmi')
 			for(var/skin_option in style_list_icons)
 				var/image/part_image = image(icon = style_list_icons[skin_option], icon_state = "[limb.limb_id]_[limb.body_zone]")
 				if(limb.aux_zone) //Hands

--- a/modular_nova/modules/synths/code/bodyparts/ears.dm
+++ b/modular_nova/modules/synths/code/bodyparts/ears.dm
@@ -2,8 +2,8 @@
 	name = "auditory sensors"
 	icon = 'modular_nova/master_files/icons/obj/surgery.dmi'
 	icon_state = "ears-ipc"
-	desc = "A pair of microphones intended to be installed in an IPC or Synthetics head, that grant the ability to hear."
-	zone = BODY_ZONE_HEAD
+	desc = "A pair of microphones intended to be installed inside a machine's chassis, that grant the ability to hear."
+	zone = BODY_ZONE_CHEST
 	slot = ORGAN_SLOT_EARS
 	gender = PLURAL
 	maxHealth = 1 * STANDARD_ORGAN_THRESHOLD


### PR DESCRIPTION
## About The Pull Request
How's it going.
Did you know? /tg/ has code to where you can right click a prosthetic limb and have it change into other varieties of limb instead of the NPC grey one. Unfortunately, this did not include our modular ones.
![image](https://github.com/NovaSector/NovaSector/assets/12636964/3c41efa7-0e64-4a56-84d3-d82849ce2622)
It now does, through the power of our lord Glob. This does not include the human-looking ones, please give me a shout if you know how we can accomplish this. Or maybe it's flavor.

Additionally, I've moved the default synth ears to their chest. This is to allow it so that if they have their head removed (by some small fucking miracle, by shears, or by that new quirk we added,) they can still hear.
![image](https://github.com/NovaSector/NovaSector/assets/12636964/30ad2354-84cd-4fb0-9aa8-a33fb7e32171)

## How This Contributes To The Nova Sector Roleplay Experience
It's kind of wack to need an entire SAD just to get an arm that looks like yours back. I'd love the opportunity to ask patients what model of prosthetic they want.

Additionally, hearing is the most important part of actually being able to roleplay. Sight's kinda optional, but hearing's vital.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
 In the description as usual.
</details>

## Changelog
:cl:
add: To cope with a number of recent audio and recording issues and to provide structural stability and insulation, mechanists across the Orion Spur have began installing their client's auditory sensors and microphones in their chests, rather than their heads.
add: Mechanists have also began switching to a more refined spraypainting process, to allow a wider variety of designs for prosthetic limbs.
/:cl:
