### PR TITLE
[NO GBP] Clears double Numbed alert

### DIFF
--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -289,12 +289,13 @@
 
 /datum/status_effect/grouped/stasis/tick(seconds_between_ticks)
 	update_time_of_death()
-	if(owner.stat >= UNCONSCIOUS) //NOVA EDIT START - STASIS KEEPS SLEEP GOING
-		owner.Sleeping(15 SECONDS) //NOVA EDIT END
+	// NOVA EDIT ADDITION START - STASIS KEEPS SLEEP GOING
+	if(owner.stat >= UNCONSCIOUS)
+		owner.Sleeping(15 SECONDS)
+	//NOVA EDIT ADDITION END
 
 /datum/status_effect/grouped/stasis/on_remove()
 	owner.remove_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED, TRAIT_STASIS, TRAIT_ANALGESIA), TRAIT_STATUS_EFFECT(id)) // NOVA EDIT CHANGE - ORIGINAL: owner.remove_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED, TRAIT_STASIS), TRAIT_STATUS_EFFECT(id))
-	owner.clear_alert("stasis numbed") //NOVA EDIT ADDITION - STASIS APPLIED NUMBED
 	owner.remove_filter("stasis_status_ripple")
 	update_time_of_death()
 	if(iscarbon(owner))


### PR DESCRIPTION
## About The Pull Request

Numbed alert was being applied twice by stasis beds after recent refactor. This will remove the extra one.

## How This Contributes To The Nova Sector Roleplay Experience

Fixes a bug, cleans up some Nova edits.

## Proof of Testing

<details>
<summary>Shown: the doubled up alerts (before this fix is applied)</summary>
  
![dreamseeker_Aybukg3TmH](https://github.com/NovaSector/NovaSector/assets/13398309/d6a1baf1-3ab2-4d81-b677-8a053f5d9f62)

</details>

## Changelog

:cl:
fix: fixes Numbed alert being added twice while in stasis
/:cl:
