### PR TITLE
[NON-MODULAR] Purple Quirks

### DIFF
--- a/code/modules/client/preferences/middleware/quirks.dm
+++ b/code/modules/client/preferences/middleware/quirks.dm
@@ -49,6 +49,7 @@
 			"customizable" = constant_data?.is_customizable(),
 			"customization_options" = customization_options,
 			"veteran_only" = initial(quirk.veteran_only), // NOVA EDIT - Veteran quirks
+			"erp_quirk" = initial(quirk.erp_quirk), // NOVA EDIT - Purple ERP quirks
 		)
 
 	return list(

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
@@ -8,6 +8,19 @@ import { getRandomization, PreferenceList } from './MainPage';
 import { ServerPreferencesFetcher } from './ServerPreferencesFetcher';
 import { useRandomToggleState } from './useRandomToggleState';
 
+// NOVA EDIT BEGIN - Purple ERP quirks
+function getNovaValueClass(quirk: Quirk) {
+  if (quirk.value > 0) {
+    return 'positive';
+  } else if (quirk.value < 0) {
+    return 'negative';
+  } else if (quirk.erp_quirk) {
+    return 'erp_quirk';
+  } else {
+    return 'neutral';
+  }
+}
+/*
 function getValueClass(value: number) {
   if (value > 0) {
     return 'positive';
@@ -17,6 +30,7 @@ function getValueClass(value: number) {
     return 'neutral';
   }
 }
+NOVA EDIT END */
 
 function getCorrespondingPreferences(
   customization_options: string[],
@@ -131,7 +145,11 @@ function QuirkDisplay(props: QuirkDisplayProps) {
         >
           <Stack vertical fill>
             <Stack.Item
+              // NOVA EDIT BEGIN - Purple ERP quirks
+              className={`${className}--${getNovaValueClass(quirk)}`}
+              /*
               className={`${className}--${getValueClass(value)}`}
+              NOVA EDIT END */
               style={{
                 borderBottom: '1px solid black',
                 padding: '2px',

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
@@ -93,6 +93,7 @@ export type Quirk = {
   customizable: boolean;
   customization_options?: string[];
   veteran_only: boolean; // NOVA EDIT - Veteran quirks
+  erp_quirk: boolean; // NOVA EDIT - Purple ERP quirks
 };
 
 // NOVA EDIT START

--- a/tgui/packages/tgui/styles/interfaces/PreferencesMenu.scss
+++ b/tgui/packages/tgui/styles/interfaces/PreferencesMenu.scss
@@ -236,6 +236,8 @@ $department_map: (
           'positive': colors.$green,
           'neutral': colors.$white,
           'negative': colors.$red,
+          // NOVA EDIT - Purple ERP quirks
+          'erp_quirk': colors.$purple,
         );
 
         @each $quality, $color-value in $quality_map {


### PR DESCRIPTION
## About The Pull Request

This PR adds a purple color to the heading of each quirk which has the `erp_quirk` variable set.

I have non-modularly modified the TG code to be auto-merge friendly by commenting-out TGUI code and replacing it.

## How This Contributes To The Nova Sector Roleplay Experience

Currently there is no visually distinct indication that a quirk is "ERP" related, and this PR fixes the issue.

I received positive feedback after showing previews of this change to players, and I heard it would be welcomed on Nova Sector.

## Proof of Testing

Tested fully on most recent Nova Sector code. Also tested on my own downstream for a long time.

<details>
<summary>Screenshots/Videos</summary>

![Screenshot 2024-02-11 071349](https://github.com/NovaSector/NovaSector/assets/17753498/fe61faa6-fe9c-4752-ab28-725f1768d6ed)

</details>

## Changelog

:cl: A.C.M.O.
qol: Added purple color to ERP quirks on the Quirks page of Character Preferences.
/:cl:
