### PR TITLE
Moves the crystallizer in void raptor atmos to not be facing a wall(and removes a fire alarm in space)

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -51589,7 +51589,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 4;
+	dir = 1;
 	initialize_directions = 8
 	},
 /turf/open/floor/iron/smooth_edge{

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -352,14 +352,17 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "afb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot{
+	dir = 1
 	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/atmos)
@@ -7300,13 +7303,16 @@
 /turf/open/floor/iron/half,
 /area/station/hallway/primary/central)
 "ciQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 5
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 5
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/atmos)
 "ciZ" = (
@@ -9829,10 +9835,6 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cXk" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
@@ -9840,6 +9842,9 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/atmospherics/components/binary/crystallizer{
+	dir = 1
+	},
 /turf/open/floor/iron/smooth_edge{
 	dir = 8
 	},
@@ -23830,18 +23835,21 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/bridge)
 "gSO" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 5
-	},
 /obj/machinery/camera/directional/east{
 	c_tag = "Atmospherics - Ports";
 	name = "atmospherics camera"
 	},
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/atmos)
 "gSS" = (
@@ -27709,7 +27717,9 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/atmos)
 "hXV" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -33251,10 +33261,16 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/storage)
 "jyF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 4
 	},
-/turf/open/floor/iron/smooth_large,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
 /area/station/engineering/atmos)
 "jyL" = (
 /obj/machinery/conveyor/inverted{
@@ -35161,6 +35177,7 @@
 /area/station/engineering/atmos/hfr_room)
 "jZq" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/miningfoundry)
 "jZS" = (
@@ -37776,13 +37793,16 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/primary/aft)
 "kIq" = (
-/obj/machinery/atmospherics/components/binary/pump,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
 /turf/open/floor/iron/smooth_edge{
 	dir = 8
 	},
@@ -48382,6 +48402,7 @@
 /obj/machinery/door/airlock/mining{
 	name = "Mining Foundry"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/cargo/miningfoundry)
 "nFg" = (
@@ -51238,10 +51259,20 @@
 	},
 /area/station/hallway/primary/fore)
 "osx" = (
-/obj/structure/lattice,
-/obj/machinery/firealarm/directional/west,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_edge,
+/area/station/engineering/atmos)
 "osJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
@@ -51552,9 +51583,15 @@
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "owP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 4;
+	initialize_directions = 8
+	},
 /turf/open/floor/iron/smooth_edge{
 	dir = 1
 	},
@@ -56767,7 +56804,6 @@
 /turf/open/floor/iron/smooth,
 /area/station/science/ordnance/office)
 "pSj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/status_display/evac/directional/south,
@@ -62679,14 +62715,11 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "rwT" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
 	},
 /turf/open/floor/iron/smooth_edge{
 	dir = 8
@@ -63885,22 +63918,15 @@
 	},
 /area/station/medical/medbay/central)
 "rOM" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 4;
-	initialize_directions = 8
-	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron/smooth_edge{
-	dir = 4
-	},
+/obj/effect/turf_decal/box,
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/atmos)
 "rOQ" = (
 /turf/open/floor/iron/smooth,
@@ -65185,6 +65211,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/smooth,
 /area/station/cargo/drone_bay)
 "shM" = (
@@ -70862,6 +70889,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hop)
+"tFh" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_corner{
+	dir = 4
+	},
+/area/station/engineering/atmos)
 "tFk" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 5
@@ -73765,10 +73800,8 @@
 	},
 /area/station/construction/mining/aux_base)
 "uvy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/meter,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/smooth_edge{
 	dir = 1
@@ -78186,19 +78219,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "vIt" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
-/turf/open/floor/iron/smooth,
+/obj/effect/turf_decal/box,
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/atmos)
 "vIv" = (
 /turf/closed/wall/r_wall,
@@ -81773,7 +81802,9 @@
 /turf/open/floor/noslip,
 /area/station/service/janitor)
 "wEJ" = (
-/obj/machinery/atmospherics/components/binary/pump,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/atmos)
 "wEK" = (
@@ -83398,9 +83429,16 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/break_room)
 "xgj" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/box,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 5
+	},
+/turf/open/floor/iron/smooth,
 /area/station/engineering/atmos)
 "xgv" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
@@ -84443,9 +84481,6 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "xtF" = (
-/obj/machinery/atmospherics/components/binary/crystallizer{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/light/directional/south,
@@ -113771,7 +113806,7 @@ hwW
 hzM
 dYh
 dYh
-jyF
+dYh
 uvy
 toq
 vsH
@@ -114281,11 +114316,11 @@ dYh
 dYh
 pAI
 pVr
-nAn
-dYh
-dYh
+osx
 hXV
-wEJ
+hXV
+dYh
+dYh
 pSj
 toq
 lEm
@@ -114540,8 +114575,8 @@ hUp
 wQU
 ciQ
 rwT
-kLU
-hXV
+tFh
+dYh
 wEJ
 owP
 toq
@@ -114796,7 +114831,7 @@ nbD
 tDe
 luV
 xgj
-xgj
+jyF
 gSO
 cXk
 kIq
@@ -133241,7 +133276,7 @@ ttw
 xMq
 xMq
 xMq
-osx
+xMq
 xMq
 xMq
 xMq


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The crystallizer always outputs south of it, which in this case was a wall, annoying!

I saw a fire alarm outside of cargo in space, I assume it was meant to be inside the forge room, so I put one in there, and added a firelock under the door so it actually does something.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
atmosians don't need to move the crystallizer if they're producing stuff that doesn't like walls(supermatter shards)
The cargo foundry now has a fire alarm and firelock! Bitrunning has also received a firelock, they already had an alarm.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
![image](https://github.com/NovaSector/NovaSector/assets/59183821/68d34d6e-1d89-4ee1-8b2a-6e9bb879802f)
woaah, no more fire alarm in space
![image](https://github.com/NovaSector/NovaSector/assets/59183821/f9dd99eb-d3f4-433a-ab4d-3752045d7cc0)

the crystallizer isn't facing a wall
![image](https://github.com/NovaSector/NovaSector/assets/59183821/ce3ff024-05a2-4927-93b7-412acd28c436)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: The crystallizer in Void Raptor atmos has been moved very slightly so the recipes no longer spawn in the wall.
fix: The cargo foundry on Void Raptor no longer has a fire alarm in space.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
