### PR TITLE
Fixes being able to flip holographic tables into reality and harvest them for materials

### DIFF
--- a/modular_nova/modules/tableflip/code/flipped_table.dm
+++ b/modular_nova/modules/tableflip/code/flipped_table.dm
@@ -52,10 +52,13 @@
 		return FALSE
 	user.balloon_alert_to_viewers("flipping table upright...")
 	if(do_after(user, max_integrity * 0.25))
-		var/obj/structure/table/new_table = new table_type(src.loc)
-		new_table.update_integrity(src.get_integrity())
+		var/obj/structure/table/unflipped_table = new table_type(src.loc)
+		unflipped_table.update_integrity(src.get_integrity())
+		if(flags_1 & HOLOGRAM_1) // no unflipping holographic tables into reality
+			unflipped_table.flags_1 |= HOLOGRAM_1
+			unflipped_table.obj_flags |= NO_DECONSTRUCTION
 		if(custom_materials)
-			new_table.set_custom_materials(custom_materials)
+			unflipped_table.set_custom_materials(custom_materials)
 		user.balloon_alert_to_viewers("table flipped upright")
 		playsound(src, 'sound/items/trayhit2.ogg', 100)
 		qdel(src)
@@ -85,6 +88,9 @@
 	flipped_table.table_type = src.type
 	if(istype(src, /obj/structure/table/greyscale)) //Greyscale tables need greyscale flags!
 		flipped_table.material_flags = MATERIAL_EFFECTS | MATERIAL_COLOR
+	if(flags_1 & HOLOGRAM_1) // no flipping holographic tables into reality
+		flipped_table.flags_1 |= HOLOGRAM_1
+		flipped_table.obj_flags |= NO_DECONSTRUCTION
 	//Finally, add the custom materials, so the flags still apply to it
 	flipped_table.set_custom_materials(custom_materials)
 

--- a/modular_nova/modules/tableflip/code/flipped_table.dm
+++ b/modular_nova/modules/tableflip/code/flipped_table.dm
@@ -55,8 +55,11 @@
 		var/obj/structure/table/unflipped_table = new table_type(src.loc)
 		unflipped_table.update_integrity(src.get_integrity())
 		if(flags_1 & HOLOGRAM_1) // no unflipping holographic tables into reality
-			unflipped_table.flags_1 |= HOLOGRAM_1
-			unflipped_table.obj_flags |= NO_DECONSTRUCTION
+			var/area/station/holodeck/holo_area = get_area(unflipped_table)
+			if(!istype(holo_area))
+				qdel(unflipped_table)
+				return
+			holo_area.linked.add_to_spawned(unflipped_table)
 		if(custom_materials)
 			unflipped_table.set_custom_materials(custom_materials)
 		user.balloon_alert_to_viewers("table flipped upright")
@@ -89,8 +92,11 @@
 	if(istype(src, /obj/structure/table/greyscale)) //Greyscale tables need greyscale flags!
 		flipped_table.material_flags = MATERIAL_EFFECTS | MATERIAL_COLOR
 	if(flags_1 & HOLOGRAM_1) // no flipping holographic tables into reality
-		flipped_table.flags_1 |= HOLOGRAM_1
-		flipped_table.obj_flags |= NO_DECONSTRUCTION
+		var/area/station/holodeck/holo_area = get_area(flipped_table)
+		if(!istype(holo_area))
+			qdel(flipped_table)
+			return
+		holo_area.linked.add_to_spawned(flipped_table)
 	//Finally, add the custom materials, so the flags still apply to it
 	flipped_table.set_custom_materials(custom_materials)
 


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/570

That's it really!

## How This Contributes To The Nova Sector Roleplay Experience

Fixes an oversight/potential material exploit with the tableflipping system.

## Proof of Testing

<details>
<summary>Holographic tables will now obey the laws of physics and cannot be dismantled</summary>
  
![dreamseeker_8aP8JaJdvV](https://github.com/NovaSector/NovaSector/assets/13398309/358210e6-6fc8-499f-a390-c1aa85a7ae43)

</details>

## Changelog

:cl:
fix: fixes being able to flip holographic tables into reality and harvest them for materials
/:cl: