### PR TITLE
ARC Mining - Granite Fixes it Edition

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -6199,13 +6199,10 @@
 /area/station/common/laser_tag)
 "bld" = (
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/stripes,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining"
+/obj/structure/rack/shelf,
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
 	},
-/obj/machinery/bouldertech/refinery,
-/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "blr" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -14734,7 +14731,6 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/structure/rack/shelf,
 /turf/open/floor/iron/smooth_edge{
 	dir = 4
 	},
@@ -33057,12 +33053,10 @@
 /turf/open/floor/engine,
 /area/station/science/ordnance/freezerchamber)
 "gmM" = (
-/obj/effect/turf_decal/stripes,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining"
+/obj/structure/rack/shelf,
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
 	},
-/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "gmN" = (
 /obj/structure/chair/sofa/bench/left,
@@ -38789,14 +38783,17 @@
 /turf/open/floor/iron/smooth_corner,
 /area/station/cargo/miningdock)
 "htI" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
 /obj/machinery/light/directional/west,
-/obj/structure/closet/crate,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/small,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/machinery/conveyor{
+	dir = 9;
+	id = "mining"
+	},
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "htK" = (
 /obj/structure/railing{
@@ -42242,12 +42239,13 @@
 /turf/open/floor/iron/smooth_edge,
 /area/station/cargo/miningdock)
 "icj" = (
-/obj/effect/turf_decal/stripes,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "mining"
 	},
-/obj/machinery/bouldertech/refinery/smelter,
 /turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "icm" = (
@@ -52034,14 +52032,14 @@
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "jUu" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
-	},
-/obj/structure/chair/plastic{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark/small,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/iron/smooth_edge{
+	dir = 8
+	},
 /area/station/cargo/miningdock)
 "jUx" = (
 /obj/item/hemostat,
@@ -68336,13 +68334,13 @@
 /area/station/command/secure_bunker)
 "naT" = (
 /obj/effect/turf_decal/stripes{
-	dir = 6
+	dir = 1
 	},
+/obj/machinery/bouldertech/brm,
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "mining"
 	},
-/obj/machinery/bouldertech/brm,
 /turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "nba" = (
@@ -72617,13 +72615,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/upper)
 "nSH" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
+/obj/structure/railing{
+	pixel_y = -5
 	},
-/obj/structure/chair/plastic{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/small,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/iron/smooth,
 /area/station/cargo/miningdock)
 "nSL" = (
 /obj/structure/chair/sofa/left/brown{
@@ -85765,9 +85761,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/upper)
 "qrp" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance/three,
-/turf/open/floor/iron/dark/small,
+/obj/machinery/conveyor_switch/oneway{
+	id = "mining";
+	dir = 1
+	},
+/obj/structure/railing{
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/iron/smooth,
 /area/station/cargo/miningdock)
 "qru" = (
 /obj/structure/rack,
@@ -92827,15 +92829,17 @@
 /turf/open/floor/vault/rock,
 /area/station/security/prison/safe)
 "rGN" = (
-/obj/structure/table,
-/obj/item/reagent_containers/cup/glass/bottle/beer{
-	pixel_x = 6;
-	pixel_y = 16
+/obj/effect/turf_decal/stripes{
+	dir = 8
 	},
-/obj/item/clothing/mask/cigarette{
-	pixel_y = 4
+/obj/effect/turf_decal/loading_area{
+	dir = 8
 	},
-/turf/open/floor/iron/dark/small,
+/obj/effect/turf_decal/caution{
+	dir = 4;
+	pixel_x = 7
+	},
+/turf/open/floor/iron/smooth_edge,
 /area/station/cargo/miningdock)
 "rGQ" = (
 /obj/effect/spawner/random/trash/cigbutt,
@@ -101411,7 +101415,6 @@
 /obj/structure/railing{
 	dir = 5
 	},
-/obj/structure/rack/shelf,
 /turf/open/floor/iron/smooth_corner{
 	dir = 8
 	},
@@ -108656,8 +108659,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper)
 "uGt" = (
-/obj/structure/closet/crate/secure/loot,
-/turf/open/floor/iron/dark/small,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/machinery/bouldertech/refinery,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining"
+	},
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "uGz" = (
 /obj/item/stack/sheet/cardboard,
@@ -120924,6 +120934,9 @@
 /obj/structure/railing/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/smooth,
 /area/station/cargo/miningdock)
 "wWy" = (
@@ -125533,6 +125546,17 @@
 /obj/structure/closet/secure_closet/security/med,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
+"xRD" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/machinery/bouldertech/refinery/smelter,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining"
+	},
+/turf/open/floor/plating,
+/area/station/cargo/miningdock)
 "xRH" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -168271,7 +168295,7 @@ wwD
 fkA
 asX
 ilS
-wvZ
+sdF
 mgL
 gXZ
 auv
@@ -168528,7 +168552,7 @@ fVT
 oTl
 uSr
 kGC
-gmM
+sdF
 mgL
 ktY
 ktY
@@ -168785,7 +168809,7 @@ txz
 oTl
 tpI
 kGC
-icj
+gmM
 lVQ
 xaN
 sHB
@@ -169054,8 +169078,8 @@ ktY
 wTQ
 pXg
 txY
-rGN
-djJ
+nSH
+xRD
 leG
 kyD
 pEc
@@ -169312,7 +169336,7 @@ ryA
 mYd
 txY
 nSH
-jvp
+icj
 bti
 kyD
 pEc
@@ -169556,7 +169580,7 @@ jbh
 jbh
 aFx
 eiY
-naT
+sdF
 lVQ
 ktY
 djJ
@@ -169568,7 +169592,7 @@ ktY
 djJ
 djJ
 txY
-qrp
+nSH
 uGt
 kgv
 kyD
@@ -169825,8 +169849,8 @@ ktY
 vHy
 bvN
 txY
-vHy
-bvN
+nSH
+icj
 sZm
 wYj
 pEc
@@ -170082,8 +170106,8 @@ ouO
 ouO
 bZm
 txY
-ktY
-mMw
+qrp
+naT
 sZm
 kyD
 pEc
@@ -170339,8 +170363,8 @@ gyg
 gvD
 qFW
 kOB
-ktY
-mMw
+nSH
+icj
 bti
 kyD
 pEc
@@ -170597,7 +170621,7 @@ jVB
 tnT
 cLb
 wWq
-mMw
+rGN
 kgv
 kyD
 pEc

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -4240,6 +4240,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 9
 	},
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/open/floor/iron/smooth_edge{
 	dir = 4
 	},
@@ -8073,6 +8076,9 @@
 /area/station/science/research)
 "cvp" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/open/floor/plating/airless,
 /area/station/cargo/miningdock)
 "cvG" = (
@@ -28300,7 +28306,6 @@
 	id = "mining";
 	dir = 8
 	},
-/obj/machinery/bouldertech/refinery,
 /turf/open/floor/plating/airless,
 /area/station/cargo/miningdock)
 "ihT" = (
@@ -30109,6 +30114,7 @@
 	id = "mining";
 	dir = 8
 	},
+/obj/machinery/bouldertech/refinery,
 /turf/open/floor/plating/airless,
 /area/station/cargo/miningdock)
 "iFY" = (
@@ -30611,6 +30617,9 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/conveyor{
+	id = "mining"
+	},
 /turf/open/floor/plating/airless,
 /area/station/cargo/miningdock)
 "iNk" = (
@@ -39887,6 +39896,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/railing{
+	dir = 5
+	},
 /turf/open/floor/plating/airless,
 /area/station/cargo/miningdock)
 "lnc" = (

--- a/code/datums/mapgen/Cavegens/IcemoonCaves.dm
+++ b/code/datums/mapgen/Cavegens/IcemoonCaves.dm
@@ -1,8 +1,7 @@
 /datum/map_generator/cave_generator/icemoon
 	weighted_open_turf_types = list(/turf/open/misc/asteroid/snow/icemoon = 19, /turf/open/misc/ice/icemoon = 1)
 	weighted_closed_turf_types = list(
-		/turf/closed/mineral/snowmountain/icemoon = 100,
-		/turf/closed/mineral/gibtonite/ice/icemoon = 4,
+		/turf/closed/mineral/random/snow = 1, // Nova Edit: Actually uses the RIGHT mineral block
 	)
 
 

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -410,8 +410,8 @@
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
 	defer_change = TRUE
-	proximity_based = TRUE
-	mineralChance = 5
+	proximity_based = FALSE // Nova Edit: Original TRUE
+	mineralChance = 8 // Nova Edit: Original 5 (13)
 
 /turf/closed/mineral/random/volcanic/mineral_chances()
 	return list(
@@ -438,7 +438,7 @@
 	baseturfs = /turf/open/misc/asteroid/snow/icemoon
 	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
 	weak_turf = TRUE
-	proximity_based = TRUE
+	proximity_based = FALSE // Nova Edit: Originally TRUE
 
 /turf/closed/mineral/random/snow/Change_Ore(ore_type, random = 0)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

TM until the real fix comes in from upstream and then we can go from there. 

**All flags for Proximity based mining are set to False**
I've seen some people not excited about seeing that, however there are multiple parties mining at any given (Ashies/Icies/Interdyne/DS2) time and ARC mining only goes 1 way.  The generation of ores is neutered, however our population is a lot higher than what TG designed their recent balance around.


Lavaland Vents are spawning normal
Lavaland Ore is spawning normal but reduced from a frequency from 13 to 8

Icemoon Vents are spawning normal
Icemoon Ore is spawning normal but reduced from a frequency from 20! to 12

VoidRaptor has their ARC Setup added
Blueshift has their ARC Setup added

Do note that all stations do not start with an ARC Setup, Delta for example gets screwed hard and only get a stack of belts and a note to follow. 

Icemoon's setup IS there, it's just down in the dorm area, TG players also didnt know about this at first


## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/22140677/2d183714-b263-4738-9ecd-34fb109fc4ad)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Brings back non-proximity based ore spawns
fix: fixes Icemoon not spawning ore 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
