### PR TITLE
[MODULAR] Automatically Closing Firedoors

### DIFF
--- a/modular_nova/master_files/code/game/machinery/doors/firedoor.dm
+++ b/modular_nova/master_files/code/game/machinery/doors/firedoor.dm
@@ -16,6 +16,8 @@
 			return TRUE
 	return FALSE
 
+// Uncomment this override to disable the auto-close feature of firedoors.
+/*
 /obj/machinery/door/firedoor/try_to_crowbar(obj/item/used_object, mob/user)
 	if(welded || operating)
 		balloon_alert(user, "opening failed!")
@@ -25,6 +27,7 @@
 		open()
 	else
 		close()
+*/
 
 /obj/machinery/door/firedoor/heavy/closed
 	icon_state = "door_closed"


### PR DESCRIPTION
## About The Pull Request

This PR comments-out the Nova Sector override of `/obj/machinery/door/firedoor/try_to_crowbar`, and enables firedoors to automatically close.

Players can hold open a firedoor using a crowbar, and it will automatically close upon walking away from the door.

## How This Contributes To The Nova Sector Roleplay Experience

This was requested in the development suggestions channel on Discord.

I believe that this change will make the station easier to fix when atmospherics-related issues arise. Players will be unable to permanently hold-open a firedoor unless they reset its fire alarm.

## Proof of Testing

Tested to ensure holding open works. Temporary opening via right-click works. Manual override with hands also works.

<details>
<summary>Screenshots/Videos</summary>

https://github.com/NovaSector/NovaSector/assets/17753498/128652a4-ff29-40c2-a0f2-e68342ee3845

</details>

## Changelog

:cl: A.C.M.O.
tweak: Enabled firedoors to automatically close when forced open.
/:cl:
