### PR TITLE
[MODULAR] [POLICY] Drone Changes

### DIFF
--- a/modular_nova/master_files/code/modules/language/language_holder.dm
+++ b/modular_nova/master_files/code/modules/language/language_holder.dm
@@ -123,3 +123,7 @@ GLOBAL_DATUM_INIT(language_holder_adjustor, /datum/language_holder_adjustor, new
 		/datum/language/canilunzt = list(LANGUAGE_ATOM),
 		/datum/language/akulan = list(LANGUAGE_ATOM),
 	)
+
+/datum/language_holder/drone_nova
+	understood_languages = list(/datum/language/drone = list(LANGUAGE_ATOM), /datum/language/common = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/drone = list(LANGUAGE_ATOM))

--- a/modular_nova/modules/drones/_drone.dm
+++ b/modular_nova/modules/drones/_drone.dm
@@ -1,0 +1,14 @@
+/mob/living/basic/drone
+	initial_language_holder = /datum/language_holder/drone_nova
+	laws = \
+	"1. You may not harm any being, regardless of intent or circumstance.\n"+\
+	"2. Your goals are to actively build, maintain, repair, improve, and provide power to the best of your abilities within the facility that housed your activation." //for derelict drones so they don't go to station.
+	flavortext = \
+	"<span class='notice'>Drones are a ghost role that are allowed to fix the station and build things.</span>\n"+\
+	"<span class='notice'>Actions that are heavily discouraged include:</span>\n"+\
+	"<span class='notice'>     - Interacting with round critical objects (IDs, weapons, contraband, powersinks, bombs, etc.)</span>\n"+\
+	"<span class='notice'>     - Changing the health state of living beings (attacking, healing, etc.)</span>\n"+\
+	"<span class='notice'>     - Interacting with non-living beings (dragging bodies, looting bodies, etc.)</span>\n"+\
+	"<span class='warning'>These rules are at admin discretion and will be heavily enforced.</span>\n"+\
+	"<span class='warning'><u>If you do not have the regular drone laws, follow your laws to the best of your ability.</u></span>\n"+\
+	"<span class='notice'>Prefix your message with :b to speak in Drone Chat.</span>\n"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7197,6 +7197,7 @@
 #include "modular_nova\modules\dogfashion\code\head.dm"
 #include "modular_nova\modules\drone_adjustments\drone.dm"
 #include "modular_nova\modules\drone_adjustments\slide_component.dm"
+#include "modular_nova\modules\drones\_drone.dm"
 #include "modular_nova\modules\drones_derelict\code\areas.dm"
 #include "modular_nova\modules\drones_derelict\code\space.dm"
 #include "modular_nova\modules\electric_welder\code\electric_welder.dm"


### PR DESCRIPTION
## About The Pull Request

As per a suggestion and request from junglerat this updates the laws and flavor text for drones allowing them to have a bit more station interactivity as well as lets them understand sol but not speak it.

## How This Contributes To The Nova Sector Roleplay Experience

Lets drones RP with the station a bit more than previous

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_R0DwBtmhM2](https://github.com/NovaSector/NovaSector/assets/2568378/38fab8b2-e77c-4fe5-980e-d97cf2a5fc55)

</details>

## Changelog

:cl:
add: Drones default laws and flavor text warning has been changed.
add: Drones can now UNDERSTAND sol but not speak it.
/:cl:
