### PR TITLE
Fixes issues and improves millstones, ant farms and seed meshes

### DIFF
--- a/modular_nova/modules/ashwalkers/code/buildings/antfarm.dm
+++ b/modular_nova/modules/ashwalkers/code/buildings/antfarm.dm
@@ -44,7 +44,7 @@
 
 /obj/structure/antfarm/Destroy()
 	STOP_PROCESSING(SSobj, src)
-	new /obj/item/stack/ore/glass/twenty(get_turf(src))
+	new /obj/item/stack/ore/glass(get_turf(src), 20)
 	return ..()
 
 /obj/structure/antfarm/process(seconds_per_tick)
@@ -67,12 +67,12 @@
 	. = ..()
 	. += span_notice("<br>There are currently [has_ants ? "" : "no "]ants in the farm.")
 	if(!has_ants)
-		. += span_notice("To add ants, feed the farm some food.")
+		. += span_notice("To add ants, feed the farm some <b>food</b>.")
 
 /obj/structure/antfarm/attackby(obj/item/attacking_item, mob/user, params)
 	if(istype(attacking_item, /obj/item/food))
 		if(has_ants)
-			balloon_alert(user, "ants are blocking the way!")
+			balloon_alert(user, "ants block the way!")
 			return
 
 		qdel(attacking_item)
@@ -82,7 +82,7 @@
 
 	if(istype(attacking_item, /obj/item/storage/bag/plants))
 		if(has_ants)
-			balloon_alert(user, "ants are blocking the way!")
+			balloon_alert(user, "ants block the way!")
 			return
 
 		balloon_alert(user, "feeding the ants")
@@ -96,6 +96,3 @@
 		return
 
 	return ..()
-
-/obj/item/stack/ore/glass/twenty
-	amount = 20

--- a/modular_nova/modules/ashwalkers/code/buildings/antfarm.dm
+++ b/modular_nova/modules/ashwalkers/code/buildings/antfarm.dm
@@ -44,7 +44,7 @@
 
 /obj/structure/antfarm/Destroy()
 	STOP_PROCESSING(SSobj, src)
-	new /obj/item/stack/ore/glass/ten(get_turf(src))
+	new /obj/item/stack/ore/glass/twenty(get_turf(src))
 	return ..()
 
 /obj/structure/antfarm/process(seconds_per_tick)
@@ -66,19 +66,28 @@
 /obj/structure/antfarm/examine(mob/user)
 	. = ..()
 	. += span_notice("<br>There are currently [has_ants ? "" : "no "]ants in the farm.")
-	. += span_notice("To add ants, feed the farm some food.")
+	if(!has_ants)
+		. += span_notice("To add ants, feed the farm some food.")
 
 /obj/structure/antfarm/attackby(obj/item/attacking_item, mob/user, params)
 	if(istype(attacking_item, /obj/item/food))
+		if(has_ants)
+			balloon_alert(user, "ants are blocking the way!")
+			return
+
 		qdel(attacking_item)
 		balloon_alert(user, "food has been placed")
 		ant_chance++
 		return
 
 	if(istype(attacking_item, /obj/item/storage/bag/plants))
+		if(has_ants)
+			balloon_alert(user, "ants are blocking the way!")
+			return
+
 		balloon_alert(user, "feeding the ants")
 		for(var/obj/item/food/selected_food in attacking_item.contents)
-			if(!do_after(user, 1 SECONDS, src))
+			if(has_ants || !do_after(user, 0.5 SECONDS, src))
 				return
 
 			qdel(selected_food)
@@ -88,5 +97,5 @@
 
 	return ..()
 
-/obj/item/stack/ore/glass/ten
-	amount = 10
+/obj/item/stack/ore/glass/twenty
+	amount = 20

--- a/modular_nova/modules/ashwalkers/code/items/ash_seedmesh.dm
+++ b/modular_nova/modules/ashwalkers/code/items/ash_seedmesh.dm
@@ -15,7 +15,7 @@
 			return
 
 		while(ore_item.amount >= 5)
-			if(!do_after(user, 5 SECONDS, src))
+			if(!do_after(user, 2 SECONDS, src))
 				user.balloon_alert(user, "have to stand still!")
 				return
 
@@ -23,7 +23,7 @@
 				user.balloon_alert(user, "unable to use five of [ore_item]!")
 				return
 
-			if(prob(70))
+			if(prob(50))
 				user.balloon_alert(user, "[ore_item] reveals nothing!")
 				continue
 

--- a/modular_nova/modules/primitive_cooking_additions/code/millstone.dm
+++ b/modular_nova/modules/primitive_cooking_additions/code/millstone.dm
@@ -35,7 +35,7 @@
 
 		. += span_notice("And it can fit <b>[maximum_contained_items - length(contents)]</b> more items in it.")
 	else
-		. += span_notice("It can hold [maximum_contained_items] items, and there is nothing in it presently.")
+		. += span_notice("It can hold <b>[maximum_contained_items]</b> items, and there is nothing in it presently.")
 
 	. += span_notice("You can [anchored ? "un" : ""]secure [src] with <b>CTRL-Shift-Click</b>.")
 	. += span_notice("With a <b>prying tool</b> of some sort, you could take [src] apart.")
@@ -112,7 +112,7 @@
 
 		return TRUE
 
-	if(!((istype(attacking_item, /obj/item/food/grown/)) || (istype(attacking_item, /obj/item/grown))))
+	if(!(istype(attacking_item, /obj/item/food/grown) || istype(attacking_item, /obj/item/grown)))
 		balloon_alert(user, "can only mill plants")
 		return ..()
 
@@ -121,7 +121,8 @@
 		return
 
 	attacking_item.forceMove(src)
-	return ..()
+	balloon_alert(user, "transferred [attacking_item]")
+	return TRUE
 
 /// Takes the content's seeds and spits them out on the turf, as well as grinding whatever the contents may be
 /obj/structure/millstone/proc/mill_it_up(mob/living/carbon/human/user)
@@ -150,7 +151,7 @@
 	for(var/target_item as anything in contents)
 		seedify(target_item, t_max = 1)
 
-	return
+	balloon_alert_to_viewers("finished grinding")
 
 #undef MILLSTONE_STAMINA_MINIMUM
 #undef MILLSTONE_STAMINA_USE


### PR DESCRIPTION
## About The Pull Request
Millstones no longer take damage when you insert something that has force (i.e. tower-cap logs) into them. Improves the feedback given by the millstone using balloon alerts when you insert items, and when you finish grinding.

Ant farms now drop the full amount of sand required to build them, when you try to build them in an invalid location. They now no longer accept food in them when ants have already appeared (because why would they?), and items inserted via plant bag usage is now two times faster (1/s -> 2/s).

Seed meshes now take 2 seconds to process 5 pieces of sand/ash instead of 5, and have a 50% chance of producing seeds, up from 30%. It's mainly to reduce the tedium of trying to obtain seeds from them, because they're otherwise a very niche and disappointing was to get seeds currently, with very low odds of ever really getting what you're after. This makes them a little more reliable and actually worth investing time into.

## How This Contributes To The Nova Sector Roleplay Experience
Fixing bugs is good. More feedback is good. Reducing tedium is also good.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
Look, it didn't get damaged from a tower-cap log!
![image](https://github.com/NovaSector/NovaSector/assets/58045821/fadc1b6e-8ed7-40be-ae3a-4177eff73655)

I got 20 sand from building an ant farm in an invalid location.
![image](https://github.com/NovaSector/NovaSector/assets/58045821/7bbfafa4-9d87-48ed-a4ac-099241b563bf)

</details>

## Changelog

:cl: GoldenAlpharex
fix: Millstones no longer take damage when produce that can do damage (like tower-cap logs) get inserted in them.
qol: Millstones now give better feedback when items are inserted and when grinding is done.
fix: Ant farms now drop all of the 20 pieces of sand that are required to make them, when built in an invalid location.
qol: Ant farms no longer accept food when ants have appeared, as it already does nothing once ants have arrived.
qol: Inserting food in an ant farm from a plant bag is now twice as fast!
qol: Seed meshes now only take 2 seconds to process 5 sand/ash, and have a 50% chance to produce a seed, up from 30%.
/:cl: