### PR TITLE
Makes *turf usable while buckled

### DIFF
--- a/modular_nova/modules/emotes/code/additionalemotes/turf_emote.dm
+++ b/modular_nova/modules/emotes/code/additionalemotes/turf_emote.dm
@@ -175,8 +175,6 @@
 		return FALSE
 	if(isspaceturf(get_turf(user)))
 		return FALSE
-	if(user.buckled)
-		return FALSE
 	else
 		return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I know this basically only affects me and maybe like one other person, but you currently can't use *turf for cute roleplay if you're buckled to stuff and I don't really know why. So.

## How This Contributes To The Nova Sector Roleplay Experience

Now you can get all cozy while sitting on a couch. Or wheelchair.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/28007787/04474b1c-3a75-4972-bd6d-e7df8d896f8a)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: *turf can now be used while buckled to things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
