### PR TITLE
[MODULAR] Removes op table numbing

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -802,11 +802,7 @@
 
 	if(potential_patient.body_position == LYING_DOWN && potential_patient.loc == loc)
 		patient = potential_patient
-		chill_out(patient) // NOVA EDIT - Operation Table Numbing
 		return
-
-	if(!isnull(patient)) // NOVA EDIT - Operation Table Numbing
-		thaw_them(patient) // NOVA EDIT - Operation Table Numbing
 
 	// Find another lying mob as a replacement.
 	for (var/mob/living/carbon/replacement_patient in loc.contents)

--- a/modular_nova/master_files/code/game/objects/structures/tables_racks.dm
+++ b/modular_nova/master_files/code/game/objects/structures/tables_racks.dm
@@ -7,14 +7,3 @@
 /obj/structure/table/reinforced/Initialize()
 	. = ..()
 	AddElement(/datum/element/liquids_height, 20)
-
-/// Used to numb a patient and apply stasis to them if enabled.
-/obj/structure/table/optable/proc/chill_out(mob/living/target)
-	playsound(src, 'sound/effects/spray.ogg', 5, TRUE, 2, frequency = rand(24750, 26550))
-	ADD_TRAIT(target, TRAIT_NUMBED, REF(src))
-	target.throw_alert("numbed", /atom/movable/screen/alert/numbed)
-
-///Used to remove the effects of stasis and numbing when a patient is unbuckled
-/obj/structure/table/optable/proc/thaw_them(mob/living/target)
-	REMOVE_TRAIT(target, TRAIT_NUMBED, REF(src))
-	target.clear_alert("numbed", /atom/movable/screen/alert/numbed)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
You may remember the saga of the optable numbing a while ago.

Added in https://github.com/Skyrat-SS13/Skyrat-tg/pull/8791, it seems to have been a side effect of adding stasis.
Changed to only numb in https://github.com/Skyrat-SS13/Skyrat-tg/pull/14385, it was kept as it was worried people would keep on with the stasis bed meta.
Removal proposed in https://github.com/Skyrat-SS13/Skyrat-tg/pull/16245, closed for some reason, never rebutted.

It makes no sense why table numb people, especially if anesthetic is right next to the table. We want to remove autopilot content from medical, and this is a good one that has no reason to exist.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
removal: Operating tables no longer numb
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
