### PR TITLE
Makes lathes ten times faster at printing items

### DIFF
--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -339,6 +339,7 @@
 				charge_per_item += design.materials[material]
 			charge_per_item = ROUND_UP((charge_per_item / (MAX_STACK_SIZE * SHEET_MATERIAL_AMOUNT)) * coefficient * 0.05 * active_power_usage)
 			var/build_time_per_item = (design.construction_time * design.lathe_time_factor) ** 0.8
+			build_time_per_item *= 0.1 // NOVA EDIT - Faster lathes
 
 			//start production
 			busy = TRUE


### PR DESCRIPTION
## About The Pull Request
It's ten times faster, that's it. It's really that shrimple.

## How This Contributes To The Nova Sector Roleplay Experience
Less time spent waiting because people upstream thought that waiting 5 seconds for a cell to print was peak gameplay.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/58045821/067a6ab9-9179-4c63-b338-b159674f54c7)

</details>

## Changelog

:cl: GoldenAlpharex
balance: Protolathes should now print items ten times faster.
/:cl: