### PR TITLE
HOTFIX: Camo Them Leggies!

### DIFF
--- a/modular_nova/modules/GAGS/greyscale_configs.dm
+++ b/modular_nova/modules/GAGS/greyscale_configs.dm
@@ -1072,10 +1072,14 @@
 	name = "Camo Pants"
 	icon_file = 'modular_nova/master_files/icons/obj/clothing/under/shorts_pants_shirts.dmi'
 	json_config = 'modular_nova/modules/GAGS/json_configs/pants_shorts_skirts_dresses/camo_pants.json'
+
 /datum/greyscale_config/camo_pants/worn
 	name = "Camo Pants (Worn)"
 	icon_file = 'modular_nova/master_files/icons/mob/clothing/under/shorts_pants_shirts.dmi'
+
 /datum/greyscale_config/camo_pants/worn/digi
+	name = "Camo Pants (Worn, Digi)"
+	icon_file = SHORTS_PANTS_SHIRTS_DIGIFILE
 
 // DRESSES / SKIRTS
 


### PR DESCRIPTION
## About The Pull Request

A mistaken keybind or possibly my own forgetfulness ate the code for digi-leg camopants.  Now they exist again.

## How This Contributes To The Nova Sector Roleplay Experience

Fixes #749

## Proof of Testing

![image](https://github.com/NovaSector/NovaSector/assets/2958111/6b782e59-4be8-4f32-9d02-6311df3c33c6)

## Changelog

:cl:
fix: camo pants now available for digi legs (again)
/:cl:
