### PR TITLE
[NON-MODULAR] Sets most alert times to *1 (ie 20 minutes, always)

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -447,21 +447,21 @@ SUBSYSTEM_DEF(shuttle)
 				return
 		if(SEC_LEVEL_BLUE)
 			//if(emergency.timeLeft(1) < emergency_call_time * 0.5) ORIGINAL
-			if(emergency.timeLeft(1) < emergency_call_time * 0.6) //NOVA EDIT CHANGE - ALERTS
+			if(emergency.timeLeft(1) < emergency_call_time * 1) //NOVA EDIT CHANGE - SHUTTLENING
 				return
 		//NOVA EDIT ADDITION BEGIN - ALERTS
 		if(SEC_LEVEL_ORANGE)
-			if(emergency.timeLeft(1) < emergency_call_time * 0.4)
+			if(emergency.timeLeft(1) < emergency_call_time * 1)
 				return
 		if(SEC_LEVEL_VIOLET)
-			if(emergency.timeLeft(1) < emergency_call_time * 0.4)
+			if(emergency.timeLeft(1) < emergency_call_time * 1)
 				return
 		if(SEC_LEVEL_AMBER)
-			if(emergency.timeLeft(1) < emergency_call_time * 0.4)
+			if(emergency.timeLeft(1) < emergency_call_time * 1)
 				return
 		//NOVA EDIT ADDITION END
 		else
-			if(emergency.timeLeft(1) < emergency_call_time * 0.25)
+			if(emergency.timeLeft(1) < emergency_call_time * 0.5) // NOVA EDIT - SHUTTLENING ORIGINAL .25
 				return
 	return 1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

On TG the shuttle comes to the station faster when it's under duress, but slower when it's on green alert. This makes sense! Green alert is the last call for antagonists to get their bits in, while a higher alert means they're on a time table to finish up before the crew "wins," such as it is. In contrast, though, here a higher alert means that something is **happening**
 (or it's a stalled out forever amber but what can you do.) We don't want **something** to be cut off.

This PR will unify blue, amber, violent, orange, and of course green to *1, or a shuttle timer of a full twenty minutes. Crisp, uniform, rounds will almost always be 3:20. Red (and delta and I guess gamma etc) is set to .5, or ten minutes, because those are actual serious business and it makes sense to hurry things along, but still have more wiggle room then the five minutes it was prior.

This is a bit hacky and I probably could have made an IF list or something, it's a non-modular edit anyway and I'd rather keep the old skeleton for further would-be edits later.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Let's stop specifically ending the round when something is going on.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

honestly this one time I didn't but it's a text edit

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: The shuttle's arrival time no longer changes based on alert, beyond red and higher.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
