### PR TITLE
More Freighter Fixes and Improvements

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/cargodiselost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/cargodiselost.dmm
@@ -120,6 +120,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/cargodise_freighter/mining)
+"ca" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/cargodise_freighter/primaryhall)
 "cd" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 8
@@ -256,11 +260,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/cargodise_freighter/vault)
-"dW" = (
-/obj/structure/lattice,
-/mob,
-/turf/template_noop,
-/area/template_noop)
 "dZ" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
@@ -317,6 +316,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/cargodise_freighter/quarters)
+"ev" = (
+/obj/structure/lattice,
+/mob,
+/turf/template_noop,
+/area/template_noop)
 "ex" = (
 /obj/machinery/door/airlock/survival_pod/glass,
 /obj/structure/fans/tiny,
@@ -984,6 +988,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/cargodise_freighter/mining)
+"pu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen,
+/area/ruin/space/has_grav/cargodise_freighter/kitchen)
 "pv" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 1
@@ -1096,6 +1106,15 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/cargodise_freighter/bridge)
+"rI" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
+/area/ruin/space/has_grav/cargodise_freighter/primaryhall)
 "rR" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -1779,10 +1798,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood/tile,
 /area/ruin/space/has_grav/cargodise_freighter/hydroponics)
-"CN" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/cargodise_freighter/primaryhall)
 "Da" = (
 /turf/open/floor/iron/kitchen,
 /area/ruin/space/has_grav/cargodise_freighter/kitchen)
@@ -1820,6 +1835,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/cargodise_freighter/kitchen)
+"Du" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/smooth_half,
+/area/ruin/space/has_grav/cargodise_freighter/primaryhall)
 "DE" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 4
@@ -2028,6 +2051,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron/smooth,
 /area/ruin/space/has_grav/cargodise_freighter/utility)
+"Ha" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/kitchen,
+/area/ruin/space/has_grav/cargodise_freighter/kitchen)
 "Hi" = (
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 4
@@ -2683,15 +2710,6 @@
 /mob/living/simple_animal/hostile/looter/ranged/space/laser,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/cargodise_freighter/vault)
-"Qp" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark/smooth_half{
-	dir = 1
-	},
-/area/ruin/space/has_grav/cargodise_freighter/primaryhall)
 "Qv" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -2742,10 +2760,6 @@
 /obj/effect/spawner/random/entertainment/money_large,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/cargodise_freighter/bridge)
-"Rg" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/kitchen,
-/area/ruin/space/has_grav/cargodise_freighter/kitchen)
 "Sc" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/iron/fifty,
@@ -2895,12 +2909,6 @@
 /obj/structure/sink/directional/east,
 /obj/structure/mirror/directional/west,
 /turf/open/floor/iron/white,
-/area/ruin/space/has_grav/cargodise_freighter/kitchen)
-"Uu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/kitchen,
 /area/ruin/space/has_grav/cargodise_freighter/kitchen)
 "UB" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -3839,7 +3847,7 @@ Gh
 Gh
 Gh
 JQ
-dW
+ev
 Ef
 Ef
 Yr
@@ -4582,7 +4590,7 @@ vH
 Gg
 By
 ty
-Uu
+pu
 Da
 Df
 Da
@@ -4591,7 +4599,7 @@ iX
 Gg
 EC
 tV
-qS
+Du
 Hv
 ci
 TC
@@ -4667,8 +4675,8 @@ FT
 FT
 FT
 JC
-Uu
-Rg
+pu
+Ha
 IP
 Gg
 UL
@@ -4720,7 +4728,7 @@ Hv
 eC
 HJ
 Hv
-CN
+ca
 Wk
 ex
 Gh
@@ -4884,7 +4892,7 @@ DE
 gY
 BF
 WY
-Qp
+rI
 Lp
 YT
 kF

--- a/_maps/RandomRuins/SpaceRuins/nova/cargodiselost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/cargodiselost.dmm
@@ -416,6 +416,7 @@
 "fS" = (
 /obj/item/disk/ammo_workbench,
 /obj/structure/table/reinforced,
+/obj/machinery/recharger,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/cargodise_freighter/vault)
 "fV" = (
@@ -1168,7 +1169,7 @@
 /area/ruin/space/has_grav/cargodise_freighter/cargo)
 "sW" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/medkit,
+/obj/item/storage/medkit/regular,
 /obj/item/storage/medkit/surgery{
 	pixel_x = 6;
 	pixel_y = 8
@@ -1230,6 +1231,11 @@
 "tL" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/automatic/pistol/sol,
+/obj/item/gun/energy/e_gun/mini{
+	pixel_y = 5
+	},
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/cargodise_freighter/quarters)
 "tN" = (
@@ -1944,9 +1950,6 @@
 "ES" = (
 /obj/structure/rack/gunrack,
 /obj/item/gun/ballistic/automatic/lanca,
-/obj/item/gun/ballistic/automatic/lanca{
-	pixel_x = 3
-	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/cargodise_freighter/vault)
 "Fb" = (
@@ -2550,7 +2553,7 @@
 /area/ruin/space/has_grav/cargodise_freighter/kitchen)
 "NQ" = (
 /obj/structure/safe,
-/obj/item/mod/module/jetpack/advanced,
+/obj/item/mod/module/jetpack,
 /obj/item/mod/control/pre_equipped/standard,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/cargodise_freighter/vault)
@@ -2640,9 +2643,6 @@
 "OY" = (
 /obj/structure/rack/gunrack,
 /obj/item/gun/ballistic/rifle/boltaction,
-/obj/item/gun/ballistic/rifle/boltaction{
-	pixel_x = 3
-	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/cargodise_freighter/vault)
 "Pa" = (

--- a/_maps/RandomRuins/SpaceRuins/nova/cargodiselost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/cargodiselost.dmm
@@ -104,6 +104,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_half,
 /area/ruin/space/has_grav/cargodise_freighter/kitchen)
 "bM" = (
@@ -255,6 +256,11 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/cargodise_freighter/vault)
+"dW" = (
+/obj/structure/lattice,
+/mob,
+/turf/template_noop,
+/area/template_noop)
 "dZ" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
@@ -294,6 +300,7 @@
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 1
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/cargodise_freighter/kitchen)
 "eo" = (
@@ -384,6 +391,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
@@ -577,6 +585,9 @@
 "iT" = (
 /obj/machinery/computer/cryopod/directional/south,
 /obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/cargodise_freighter/kitchen)
 "iU" = (
@@ -1169,6 +1180,8 @@
 /obj/item/folded_navigation_gigabeacon,
 /obj/structure/cable,
 /obj/item/circuitboard/computer/powermonitor,
+/obj/item/circuitboard/machine/biogenerator/food_replicator,
+/obj/item/flatpacked_machine,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/cargodise_freighter/utility)
 "ty" = (
@@ -1399,9 +1412,9 @@
 /turf/open/floor/iron/kitchen,
 /area/ruin/space/has_grav/cargodise_freighter/kitchen)
 "xw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/cold/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/cargodise_freighter/kitchen)
 "xy" = (
@@ -1766,6 +1779,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood/tile,
 /area/ruin/space/has_grav/cargodise_freighter/hydroponics)
+"CN" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/cargodise_freighter/primaryhall)
 "Da" = (
 /turf/open/floor/iron/kitchen,
 /area/ruin/space/has_grav/cargodise_freighter/kitchen)
@@ -2276,6 +2293,7 @@
 	},
 /area/ruin/space/has_grav/cargodise_freighter/primaryhall)
 "Kr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/cargodise_freighter/kitchen)
 "Kt" = (
@@ -2479,6 +2497,7 @@
 "Ny" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/light/cold/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/cargodise_freighter/kitchen)
 "NC" = (
@@ -2602,6 +2621,7 @@
 "Pa" = (
 /obj/machinery/shower/directional/south,
 /obj/item/soap,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/cargodise_freighter/kitchen)
 "Pe" = (
@@ -2663,6 +2683,15 @@
 /mob/living/simple_animal/hostile/looter/ranged/space/laser,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/cargodise_freighter/vault)
+"Qp" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
+/area/ruin/space/has_grav/cargodise_freighter/primaryhall)
 "Qv" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -2713,6 +2742,10 @@
 /obj/effect/spawner/random/entertainment/money_large,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/cargodise_freighter/bridge)
+"Rg" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/kitchen,
+/area/ruin/space/has_grav/cargodise_freighter/kitchen)
 "Sc" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/iron/fifty,
@@ -2862,6 +2895,12 @@
 /obj/structure/sink/directional/east,
 /obj/structure/mirror/directional/west,
 /turf/open/floor/iron/white,
+/area/ruin/space/has_grav/cargodise_freighter/kitchen)
+"Uu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen,
 /area/ruin/space/has_grav/cargodise_freighter/kitchen)
 "UB" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -3800,7 +3839,7 @@ Gh
 Gh
 Gh
 JQ
-Ef
+dW
 Ef
 Ef
 Yr
@@ -4543,7 +4582,7 @@ vH
 Gg
 By
 ty
-Da
+Uu
 Da
 Df
 Da
@@ -4628,8 +4667,8 @@ FT
 FT
 FT
 JC
-Da
-Da
+Uu
+Rg
 IP
 Gg
 UL
@@ -4681,7 +4720,7 @@ Hv
 eC
 HJ
 Hv
-Wk
+CN
 Wk
 ex
 Gh
@@ -4845,7 +4884,7 @@ DE
 gY
 BF
 WY
-Lp
+Qp
 Lp
 YT
 kF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a flat-packed Rapid Construction Fab, and a Colonial Supply board to the freighter, alongside a few missing lights and vents.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
The lights and vents are primarily just fixes that I missed while putting the remake together initially. That being said, the RCF and Colonial Supply machines both add a little bit more flexibility and independence to the role.

Not to mention, instead of relying on solars, the crew can fashion out some other makeshift solutions with the machines the RCF can print! Overall, I'm just hoping to improve the QoL of the role somewhat, and make rounds feel more varied for the freighter crew.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
Included below is a screenshot of one of the areas with some added lights, and vents, and another one showing the RCF set up in the Freighter's engineering bay.
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/134661012/aea11043-fe37-4df5-a0a9-daaefe1fbe80)

![image](https://github.com/NovaSector/NovaSector/assets/134661012/89d8e062-0c6f-499d-8a02-1080ab4bd1ae)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added the Rapid Constructor Fab and a Colonial Supply core to the Freighter ghost role.
fix: Fixed a few missing lights, and vents aboard the Freighter ghost role.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
