### PR TITLE
blacklists the mantis blade implant from being hacked by the hackerman implant

### DIFF
--- a/modular_nova/modules/implants/code/augments_head.dm
+++ b/modular_nova/modules/implants/code/augments_head.dm
@@ -171,6 +171,7 @@
 		/obj/machinery/computer/holodeck,
 		/obj/machinery/computer/emergency_shuttle,
 		/obj/machinery/recycler,
+		/obj/item/organ/internal/cyberimp/arm/armblade,
 	)
 	/// How far away we can hack things
 	var/hack_range = 2


### PR DESCRIPTION
this implant was basically never meant to have an easily accessible emag and it kind of shows

jury's out on if this thing deserves to exist at all but 'my free energy sword' is a bit much
## Proof of Testing

it worked

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: balancejakked the mantis blade implant into not being hackable by the binyat
/:cl:
