### PR TITLE
Update to Hearthkin Map

### DIFF
--- a/_maps/RandomRuins/IceRuins/nova/icemoon_underground_icewalker_lower.dmm
+++ b/_maps/RandomRuins/IceRuins/nova/icemoon_underground_icewalker_lower.dmm
@@ -167,12 +167,8 @@
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "dS" = (
-/obj/structure/bed/maint{
-	pixel_y = 13
-	},
-/obj/item/bedsheet/black{
-	pixel_y = 12
-	},
+/obj/structure/wall_torch/spawns_lit/directional/north,
+/obj/structure/curtain/bounty,
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "ed" = (
@@ -245,6 +241,22 @@
 "fY" = (
 /obj/structure/flora/ash,
 /turf/open/misc/dirt/icemoon,
+/area/ruin/unpowered/primitive_catgirl_den)
+"gd" = (
+/obj/structure/rack/wooden,
+/obj/item/towel{
+	pixel_y = 9;
+	pixel_x = 5
+	},
+/obj/item/towel{
+	pixel_y = -5;
+	pixel_x = 1
+	},
+/obj/item/towel{
+	pixel_y = -5;
+	pixel_x = -5
+	},
+/turf/open/floor/wood/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "gt" = (
 /obj/structure/rack/wooden,
@@ -556,18 +568,12 @@
 /area/ruin/unpowered/primitive_catgirl_den)
 "mN" = (
 /obj/structure/wall_torch/spawns_lit/directional/north,
-/obj/structure/rack/wooden,
-/obj/item/towel{
-	pixel_y = -5;
-	pixel_x = -5
+/obj/structure/bed/maint,
+/obj/structure/bed/maint{
+	pixel_y = 13
 	},
-/obj/item/towel{
-	pixel_y = -5;
-	pixel_x = 1
-	},
-/obj/item/towel{
-	pixel_y = 9;
-	pixel_x = 5
+/obj/item/bedsheet/black/double{
+	dir = 1
 	},
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
@@ -678,15 +684,13 @@
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "pc" = (
-/obj/structure/table/wood,
-/obj/item/plate/oven_tray/material/fake_brass{
-	pixel_y = 5;
-	pixel_x = -13
+/obj/item/bedsheet/black{
+	pixel_y = 12
 	},
-/obj/item/stack/sheet/bone{
-	pixel_y = 7;
-	pixel_x = -13
+/obj/structure/bed/maint{
+	pixel_y = 13
 	},
+/obj/structure/bed/dogbed,
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "pA" = (
@@ -783,6 +787,18 @@
 /obj/machinery/oven/stone,
 /turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
+"qU" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/obj/structure/mineral_door/wood/large_gate{
+	dir = 1
+	},
+/turf/open/misc/dirt/icemoon,
+/area/ruin/unpowered/primitive_catgirl_den)
 "ra" = (
 /obj/structure/rack/wooden,
 /turf/open/misc/dirt/icemoon,
@@ -839,15 +855,8 @@
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "rX" = (
-/obj/structure/rack/wooden,
-/obj/item/reagent_containers/cup/glass/bottle/hooch{
-	pixel_y = 2;
-	pixel_x = -5
-	},
-/obj/item/reagent_containers/cup/glass/trophy/bronze_cup{
-	pixel_x = 8;
-	pixel_y = 4
-	},
+/obj/structure/wall_torch/spawns_lit/directional/south,
+/obj/structure/curtain/bounty,
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "sf" = (
@@ -952,6 +961,7 @@
 /obj/item/seeds/olive,
 /obj/item/seeds/peanut,
 /obj/item/seeds/peas,
+/obj/item/seeds/banana,
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "vx" = (
@@ -1173,8 +1183,7 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "Br" = (
-/obj/structure/wall_torch/spawns_lit/directional/north,
-/obj/structure/bed/dogbed,
+/obj/structure/closet/xenoarch/ashwalker_version,
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "BO" = (
@@ -1188,8 +1197,13 @@
 /turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "CQ" = (
-/obj/structure/wall_torch/spawns_lit/directional/north,
-/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/obj/structure/mineral_door/wood/large_gate,
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "CT" = (
@@ -1479,6 +1493,24 @@
 	},
 /turf/open/water/hot_spring,
 /area/ruin/unpowered/primitive_catgirl_den)
+"KO" = (
+/obj/structure/rack/wooden,
+/obj/item/pickaxe/mini{
+	pixel_x = -5
+	},
+/obj/item/pickaxe/mini{
+	pixel_x = 5
+	},
+/obj/item/ore_sensor{
+	pixel_y = -1;
+	pixel_x = -5
+	},
+/obj/item/ore_sensor{
+	pixel_y = -1;
+	pixel_x = 5
+	},
+/turf/open/misc/dirt/icemoon,
+/area/ruin/unpowered/primitive_catgirl_den)
 "Lj" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -1546,19 +1578,7 @@
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "NC" = (
-/obj/structure/rack/wooden,
-/obj/item/reagent_containers/cup/beaker/large/blowing_glass{
-	pixel_y = 9;
-	pixel_x = -5
-	},
-/obj/item/reagent_containers/cup/beaker/large/blowing_glass{
-	pixel_y = 9;
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/cup/beaker/large/ceramic{
-	pixel_y = -5;
-	pixel_x = 7
-	},
+/obj/structure/curtain/bounty,
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "NJ" = (
@@ -1803,9 +1823,12 @@
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "Ti" = (
-/obj/structure/table/wood,
-/obj/item/knife/combat/bone{
-	pixel_y = 5
+/obj/structure/bed/maint,
+/obj/structure/bed/maint{
+	pixel_y = 13
+	},
+/obj/item/bedsheet/black/double{
+	dir = 1
 	},
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
@@ -1857,7 +1880,15 @@
 /turf/open/floor/wood/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "UT" = (
-/obj/structure/mineral_door/wood/large_gate,
+/obj/item/reagent_containers/cup/glass/bottle/hooch{
+	pixel_y = 2;
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/cup/glass/trophy/bronze_cup{
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/obj/structure/rack/wooden,
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "UV" = (
@@ -1906,6 +1937,10 @@
 /obj/item/hatchet/wooden{
 	pixel_y = 5;
 	pixel_x = 4
+	},
+/obj/item/ore_sensor{
+	pixel_y = -1;
+	pixel_x = -5
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
@@ -1964,6 +1999,18 @@
 	pixel_y = 11;
 	pixel_x = -1
 	},
+/obj/item/reagent_containers/cup/beaker/large/blowing_glass{
+	pixel_y = 9;
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/cup/beaker/large/blowing_glass{
+	pixel_y = 9;
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/cup/beaker/large/ceramic{
+	pixel_y = -5;
+	pixel_x = 7
+	},
 /turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "XK" = (
@@ -2001,7 +2048,6 @@
 /turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "Zs" = (
-/obj/structure/wall_torch/spawns_lit/directional/south,
 /obj/item/pillow/random{
 	pixel_y = 4
 	},
@@ -2638,7 +2684,7 @@ PG
 Sf
 ou
 GU
-Sf
+gd
 Ob
 GN
 GN
@@ -2680,7 +2726,7 @@ cw
 cw
 Df
 Lz
-qM
+ZJ
 Uk
 Ry
 GN
@@ -3077,7 +3123,7 @@ oJ
 yF
 VT
 ra
-ZJ
+Br
 yF
 oJ
 oJ
@@ -3188,7 +3234,7 @@ GN
 pa
 oX
 ZJ
-lf
+ZJ
 ZJ
 rL
 pa
@@ -3231,7 +3277,7 @@ pa
 hA
 ZJ
 Ti
-au
+ZJ
 sJ
 pa
 oJ
@@ -3271,7 +3317,7 @@ GN
 GN
 pa
 kF
-Vs
+ZJ
 pc
 ZJ
 OM
@@ -3313,9 +3359,9 @@ GN
 yF
 yF
 yF
-OI
+dS
 NC
-RC
+rX
 yF
 yF
 yF
@@ -3354,13 +3400,13 @@ GN
 GN
 GN
 pa
-hA
+rv
 ZJ
 RR
 ZJ
-rX
+ZJ
+UT
 pa
-oJ
 oJ
 oJ
 Te
@@ -3396,13 +3442,13 @@ yF
 GN
 GN
 pa
-kF
+kp
 ZJ
 ZJ
 ZJ
 ZJ
-UT
-aW
+ZJ
+CQ
 Zu
 Zu
 yK
@@ -3438,13 +3484,13 @@ II
 JN
 zS
 pa
-dS
+eS
 ZJ
 lf
 ZJ
+ZJ
 mk
 pa
-oJ
 JN
 Ug
 oJ
@@ -3480,11 +3526,11 @@ oJ
 oJ
 yF
 yF
-yF
-Br
+OI
+ZJ
 oA
 Zs
-yF
+RC
 yF
 yF
 bX
@@ -3520,13 +3566,13 @@ aW
 aW
 aW
 qu
-oJ
 pa
 qq
+ZJ
 gU
 jm
 au
-rv
+ZJ
 pa
 pb
 qu
@@ -3562,13 +3608,13 @@ oJ
 oJ
 Vb
 JN
-RY
-iJ
+qU
+ZJ
 ZJ
 rK
 DY
 ZJ
-kp
+ZJ
 pa
 jw
 qg
@@ -3604,13 +3650,13 @@ hQ
 Bc
 xI
 oJ
-oJ
 pa
 lg
+ZJ
 Vs
 gY
 wM
-eS
+ZJ
 pa
 Ug
 oJ
@@ -3637,7 +3683,7 @@ Yf
 EA
 yF
 ZJ
-Yf
+KO
 pa
 JW
 yD
@@ -3648,8 +3694,8 @@ kS
 FI
 yF
 yF
-yF
-CQ
+OI
+sK
 tI
 wN
 yF
@@ -3777,7 +3823,7 @@ pa
 PO
 oK
 qM
-aK
+ZJ
 vx
 qO
 yF

--- a/_maps/RandomRuins/IceRuins/nova/icemoon_underground_icewalker_upper.dmm
+++ b/_maps/RandomRuins/IceRuins/nova/icemoon_underground_icewalker_upper.dmm
@@ -809,6 +809,10 @@
 	pixel_x = 3
 	},
 /obj/item/pen/charcoal,
+/obj/item/reagent_containers/cup/primitive_centrifuge{
+	pixel_x = -14;
+	pixel_y = -1
+	},
 /turf/open/floor/wood/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "CS" = (
@@ -1018,18 +1022,6 @@
 /area/ruin/unpowered/primitive_catgirl_den)
 "Op" = (
 /obj/structure/closet/crate/wooden/storage_barrel,
-/obj/item/bedsheet/black{
-	pixel_x = 5;
-	pixel_y = -2
-	},
-/obj/item/bedsheet/black{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/bedsheet/black{
-	pixel_x = 5;
-	pixel_y = 8
-	},
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "Ou" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives an update to the hearthkin map: 

- Adds the ashwalker version of the xenoarchaelogy locker too to the hearthkin camp.
- Modified the mess hall to allow walking with ease.
- Adds a starting centrifuge to the healing den.
- Adds three more ore sensors.
- Adds a banana seed pack to one of the barrels in the garden.
- Removed excess bedsheets in the healing den.

## How This Contributes To The Nova Sector Roleplay Experience

Every time we bump with another in the kitchen area table, we lose 1 point of patience. The expansion to the mess hall will help with it.

Bananas were added also to help make seiver, to heal toxins when needed.

And finally, the xenoarchaeology locker was added to allow for hearthkin to find strange plants, and other useful "artifacts" in rocks. 

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
![image](https://github.com/NovaSector/NovaSector/assets/38175176/12c69962-47ed-4cbf-92ab-8d117ec109d4)
![image](https://github.com/NovaSector/NovaSector/assets/38175176/3212698d-707f-401a-b9c4-dc93122583c8)
![image](https://github.com/NovaSector/NovaSector/assets/38175176/3c812435-8aa2-4457-b4b3-d9c5a2960de6)
![image](https://github.com/NovaSector/NovaSector/assets/38175176/71986b58-a14d-4993-b560-ea442df12f9d)
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
sound: added/modified/removed audio or sound effects
image: added/modified/removed some icons or images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
