### PR TITLE
[POLICY] [MODULER] Removes the microbomb from the opfor menu

### DIFF
--- a/modular_nova/modules/opposing_force/code/equipment/implants.dm
+++ b/modular_nova/modules/opposing_force/code/equipment/implants.dm
@@ -91,11 +91,13 @@
 	admin_note = "Allows the user to break handcuffs or e-snares four times, after it will run out and become useless."
 	description = "An implanter that grants you the ability to break out of handcuffs a certain number of times."
 
+/* Removal pending replacment
 /datum/opposing_force_equipment/implants_illegal/micro
 	name = "Microbomb Implant"
 	admin_note = "RRs the user."
 	item_type = /obj/item/implanter/explosive
 	description = "An implanter that will make you explode on death in a decent-sized explosion."
+*/
 
 /datum/opposing_force_equipment/implants_illegal/emp
 	name = "EMP Implant"


### PR DESCRIPTION
## About The Pull Request

This makes the microbomb implant unable to be picked from the opfor panel

## How This Contributes To The Nova Sector Roleplay Experience

This matches new policys

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![1xXrvEwJL7](https://github.com/NovaSector/NovaSector/assets/2568378/6eaf99c6-4857-4662-a997-c1beb7ecd3b5)

</details>

## Changelog

:cl:
del: The syndicate recently lost their supplier of microbomb implants and no longer are capable of providing the explosive devices to agents in the field.
/:cl:
