### PR TITLE
Peddling Purple Prose: Porting the 'Do' action from F13

### DIFF
--- a/code/__DEFINES/~nova_defines/keybindings.dm
+++ b/code/__DEFINES/~nova_defines/keybindings.dm
@@ -4,3 +4,5 @@
 #define COMSIG_KB_CLIENT_WHISPER_DOWN "keybinding_client_whisper_down"
 #define COMSIG_KB_LIVING_COMBAT_INDICATOR "keybinding_living_combat_indicator"
 #define COMSIG_KB_CARBON_TOGGLE_SAFETY "keybinding_carbon_toggle_safety"
+#define COMSIG_KB_CLIENT_DO_DOWN "keybinding_client_do_down"
+#define COMSIG_KB_CLIENT_DO_LONGER_DOWN "keybinding_client_do_longer_down"

--- a/code/__DEFINES/~nova_defines/say.dm
+++ b/code/__DEFINES/~nova_defines/say.dm
@@ -1,3 +1,4 @@
 #define MAX_FLAVOR_LEN 4096		//double the maximum message length.
 #define LOOC_CHANNEL "LOOC" // LOOC
 #define WHIS_CHANNEL "Whis" // Whisper
+#define DO_CHANNEL "Do" // Do

--- a/code/modules/tgui_input/say_modal/speech.dm
+++ b/code/modules/tgui_input/say_modal/speech.dm
@@ -54,6 +54,8 @@
 		if(WHIS_CHANNEL)
 			client.mob.whisper_verb(entry)
 			return TRUE
+		if(DO_CHANNEL)
+			client.mob.do_verb(entry)
 		// NOVA EDIT ADDITION END
 	return FALSE
 

--- a/modular_nova/modules/customization/datums/keybinding/communication.dm
+++ b/modular_nova/modules/customization/datums/keybinding/communication.dm
@@ -23,3 +23,33 @@
 		return
 	winset(user, null, "command=[user.tgui_say_create_open_command(WHIS_CHANNEL)]")
 	return TRUE
+
+/datum/keybinding/client/communication/Do
+	hotkey_keys = list("K")
+	name = DO_CHANNEL
+	full_name = "Do"
+	keybind_signal = COMSIG_KB_CLIENT_DO_DOWN
+
+/datum/keybinding/client/communication/Do/down(client/user)
+	. = ..()
+	if(.)
+		return
+	winset(user, null, "command=[user.tgui_say_create_open_command(DO_CHANNEL)]")
+	return TRUE
+
+/datum/keybinding/client/communication/Do_longer
+	hotkey_keys = list("CtrlK")
+	name = "do_longer"
+	full_name = "Do (Longer)"
+	keybind_signal = COMSIG_KB_CLIENT_DO_DOWN
+
+/datum/keybinding/client/communication/Do_longer/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/message_text = tgui_input_text(user, "Write out your Do action:", "Do (Longer)" , null, MAX_MESSAGE_LEN, TRUE)
+	if (!message_text)
+		return
+
+	user.mob.do_verb(message_text)
+	return TRUE

--- a/modular_nova/modules/roleplay_do/code/do_checks.dm
+++ b/modular_nova/modules/roleplay_do/code/do_checks.dm
@@ -1,0 +1,20 @@
+/mob/proc/do_checks(message)
+	if(!length(message))
+		return FALSE
+
+	if(GLOB.say_disabled)	//This is here to try to identify lag problems
+		to_chat(usr, span_danger("Speech is currently admin-disabled."))
+		return FALSE
+
+	//quickly calc our name stub again: duplicate this in say.dm override
+	var/name_stub = " (<b>[usr]</b>)"
+	if(length(message) > (MAX_MESSAGE_LEN - length(name_stub)))
+		to_chat(usr, message)
+		to_chat(usr, span_warning("^^^----- The preceeding message has been DISCARDED for being over the maximum length of [MAX_MESSAGE_LEN]. It has NOT been sent! -----^^^"))
+		return FALSE
+
+	if(usr.stat == SOFT_CRIT || usr.stat == UNCONSCIOUS || usr.stat == DEAD)
+		to_chat(usr, span_notice("You cannot send a Do in your current condition."))
+		return FALSE
+
+	return TRUE

--- a/modular_nova/modules/roleplay_do/code/do_verbs.dm
+++ b/modular_nova/modules/roleplay_do/code/do_verbs.dm
@@ -1,0 +1,36 @@
+/mob/verb/do_verb(message as message)
+	set name = "do"
+	set category = "IC"
+	set instant = TRUE
+
+	if(GLOB.say_disabled)
+		to_chat(usr, span_danger("Speech is currently admin-disabled."))
+		return
+
+	if(message)
+		QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_VERB_REF(/mob, do_actual_verb), message), SSspeech_controller)
+
+/mob/verb/do_actual_verb(message as message)
+	if (!message || !do_checks(message))
+		return
+
+	if (!try_speak(message)) // ensure we pass the vibe check (filters, etc)
+		return
+
+	var/name_stub = " (<b>[usr]</b>)"
+	message = usr.say_emphasis(message)
+	message = trim(copytext_char(message, 1, (MAX_MESSAGE_LEN - length(name_stub))))
+	var/message_with_name = message + name_stub
+
+	usr.log_message(message, LOG_EMOTE)
+
+	var/list/viewers = view(usr.loc)
+
+	for(var/mob/ghost as anything in GLOB.dead_mob_list)
+		if((ghost.client?.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(ghost in viewers))
+			ghost.show_message(span_emote(message_with_name))
+
+	for(var/mob/reciever in viewers)
+		reciever.show_message(span_emote(message_with_name), alt_msg = span_emote(message_with_name))
+		if (reciever.client?.prefs.read_preference(/datum/preference/toggle/enable_runechat))
+			create_chat_message(usr, null, message, null, EMOTE_MESSAGE)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7962,6 +7962,8 @@
 #include "modular_nova\modules\robot_limb_detach\code\robot_limb_detach_quirk.dm"
 #include "modular_nova\modules\rod-stopper\code\immovable_nova.dm"
 #include "modular_nova\modules\rod-stopper\code\rodstopper.dm"
+#include "modular_nova\modules\roleplay_do\code\do_checks.dm"
+#include "modular_nova\modules\roleplay_do\code\do_verbs.dm"
 #include "modular_nova\modules\salon\code\barber.dm"
 #include "modular_nova\modules\salon\code\barber_chair.dm"
 #include "modular_nova\modules\salon\code\barbervend.dm"

--- a/tgui/packages/tgui-say/ChannelIterator.ts
+++ b/tgui/packages/tgui-say/ChannelIterator.ts
@@ -5,6 +5,7 @@ export type Channel =
   // NOVA EDIT ADDITION START
   | 'Whis'
   | 'LOOC'
+  | 'Do'
   // NOVA EDIT ADDITION END
   | 'OOC'
   | 'Admin';
@@ -24,6 +25,7 @@ export class ChannelIterator {
     // NOVA EDIT ADDITION
     'Whis',
     'LOOC',
+    'Do',
     // NOVA EDIT ADDITION
     'OOC',
     'Admin',

--- a/tgui/packages/tgui-say/constants/index.tsx
+++ b/tgui/packages/tgui-say/constants/index.tsx
@@ -5,6 +5,7 @@ export const CHANNELS = [
   'Me',
   'Whis', // NOVA EDIT ADDITION - CUSTOMIZATION
   'LOOC', // NOVA EDIT ADDITION - CUSTOMIZATION
+  'Do', //NOVA EDIT ADDITION - Do roleplay addition
   'OOC',
   'Admin',
 ] as const;

--- a/tgui/packages/tgui-say/styles/colors.scss
+++ b/tgui/packages/tgui-say/styles/colors.scss
@@ -28,6 +28,7 @@ $_channel_map: (
   'Synd': #8f4a4b,
   // NOVA EDIT ADDITION
   'Whis': #7c7fd9,
+  'Do': #59da7e,
 );
 
 $channel_keys: map.keys($_channel_map) !default;


### PR DESCRIPTION
## About The Pull Request

Inspired quite directly from https://github.com/f13babylon/f13babylon/pull/200 after several people requested it in #main-talk earlier today, I've taken the liberty of porting a best shot implementation of a 'do' action in our codebase - fully, in TGUI as a new chat channel similar to LOOC and whispers plus a longform version.

The command is initially bound to K in its TGUI shortform, and Ctrl+K in its input longform. Totally changeable to whatever you like!

A picture's worth a thousand words, so here's some snippets of Do in its natural habitat:

![dreamseeker_CtDthPuxwS](https://github.com/NovaSector/NovaSector/assets/966289/688bef65-8545-4ae2-9e90-6bc882bd91e0)

![dreamseeker_WF580G3tx8](https://github.com/NovaSector/NovaSector/assets/966289/858f5480-588f-4708-81d2-1b6991abd3d7)

![](https://puu.sh/K01gp/762f7c3684.png)

![](https://puu.sh/K01gu/942355f8a6.png)

As noted, Do sends as much via runechat as it can for shortform enjoyers. At some point I'll figure out how to change the asterisk in runechat emotes into something else, but that something else is not today.

## How This Contributes To The Nova Sector Roleplay Experience

Though simple in nature, this adds an entirely new way for people to express themselves in prose without having to innately include their character in the end result. Allows for a *lot* of believable soft-DMing of the environment in many cases - this kind of functionality is a staple in many MUD codebases for this reason, and it'll do wonders for people who like it here.

## Proof of Testing

See description!

## Changelog

:cl: yooriss
add: A new form of emoting is available called 'Do', accessible via the K and Ctrl-K keybinds by default (as well as the 'Do' verb). Do doesn't put your character name first and instead includes it in brackets at the end, so you can use it to write better prose and even narrate things in the environment around you with less clunkiness! Try it out today.
/:cl: