### PR TITLE
Contractor Stuff - armor booster speed consistency, 

### DIFF
--- a/code/modules/jobs/job_types/spawner/ghost_role.dm
+++ b/code/modules/jobs/job_types/spawner/ghost_role.dm
@@ -3,3 +3,4 @@
 /datum/job/ghost_role
 	title = ROLE_GHOST_ROLE
 	policy_index = ROLE_GHOST_ROLE
+	paycheck = PAYCHECK_ZERO // nuh uh

--- a/modular_nova/modules/contractor/code/datums/midround/outfit.dm
+++ b/modular_nova/modules/contractor/code/datums/midround/outfit.dm
@@ -27,6 +27,13 @@
 
 	id_trim = /datum/id_trim/chameleon/contractor
 
+/datum/outfit/contractor/post_equip(mob/living/carbon/human/user, visualsOnly)
+	. = ..()
+	if(visualsOnly)
+		return
+	handlebank(user)
+
+
 /datum/outfit/contractor_preview
 	name = "Syndicate Contractor (Preview only)"
 

--- a/modular_nova/modules/contractor/code/items/modsuit/modules.dm
+++ b/modular_nova/modules/contractor/code/items/modsuit/modules.dm
@@ -1,8 +1,9 @@
 /obj/item/mod/module/baton_holster
 	name = "MOD baton holster module"
-	desc = "A module installed into the chest of a MODSuit, this allows you \
-		to retrieve an inserted baton from the suit at will. Insert a baton \
-		by hitting the module, while it is removed from the suit, with the baton."
+	desc = "A module installed into the forearm and palm of a MODsuit, this allows you \
+		to retrieve an inserted baton from the suit at will, and provides the benefit of being \
+		magnetically locked, making it near-impossible to force out of a user's hands. \
+		Insert a baton by hitting the module, while it is removed from the suit, with the baton."
 	icon_state = "holster"
 	icon = 'modular_nova/modules/contractor/icons/modsuit_modules.dmi'
 	module_type = MODULE_ACTIVE
@@ -37,21 +38,22 @@
 
 /obj/item/mod/module/baton_holster/preloaded
 	eaten_baton = TRUE
-	device = /obj/item/melee/baton/telescopic/contractor_baton
 
 /obj/item/mod/module/baton_holster/preloaded/upgraded
 	device = /obj/item/melee/baton/telescopic/contractor_baton/upgraded
 
 /obj/item/mod/module/chameleon/contractor // zero complexity module to match pre-TGification
+	removable = FALSE
 	complexity = 0
 
 /obj/item/mod/module/armor_booster/contractor // Much flatter distribution because contractor suit gets a shitton of armor already
 	armor_mod = /datum/armor/contract_booster
-	speed_added = -0.5 //Bulky as shit
-	desc = "An embedded set of armor plates, allowing the suit's already extremely high protection \
-		to be increased further. However, the plating, while deployed, will slow down the user \
-		and make the suit unable to vacuum seal so this extra armor provides zero ability for extravehicular activity while deployed."
+	desc = "An integrated set of auxiliary armor plates, allowing the suit's modest protection to be increased further. \
+	However, the plating cannot deploy with the suit's vacuum sealing components, and thus provides zero ability for extravehicular activity while deployed."
 
+// 35 melee 40 bullet 35 laser 35 energy when deployed
+// compare/contrast w/ syndicate mod:
+// 40 melee 50 bullet 30 laser 30 energy
 /datum/armor/contract_booster
 	melee = 20
 	bullet = 20
@@ -60,8 +62,8 @@
 
 /obj/item/mod/module/springlock/contractor
 	name = "MOD magnetic deployment module"
-	desc = "A much more modern version of a springlock system. \
-	This is a module that uses magnets to speed up the deployment and retraction time of your MODsuit."
+	desc = "A much more modern version of a springlock system, utilizing magnets to speed up the deployment and retraction time of a MODsuit \
+	with a distinct lack of ability to snap into place when exposed to moisture."
 	icon_state = "magnet"
 	icon = 'modular_nova/modules/contractor/icons/modsuit_modules.dmi'
 

--- a/modular_nova/modules/contractor/code/items/modsuit/theme.dm
+++ b/modular_nova/modules/contractor/code/items/modsuit/theme.dm
@@ -1,22 +1,22 @@
 /datum/mod_theme/contractor
 	name = "contractor"
-	desc = "A top-tier MODSuit developed with cooperation of Cybersun Industries and the Gorlex Marauders, a favorite of Syndicate Contractors."
-	extended_desc = "A rare depart from the Syndicate's usual color scheme, the Contractor MODsuit is produced and manufactured \
-		for specialty contractors. The build is a streamlined layering consisting of shaped Plastitanium, \
-		and composite ceramic, while the under suit is lined with a lightweight Kevlar and durathread hybrid weave \
-		to provide ample protection to the user where the plating doesn't, with an illegal onboard electric powered \
-		ablative shield module to provide resistance against conventional energy firearms. \
-		In addition, it has an in-built chameleon system, allowing you to disguise the suit while undeployed. \
-		A small tag hangs off of it reading; 'Property of the Gorlex Marauders, with assistance from Cybersun Industries. \
-		All rights reserved, tampering with suit will void warranty."
+	desc = "A MODSuit developed as a joint venture of Cybersun Industries and the Gorlex Marauders; standard-issue for Syndicate contractors."
+	extended_desc = "A rare departure from the Syndicate's usual color scheme, the Contractor MODsuit is produced and manufactured \
+		for specialty contractors, built for travelling and fighting light, providing no encumberance when deactivated, but slight encumberance otherwise. \
+		The external plating is composed of streamlined layers of shaped plastitanium and composite ceramic, \
+		while the undersuit is lined with an ablative kevlar hybrid weave to provide ample protection to the user where the plating doesn't. \
+		Unfortunately, the sacrifices made for a lightweight build mean that it is slightly less armored than its crimson siblings. \
+		In addition, it has an integrated chameleon system, allowing you to disguise the suit while undeployed. \
+		A small tag hangs off of it, reading 'Property of the Gorlex Marauders, with assistance from Cybersun Industries. \
+		All rights reserved, tampering with suit will void warranty.'"
 	default_skin = "contractor"
 	armor_type = /datum/armor/mod_theme_contractor
 	resistance_flags = FIRE_PROOF
 	atom_flags = PREVENT_CONTENTS_EXPLOSION_1
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
-	slowdown_inactive = 0.5
-	slowdown_active = 0
+	slowdown_inactive = 0 // for the chameleon module synergy
+	slowdown_active = 0.5
 	ui_theme = "syndicate"
 	inbuilt_modules = list(/obj/item/mod/module/armor_booster/contractor, /obj/item/mod/module/chameleon/contractor)
 	allowed_suit_storage = list(


### PR DESCRIPTION
## About The Pull Request
Drifting contractors get their own bank account.
Contractor MOD's chameleon module is now unremovable, because it's a snowflake 0-complexity one.
Contractor MOD has no slowdown when turned off (for use with the chameleon module), but has some slowdown when enabled. Its armor booster is now consistent with every other armor booster in the game, providing just enough speed to negate its slowdown.

## How This Contributes To The Nova Sector Roleplay Experience
Contractors no longer have to mug innocent stationgoers to not get bombarded with briefcases of cash. The MOD's stealth aspect (chameleon module) sucks less to use. The armor booster's slowdown is no longer the inverse of what it usually is (e.g. syndicate MOD having no slowdown when boosted, slowdown when unboosted).

## Proof of Testing

![image](https://github.com/NovaSector/NovaSector/assets/31829017/2bd20a10-a410-48fa-a128-4aca0d199155)

## Changelog

:cl:
add: Drifting contractors now get their own bank account.
balance: The contractor MODsuit now has no slowdown when deactivated to facilitate use of its integrated chameleon module.
balance: The contractor MODsuit's 0-complexity chameleon module is now unremovable.
balance: The contractor MODsuit now has slowdown when activated, and its armor booster has been made consistent (it now reduces slowdown instead of adding it, when toggled on).
fix: Ghostrole bank accounts no longer steal money from the station civilian account.
/:cl:

