### PR TITLE
I Cooka Da Pizza: Void Raptor Kitchen tweaks

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -699,13 +699,13 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/science/xenobiology)
 "ajR" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sink/directional/west,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/green/diagonal_centre,
+/obj/structure/cable,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
 "ajT" = (
@@ -946,8 +946,11 @@
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/cmo)
 "anP" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/deepfryer,
+/obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "anW" = (
@@ -3401,15 +3404,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "aXm" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/service/general,
+/obj/effect/turf_decal/tile/green/diagonal_centre,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/service/glass{
-	name = "Service Hall"
-	},
-/turf/open/floor/iron/large,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
 "aXr" = (
 /obj/structure/table/wood,
@@ -4209,10 +4211,14 @@
 /turf/open/floor/plating,
 /area/station/security/warden)
 "bkq" = (
-/obj/effect/landmark/start/cook,
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/secondary/service)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sink/kitchen/directional/east{
+	pixel_x = -19
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/hallway/primary/fore)
 "bkr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/start/bartender,
@@ -4760,13 +4766,11 @@
 	},
 /area/station/hallway/primary/central)
 "btx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/secondary/service)
+/obj/structure/flora/bush/fullgrass,
+/obj/structure/flora/bush/ferny,
+/obj/structure/window/fulltile,
+/turf/open/floor/grass,
+/area/station/service/kitchen)
 "btY" = (
 /obj/structure/table/glass,
 /obj/item/folder/white{
@@ -5886,6 +5890,11 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "bMJ" = (
@@ -6076,10 +6085,18 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/construction/mining/aux_base)
 "bOI" = (
-/obj/effect/landmark/start/hangover,
-/obj/structure/chair/stool/directional/north,
+/obj/structure/table,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/structure/displaycase/forsale/kitchen{
+	pixel_y = 8
+	},
 /turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
+/area/station/service/kitchen)
 "bOJ" = (
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
@@ -6264,16 +6281,15 @@
 	},
 /area/station/engineering/atmos)
 "bRS" = (
+/obj/structure/table,
 /obj/machinery/requests_console/directional/west{
 	department = "Kitchen";
 	name = "Kitchen Requests Console"
 	},
-/obj/structure/table,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "kitchen_counter";
-	name = "Kitchen Counter Shutters"
+/obj/machinery/microwave{
+	desc = "Cooks and boils stuff, somehow.";
+	pixel_x = -2;
+	pixel_y = 5
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
@@ -7606,19 +7622,35 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "coC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/sink/kitchen/directional/east{
-	pixel_x = -19
-	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/cook,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "coJ" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/chem_master/condimaster{
-	name = "CondiMaster Neo";
-	pixel_x = 7
+/obj/structure/table,
+/obj/item/reagent_containers/condiment/saltshaker{
+	desc = "Salt. From space oceans, presumably. A staple of modern medicine.";
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets/donkpocketpizza{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/storage/box/donkpockets/donkpocketteriyaki{
+	pixel_x = 5;
+	pixel_y = 9
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
@@ -9004,12 +9036,14 @@
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 9
 	},
-/obj/machinery/firealarm/directional/north{
-	pixel_x = -6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/light_switch/directional/north{
+	pixel_x = 14
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "cIZ" = (
@@ -11873,6 +11907,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green/diagonal_centre,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
 "dAz" = (
@@ -14211,12 +14248,16 @@
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/fore)
 "eeS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/effect/turf_decal/tile/green/diagonal_centre,
+/obj/machinery/status_display/ai/directional/west,
+/obj/structure/table,
+/obj/machinery/fax{
+	fax_name = "Service Hallway";
+	name = "Service Fax Machine";
+	pixel_y = 3
 	},
-/turf/open/floor/iron/kitchen,
-/area/station/service/kitchen)
+/turf/open/floor/iron/diagonal,
+/area/station/hallway/secondary/service)
 "eeX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -14516,8 +14557,8 @@
 /turf/open/floor/pod/dark,
 /area/station/service/chapel)
 "eil" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/machinery/chem_mass_spec,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/freezer,
 /area/station/medical/pharmacy)
 "ein" = (
@@ -14701,8 +14742,6 @@
 /area/station/command/bridge)
 "ekG" = (
 /obj/structure/table,
-/obj/item/plate,
-/obj/item/food/sausage,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "ekQ" = (
@@ -14779,12 +14818,12 @@
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai)
 "ely" = (
-/obj/machinery/gibber,
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/light/cold/directional/east,
+/obj/machinery/gibber,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "elB" = (
@@ -15268,11 +15307,21 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/bridge)
 "esZ" = (
-/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/service/general,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/door/airlock/service/glass{
+	name = "Service Hall"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/large,
 /area/station/service/cafeteria)
 "etd" = (
 /obj/structure/cable,
@@ -15979,12 +16028,9 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/station/security/execution/transfer)
 "eEd" = (
-/obj/machinery/modular_computer/preset/cargochat/service,
 /obj/structure/sign/poster/random/directional/north,
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/turf_decal/trimline/brown/filled/mid_joiner,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/large,
 /area/station/hallway/secondary/service)
 "eEi" = (
 /obj/effect/turf_decal/tile/dark_red/anticorner,
@@ -16270,35 +16316,20 @@
 /turf/open/floor/iron/smooth_edge,
 /area/station/cargo/storage)
 "eGy" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/structure/window/spawner/directional/east,
-/obj/machinery/door/window/left/directional/north{
-	name = "Kitchen Window";
-	req_access = list("kitchen")
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen_service";
-	name = "Service Shutter"
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/item/paper_bin{
-	pixel_y = 4
-	},
-/obj/item/pen{
-	pixel_y = 4
-	},
-/turf/open/floor/iron/large,
+/obj/structure/fake_stairs/directional/north,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "eGT" = (
 /obj/effect/turf_decal/weather/snow,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
 /obj/machinery/firealarm/directional/north,
-/obj/machinery/light_switch/directional/west{
-	pixel_x = -24
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
@@ -17460,14 +17491,15 @@
 /turf/open/floor/iron/smooth,
 /area/station/command/cc_dock)
 "eYX" = (
-/obj/structure/chair/sofa/corp/right{
-	color = "#DE3A3A";
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "eYY" = (
@@ -18346,19 +18378,17 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "foi" = (
-/obj/structure/chair/sofa/corp/corner{
-	color = "#DE3A3A";
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/railing/corner{
 	dir = 8
 	},
-/obj/machinery/status_display/ai/directional/east,
-/obj/item/radio/intercom/directional/south{
-	pixel_x = 4
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
 	},
-/obj/machinery/light_switch/directional/south{
-	pixel_x = -9
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "fok" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
@@ -18806,10 +18836,19 @@
 /area/station/maintenance/department/crew_quarters/bar)
 "fva" = (
 /obj/structure/table,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -2;
-	pixel_y = 5
+/obj/item/reagent_containers/condiment/saltshaker{
+	desc = "Salt. From space oceans, presumably. A staple of modern medicine.";
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/effect/spawner/random/food_or_drink/cake_ingredients,
+/obj/item/kitchen/rollingpin{
+	pixel_x = -4
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
@@ -18962,10 +19001,15 @@
 /turf/open/floor/iron/grimy,
 /area/station/commons/lounge)
 "fxo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
+/obj/structure/table,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/turf/open/floor/iron/large,
+/area/station/service/kitchen)
 "fxD" = (
 /obj/structure/sign/warning/chem_diamond/directional/north,
 /obj/structure/rack/shelf,
@@ -19826,17 +19870,20 @@
 	},
 /area/station/cargo/storage)
 "fMm" = (
-/obj/structure/table,
-/obj/structure/displaycase/forsale/kitchen{
-	pixel_y = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
+/obj/machinery/button/door/directional/south{
 	id = "kitchen_counter";
-	name = "Kitchen Counter Shutters"
+	name = "Counter Shutters Control"
 	},
-/turf/open/floor/iron/large,
+/obj/structure/table,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/processor{
+	pixel_y = 12
+	},
+/obj/item/holosign_creator/robot_seat/restaurant,
+/obj/structure/railing,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "fMy" = (
 /obj/structure/cable,
@@ -20602,11 +20649,15 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/electrical)
 "fZg" = (
-/obj/effect/turf_decal/loading_area{
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner,
+/obj/machinery/computer/department_orders/service,
+/turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/service)
 "fZo" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
@@ -22082,16 +22133,17 @@
 /turf/open/floor/iron/small,
 /area/station/hallway/secondary/exit/departure_lounge)
 "gtJ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 10
+/obj/effect/turf_decal/bot,
+/obj/structure/disposaloutlet{
+	dir = 4;
+	name = "Cargo Deliveries"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/mid_joiner,
-/obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/computer/order_console/cook,
-/turf/open/floor/iron/smooth_large,
+/obj/structure/window/spawner/directional/west,
+/obj/structure/window/spawner/directional/south,
+/turf/open/floor/iron/large,
 /area/station/hallway/secondary/service)
 "gtM" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -22446,6 +22498,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "gzn" = (
@@ -22913,13 +22969,9 @@
 /turf/open/floor/carpet,
 /area/station/service/library)
 "gFG" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/mob/living/basic/goat/pete,
 /obj/effect/turf_decal/weather/snow,
+/mob/living/basic/goat/pete,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "gFW" = (
@@ -23128,11 +23180,10 @@
 /area/station/security/brig)
 "gIO" = (
 /obj/effect/turf_decal/weather/snow,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 1
-	},
 /obj/effect/landmark/event_spawn,
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "gIT" = (
@@ -23525,16 +23576,11 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/engine/atmos)
 "gOj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/freezer{
-	critical_machine = 1;
-	name = "Coldroom"
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/structure/fans/tiny,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/turf/closed/wall,
+/area/station/service/kitchen)
 "gOn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -25421,6 +25467,11 @@
 /area/station/maintenance/starboard/greater)
 "hqe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/cook,
+/obj/structure/railing/corner,
+/obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "hqf" = (
@@ -26280,7 +26331,11 @@
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/hop)
 "hBP" = (
-/turf/closed/wall,
+/obj/effect/turf_decal/tile/green/diagonal_centre,
+/obj/machinery/light_switch/directional/west,
+/obj/machinery/light/directional/west,
+/obj/machinery/icecream_vat,
+/turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
 "hBQ" = (
 /obj/structure/lattice/catwalk,
@@ -26546,9 +26601,10 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/aft)
 "hEN" = (
-/obj/effect/landmark/start/bouncer,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/window/fulltile,
+/turf/open/floor/grass,
+/area/station/service/kitchen)
 "hER" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -26585,14 +26641,19 @@
 /turf/open/floor/glass/reinforced,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hFu" = (
-/obj/effect/turf_decal/bot,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Service - Service Hall";
 	dir = 9;
 	name = "service camera"
 	},
-/turf/open/floor/iron/large,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner,
+/obj/machinery/modular_computer/preset/cargochat/service,
+/turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/service)
 "hFA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -27550,9 +27611,15 @@
 	},
 /area/station/engineering/atmos)
 "hUv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/structure/chair/stool/directional/west{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "hUD" = (
@@ -28756,16 +28823,17 @@
 /area/station/maintenance/starboard/fore)
 "iog" = (
 /obj/structure/table,
-/obj/effect/spawner/random/food_or_drink/cake_ingredients,
+/obj/machinery/reagentgrinder{
+	pixel_x = 4;
+	pixel_y = 18
+	},
 /obj/item/reagent_containers/condiment/enzyme{
 	pixel_x = -10;
 	pixel_y = 18
 	},
-/obj/item/kitchen/rollingpin{
-	pixel_x = 4
-	},
 /obj/item/reagent_containers/cup/beaker{
-	pixel_x = 5
+	pixel_x = -8;
+	pixel_y = 7
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
@@ -29225,18 +29293,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "itf" = (
-/obj/machinery/computer/department_orders/service,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/brown/filled/mid_joiner,
-/obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
-	dir = 4
-	},
 /obj/structure/noticeboard/directional/north,
 /obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron/smooth_large,
+/obj/structure/window/spawner/directional/west{
+	dir = 4
+	},
+/turf/open/floor/iron/large,
 /area/station/hallway/secondary/service)
 "iti" = (
 /obj/structure/table/wood,
@@ -29466,33 +29529,16 @@
 /turf/open/floor/grass,
 /area/station/command/heads_quarters/hos)
 "ivZ" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 5;
-	pixel_y = 3
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/storage/box/donkpockets/donkpocketpizza{
-	pixel_x = 5;
-	pixel_y = 6
+/obj/structure/railing{
+	dir = 4
 	},
-/obj/item/storage/box/donkpockets/donkpocketteriyaki{
-	pixel_x = 5;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/condiment/saltshaker{
-	desc = "Salt. From space oceans, presumably. A staple of modern medicine.";
-	pixel_x = -8;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/knife/kitchen{
-	pixel_x = -13;
-	pixel_y = 3
-	},
+/obj/structure/fake_stairs/directional/north,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "iwe" = (
@@ -30336,8 +30382,12 @@
 /area/station/security/prison)
 "iIG" = (
 /obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/box,
-/obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/structure/table,
+/obj/machinery/microwave{
+	desc = "Cooks and boils stuff, somehow.";
+	pixel_x = -2;
+	pixel_y = 5
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "iJg" = (
@@ -30382,15 +30432,11 @@
 	},
 /area/station/engineering/atmos)
 "iJt" = (
-/obj/machinery/light_switch/directional/south{
-	pixel_x = -15
-	},
 /obj/machinery/firealarm/directional/east,
-/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/vending/dinnerware,
 /obj/item/toy/figure/chef{
 	pixel_y = 16
 	},
-/obj/machinery/vending/dinnerware,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "iJB" = (
@@ -31060,18 +31106,11 @@
 /turf/open/floor/iron/grimy,
 /area/station/commons/lounge)
 "iUy" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/disposaloutlet{
-	dir = 4;
-	name = "Cargo Deliveries"
-	},
-/obj/structure/window/spawner/directional/west,
-/obj/structure/window/spawner/directional/south,
-/turf/open/floor/iron/large,
-/area/station/hallway/secondary/service)
+/turf/closed/wall,
+/area/station/service/kitchen)
 "iUz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -31762,10 +31801,12 @@
 "jdH" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/obj/machinery/griddle{
-	pixel_x = 4
-	},
 /obj/machinery/light/directional/north,
+/obj/structure/table,
+/obj/machinery/light_switch/directional/north{
+	pixel_y = 23;
+	pixel_x = 13
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "jdN" = (
@@ -33697,16 +33738,12 @@
 /area/station/maintenance/starboard/greater)
 "jDX" = (
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/weather/snow,
 /obj/machinery/door/window/right/directional/west{
 	name = "Kitchen Deliveries";
 	req_access = list("kitchen")
 	},
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "jDY" = (
@@ -34843,9 +34880,6 @@
 	},
 /area/station/command/gateway)
 "jUL" = (
-/obj/structure/chair/sofa/corp/left{
-	color = "#DE3A3A"
-	},
 /obj/machinery/light/warm/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Service - Cafeteria Fore";
@@ -34857,6 +34891,9 @@
 /obj/item/radio/intercom/directional/north{
 	pixel_x = -6
 	},
+/obj/structure/table,
+/obj/item/plate,
+/obj/item/food/sausage,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "jUZ" = (
@@ -36256,9 +36293,19 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "koZ" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/machinery/pollution_scrubber{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/obj/structure/table,
+/turf/open/floor/iron/large,
+/area/station/service/kitchen)
 "kpg" = (
 /obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
 /obj/structure/disposalpipe/segment{
@@ -37910,25 +37957,13 @@
 	},
 /area/station/science/xenobiology)
 "kKA" = (
-/obj/structure/table,
-/obj/machinery/door/firedoor,
-/obj/structure/desk_bell{
-	pixel_x = -7;
-	pixel_y = 9
+/obj/structure/chair/sofa/corp/right{
+	color = "#DE3A3A";
+	dir = 4
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "kitchen_counter";
-	name = "Kitchen Counter Shutters"
-	},
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = 3
-	},
-/turf/open/floor/iron/large,
-/area/station/service/kitchen)
+/obj/structure/window/spawner/directional/west,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/cafeteria)
 "kKC" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate/freezer{
@@ -39612,10 +39647,8 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/storage)
 "liO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/cook,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "liS" = (
@@ -39729,7 +39762,7 @@
 "lkz" = (
 /obj/structure/chair/sofa/corp/left{
 	color = "#DE3A3A";
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
@@ -41362,15 +41395,11 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "lHd" = (
-/obj/structure/chair/sofa/corp/right{
-	color = "#DE3A3A";
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
+/obj/effect/landmark/start/cook,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "lHf" = (
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 1
@@ -43552,11 +43581,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light_switch/directional/north{
-	pixel_x = -14
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -44833,9 +44858,16 @@
 /turf/open/floor/wood,
 /area/station/maintenance/rus_gambling)
 "mFX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/cook,
+/obj/structure/table,
+/obj/item/plate/large,
+/obj/item/plate,
+/obj/item/plate/small{
+	pixel_y = 1
+	},
+/obj/item/knife/butcher{
+	pixel_x = 5
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "mGv" = (
@@ -45943,13 +45975,13 @@
 /area/station/engineering/atmos)
 "mVt" = (
 /obj/effect/turf_decal/weather/snow,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom{
-	dir = 4
+/obj/machinery/camera/directional/west{
+	c_tag = "Service - Kitchen Coldroom";
+	dir = 10;
+	name = "service camera"
 	},
-/obj/item/wrench{
-	pixel_x = -3;
-	pixel_y = -3
-	},
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "mVv" = (
@@ -48076,10 +48108,10 @@
 /turf/open/floor/iron/smooth_edge,
 /area/station/engineering/atmos)
 "nzv" = (
-/obj/structure/cable,
-/obj/machinery/griddle,
-/turf/open/floor/iron/kitchen,
-/area/station/service/kitchen)
+/obj/structure/flora/bush/jungle,
+/obj/structure/window/fulltile,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "nzw" = (
 /obj/structure/rack,
 /obj/item/poster/random_contraband,
@@ -48855,11 +48887,8 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "nMk" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_x = 8;
-	pixel_y = 6
-	},
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "nMr" = (
@@ -48976,8 +49005,7 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/drone_bay)
 "nNS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/cook,
+/obj/machinery/deepfryer,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "nOq" = (
@@ -49298,14 +49326,9 @@
 /area/station/science/xenobiology)
 "nRy" = (
 /obj/effect/turf_decal/weather/snow,
-/obj/machinery/icecream_vat,
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/obj/machinery/camera/directional/west{
-	c_tag = "Service - Kitchen Coldroom";
-	dir = 10;
-	name = "service camera"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "nRz" = (
@@ -49529,21 +49552,13 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/fitness/recreation/entertainment)
 "nTI" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/light_switch/directional/west,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/fax{
-	fax_name = "Service Hallway";
-	name = "Service Fax Machine";
-	pixel_y = 3
-	},
 /obj/effect/turf_decal/tile/green/diagonal_centre,
-/obj/machinery/light/directional/west,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
 "nTS" = (
@@ -49627,15 +49642,17 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "nUo" = (
-/obj/structure/chair/sofa/corp/left{
-	color = "#DE3A3A";
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/freezer{
+	critical_machine = 1;
+	name = "Coldroom"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/structure/fans/tiny,
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "nUy" = (
 /obj/effect/turf_decal/trimline/green/filled/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49960,8 +49977,18 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "nYG" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/large,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/computer/order_console/cook,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner,
+/turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/service)
 "nYI" = (
 /obj/effect/landmark/secequipment,
@@ -50105,6 +50132,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sink/directional/south,
 /obj/effect/turf_decal/siding/green,
+/obj/machinery/firealarm/directional/north{
+	pixel_x = -6
+	},
 /turf/open/floor/iron/edge,
 /area/station/service/hydroponics)
 "ocb" = (
@@ -50178,9 +50208,19 @@
 	},
 /area/station/medical/surgery)
 "ocK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/box,
-/obj/machinery/holopad,
+/obj/machinery/reagentgrinder{
+	pixel_x = -4;
+	pixel_y = 18
+	},
+/obj/item/reagent_containers/condiment/enzyme{
+	pixel_x = 10;
+	pixel_y = 18
+	},
+/obj/item/reagent_containers/cup/beaker{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/structure/table,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "ocV" = (
@@ -50767,12 +50807,19 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/greater)
 "olm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/event_spawn,
+/obj/structure/table,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/structure/desk_bell{
+	pixel_x = 7;
+	pixel_y = 10
+	},
 /turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
+/area/station/service/kitchen)
 "olo" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -50805,7 +50852,6 @@
 /turf/open/floor/wood/parquet,
 /area/station/common/night_club)
 "olG" = (
-/obj/machinery/status_display/ai/directional/west,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/green/diagonal_centre,
 /turf/open/floor/iron/diagonal,
@@ -54004,18 +54050,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "pei" = (
-/obj/structure/table,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "kitchen_counter";
-	name = "Kitchen Counter Shutters"
-	},
-/obj/item/storage/box/papersack{
-	icon_state = "paperbag_NanotrasenStandard_closed";
-	pixel_y = 4
-	},
-/turf/open/floor/iron/large,
+/obj/effect/landmark/start/cook,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "pep" = (
 /obj/structure/table/glass,
@@ -56928,26 +56964,14 @@
 /turf/open/floor/wood/large,
 /area/station/commons/fitness/recreation)
 "pUt" = (
-/obj/structure/table,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/serviette_pack{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/structure/sink/kitchen/directional/west{
+	pixel_x = 19
 	},
-/obj/item/reagent_containers/condiment/saltshaker{
-	desc = "Salt. From space oceans, presumably. A staple of modern medicine.";
-	pixel_x = -8;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/hallway/primary/fore)
 "pUu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58595,18 +58619,27 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/starboard/lesser)
 "qor" = (
+/obj/item/plate/oven_tray{
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/obj/item/plate/oven_tray{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/apron/chef{
+	pixel_y = 11
+	},
+/obj/item/book/manual/wiki/cooking_to_serve_man{
+	pixel_x = 3;
+	pixel_y = 2
+	},
 /obj/structure/table,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "kitchen_counter";
-	name = "Kitchen Counter Shutters"
+/obj/item/knife/kitchen{
+	pixel_x = -13;
+	pixel_y = 3
 	},
-/obj/machinery/pollution_scrubber{
-	pixel_x = -7;
-	pixel_y = -4
-	},
-/turf/open/floor/iron/large,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "qoE" = (
 /obj/machinery/digital_clock{
@@ -59141,8 +59174,12 @@
 /turf/open/floor/wood/parquet,
 /area/station/common/night_club)
 "qwy" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
+/obj/structure/chair/stool/directional/west{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "qwH" = (
@@ -59431,9 +59468,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/fore)
 "qAn" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
 /obj/effect/turf_decal/weather/snow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -63382,10 +63416,9 @@
 /turf/open/floor/iron/freezer,
 /area/station/command/heads_quarters/captain/private)
 "rGx" = (
-/obj/machinery/button/door/directional/south{
-	id = "kitchen_counter";
-	name = "Counter Shutters Control"
-	},
+/obj/structure/railing/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark/corner,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "rGH" = (
@@ -64147,8 +64180,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "rSO" = (
-/obj/structure/table,
-/obj/item/plate,
+/obj/structure/chair/sofa/corp/right{
+	color = "#DE3A3A";
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "rSZ" = (
@@ -64709,13 +64745,14 @@
 /area/station/commons/lounge)
 "sbx" = (
 /obj/machinery/airalarm/directional/north,
-/obj/structure/chair/sofa/corp/corner{
-	color = "#DE3A3A";
-	dir = 4
-	},
 /obj/effect/landmark/start/assistant,
 /obj/machinery/light_switch/directional/north{
 	pixel_x = 13
+	},
+/obj/structure/window/spawner/directional/west,
+/obj/structure/chair/sofa/corp/left{
+	color = "#DE3A3A";
+	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
@@ -65088,11 +65125,11 @@
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/science/research)
 "sha" = (
-/obj/machinery/light/warm/directional/east,
-/obj/machinery/status_display/evac/directional/east,
-/obj/structure/chair/stool/directional/north,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/station/service/kitchen)
 "shd" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -65834,15 +65871,11 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/research)
 "ssw" = (
-/obj/machinery/biogenerator,
 /obj/machinery/door/firedoor,
-/obj/structure/window/spawner/directional/east,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id = "hydroponics_counter";
-	name = "Hydroponics Counter Shutters"
+/obj/machinery/door/airlock/hydroponics/glass{
+	name = "Hydroponics"
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /turf/open/floor/iron/large,
 /area/station/service/hydroponics)
 "ssL" = (
@@ -67102,13 +67135,10 @@
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/fore)
 "sJb" = (
-/obj/structure/kitchenspike,
 /obj/effect/turf_decal/weather/snow,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/tlv_cold_room,
+/obj/structure/kitchenspike,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "sJd" = (
@@ -68709,15 +68739,30 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "tdO" = (
+/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hydroponics/glass{
-	name = "Hydroponics"
+/obj/item/paper_bin{
+	pixel_y = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/item/pen{
+	pixel_y = 4
+	},
+/obj/structure/window/spawner/directional/east{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/window/left/directional/south{
+	name = "Hydroponics Desk";
+	req_access = list("hydroponics")
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id = "hydroponics_counter";
+	name = "Hydroponics Counter Shutters"
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/large,
 /area/station/service/hydroponics)
 "tdY" = (
@@ -68922,10 +68967,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/south,
-/obj/machinery/camera{
-	c_tag = "Service - Kitchen";
-	name = "service camera"
-	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "tgQ" = (
@@ -69090,25 +69131,16 @@
 	},
 /area/station/hallway/primary/central/aft)
 "tiJ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/paper_bin{
-	pixel_y = 4
-	},
-/obj/item/pen{
-	pixel_y = 4
-	},
-/obj/structure/window/spawner/directional/east,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/window/left/directional/south{
-	name = "Hydroponics Desk";
-	req_access = list("hydroponics")
-	},
+/obj/machinery/biogenerator,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
 	id = "hydroponics_counter";
 	name = "Hydroponics Counter Shutters"
 	},
+/obj/machinery/door/firedoor,
+/obj/structure/window/spawner/directional/east,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/large,
 /area/station/service/hydroponics)
 "tiL" = (
@@ -69151,14 +69183,13 @@
 /turf/open/floor/iron/large,
 /area/station/commons/fitness/recreation)
 "tja" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/weather/snow,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/machinery/light_switch/directional/west{
+	pixel_x = -24
 	},
+/obj/structure/cable,
+/obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "tjr" = (
@@ -69276,9 +69307,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "tlk" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/plasticflaps/opaque{
 	name = "Kitchen Deliveries"
@@ -69288,6 +69316,7 @@
 	location = "Kitchen"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/large,
 /area/station/maintenance/starboard/greater)
 "tlq" = (
@@ -70991,8 +71020,7 @@
 /turf/open/floor/vault,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
 "tGD" = (
-/obj/effect/turf_decal/box,
-/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/machinery/griddle,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "tGJ" = (
@@ -71431,10 +71459,15 @@
 /turf/open/floor/iron/white/diagonal,
 /area/station/science/research)
 "tNI" = (
-/obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/secondary/service)
+/obj/structure/chair/stool/directional/west{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/commons/lounge)
 "tNN" = (
 /obj/structure/window/spawner/directional/east,
 /turf/open/floor/grass,
@@ -71726,15 +71759,13 @@
 	},
 /area/station/hallway/secondary/command)
 "tSE" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/secondary/service)
+/obj/structure/flora/bush/jungle/a/style_3,
+/obj/structure/window/fulltile,
+/turf/open/floor/grass,
+/area/station/service/kitchen)
 "tSH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/green{
@@ -71789,18 +71820,11 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay/central)
 "tTC" = (
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "kitchen_counter";
-	name = "Kitchen Counter Shutters"
+/obj/structure/railing/corner,
+/obj/structure/sink/kitchen/directional/west{
+	pixel_x = 18
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/pollution_scrubber{
-	pixel_x = 14;
-	pixel_y = -4
-	},
-/turf/open/floor/iron/large,
+/turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "tTI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -71868,8 +71892,8 @@
 /area/station/hallway/primary/fore)
 "tUw" = (
 /obj/effect/turf_decal/weather/snow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/hidden,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/sink/kitchen/directional/north,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "tUB" = (
@@ -72076,15 +72100,22 @@
 /turf/open/floor/iron/freezer,
 /area/station/medical/chemistry)
 "tZu" = (
-/obj/structure/table,
-/obj/item/plate/large,
-/obj/item/plate,
-/obj/item/plate/small{
-	pixel_y = 1
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/item/knife/butcher{
-	pixel_x = 13;
-	pixel_y = 3
+/obj/effect/turf_decal/box,
+/obj/machinery/camera{
+	c_tag = "Service - Kitchen";
+	name = "service camera";
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
@@ -76775,10 +76806,9 @@
 	},
 /area/station/science/genetics)
 "vmS" = (
-/obj/structure/chair/stool/directional/east,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
+/obj/structure/sign/poster/contraband/mothic_rations,
+/turf/closed/wall,
+/area/station/service/kitchen)
 "vmX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock{
@@ -79507,7 +79537,6 @@
 /area/station/security/brig)
 "vZc" = (
 /obj/structure/cable,
-/obj/effect/landmark/start/cook,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "vZk" = (
@@ -80087,9 +80116,7 @@
 /area/station/service/chapel)
 "whq" = (
 /obj/structure/table,
-/obj/machinery/processor{
-	pixel_y = 12
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "whu" = (
@@ -80525,6 +80552,21 @@
 "woE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/structure/table,
+/obj/item/serviette_pack{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	desc = "Salt. From space oceans, presumably. A staple of modern medicine.";
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = -8;
+	pixel_y = 2
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
@@ -81130,6 +81172,7 @@
 /obj/structure/closet/secure_closet/chemical,
 /obj/item/storage/box/syringes,
 /obj/item/storage/box/beakers,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/freezer,
 /area/station/medical/pharmacy)
 "wwA" = (
@@ -82698,12 +82741,8 @@
 	},
 /area/station/service/hydroponics/garden)
 "wQw" = (
-/obj/structure/kitchenspike,
 /obj/effect/turf_decal/weather/snow,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/sink/kitchen/directional/west,
+/obj/structure/kitchenspike,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "wQx" = (
@@ -83436,7 +83475,7 @@
 	},
 /obj/structure/chair/sofa/corp/left{
 	color = "#DE3A3A";
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
@@ -85076,21 +85115,15 @@
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "xDK" = (
-/obj/structure/table,
-/obj/item/plate/oven_tray{
-	pixel_x = -2;
-	pixel_y = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/plate/oven_tray{
-	pixel_x = -2;
-	pixel_y = 3
+/obj/machinery/chem_master/condimaster,
+/obj/structure/railing{
+	dir = 6
 	},
-/obj/item/clothing/suit/apron/chef{
-	pixel_y = 11
-	},
-/obj/item/book/manual/wiki/cooking_to_serve_man{
-	pixel_x = 3;
-	pixel_y = 2
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
@@ -86247,11 +86280,15 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/medical/morgue)
 "xUG" = (
-/obj/structure/chair/stool/directional/east,
-/obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/structure/table,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "xUK" = (
 /obj/structure/disposaloutlet{
 	dir = 1;
@@ -87171,18 +87208,6 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"yjs" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/landmark/event_spawn,
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/box,
-/obj/structure/sink/kitchen/directional/west{
-	pixel_x = 19
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/service/kitchen)
 "yjw" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/stairs/left{
@@ -118828,7 +118853,7 @@ oUR
 lnS
 cHc
 waR
-sgE
+tNI
 nmm
 sgE
 pEL
@@ -119382,7 +119407,7 @@ aAN
 gut
 nXW
 sLk
-sUt
+ayp
 kny
 nXW
 nhR
@@ -119896,7 +119921,7 @@ sCO
 hGE
 gQm
 fft
-ayp
+sUt
 daB
 mYW
 kyV
@@ -121399,11 +121424,11 @@ qSu
 rUj
 bPZ
 sbx
-anI
+kKA
 lxC
 cnA
-nUo
-anI
+rUb
+kLz
 uPO
 fHc
 pYI
@@ -121659,8 +121684,8 @@ jUL
 ekG
 kLz
 cnA
-pUt
-gOt
+rUb
+kLz
 kLz
 bNy
 bhD
@@ -121912,13 +121937,13 @@ wAA
 mDP
 cau
 cau
-hEN
-hUv
 qwy
-cnA
+qwy
+qwy
+hUv
 eYX
 lkz
-kLz
+anI
 rUb
 qQh
 fVT
@@ -122165,17 +122190,17 @@ qLY
 mMs
 vDG
 qAl
-bPZ
-bPZ
-cau
+jSC
+jSC
+btx
 koZ
-vmS
+tdn
 xUG
 fxo
 olm
 gyK
 woE
-kLz
+gOt
 vyb
 kPh
 ooa
@@ -122425,9 +122450,9 @@ lcT
 bnA
 bRS
 qor
-tdn
+nNS
 pei
-kKA
+xFd
 tTC
 bOI
 bMB
@@ -122681,15 +122706,15 @@ tUt
 lkG
 wrT
 coJ
+coC
 xRG
-eeS
-nNS
-xFd
+xRG
+liO
 fMm
 sha
 esZ
-lHd
-foi
+bPZ
+bPZ
 fLp
 cIT
 hhJ
@@ -122939,15 +122964,15 @@ eGd
 jSC
 jdH
 ibK
-yjs
+xFd
 ocK
 rGx
-jSC
-hBP
+xDK
+hEN
 aXm
 hBP
-hBP
-fLp
+eeS
+nzv
 mkD
 fuP
 roz
@@ -123191,16 +123216,16 @@ uGz
 gWt
 irg
 hvD
-hUS
+pUt
 eGd
 bnA
-nzv
+tGD
 puH
-tZu
+xFd
+gZD
 anP
-hqe
 eGy
-tNI
+ogb
 dAy
 nTI
 olG
@@ -123448,17 +123473,17 @@ qCB
 hgZ
 irg
 jrX
-hUS
+bkq
 eGd
 bnA
-gZD
+tGD
 vZc
 nMk
-xDK
+gZD
 hqe
-ogb
-bkq
-btx
+ivZ
+cbf
+dAy
 eWX
 vOZ
 ssw
@@ -123707,13 +123732,13 @@ wzH
 hRr
 fba
 cUM
-jSC
+vmS
 whq
 orv
-ivZ
+xFd
 iog
-bLx
-cbf
+foi
+tZu
 tSE
 lWH
 gKB
@@ -123966,9 +123991,9 @@ hUS
 eGd
 bnA
 fva
+lHd
 pow
-coC
-liO
+pow
 tgy
 jSC
 iUy
@@ -124224,7 +124249,7 @@ eGd
 bnA
 iIG
 mFX
-tGD
+bLx
 ehn
 iJt
 jSC
@@ -124480,11 +124505,11 @@ hUS
 slJ
 hfU
 hfU
+hfU
+nUo
+hfU
+hfU
 gOj
-hfU
-hfU
-hfU
-jSC
 hFu
 ctf
 uNs

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -919,9 +919,20 @@
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "anI" = (
-/obj/structure/chair/sofa/corp/right{
-	color = "#DE3A3A";
-	dir = 4
+/obj/structure/table,
+/obj/item/serviette_pack{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	desc = "Salt. From space oceans, presumably. A staple of modern medicine.";
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = -8;
+	pixel_y = 2
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
@@ -2318,9 +2329,13 @@
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "aJs" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/station/cargo/storage)
+/obj/structure/chair/sofa/corp/right{
+	color = "#DE3A3A";
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/cafeteria)
 "aJH" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/structure/disposalpipe/segment{
@@ -4211,14 +4226,12 @@
 /turf/open/floor/plating,
 /area/station/security/warden)
 "bkq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/chair/sofa/corp/left{
+	color = "#DE3A3A";
+	dir = 8
 	},
-/obj/structure/sink/kitchen/directional/east{
-	pixel_x = -19
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/hallway/primary/fore)
+/turf/open/floor/iron/cafeteria,
+/area/station/service/cafeteria)
 "bkr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/start/bartender,
@@ -6840,7 +6853,7 @@
 /area/station/security/checkpoint/engineering)
 "cbP" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "cbV" = (
 /obj/effect/landmark/start/hangover,
@@ -8105,7 +8118,7 @@
 /area/station/science/research)
 "cvp" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "cvG" = (
 /obj/structure/sign/warning/biohazard/directional/east,
@@ -15978,9 +15991,9 @@
 /turf/closed/wall/r_wall,
 /area/station/science/research)
 "eDx" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/plating/airless,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/security/checkpoint/supply)
 "eDF" = (
 /obj/structure/chair/stool/directional/west,
@@ -16330,7 +16343,7 @@
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/obj/structure/closet/secure_closet/freezer/meat,
+/obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "eGZ" = (
@@ -19058,7 +19071,7 @@
 /area/station/service/chapel/funeral)
 "fye" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/cargo/office)
 "fys" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
@@ -19960,12 +19973,12 @@
 /turf/open/floor/wood/large,
 /area/station/security/courtroom)
 "fNX" = (
+/obj/machinery/bouldertech/refinery/smelter,
 /obj/machinery/conveyor/inverted{
 	dir = 5;
 	id = "mining"
 	},
-/obj/machinery/bouldertech/refinery/smelter,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "fNY" = (
 /obj/structure/closet/l3closet/virology,
@@ -26600,11 +26613,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/aft)
-"hEN" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/fulltile,
-/turf/open/floor/grass,
-/area/station/service/kitchen)
 "hER" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -28363,12 +28371,12 @@
 /area/station/medical/virology)
 "ihS" = (
 /obj/machinery/light/directional/north,
+/obj/machinery/bouldertech/refinery,
 /obj/machinery/conveyor{
 	id = "mining";
 	dir = 8
 	},
-/obj/machinery/bouldertech/refinery,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "ihT" = (
 /obj/structure/cable,
@@ -29530,8 +29538,6 @@
 /area/station/command/heads_quarters/hos)
 "ivZ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -29539,6 +29545,8 @@
 	dir = 4
 	},
 /obj/structure/fake_stairs/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "iwe" = (
@@ -30006,7 +30014,7 @@
 /area/station/engineering/supermatter/room)
 "iCW" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/command/heads_quarters/qm)
 "iCZ" = (
 /obj/machinery/computer/communications,
@@ -30155,7 +30163,7 @@
 	id = "mining";
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "iFY" = (
 /obj/structure/cable,
@@ -30657,7 +30665,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "iNk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31804,7 +31812,6 @@
 /obj/machinery/light/directional/north,
 /obj/structure/table,
 /obj/machinery/light_switch/directional/north{
-	pixel_y = 23;
 	pixel_x = 13
 	},
 /turf/open/floor/iron/kitchen,
@@ -33438,13 +33445,13 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
 "jAS" = (
+/obj/machinery/bouldertech/brm,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/conveyor{
 	id = "mining";
 	dir = 1
 	},
-/obj/machinery/bouldertech/brm,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "jBm" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -33743,7 +33750,6 @@
 	req_access = list("kitchen")
 	},
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "jDY" = (
@@ -39778,7 +39784,7 @@
 /area/station/commons/vacant_room/office)
 "lkM" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/cargo/sorting)
 "lkR" = (
 /obj/effect/spawner/random/structure/table_fancy,
@@ -39920,7 +39926,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "lnc" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
@@ -45980,8 +45986,8 @@
 	dir = 10;
 	name = "service camera"
 	},
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/structure/sink/kitchen/directional/east,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "mVv" = (
@@ -48050,7 +48056,7 @@
 /area/station/maintenance/starboard/greater)
 "nyf" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/cargo/miningoffice)
 "nyh" = (
 /obj/structure/window/reinforced/spawner/directional/west{
@@ -51993,7 +51999,7 @@
 	dir = 6;
 	id = "mining"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "oCo" = (
 /obj/structure/railing/corner{
@@ -56963,15 +56969,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/wood/large,
 /area/station/commons/fitness/recreation)
-"pUt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sink/kitchen/directional/west{
-	pixel_x = 19
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/hallway/primary/fore)
 "pUu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64179,14 +64176,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"rSO" = (
-/obj/structure/chair/sofa/corp/right{
-	color = "#DE3A3A";
-	dir = 8
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "rSZ" = (
 /obj/item/kirbyplants/random,
 /obj/item/radio/intercom/directional/west,
@@ -68967,6 +68956,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/camera{
+	c_tag = "Service - Kitchen";
+	name = "service camera"
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "tgQ" = (
@@ -69316,7 +69309,6 @@
 	location = "Kitchen"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/large,
 /area/station/maintenance/starboard/greater)
 "tlq" = (
@@ -71821,9 +71813,7 @@
 /area/station/medical/medbay/central)
 "tTC" = (
 /obj/structure/railing/corner,
-/obj/structure/sink/kitchen/directional/west{
-	pixel_x = 18
-	},
+/obj/structure/sink/kitchen/directional/west,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "tTI" = (
@@ -71892,8 +71882,6 @@
 /area/station/hallway/primary/fore)
 "tUw" = (
 /obj/effect/turf_decal/weather/snow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/sink/kitchen/directional/north,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "tUB" = (
@@ -72105,11 +72093,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/box,
-/obj/machinery/camera{
-	c_tag = "Service - Kitchen";
-	name = "service camera";
-	dir = 4
-	},
 /obj/structure/railing{
 	dir = 10
 	},
@@ -75545,11 +75528,11 @@
 /turf/open/floor/vault,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "uTk" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/cargo/sorting)
 "uTs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -77170,9 +77153,9 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/engine/atmos/lesser)
 "vsK" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/airless,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/cargo/office)
 "vsS" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -77647,14 +77630,13 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "vyb" = (
-/obj/machinery/restaurant_portal/restaurant,
 /obj/machinery/light/warm/directional/east,
-/obj/effect/turf_decal/delivery/red,
 /obj/machinery/status_display/ai/directional/east,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/iron/smooth_large,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "vyc" = (
 /obj/machinery/door/firedoor,
@@ -79163,9 +79145,9 @@
 	},
 /area/station/engineering/atmos)
 "vUt" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/airless,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/cargo/sorting)
 "vUB" = (
 /obj/machinery/incident_display/delam,
@@ -80553,21 +80535,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/item/serviette_pack{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/structure/chair/sofa/corp/right{
+	color = "#DE3A3A";
+	dir = 8
 	},
-/obj/item/reagent_containers/condiment/saltshaker{
-	desc = "Salt. From space oceans, presumably. A staple of modern medicine.";
-	pixel_x = -8;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = -8;
-	pixel_y = 2
-	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "woG" = (
@@ -83473,11 +83445,9 @@
 	c_tag = "Service - Cafeteria Aft";
 	name = "service camera"
 	},
-/obj/structure/chair/sofa/corp/left{
-	color = "#DE3A3A";
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/restaurant_portal/restaurant,
+/obj/effect/turf_decal/delivery/red,
+/turf/open/floor/iron/smooth_large,
 /area/station/service/cafeteria)
 "xgv" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
@@ -121685,8 +121655,8 @@ ekG
 kLz
 cnA
 rUb
-kLz
-kLz
+lkz
+aJs
 bNy
 bhD
 jYr
@@ -121942,8 +121912,8 @@ qwy
 qwy
 hUv
 eYX
-lkz
 anI
+gOt
 rUb
 qQh
 fVT
@@ -122200,7 +122170,7 @@ fxo
 olm
 gyK
 woE
-gOt
+bkq
 vyb
 kPh
 ooa
@@ -122456,7 +122426,7 @@ xFd
 tTC
 bOI
 bMB
-rSO
+kLz
 xgl
 fLp
 oie
@@ -122968,7 +122938,7 @@ xFd
 ocK
 rGx
 xDK
-hEN
+bnA
 aXm
 hBP
 eeS
@@ -123216,7 +123186,7 @@ uGz
 gWt
 irg
 hvD
-pUt
+hUS
 eGd
 bnA
 tGD
@@ -123473,7 +123443,7 @@ qCB
 hgZ
 irg
 jrX
-bkq
+hUS
 eGd
 bnA
 tGD
@@ -129185,14 +129155,14 @@ xdZ
 nyf
 nyf
 yaj
-aJs
+wuW
 sFi
 sFi
 uTU
 hcS
 sle
-aJs
-aJs
+wuW
+wuW
 uTU
 myM
 sle
@@ -129700,7 +129670,7 @@ ueJ
 gjq
 nyf
 gZb
-aJs
+wuW
 wVQ
 udn
 aRn
@@ -129957,7 +129927,7 @@ jay
 dMl
 nyf
 cKl
-aJs
+wuW
 eGw
 udn
 twB
@@ -130214,7 +130184,7 @@ pjT
 pjT
 pjT
 cYx
-aJs
+wuW
 pqc
 udn
 gqC

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -919,21 +919,11 @@
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "anI" = (
-/obj/structure/table,
-/obj/item/serviette_pack{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/structure/chair/sofa/corp/right{
+	color = "#DE3A3A";
+	dir = 4
 	},
-/obj/item/reagent_containers/condiment/saltshaker{
-	desc = "Salt. From space oceans, presumably. A staple of modern medicine.";
-	pixel_x = -8;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = -8;
-	pixel_y = 2
-	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "anM" = (
@@ -2328,14 +2318,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
-"aJs" = (
-/obj/structure/chair/sofa/corp/right{
-	color = "#DE3A3A";
-	dir = 4
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "aJH" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/structure/disposalpipe/segment{
@@ -4225,13 +4207,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/warden)
-"bkq" = (
-/obj/structure/chair/sofa/corp/left{
-	color = "#DE3A3A";
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "bkr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/start/bartender,
@@ -64176,6 +64151,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"rSO" = (
+/obj/structure/chair/sofa/corp/right{
+	color = "#DE3A3A";
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/cafeteria)
 "rSZ" = (
 /obj/item/kirbyplants/random,
 /obj/item/radio/intercom/directional/west,
@@ -77635,8 +77618,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/restaurant_portal/restaurant,
+/turf/open/floor/iron/smooth_large,
 /area/station/service/cafeteria)
 "vyc" = (
 /obj/machinery/door/firedoor,
@@ -80535,11 +80519,21 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/structure/chair/sofa/corp/right{
-	color = "#DE3A3A";
-	dir = 8
+/obj/structure/table,
+/obj/item/serviette_pack{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/obj/effect/landmark/start/assistant,
+/obj/item/reagent_containers/condiment/saltshaker{
+	desc = "Salt. From space oceans, presumably. A staple of modern medicine.";
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = -8;
+	pixel_y = 2
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "woG" = (
@@ -83445,9 +83439,11 @@
 	c_tag = "Service - Cafeteria Aft";
 	name = "service camera"
 	},
-/obj/machinery/restaurant_portal/restaurant,
-/obj/effect/turf_decal/delivery/red,
-/turf/open/floor/iron/smooth_large,
+/obj/structure/chair/sofa/corp/left{
+	color = "#DE3A3A";
+	dir = 8
+	},
+/turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "xgv" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
@@ -121655,8 +121651,8 @@ ekG
 kLz
 cnA
 rUb
-lkz
-aJs
+kLz
+kLz
 bNy
 bhD
 jYr
@@ -121912,8 +121908,8 @@ qwy
 qwy
 hUv
 eYX
+lkz
 anI
-gOt
 rUb
 qQh
 fVT
@@ -122170,7 +122166,7 @@ fxo
 olm
 gyK
 woE
-bkq
+gOt
 vyb
 kPh
 ooa
@@ -122426,7 +122422,7 @@ xFd
 tTC
 bOI
 bMB
-kLz
+rSO
 xgl
 fLp
 oie


### PR DESCRIPTION
## About The Pull Request
This PR renovates & expands the Kitchen, adds two missing decals to the Pharmacy, and fixes airless tiles in Mining Dock & Cargo.

## How This Contributes To The Nova Sector Roleplay Experience
Nearly all Chef mains share the same complaint that the kitchen is too small, and when there's two chefs, it's especially stifling to move around and cook in. The PR offers both chefs their own space to work in, plenty of walking space, and an overall spacious and pleasant kitchen to work in. Fake stairs were added to make the kitchen's appearance less flat and have a sense of elevation to it.

To make this happen without compromising pretty much the entire map, some of Service Hall's space had to be eaten which shouldn't be an issue since that room's entire purpose is to receive crates, print stuff and leave anyways.

## Proof of Testing
![oldnew](https://github.com/NovaSector/NovaSector/assets/136726218/8cb03dd6-66dd-47fd-8af9-e370d8343d54)
![newkitchenn](https://github.com/NovaSector/NovaSector/assets/136726218/d4022493-38ab-4f6f-896b-6206a0ec509f)

## Changelog
:cl:
add: Void Raptor's Kitchen is renovated and more spacious.
fix: Void Raptor Mining Dock should have air again.
/:cl:
