### PR TITLE
Hearthkin Ghost Role Increase in Slots

### DIFF
--- a/modular_nova/modules/primitive_catgirls/code/spawner.dm
+++ b/modular_nova/modules/primitive_catgirls/code/spawner.dm
@@ -22,7 +22,7 @@
 	quirks_enabled = TRUE
 	random_appearance = FALSE
 	loadout_enabled = FALSE
-	uses = 9
+	uses = 12
 	deletes_on_zero_uses_left = FALSE
 
 /obj/effect/mob_spawn/ghost_role/human/primitive_catgirl/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

Due to an increase in the amount of hearthkin players, the need to increase the amount of their ghost role spawns was born. 

## How This Contributes To The Nova Sector Roleplay Experience

People won't be locked out of playing if they don't join the moment the round starts. At least, that's the hope. 

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/38175176/608add5e-a19a-48d7-b90f-f294c30bea15)
![image](https://github.com/NovaSector/NovaSector/assets/38175176/90cf11cc-8b4f-4637-8879-10fe252c665f)
![image](https://github.com/NovaSector/NovaSector/assets/38175176/1daf0446-296b-4423-ba6b-05f9e5ac10a4)
</details>

## Changelog

:cl:MortoSasye
code: The amount of slots for hearthkin (primitive demihumans) was changed to 12 from 9.
/:cl:
