### PR TITLE
Changes the icon for sharp claws

### DIFF
--- a/modular_nova/master_files/code/datums/traits/good.dm
+++ b/modular_nova/master_files/code/datums/traits/good.dm
@@ -27,7 +27,7 @@
 	gain_text = span_notice("Your palms hurt a bit from the sharpness of your nails.")
 	lose_text = span_danger("You feel a distinct emptiness as your nails dull; good luck scratching that itch.")
 	medical_record_text = "Patient ended up scratching through the examination table's cushions; recommended they look into clipping their claws."
-	icon = FA_ICON_HAND
+	icon = FA_ICON_LINES_LEANING
 
 /datum/quirk/sharpclaws/add(client/client_source)
 	var/mob/living/carbon/human/human_holder = quirk_holder


### PR DESCRIPTION
## About The Pull Request

It was conflicting with the one for the new 'touchy' quirk. This will fix the CI issues.

## How This Contributes To The Nova Sector Roleplay Experience

Gets rid of the CI warning.

## Proof of Testing

<details>
<summary>The new icon looks like this</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/13398309/ad00b7b4-11a0-4fd5-9839-4cf6a8d574df)


</details>

## Changelog

:cl:
fix: 'Sharp Claws' quirk now has a different icon, to distinguish it from the new 'Touchy' quirk
/:cl: