### PR TITLE
[Modular] Fixes modular instances of mouse_opacity

### DIFF
--- a/code/game/objects/items/tcg/tcg_machines.dm
+++ b/code/game/objects/items/tcg/tcg_machines.dm
@@ -282,7 +282,7 @@ GLOBAL_LIST_EMPTY(tcgcard_machine_radial_choices)
 #undef DEFAULT_MODIFIED_COLOR
 
 /obj/effect/overlay/card_summon
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 ///A button that generates a player manipulable bar of icons, in this case a mana bar.
 /obj/machinery/trading_card_button

--- a/code/game/objects/items/tcg/tcg_machines.dm
+++ b/code/game/objects/items/tcg/tcg_machines.dm
@@ -282,7 +282,7 @@ GLOBAL_LIST_EMPTY(tcgcard_machine_radial_choices)
 #undef DEFAULT_MODIFIED_COLOR
 
 /obj/effect/overlay/card_summon
-	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	mouse_opacity = 0
 
 ///A button that generates a player manipulable bar of icons, in this case a mana bar.
 /obj/machinery/trading_card_button

--- a/modular_nova/master_files/code/modules/mob/living/emote_popup.dm
+++ b/modular_nova/master_files/code/modules/mob/living/emote_popup.dm
@@ -4,7 +4,7 @@
 	layer = FLY_LAYER
 	plane = GAME_PLANE
 	appearance_flags = APPEARANCE_UI_IGNORE_ALPHA | KEEP_APART
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /**
  * A proc type that, when called, causes a image/sprite to appear above whatever entity it is called on.

--- a/modular_nova/modules/gunpoint/code/gunpoint_datum.dm
+++ b/modular_nova/modules/gunpoint/code/gunpoint_datum.dm
@@ -4,7 +4,7 @@
 	layer = FLY_LAYER
 	plane = GAME_PLANE
 	appearance_flags = APPEARANCE_UI_IGNORE_ALPHA | KEEP_APART
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /datum/gunpoint
 	var/mob/living/source

--- a/modular_nova/modules/mapping/code/planet_turfs.dm
+++ b/modular_nova/modules/mapping/code/planet_turfs.dm
@@ -60,7 +60,7 @@
 	icon = 'modular_nova/modules/mapping/icons/dungeon.dmi'
 	icon_state = "deep_snow"
 	density = 0
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	layer = ABOVE_MOB_LAYER
 	anchored = TRUE
 	vis_flags = NONE


### PR DESCRIPTION

## About The Pull Request

This sets all of the instances of mouse_opacity in modular files to use the define for mouse opacity to remain consistent with other instances of mouse opacity being set in TG rather than having ours as a static number

## How This Contributes To The Nova Sector Roleplay Experience

Consistency across modular files is good

## Proof of Testing

Going to skip this for this PR as its just minor edits that shouldn't have any noticeable impacts

## Changelog

Nothing player facing, its all minor fixes