### PR TITLE
Oh God The Zipper's Stuck: Entombed quirk granting unremovable roundstart MODsuit

### DIFF
--- a/modular_nova/master_files/code/modules/entombed_quirk/code/entombed.dm
+++ b/modular_nova/master_files/code/modules/entombed_quirk/code/entombed.dm
@@ -1,0 +1,156 @@
+/datum/quirk/equipping/entombed
+	name = "Entombed"
+	desc = "You are permanently fused to (or otherwise reliant on) a single MOD unit that can never be removed from your person. If it runs out of charge, you'll start to die!"
+	gain_text = span_warning("Your exosuit is both prison and home.")
+	lose_text = span_notice("At last, you're finally free from that horrible exosuit.")
+	medical_record_text = "Patient is physiologically reliant on a MOD unit for homeostasis. Do not attempt removal."
+	value = 0
+	icon = FA_ICON_SUITCASE
+	forced_items = list(/obj/item/mod/control/pre_equipped/entombed = list(ITEM_SLOT_BACK))
+	/// The modsuit we're stuck in
+	var/obj/item/mod/control/pre_equipped/entombed/modsuit
+
+/datum/quirk/equipping/entombed/add_unique(client/client_source)
+	. = ..()
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	if (istype(human_holder.back, /obj/item/mod/control/pre_equipped/entombed))
+		modsuit = human_holder.back // link this up to the quirk for easy access
+
+	if (isnull(modsuit))
+		return
+
+	// set all of our customization stuff from prefs, if we have it
+	var/modsuit_skin = client_source?.prefs.read_preference(/datum/preference/choiced/entombed_skin)
+
+	if (modsuit_skin == NONE)
+		modsuit_skin = "civilian"
+
+	modsuit.skin = lowertext(modsuit_skin)
+
+	var/modsuit_name = client_source?.prefs.read_preference(/datum/preference/text/entombed_mod_name)
+	if (modsuit_name)
+		modsuit.name = modsuit_name
+
+	var/modsuit_desc = client_source?.prefs.read_preference(/datum/preference/text/entombed_mod_desc)
+	if (modsuit_desc)
+		modsuit.desc = modsuit_desc
+
+	var/modsuit_skin_prefix = client_source?.prefs.read_preference(/datum/preference/text/entombed_mod_prefix)
+	if (modsuit_skin_prefix)
+		modsuit.theme.name = lowertext(modsuit_skin_prefix)
+
+	// quickly deploy it on roundstart
+	modsuit.quick_activation()
+	// lower the helmet for style points and also to make chargen less annoying
+	var/obj/item/clothing/head/mod/helmet = locate() in modsuit.mod_parts
+	modsuit.retract(human_holder, helmet)
+
+	// deploy specific racial features - ethereals get ethereal cores, plasmamen get free plasma stabilizer module
+	if (isethereal(human_holder))
+		var/obj/item/mod/core/ethereal/eth_core = new
+		eth_core.install(modsuit)
+	else if (isplasmaman(human_holder))
+		var/obj/item/mod/module/plasma_stabilizer/entombed/plasma_stab = new
+		modsuit.install(plasma_stab, human_holder)
+
+/datum/quirk/equipping/entombed/remove()
+	QDEL_NULL(modsuit)
+
+/datum/quirk_constant_data/entombed
+	associated_typepath = /datum/quirk/equipping/entombed
+	customization_options = list(/datum/preference/choiced/entombed_skin, /datum/preference/text/entombed_mod_name, /datum/preference/text/entombed_mod_desc, /datum/preference/text/entombed_mod_prefix)
+
+/datum/preference/choiced/entombed_skin
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "entombed_skin"
+	savefile_identifier = PREFERENCE_CHARACTER
+	can_randomize = FALSE
+
+/datum/preference/choiced/entombed_skin/init_possible_values()
+	return list(
+		"Standard",
+		"Civilian",
+		"Colonist",
+		"Engineering",
+		"Atmospheric",
+		"Advanced",
+		"Mining",
+		"Loader",
+		"Medical",
+		"Rescue",
+		"Security",
+		"Cosmohonk",
+		"Interdyne",
+		"Prototype",
+	)
+
+/datum/preference/choiced/entombed_skin/create_default_value()
+	return "Civilian"
+
+/datum/preference/choiced/entombed_skin/is_accessible(datum/preferences/preferences)
+	if (!..())
+		return FALSE
+
+	return "Entombed" in preferences.all_quirks
+
+/datum/preference/choiced/entombed_skin/apply_to_human(mob/living/carbon/human/target, value)
+	return
+
+/datum/preference/text/entombed_mod_name
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "entombed_mod_name"
+	savefile_identifier = PREFERENCE_CHARACTER
+	can_randomize = FALSE
+	maximum_value_length = 32
+
+/datum/preference/choiced/entombed_mod_name/is_accessible(datum/preferences/preferences)
+	if (!..())
+		return FALSE
+
+	return "Entombed" in preferences.all_quirks
+
+/datum/preference/text/entombed_mod_name/serialize(input)
+	return htmlrendertext(input)
+
+/datum/preference/text/entombed_mod_name/apply_to_human(mob/living/carbon/human/target, value)
+	return
+
+/datum/preference/text/entombed_mod_desc
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "entombed_mod_desc"
+	savefile_identifier = PREFERENCE_CHARACTER
+	can_randomize = FALSE
+
+/datum/preference/choiced/entombed_mod_desc/is_accessible(datum/preferences/preferences)
+	if (!..())
+		return FALSE
+
+	return "Entombed" in preferences.all_quirks
+
+/datum/preference/text/entombed_mod_desc/serialize(input)
+	return htmlrendertext(input)
+
+/datum/preference/text/entombed_mod_desc/apply_to_human(mob/living/carbon/human/target, value)
+	return
+
+/datum/preference/text/entombed_mod_prefix
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "entombed_mod_prefix"
+	savefile_identifier = PREFERENCE_CHARACTER
+	can_randomize = FALSE
+	maximum_value_length = 16
+
+/datum/preference/text/entombed_mod_prefix/is_accessible(datum/preferences/preferences)
+	if (!..())
+		return FALSE
+
+	return "Entombed" in preferences.all_quirks
+
+/datum/preference/text/entombed_mod_prefix/serialize(input)
+	return htmlrendertext(input)
+
+/datum/preference/text/entombed_mod_prefix/create_default_value()
+	return "Fused"
+
+/datum/preference/text/entombed_mod_prefix/apply_to_human(mob/living/carbon/human/target, value)
+	return

--- a/modular_nova/master_files/code/modules/entombed_quirk/code/entombed_mod.dm
+++ b/modular_nova/master_files/code/modules/entombed_quirk/code/entombed_mod.dm
@@ -1,0 +1,55 @@
+/datum/mod_theme/entombed
+	name = "fused"
+	desc = "Circumstances have rendered this protective suit into someone's second skin. Literally."
+	extended_desc = "Some great aspect of someone's past has permanently bound them to this device, for better or worse."
+
+	default_skin = "civilian"
+	armor_type = /datum/armor/mod_entombed
+	resistance_flags = FIRE_PROOF | ACID_PROOF | INDESTRUCTIBLE // It is better to die for the Emperor than live for yourself.
+	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
+	siemens_coefficient = 0
+	complexity_max = DEFAULT_MAX_COMPLEXITY - 5
+	charge_drain = DEFAULT_CHARGE_DRAIN
+	slowdown_inactive = 2.5 // very slow because the quirk infers you rely on this to move/exist
+	slowdown_active = 0.95
+	inbuilt_modules = list(
+		/obj/item/mod/module/joint_torsion/entombed,
+		/obj/item/mod/module/storage
+	)
+	allowed_suit_storage = list(
+		/obj/item/tank/internals,
+		/obj/item/flashlight,
+	)
+
+/datum/armor/mod_entombed
+	melee = ARMOR_LEVEL_WEAK
+	bullet = ARMOR_LEVEL_WEAK
+	laser = ARMOR_LEVEL_WEAK
+	energy = ARMOR_LEVEL_WEAK
+	bomb = ARMOR_LEVEL_WEAK
+	bio = ARMOR_LEVEL_WEAK
+	fire = ARMOR_LEVEL_WEAK
+	acid = ARMOR_LEVEL_WEAK
+	wound = WOUND_ARMOR_WEAK
+
+/obj/item/mod/module/joint_torsion/entombed
+	name = "internal joint torsion adaptation"
+	desc = "Your adaptation to life in this MODsuit shell allows you to ambulate in such a way that your movements recharge the suit's internal batteries slightly, but only while under the effect of gravity."
+	removable = FALSE
+	complexity = 0
+	power_per_step = DEFAULT_CHARGE_DRAIN * 0.4
+
+/obj/item/mod/module/plasma_stabilizer/entombed
+	name = "colony-stabilized interior seal"
+	desc = "Your colony has fully integrated the internal segments of your suit's plate into your skeleton, forming a hermetic seal between you and the outside world from which none of your atmosphere can escape. This is enough to allow your head to view the world with your helmet retracted."
+	complexity = 0
+	idle_power_cost = 0
+	removable = FALSE
+
+/obj/item/mod/control/pre_equipped/entombed
+	theme = /datum/mod_theme/entombed
+	applied_cell = /obj/item/stock_parts/cell/high
+
+/obj/item/mod/control/pre_equipped/entombed/Initialize(mapload, new_theme, new_skin, new_core)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, QUIRK_TRAIT)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6395,6 +6395,8 @@
 #include "modular_nova\master_files\code\modules\clothing\under\jobs\security.dm"
 #include "modular_nova\master_files\code\modules\clothing\under\jobs\civilian\civilian.dm"
 #include "modular_nova\master_files\code\modules\clothing\under\jobs\civilian\suits.dm"
+#include "modular_nova\master_files\code\modules\entombed_quirk\code\entombed.dm"
+#include "modular_nova\master_files\code\modules\entombed_quirk\code\entombed_mod.dm"
 #include "modular_nova\master_files\code\modules\events\_event.dm"
 #include "modular_nova\master_files\code\modules\experisci\experiment.dm"
 #include "modular_nova\master_files\code\modules\food_and_drinks\recipes\food_mixtures.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/entombed.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/entombed.tsx
@@ -1,0 +1,30 @@
+// THIS IS A NOVA SECTOR UI FILE
+import {
+  Feature,
+  FeatureChoiced,
+  FeatureDropdownInput,
+  FeatureShortTextInput,
+  FeatureTextInput,
+} from '../../base';
+
+export const entombed_skin: FeatureChoiced = {
+  name: 'MODsuit Skin',
+  component: FeatureDropdownInput,
+};
+
+export const entombed_mod_name: Feature<string> = {
+  name: 'MODsuit Control Unit Name',
+  component: FeatureShortTextInput,
+};
+
+export const entombed_mod_desc: Feature<string> = {
+  name: 'MODsuit Control Unit Description',
+  component: FeatureTextInput,
+};
+
+export const entombed_mod_prefix: Feature<string> = {
+  name: 'MODsuit Deployed Prefix',
+  description:
+    "This is appended to any deployed pieces of MODsuit gear, like the chest, helmet, etc. The default is 'fused' - try to use an adjective, if you can.",
+  component: FeatureShortTextInput,
+};


### PR DESCRIPTION
## About The Pull Request

A neat little twist on the idea of roundstart MODsuits, this PR adds a new quirk called Entombed which traps your character inside a relatively low-grade creation *permanently*. Here's the full details:

- The 'fused' entombed MODsuit has 10 complexity and class III armor to all damage types except wounding, which remains at I.
   - It it is also indestructible and can't be burned or melted off you with acid.
   - This may seem high, but the only way you can upgrade this throughout the course of the round is via modules, and you don't have much complexity to throw around.
- You cannot remove this MODsuit. Ever. The unit can't be stripped from you, either.
- The MODsuit is *very* slow when unpowered, almost twice as slow as an ordinary MOD. Think of this as a soft version of the Hemophage's dormant tumor.
- The appearance (skin), name, description and deployed piece prefix of the suit are all customizable via the quirk preferences menu.
   - Changing the skin does not alter the stats of the MODsuit in any way - it's purely cosmetic.
- If you're an Ethereal, the MODsuit begins play with an ethereal MOD core.
- If you're a Plasmaman, the MODsuit begins play with a unremovable 0 complexity plasma stabilizer module, allowing you to take off ONLY YOUR HELMET and not combust to death.
- All races start with a unremovable 0 complexity modified joint torsion module, which provides a small amount of charge to your suit when you move around. I've balanced this around providing just enough to make the *base* suit not really lose much charge while you're actively moving. That goes right out of the window once you start adding modules that draw passive charge of your own, though.
- (NOT ADDED YET) If your MODsuit's charge runs out, you take a hefty lump of toxin damage every tick until you charge it up again, to reflect your physiology or the suit's life support systems shutting down.

There are no forced limits on deploying parts - I initially thought about locking all but the head parts into permanent deployment, but I think that'd kind of suck for some concepts and so have opted to leave it to the player to decide.

## How This Contributes To The Nova Sector Roleplay Experience

This opens up a slew of concepts, from infirm characters relying on specialized life support systems via exosuits, to slimes who can't maintain humanoid form without the rigidity of a suit, to engineer plasmamen who've colonized an entire modsuit with a skeleton stuck inside it and become inexorably linked. Maybe you play a veteran who has deep-rooted trauma preventing them from leaving the safety of their suit.

It's really up to you. Importantly, it's *cool* and customizable.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![IZ3JqWFbPm](https://github.com/NovaSector/NovaSector/assets/966289/d74a9960-b1dd-4dce-8614-27da4221de4e)

![dreamseeker_K7iBskzCaC](https://github.com/NovaSector/NovaSector/assets/966289/8c5c358b-af92-4f7b-bab9-e6deeed7e7b4)

![dreamseeker_I2gOX0synx](https://github.com/NovaSector/NovaSector/assets/966289/00b833fe-076d-4203-b7ed-d6026830e133)

</details>

## Changelog

:cl: yooriss
add: The Entombed quirk has been added, allowing characters to start off with a permanently unremovable low-end MODsuit stuck to their back slot. Letting the suit's charge run low will eventually kill you, and the quirk has special interactions with both Ethereals and Plasmamen!
/:cl:
