### PR TITLE
A few more alternative job titles

### DIFF
--- a/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -29,6 +29,7 @@
 		"Trader",
 		"Off-Duty Crew",
 		"Off-Duty Staff",
+		"Colonist",
 	)
 
 /datum/job/atmospheric_technician
@@ -63,6 +64,7 @@
 		"Bitdomain Technician",
 		"Data Retrieval Specialist",
 		"Netdiver",
+		"Netrunner",
 		"Pod Jockey",
 		"Union Bitrunner",
 		"Junior Runner",
@@ -91,6 +93,7 @@
 	alt_titles = list(
 		"Bouncer",
 		"Service Guard",
+		"Doorman",
 	)
 
 /datum/job/corrections_officer
@@ -299,6 +302,7 @@
 		"Paramedic",
 		"Emergency Medical Technician",
 		"Search and Rescue Technician",
+		"Trauma Team",
 	)
 
 /datum/job/prisoner
@@ -343,6 +347,7 @@
 	alt_titles = list(
 		"Roboticist",
 		"Biomechanical Engineer",
+		"Cyberneticist",
 		"Machinist",
 		"Mechatronic Engineer",
 		"Apprentice Roboticist",
@@ -360,6 +365,7 @@
 		"Lab Technician",
 		"Ordnance Technician",
 		"Plasma Researcher",
+		"Resonance Researcher",
 		"Theoretical Physicist",
 		"Xenoarchaeologist",
 		"Xenobiologist",


### PR DESCRIPTION
## About The Pull Request

Really simple, just a few more alt job titles for the following roles:

- Assistant gains **Colonist**, for people who want to predominately occupy themselves building external structures on the ground with our vast array of frontier equipment.
- Service Guard gains **Doorman**, a fancier spin on bouncer for people who want to play along with high-culture stuff available in other roles (mixologist, concierge, etc).
- Paramedic gains **Trauma Team**. PLACE THE PATIENT ON THE GROUND.
- Bitrunner gains **Netrunner**, a combination of netdiver & bitrunner which is also a common hackerman staple in many decker-adjacent bits of fiction.
- Roboticist gains **Cyberneticist**, for characters who want to delineate themselves as focusing mostly on dealing with augmented limbs and implants.
- Scientist gains **Resonance Researcher**, for characters who want to signal their interest in dealing with RSD-related technology or anything like that.

I figured these would be nice to have for people who want to lean harder into certain tropes.

## How This Contributes To The Nova Sector Roleplay Experience

Titles are minor but important bits of fantasy. The little things help!

## Proof of Testing

It compiles!

## Changelog

:cl: yooriss
add: The Colonist, Doorman, Trauma Team, Netrunner, Cyberneticist and Resonance Researcher job alternate titles have been added to their appropriate jobs (Assistant, Service Guard, Paramedic, Bitrunner, Roboticist and Scientist respectively).
/:cl: