### PR TITLE
Ghost roles now have their job title set properly on spawn

### DIFF
--- a/modular_nova/master_files/code/modules/mob_spawn/mob_spawn.dm
+++ b/modular_nova/master_files/code/modules/mob_spawn/mob_spawn.dm
@@ -1,4 +1,4 @@
-/obj/effect/mob_spawn/ghost_role/
+/obj/effect/mob_spawn/ghost_role
 	/// set this to make the spawner use the outfit.name instead of its name var for things like cryo announcements and ghost records
 	/// modifying the actual name during the game will cause issues with the GLOB.mob_spawners associative list
 	var/use_outfit_name
@@ -59,3 +59,12 @@
 // TODO: refactor create() and special() so that this is no longer necessary
 /obj/effect/mob_spawn/ghost_role/proc/post_transfer_prefs(mob/living/new_spawn)
 	return
+
+
+/obj/effect/mob_spawn/ghost_role/human/special(mob/living/spawned_mob, mob/mob_possessor)
+	. = ..()
+	var/mob/living/carbon/human/spawned_human = spawned_mob
+	var/datum/job/spawned_job = SSjob.GetJobType(spawner_job_path)
+
+	spawned_human.job = spawned_job.title
+


### PR DESCRIPTION
## About The Pull Request
It's always bothered me that you couldn't search a ghost role player in the player panel by their job's title, so I fixed it so that now, you can do just that!

![image](https://github.com/NovaSector/NovaSector/assets/58045821/99b275bf-45a8-4d2f-900d-242726a62b67)

## How This Contributes To The Nova Sector Roleplay Experience
It makes it easier for staff to look up certain roles by name rather than by player name.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/58045821/99b275bf-45a8-4d2f-900d-242726a62b67)

</details>

## Changelog

:cl: GoldenAlpharex
fix: Humanoid ghost roles now receive their job title on their mob, when that was previously not the case.
admin: Humanoid ghost roles can now be searched by job title in the Player Panel directory (and will show up everywhere else that displays the job title).
/:cl: