### PR TITLE
[MANUAL MIRROR] AI Observations

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1076,6 +1076,8 @@
 
 	else if(mind)
 		RegisterSignal(target, COMSIG_LIVING_DEATH, PROC_REF(disconnect_shell))
+		for (var/mob/dead/observer/viewer in src.observers)
+			viewer.ManualFollow(target)
 		deployed_shell = target
 		target.deploy_init(src)
 		mind.transfer_to(target)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -932,6 +932,8 @@
 	mainframe.UnregisterSignal(src, COMSIG_LIVING_DEATH)
 	mainframe.redeploy_action.Grant(mainframe)
 	mainframe.redeploy_action.last_used_shell = src
+	for (var/mob/dead/observer/viewer in src.observers)
+			viewer.ManualFollow(mainframe)
 	mind.transfer_to(mainframe)
 	deployed = FALSE
 	mainframe.deployed_shell = null

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -933,7 +933,7 @@
 	mainframe.redeploy_action.Grant(mainframe)
 	mainframe.redeploy_action.last_used_shell = src
 	for (var/mob/dead/observer/viewer in src.observers)
-			viewer.ManualFollow(mainframe)
+		viewer.ManualFollow(mainframe)
 	mind.transfer_to(mainframe)
 	deployed = FALSE
 	mainframe.deployed_shell = null


### PR DESCRIPTION
## About The Pull Request

QOL for dchat gamers: observing an AI Eye will be consistent as they hop in and out of shells.
Manual mirror of https://github.com/SomeRandomOwl/tgstation/tree/aiobservations

This REALLY SHOULD HAVE GONE TO MY repo but WHOOPSIE I'm bad at GitHub.

## How This Contributes To The Nova Sector Roleplay Experience

Admins & dchat gamers alike can now keep consistent tabs on what the AI's up to, even if they're shifting between shell & eye frequently.

## Proof of Testing

N/A yet, that's why this is being TM'd here

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl: SomeRandomOwl
qol: Orbiting an AI eye will also make you orbit any shells the AI uses, and vice-versa.
/:cl:
