### PR TITLE
Piped Out: Fixes Service Hall pipes on Void Raptor

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -1396,9 +1396,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/mid_joiner,
 /obj/machinery/computer/department_orders/service,
 /obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/service)
 "aus" = (
@@ -1689,7 +1686,12 @@
 /obj/effect/turf_decal/tile/green/diagonal_centre,
 /obj/machinery/light_switch/directional/west,
 /obj/machinery/light/directional/west,
-/obj/machinery/icecream_vat,
+/obj/structure/table,
+/obj/machinery/fax{
+	fax_name = "Service Hallway";
+	name = "Service Fax Machine";
+	pixel_y = 3
+	},
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
 "ayH" = (
@@ -3933,13 +3935,21 @@
 /turf/open/floor/wood/large,
 /area/station/commons/fitness/recreation)
 "bdX" = (
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/box,
 /obj/item/radio/intercom/directional/south,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/green/diagonal_centre,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/cultivator,
+/obj/item/reagent_containers/cup/glass/shaker,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/head/utility/chefhat,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/lights/mixed,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
 "beb" = (
@@ -5013,9 +5023,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/mid_joiner,
 /obj/machinery/modular_computer/preset/cargochat/service,
 /obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/service)
 "bxm" = (
@@ -11296,8 +11303,10 @@
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/fore)
 "dsd" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/green/diagonal_centre,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
 "dsg" = (
@@ -17314,9 +17323,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/green/diagonal_centre,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
@@ -18654,7 +18660,7 @@
 /obj/structure/sign/poster/random/directional/north,
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 10
 	},
 /turf/open/floor/iron/large,
 /area/station/hallway/secondary/service)
@@ -23114,12 +23120,11 @@
 "gIy" = (
 /obj/effect/turf_decal/tile/green/diagonal_centre,
 /obj/machinery/status_display/ai/directional/west,
-/obj/structure/table,
-/obj/machinery/fax{
-	fax_name = "Service Hallway";
-	name = "Service Fax Machine";
-	pixel_y = 3
+/obj/effect/turf_decal/box,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
 "gIB" = (
@@ -23292,11 +23297,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/green/diagonal_centre,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
 "gKO" = (
@@ -23825,9 +23829,6 @@
 /obj/structure/noticeboard/directional/north,
 /obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/iron/large,
 /area/station/hallway/secondary/service)
 "gRx" = (
@@ -24444,9 +24445,6 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/mid_joiner,
 /obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/service)
 "haU" = (
@@ -29954,16 +29952,16 @@
 /turf/open/floor/iron/edge,
 /area/station/service/hydroponics)
 "iAU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green/diagonal_centre,
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
 "iBe" = (
@@ -38890,14 +38888,8 @@
 /area/station/maintenance/department/engine/atmos)
 "kXo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/green/diagonal_centre,
 /obj/machinery/status_display/ai/directional/north,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -69770,21 +69762,12 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/aft/greater)
 "trR" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas,
-/obj/item/reagent_containers/cup/glass/shaker,
-/obj/item/cultivator,
-/obj/item/clothing/head/utility/chefhat,
-/obj/item/storage/box/lights/mixed,
-/obj/effect/spawner/random/maintenance,
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/green/diagonal_centre,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/item/storage/box/drinkingglasses,
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/obj/effect/turf_decal/bot,
+/obj/machinery/icecream_vat,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
 "tsb" = (
@@ -75021,7 +75004,6 @@
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/blueshield)
 "uNs" = (
-/obj/structure/table,
 /obj/item/kitchen/rollingpin{
 	pixel_y = 4
 	},
@@ -75037,10 +75019,11 @@
 	pixel_x = -11;
 	pixel_y = 4
 	},
+/obj/effect/turf_decal/tile/green/diagonal_centre,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green/diagonal_centre,
+/obj/structure/table,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
 "uNu" = (
@@ -75965,7 +75948,6 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "vaJ" = (
-/obj/structure/table,
 /obj/item/storage/bag/plants{
 	pixel_y = 2
 	},
@@ -75973,10 +75955,11 @@
 	pixel_y = 3
 	},
 /obj/machinery/newscaster/directional/south,
+/obj/effect/turf_decal/tile/green/diagonal_centre,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green/diagonal_centre,
+/obj/structure/table,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
 "vaL" = (
@@ -77043,11 +77026,11 @@
 	},
 /area/station/holodeck/rec_center)
 "vrL" = (
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/rnd/production/techfab/department/service,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/box,
-/obj/machinery/rnd/production/techfab/department/service,
 /turf/open/floor/iron/large,
 /area/station/hallway/secondary/service)
 "vrU" = (
@@ -77457,9 +77440,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/green/diagonal_centre,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
 "vwz" = (
@@ -77997,9 +77977,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/turf_decal/tile/green/diagonal_centre,
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
@@ -78464,7 +78441,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/green/diagonal_centre,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/service)
@@ -123710,7 +123687,7 @@ nRS
 fvY
 ePd
 sSm
-iAU
+aaY
 gKB
 oSm
 hGX
@@ -124995,7 +124972,7 @@ iEJ
 hfU
 frZ
 vLg
-ctf
+iAU
 bdX
 fLp
 qEC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes Service Hall's pipes on Void Raptor. I tested them on my last PR but they somehow broke (because there's three pipes contesting in the same tiny room fusing to the wrong pipes so I moved the hall's disposal bin to a different spot). Pipes were tested ingame - trash goes to Cargo from Service Hall, Janitor's Closet and Kitchen as it should, and crates sent from Cargo actually goes through the Service chute.

## How This Contributes To The Nova Sector Roleplay Experience
Sorts trash, crates and mail like it should!

## Proof of Testing
![ddscsd](https://github.com/NovaSector/NovaSector/assets/136726218/928c44b3-3d2b-4472-87a2-bd9ea380074d)


## Changelog
:cl:
fix: Service Hall's disposal pipes are fixed on Void Raptor.
/:cl:
