### PR TITLE
Fixes Blueshift's forge door randomly bolting.

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -54713,7 +54713,6 @@
 /area/station/medical/medbay/central)
 "ksK" = (
 /obj/machinery/door/airlock{
-	id_tag = "commissarydoor";
 	name = "Forge"
 	},
 /obj/structure/cable,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Turns out, it's not just randomly bolting. It was copied from the commissary so whenever someone bolted the commissary, it bolted the forge, too.

## How This Contributes To The Nova Sector Roleplay Experience

Doors "randomly" bolting you in isn't fun,


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: blueshift's forge no longer randomly bolts shut.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
