### PR TITLE
Ruin cleanup pass 1 - Shuttle8532, Icewalkers, Cafe

### DIFF
--- a/_maps/RandomRuins/IceRuins/nova/icemoon_underground_icewalker_lower.dmm
+++ b/_maps/RandomRuins/IceRuins/nova/icemoon_underground_icewalker_lower.dmm
@@ -420,6 +420,12 @@
 /obj/structure/flora/ash/leaf_shroom,
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
+"ki" = (
+/obj/structure/railing{
+	invisibility = 100
+	},
+/turf/open/floor/stone/icemoon,
+/area/ruin/unpowered/primitive_catgirl_den)
 "kp" = (
 /obj/structure/closet/crate/wooden/storage_barrel,
 /obj/item/food/cheese/mozzarella{
@@ -1097,6 +1103,13 @@
 	},
 /obj/effect/turf_decal/weather/snow/corner,
 /turf/open/misc/dirt/icemoon,
+/area/ruin/unpowered/primitive_catgirl_den)
+"yN" = (
+/obj/item/clothing/neck/necklace/hearthkin,
+/obj/structure/wall_torch/spawns_lit/directional/east,
+/obj/structure/wall_torch/spawns_lit/directional/west,
+/obj/structure/table/bronze,
+/turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "yR" = (
 /obj/structure/rack/wooden,
@@ -1800,7 +1813,6 @@
 /area/ruin/unpowered/primitive_catgirl_den)
 "Sf" = (
 /obj/structure/rack/wooden,
-/obj/item/clothing/neck/necklace/hearthkin,
 /turf/open/floor/wood/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "SF" = (
@@ -3309,11 +3321,11 @@ yM
 oJ
 oJ
 Te
-ZJ
-GN
-GN
-GN
-GN
+RC
+yF
+pa
+pa
+yF
 yF
 GN
 GN
@@ -3352,11 +3364,11 @@ oJ
 Vb
 no
 pb
-GN
-GN
-GN
-GN
-GN
+iJ
+Zq
+ki
+yN
+yF
 GN
 yF
 yF
@@ -3395,9 +3407,9 @@ oJ
 oJ
 Rq
 yF
-GN
-GN
-GN
+pa
+pa
+yF
 GN
 GN
 GN

--- a/_maps/RandomRuins/IceRuins/nova/icemoon_underground_icewalker_lower.dmm
+++ b/_maps/RandomRuins/IceRuins/nova/icemoon_underground_icewalker_lower.dmm
@@ -1800,6 +1800,7 @@
 /area/ruin/unpowered/primitive_catgirl_den)
 "Sf" = (
 /obj/structure/rack/wooden,
+/obj/item/clothing/neck/necklace/hearthkin,
 /turf/open/floor/wood/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "SF" = (
@@ -1961,7 +1962,6 @@
 /obj/item/ammo_casing/arrow/bone,
 /obj/item/ammo_casing/arrow/bone,
 /obj/item/ammo_casing/arrow/bone,
-/obj/item/ammo_casing/arrow/bronze,
 /obj/item/ammo_casing/arrow/ash,
 /obj/item/ammo_casing/arrow/ash,
 /obj/item/ammo_casing/arrow,

--- a/_maps/RandomRuins/IceRuins/nova/icemoon_underground_icewalker_lower.dmm
+++ b/_maps/RandomRuins/IceRuins/nova/icemoon_underground_icewalker_lower.dmm
@@ -420,12 +420,6 @@
 /obj/structure/flora/ash/leaf_shroom,
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
-"ki" = (
-/obj/structure/railing{
-	invisibility = 100
-	},
-/turf/open/floor/stone/icemoon,
-/area/ruin/unpowered/primitive_catgirl_den)
 "kp" = (
 /obj/structure/closet/crate/wooden/storage_barrel,
 /obj/item/food/cheese/mozzarella{
@@ -1046,6 +1040,13 @@
 /obj/structure/wall_torch/spawns_lit/directional/west,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
+"xu" = (
+/obj/item/clothing/neck/necklace/hearthkin,
+/obj/structure/wall_torch/spawns_lit/directional/east,
+/obj/structure/wall_torch/spawns_lit/directional/west,
+/obj/structure/table/bronze,
+/turf/open/floor/stone/icemoon,
+/area/ruin/unpowered/primitive_catgirl_den)
 "xI" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 9
@@ -1103,13 +1104,6 @@
 	},
 /obj/effect/turf_decal/weather/snow/corner,
 /turf/open/misc/dirt/icemoon,
-/area/ruin/unpowered/primitive_catgirl_den)
-"yN" = (
-/obj/item/clothing/neck/necklace/hearthkin,
-/obj/structure/wall_torch/spawns_lit/directional/east,
-/obj/structure/wall_torch/spawns_lit/directional/west,
-/obj/structure/table/bronze,
-/turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "yR" = (
 /obj/structure/rack/wooden,
@@ -1292,6 +1286,10 @@
 /obj/item/gun/ballistic/bow/longbow,
 /obj/item/storage/bag/quiver,
 /turf/open/misc/dirt/icemoon,
+/area/ruin/unpowered/primitive_catgirl_den)
+"EL" = (
+/obj/structure/railing/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "FB" = (
 /obj/structure/mannequin/wood,
@@ -3366,8 +3364,8 @@ no
 pb
 iJ
 Zq
-ki
-yN
+EL
+xu
 yF
 GN
 yF
@@ -3410,7 +3408,7 @@ yF
 pa
 pa
 yF
-GN
+yF
 GN
 GN
 pa

--- a/_maps/RandomRuins/SpaceRuins/nova/shuttle8532.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/shuttle8532.dmm
@@ -102,9 +102,6 @@
 /obj/machinery/porta_turret_cover,
 /turf/open/floor/engine/airless,
 /area/ruin/space/has_grav/shuttle8532bridge)
-"bx" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/space/has_grav/shuttle8532engineering)
 "by" = (
 /obj/item/shard,
 /obj/structure/lattice,
@@ -514,7 +511,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532researchbay)
 "jQ" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "kp" = (
 /obj/structure/lattice/catwalk,
@@ -531,7 +528,7 @@
 	nightshift_light_color = "#FF0000";
 	pixel_y = 32
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/shuttle8532bridge)
 "ky" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -1015,7 +1012,7 @@
 /area/ruin/space/has_grav/shuttle8532researchbay)
 "vE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/shuttle8532engineering)
 "vG" = (
 /obj/item/stack/cable_coil/cut,
@@ -1126,12 +1123,9 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532researchbay)
-"xN" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/space/has_grav/shuttle8532researchbay)
 "xO" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/space/has_grav/shuttle8532crewquarters)
+/turf/closed/indestructible/syndicate,
+/area/ruin/space/has_grav/shuttle8532bridge)
 "xR" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/cable,
@@ -1203,7 +1197,7 @@
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "zz" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/shuttle8532engineering)
 "zA" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -1359,7 +1353,7 @@
 	dir = 9;
 	system_id = "ship_outer_turrets"
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/shuttle8532researchbay)
 "BR" = (
 /obj/item/chair{
@@ -1542,7 +1536,7 @@
 	nightshift_light_color = "#00FF00";
 	pixel_y = 32
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/shuttle8532bridge)
 "EQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1669,8 +1663,7 @@
 /obj/machinery/door/poddoor{
 	id = "abandonedshipbridgeblast"
 	},
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/turf/open/floor/plating,
+/turf/closed/indestructible/opsglass,
 /area/ruin/space/has_grav/shuttle8532bridge)
 "HW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2068,7 +2061,7 @@
 /turf/template_noop,
 /area/template_noop)
 "QR" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/shuttle8532engineering)
 "Ra" = (
 /obj/structure/table/reinforced,
@@ -2111,7 +2104,7 @@
 	dir = 5;
 	system_id = "ship_outer_turrets"
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/shuttle8532researchbay)
 "RY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2156,7 +2149,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "SJ" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/shuttle8532researchbay)
 "Tq" = (
 /turf/open/floor/engine/airless,
@@ -2313,7 +2306,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532researchbay)
 "Wz" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/shuttle8532cargohall)
 "WH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -2531,7 +2524,7 @@
 qb
 qb
 kx
-pu
+xO
 qb
 qb
 qb
@@ -2594,7 +2587,7 @@ qb
 qb
 by
 ZK
-pu
+xO
 jQ
 jQ
 qb
@@ -2657,7 +2650,7 @@ qb
 qb
 OQ
 vK
-pu
+xO
 Vf
 jQ
 qb
@@ -2783,7 +2776,7 @@ qb
 qb
 ZN
 bs
-pu
+xO
 Fu
 jQ
 jQ
@@ -2844,9 +2837,9 @@ qb
 "}
 (6,1,1) = {"
 qb
-pu
+xO
 EE
-pu
+xO
 Lt
 NJ
 La
@@ -2907,11 +2900,11 @@ qb
 "}
 (7,1,1) = {"
 qb
-pu
-pu
-pu
-pu
-pu
+xO
+xO
+xO
+xO
+xO
 xK
 jQ
 jQ
@@ -2974,7 +2967,7 @@ Uy
 XQ
 fp
 HK
-pu
+xO
 cg
 Hs
 oR
@@ -2989,7 +2982,7 @@ qb
 qb
 CO
 BL
-xN
+SJ
 fd
 Bp
 jM
@@ -3037,7 +3030,7 @@ zA
 ZU
 Vi
 ks
-pu
+xO
 jQ
 jQ
 iy
@@ -3100,14 +3093,14 @@ eV
 Wq
 Pn
 ff
-pu
+xO
 VB
 BK
 DY
 id
 tw
 mq
-xO
+jQ
 jQ
 Gz
 xp
@@ -3163,7 +3156,7 @@ eV
 Gv
 Vi
 BS
-pu
+xO
 sH
 Ds
 uq
@@ -3226,7 +3219,7 @@ ji
 Vi
 NK
 ps
-pu
+xO
 ha
 Ds
 wU
@@ -3272,7 +3265,7 @@ qb
 qb
 qb
 QR
-bx
+QR
 pq
 Eq
 Yq
@@ -3289,7 +3282,7 @@ Ji
 fn
 zG
 Ep
-pu
+xO
 RE
 uK
 wU
@@ -3352,7 +3345,7 @@ eV
 Vi
 eC
 ER
-pu
+xO
 UN
 Ds
 re
@@ -3478,7 +3471,7 @@ eV
 nd
 Vj
 xR
-pu
+xO
 uG
 yz
 Nx
@@ -3541,7 +3534,7 @@ Ra
 jJ
 OZ
 ff
-pu
+xO
 RE
 Ds
 yv
@@ -3604,7 +3597,7 @@ zX
 Vi
 Qv
 Se
-pu
+xO
 Ue
 TM
 Ip
@@ -3667,7 +3660,7 @@ eV
 Vi
 Vi
 Ux
-pu
+xO
 ac
 TM
 yv
@@ -3730,14 +3723,14 @@ eV
 Wq
 FW
 Hg
-pu
+xO
 jh
 iP
 ef
 zi
 ce
 pG
-xO
+jQ
 jQ
 Yf
 xp
@@ -3788,12 +3781,12 @@ YO
 qb
 "}
 (21,1,1) = {"
-pu
+xO
 eV
 vS
 Vi
 qP
-pu
+xO
 jQ
 jQ
 aw
@@ -3851,12 +3844,12 @@ YO
 qb
 "}
 (22,1,1) = {"
-pu
-Uy
+xO
+xO
 Yk
 Ci
 HK
-pu
+xO
 lt
 VF
 NJ
@@ -3915,11 +3908,11 @@ ve
 "}
 (23,1,1) = {"
 qb
-pu
-pu
-pu
-pu
-pu
+xO
+xO
+xO
+xO
+xO
 NJ
 jQ
 jQ
@@ -3980,7 +3973,7 @@ hP
 ts
 OQ
 nx
-pu
+xO
 CG
 Fu
 Ff
@@ -4043,7 +4036,7 @@ qb
 qb
 OQ
 Xu
-pu
+xO
 NJ
 jQ
 jQ
@@ -4169,7 +4162,7 @@ qb
 qb
 tP
 bs
-pu
+xO
 Qn
 jQ
 qb
@@ -4230,9 +4223,9 @@ ve
 "}
 (28,1,1) = {"
 qb
-pu
+xO
 ds
-pu
+xO
 jQ
 jQ
 qb
@@ -4280,7 +4273,7 @@ qb
 qb
 qb
 QR
-bx
+QR
 oJ
 kL
 gE
@@ -4295,7 +4288,7 @@ hP
 qb
 qb
 EM
-pu
+xO
 qb
 qb
 qb

--- a/_maps/RandomRuins/SpaceRuins/nova/shuttle8532.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/shuttle8532.dmm
@@ -34,6 +34,7 @@
 /obj/machinery/door/poddoor{
 	id = "abandonedshiphatch"
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "ay" = (
@@ -74,6 +75,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/shuttle8532engineering)
+"ba" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/rglass/fifty{
+	pixel_y = 6
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/has_grav/shuttle8532engineering)
 "bo" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/structure/chair/sofa/bench{
@@ -93,6 +102,9 @@
 /obj/machinery/porta_turret_cover,
 /turf/open/floor/engine/airless,
 /area/ruin/space/has_grav/shuttle8532bridge)
+"bx" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/shuttle8532engineering)
 "by" = (
 /obj/item/shard,
 /obj/structure/lattice,
@@ -323,6 +335,14 @@
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532cargohall)
+"gE" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/plastic/fifty{
+	pixel_y = 5
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/has_grav/shuttle8532engineering)
 "gI" = (
 /obj/effect/mine/explosive,
 /obj/effect/decal/cleanable/blood,
@@ -353,6 +373,7 @@
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "hf" = (
 /obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/shuttle8532bridge)
 "hh" = (
@@ -411,6 +432,7 @@
 /obj/machinery/door/poddoor{
 	id = "abandonedshiphatch"
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "iG" = (
@@ -492,7 +514,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532researchbay)
 "jQ" = (
-/turf/closed/wall/r_wall,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "kp" = (
 /obj/structure/lattice/catwalk,
@@ -509,7 +531,7 @@
 	nightshift_light_color = "#FF0000";
 	pixel_y = 32
 	},
-/turf/closed/wall/r_wall,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/shuttle8532bridge)
 "ky" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -712,7 +734,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532bridge)
 "pu" = (
-/turf/closed/wall/r_wall,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/shuttle8532bridge)
 "py" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -993,7 +1015,7 @@
 /area/ruin/space/has_grav/shuttle8532researchbay)
 "vE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/turf/closed/wall/r_wall,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/shuttle8532engineering)
 "vG" = (
 /obj/item/stack/cable_coil/cut,
@@ -1104,6 +1126,12 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532researchbay)
+"xN" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/shuttle8532researchbay)
+"xO" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/shuttle8532crewquarters)
 "xR" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/cable,
@@ -1175,7 +1203,7 @@
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "zz" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/shuttle8532engineering)
 "zA" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -1331,7 +1359,7 @@
 	dir = 9;
 	system_id = "ship_outer_turrets"
 	},
-/turf/closed/wall/r_wall,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/shuttle8532researchbay)
 "BR" = (
 /obj/item/chair{
@@ -1514,7 +1542,7 @@
 	nightshift_light_color = "#00FF00";
 	pixel_y = 32
 	},
-/turf/closed/wall/r_wall,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/shuttle8532bridge)
 "EQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1567,6 +1595,12 @@
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532cargohall)
+"FW" = (
+/mob/living/basic/trooper/syndicate/melee/space/anthro/lizard{
+	faction = null
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/has_grav/shuttle8532bridge)
 "Gv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mob_spawn/corpse/human/syndicatecommando,
@@ -1632,10 +1666,10 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532bridge)
 "HP" = (
-/obj/structure/window/reinforced/fulltile,
 /obj/machinery/door/poddoor{
 	id = "abandonedshipbridgeblast"
 	},
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/shuttle8532bridge)
 "HW" = (
@@ -1836,7 +1870,9 @@
 /turf/open/floor/engine/airless,
 /area/ruin/space/has_grav/shuttle8532engineering)
 "MM" = (
-/mob/living/basic/trooper/syndicate/melee/space,
+/mob/living/basic/trooper/syndicate/melee/sword/space/stormtrooper{
+	faction = null
+	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532engineering)
 "MO" = (
@@ -1966,6 +2002,12 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532researchbay)
+"Pn" = (
+/mob/living/basic/trooper/syndicate/ranged/shotgun/space/stormtrooper/anthro/fox{
+	faction = null
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/has_grav/shuttle8532bridge)
 "Ps" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/mapping_helpers/broken_floor,
@@ -2026,7 +2068,7 @@
 /turf/template_noop,
 /area/template_noop)
 "QR" = (
-/turf/closed/wall/r_wall,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/shuttle8532engineering)
 "Ra" = (
 /obj/structure/table/reinforced,
@@ -2069,7 +2111,7 @@
 	dir = 5;
 	system_id = "ship_outer_turrets"
 	},
-/turf/closed/wall/r_wall,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/shuttle8532researchbay)
 "RY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2114,7 +2156,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "SJ" = (
-/turf/closed/wall/r_wall,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/shuttle8532researchbay)
 "Tq" = (
 /turf/open/floor/engine/airless,
@@ -2183,8 +2225,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532bridge)
 "Uy" = (
-/mob/living/basic/trooper/syndicate/melee/space,
-/turf/open/floor/iron/airless,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/shuttle8532bridge)
 "UN" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -2272,7 +2313,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532researchbay)
 "Wz" = (
-/turf/closed/wall/r_wall,
+/turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/shuttle8532cargohall)
 "WH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -2929,7 +2970,7 @@ qb
 "}
 (8,1,1) = {"
 pu
-pu
+Uy
 XQ
 fp
 HK
@@ -2948,7 +2989,7 @@ qb
 qb
 CO
 BL
-SJ
+xN
 fd
 Bp
 jM
@@ -2994,7 +3035,7 @@ qb
 pu
 zA
 ZU
-Uy
+Vi
 ks
 pu
 jQ
@@ -3057,7 +3098,7 @@ qb
 HP
 eV
 Wq
-Vi
+Pn
 ff
 pu
 VB
@@ -3066,7 +3107,7 @@ DY
 id
 tw
 mq
-jQ
+xO
 jQ
 Gz
 xp
@@ -3231,7 +3272,7 @@ qb
 qb
 qb
 QR
-QR
+bx
 pq
 Eq
 Yq
@@ -3623,7 +3664,7 @@ hP
 (19,1,1) = {"
 HP
 eV
-Uy
+Vi
 Vi
 Ux
 pu
@@ -3687,7 +3728,7 @@ qb
 HP
 eV
 Wq
-Vi
+FW
 Hg
 pu
 jh
@@ -3696,7 +3737,7 @@ ef
 zi
 ce
 pG
-jQ
+xO
 jQ
 Yf
 xp
@@ -3811,7 +3852,7 @@ qb
 "}
 (22,1,1) = {"
 pu
-pu
+Uy
 Yk
 Ci
 HK
@@ -4239,11 +4280,11 @@ qb
 qb
 qb
 QR
-QR
+bx
 oJ
 kL
-Yq
-JB
+gE
+ba
 QR
 HW
 Tt

--- a/_maps/map_files/generic/CentCom_nova_z2.dmm
+++ b/_maps/map_files/generic/CentCom_nova_z2.dmm
@@ -1406,6 +1406,10 @@
 	pixel_y = 16;
 	pixel_x = -2
 	},
+/obj/item/clothing/neck/necklace/hearthkin,
+/obj/item/clothing/neck/necklace/hearthkin,
+/obj/item/clothing/neck/necklace/hearthkin,
+/obj/item/clothing/neck/necklace/hearthkin,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafepark)
 "avn" = (
@@ -5517,7 +5521,8 @@
 /area/centcom/interlink)
 "dgl" = (
 /obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/stairs,
+/obj/structure/fake_stairs/directional/north,
+/turf/open/space/basic,
 /area/centcom/holding/cafepark)
 "dgV" = (
 /turf/open/floor/iron/white,
@@ -7365,6 +7370,10 @@
 /area/centcom/interlink)
 "gZK" = (
 /obj/structure/table/wood,
+/obj/item/clothing/neck/necklace/ashwalker,
+/obj/item/clothing/neck/necklace/ashwalker,
+/obj/item/clothing/neck/necklace/ashwalker,
+/obj/item/clothing/neck/necklace/ashwalker,
 /turf/open/floor/fakebasalt,
 /area/centcom/holding/cafepark)
 "gZM" = (

--- a/modular_nova/modules/mapping/code/icemoon.dm
+++ b/modular_nova/modules/mapping/code/icemoon.dm
@@ -4,7 +4,7 @@
 /*------*/
 
 /datum/map_template/ruin/icemoon/underground/nova/mining_site_below
-	name = "Mining Site Underground"
+	name = "Ice_ruin Mining Site Underground"
 	id = "miningsite-underground"
 	description = "The Iceminer arena."
 	prefix = "_maps/RandomRuins/IceRuins/nova/"
@@ -12,7 +12,7 @@
 	always_place = TRUE
 
 /datum/map_template/ruin/icemoon/underground/nova/interdyne_base
-	name = "Interdyne Pharmaceuticals Nova Sector Base 8817238"
+	name = "Ice_ruin Interdyne Pharmaceuticals Nova Sector Base 8817238"
 	id = "ice-base"
 	description = "A planetside Interdyne research facility developing biological weapons; it is closely guarded by an elite team of agents."
 	prefix = "_maps/RandomRuins/IceRuins/nova/"

--- a/modular_nova/modules/mapping/code/lavaland.dm
+++ b/modular_nova/modules/mapping/code/lavaland.dm
@@ -4,7 +4,7 @@
 /*------*/
 
 /datum/map_template/ruin/lavaland/ash_walker
-	name = "Ash Walker Nest"
+	name = "Lava_Ruin Ash Walker Nest"
 	id = "ash-walker"
 	description = "A race of unbreathing lizards live here, that run faster than a human can, worship a broken dead city, and are capable of reproducing by something involving tentacles? \
 	Probably best to stay clear."
@@ -14,7 +14,7 @@
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/nova/interdyne_base
-	name = "Interdyne Pharmaceutics Nova Sector Base 3c76928"
+	name = "Lava_Ruin Interdyne Pharmaceutics Nova Sector Base 3c76928"
 	id = "lava-base"
 	description = "A planetside Interdyne research facility developing biological weapons; it is closely guarded by an elite team of agents."
 	prefix = "_maps/RandomRuins/LavaRuins/nova/"

--- a/modular_nova/modules/mapping/code/space.dm
+++ b/modular_nova/modules/mapping/code/space.dm
@@ -7,7 +7,7 @@
 	id = "whiteshipruin_box_nova"
 	prefix = "_maps/RandomRuins/SpaceRuins/nova/"
 	suffix = "whiteshipruin_box.dmm"
-	name = "NT Medical Ship"
+	name = "Space_Ruin NT Medical Ship"
 	description = "An ancient ship, said to be among the first discovered derelicts near Space Station 13 that was still in working order. \
 	Aged and deprecated by time, this relic of a vessel is now broken beyond repair."
 
@@ -15,163 +15,152 @@
 	id = "spacehotel"
 	prefix = "_maps/RandomRuins/SpaceRuins/nova/"
 	suffix = "spacehotel.dmm"
-	name = "The Twin-Nexus Hotel"
+	name = "Space_Ruin The Twin-Nexus Hotel"
 	description = "An interstellar hotel, where the weary spaceman can rest their head and relax, assured that the residental staff will not murder them in their sleep. Probably."
 
 /datum/map_template/ruin/space/nova/des_two
 	name = "DS-2"
 	id = "des_two"
 	description = "If DS-1 was so good..."
-	suffix = "des_two.dmm"
+	suffix = "Space_Ruin DS2"
 	always_place = TRUE
 
 /datum/map_template/ruin/space/nova/derelictferry
 	id = "derelictferry"
 	suffix = "derelictferry.dmm"
-	name = "Derelict Ferry"
+	name = "Space_Ruin Derelict Ferry"
 	description = "Clearly once a ferry fielded by Central Command to send their staff to nearby stations, this ship's seen better days."
 
 /datum/map_template/ruin/space/nova/posterpandamonium
 	id = "posterpandamonium"
 	suffix = "posterpandamonium.dmm"
-	name = "Abandoned Outpost"
+	name = "Space_Ruin Abandoned Outpost"
 	description = "Whilst nicely furnished and filled with all sorts of posters, whoever once lived here seems long gone."
 
 /datum/map_template/ruin/space/nova/prisonshuttle
 	id = "prisonshuttle"
 	suffix = "prisonshuttle.dmm"
-	name = "Partisan Shuttle"
+	name = "Space_Ruin Partisan Shuttle"
 	description = "You can faintly hear hardbass."
 
 /datum/map_template/ruin/space/nova/toystore
 	id = "toystore"
 	suffix = "toystore.dmm"
-	name = "Toy Store"
+	name = "Space_Ruin Toy Store"
 	description = "A once state-of-the-art store, now left derelict after the company behind it went bankrupt. Maybe they shouldn't have picked such a remote location."
 
 /datum/map_template/ruin/space/nova/waypointstation
 	id = "waypointstation"
 	suffix = "waypointstation.dmm"
-	name = "Waypoint Station"
+	name = "Space_Ruin Waypoint Station"
 	description = "Previously used as a refueling stop for larger ships, unintentional syndicate intervention has turned this station into a combat zone."
 
 /datum/map_template/ruin/space/nova/alientoollab
 	id = "alientoollab"
 	suffix = "alientoollab.dmm"
-	name = "Abductor Replication Facility"
+	name = "Space_Ruin Abductor Replication Facility"
 	description = "A mad doctor's dreams were dashed when he finally disclosed to both his funders that each other existed, leaving behind his work for the looters."
 
 /datum/map_template/ruin/space/nova/codealpha
 	id = "codealpha"
 	suffix = "codealpha.dmm"
-	name = "Code Alpha Supplementary Station"
+	name = "Space_Ruin Code Alpha Supplementary Station"
 	description = "The mess hall of a once bustling supplementary station, to be deployed alongside SS13."
 
 /datum/map_template/ruin/space/nova/smugglies  //Excuse me sir, do you have money printers in here?
 	id = "smugglies"
 	suffix = "smugglies.dmm"
-	name = "Suspicious Cargo Installation"
+	name = "Space_Ruin Suspicious Cargo Installation"
 	description = "*SCREECH* RDM RDM RDM"
 
 /datum/map_template/ruin/space/nova/clothing_facility
 	id = "clothing_facility"
 	suffix = "clothing_facility.dmm"
-	name = "Abandoned Clothing Facility"
+	name = "Space_Ruin Abandoned Clothing Facility"
 	description = "A den of bad ideas. Secborgs were made here!"
 
 /datum/map_template/ruin/space/nova/luna
 	id = "luna"
 	suffix = "luna.dmm"
-	name = "Luna"
+	name = "Space_Ruin Luna"
 	description = "Please note for ethical concerns all experimentation regarding writing artificial intelligence units to beleive they are A, A fictional character and B, human have been suspended. Have a pleasant shift."
 
 /datum/map_template/ruin/space/nova/blackmarket
 	id = "blackmarket"
 	suffix = "blackmarket.dmm"
-	name = "Shady Market"
+	name = "Space_Ruin Shady Market"
 	description = "Whaddya buyin'?"
 
 /datum/map_template/ruin/space/nova/shuttle8532
 	id = "shuttle8532"
 	suffix = "shuttle8532.dmm"
-	name = "Shuttle 8532"
+	name = "Space_Ruin Shuttle 8532"
 	description = "While nobody can predict what space has to offer for the sailors that ride its waves, nobody is quite expecting a meteroid half the size of your shuttle to split it in half."
 
 /datum/map_template/ruin/space/nova/ghostship
 	id = "ghostship"
 	suffix = "ghostship.dmm"
-	name = "Ghost Ship"
+	name = "Space_Ruin Ghost Ship"
 	description = "An ancient ship, seemingly pre-bluespace in design yet retrofitted with newer systems. Seemingly just up-and-abandoned in the middle of space..."
 
 /datum/map_template/ruin/space/nova/salvagepost
 	id = "salvagepost"
 	suffix = "salvagepost.dmm"
-	name = "Pre-Bluespace Salvage Post"
+	name = "Space_Ruin Pre-Bluespace Salvage Post"
 	description = "An extremely old, long forgotten post used to salvage damaged or decommissioned ships before bluespace transportation. Surprising its stayed intact so long."
 
 /datum/map_template/ruin/space/nova/vaulttango
 	id = "vaulttango"
 	suffix = "vaulttango.dmm"
-	name = "ARBORLINK Vault Tango"
+	name = "Space_Ruin ARBORLINK Vault Tango"
 	description = "Nanotrasen isn't the only corporation experimenting in advanced bluespace technology."
 
 /datum/map_template/ruin/space/nova/friendship
 	id = "friendship"
 	suffix = "wreckedfriendship.dmm"
-	name = "NTSS Friendship"
+	name = "Space_Ruin NTSS Friendship"
 	description = "120 people.. one ship. It's unsurprising."
 
 /datum/map_template/ruin/space/nova/homestead
 	id = "homestead"
 	suffix = "wreckedhomestead.dmm"
-	name = "NTSS Homestead"
+	name = "Space_Ruin NTSS Homestead"
 	description = "A wrecked ship."
-
-/datum/map_template/ruin/space/nova/medieval1
-	id = "medieval1"
-	suffix = "medieval1.dmm"
-	name = "Medieval 1"
-	description = "A forgotten peice of history left overrun with a reminder of what brought its destruction"
 
 /datum/map_template/ruin/space/nova/cargodiselost
 	id = "CargodiseLost"
 	suffix = "cargodiselost.dmm"
-	name = "Cargodise Lost"
+	name = "Space_Ruin Cargodise Lost"
 	description = "A small crew of freight-haulers are marooned in space after pirates knock out their engines. They must survive off of the cargo on board their ship and fend off the pirate boarders on their ship."
 
 /datum/map_template/ruin/space/nova/infestedntship
 	suffix = "scrapheap.dmm"
-	name = "NT Research Vessel"
+	name = "Space_Ruin NT Research Vessel"
 	description = "A zombie-infested NT ship, seemingly dedicated to medical research."
 
 /datum/map_template/ruin/space/nova/piratefort
 	suffix = "piratefort.dmm"
-	name = "Pirate Fort"
+	name = "Space_Ruin Pirate Fort"
 	description = "A pirate hideout in deep space."
 
 /datum/map_template/ruin/space/nova/syndibase
 	suffix = "syndibase.dmm"
-	name = "Syndicate Outpost"
+	name = "Space_Ruin Syndicate Outpost"
 	description = "A Syndicate research outpost in deep space."
 
 /datum/map_template/ruin/space/nova/crash
 	suffix = "crash.dmm"
-	name = "Crashed Boat"
+	name = "Space_Ruin Crashed Boat"
 	description = "A small ferry crashed into an asteroid."
 
 /datum/map_template/ruin/space/nova/shuttlescrap
 	suffix = "shuttlescrap.dmm"
-	name = "Broken Shuttle"
+	name = "Space_Ruin Broken Shuttle"
 	description = "A small shuttle that clearly got clipped by something."
-
-/datum/map_template/ruin/space/nova/gorilla
-	suffix = "gorilla.dmm"
-	name = "Gorilla"
-	description = "There is no need to be upset."
 
 /datum/map_template/ruin/space/nova/escapefromtarkon
 	suffix = "port_tarkon.dmm"
-	name = "Port Tarkon"
+	name = "Space_Ruin Port Tarkon"
 	id = "escapefromtarkon"
 	description = "An ambitious goal, A step forward, A trial run for the Tarkon drill, ment to implant mining stations within meteors. Decades of disaster have, however, left this one... Unattended for far too long."
 	always_place = TRUE

--- a/modular_nova/modules/primitive_catgirls/code/clothing.dm
+++ b/modular_nova/modules/primitive_catgirls/code/clothing.dm
@@ -207,4 +207,4 @@
 	var/mob/living/carbon/human/H = user
 	if(H.get_item_by_slot(ITEM_SLOT_NECK) == src && !QDELETED(src)) //This can be called as a part of destroy
 		user.remove_language(/datum/language/primitive_catgirl/, source = LANGUAGE_TRANSLATOR)
-		to_chat(user, span_boldnotice("You feel the alien mind of the Necropolis lose its interest in you as you remove the necklace. The eye closes, and your mind does as well, losing its grasp of Ashtongue."))
+		to_chat(user, span_boldnotice("You feel the alien unease lessen as the gem loses its interest in you after removing it. The eye closes, and your mind does as well, losing its grasp of Hearthkin."))

--- a/modular_nova/modules/primitive_catgirls/code/clothing.dm
+++ b/modular_nova/modules/primitive_catgirls/code/clothing.dm
@@ -177,3 +177,34 @@
 
 /obj/item/forging/reagent_weapon/axe/fake_copper
 	custom_materials = list(/datum/material/copporcitite = SHEET_MATERIAL_AMOUNT)
+
+//DEFAULT NECK ITEMS OVERRIDE//
+/obj/item/clothing/neck
+	w_class = WEIGHT_CLASS_SMALL
+
+//HEARTHKIN TRANSLATOR NECKLACE
+/obj/item/clothing/neck/necklace/hearthkin
+	name = "gemmed necklace"
+	desc = "A necklace crafted from a gem found in the frozen wastes. This imbues overdwellers with an unnatural understanding of the Hearthkin while worn."
+	icon = 'modular_nova/master_files/icons/obj/clothing/neck.dmi'
+	icon_state = "ashnecklace"
+	worn_icon = 'modular_nova/master_files/icons/mob/clothing/neck.dmi'
+	icon_state = "ashnecklace"
+	w_class = WEIGHT_CLASS_SMALL //allows this to fit inside of pockets.
+
+/obj/item/clothing/neck/necklace/hearthkin/equipped(mob/user, slot)
+	. = ..()
+	if(!ishuman(user))
+		return
+	if(slot & ITEM_SLOT_NECK)
+		user.grant_language(/datum/language/primitive_catgirl/, source = LANGUAGE_TRANSLATOR)
+		to_chat(user, span_boldnotice("Slipping the necklace on, you feel the insidious creep of a dark nature enter your bones, your very shadow and soul. You find yourself with an unnatural knowledge of the Hearthkin; but the amulet's eye stares back at you. Causing you to shiver with unease, you dont want to keep this on forever."))
+
+/obj/item/clothing/neck/necklace/hearthkin/dropped(mob/user)
+	. = ..()
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if(H.get_item_by_slot(ITEM_SLOT_NECK) == src && !QDELETED(src)) //This can be called as a part of destroy
+		user.remove_language(/datum/language/primitive_catgirl/, source = LANGUAGE_TRANSLATOR)
+		to_chat(user, span_boldnotice("You feel the alien mind of the Necropolis lose its interest in you as you remove the necklace. The eye closes, and your mind does as well, losing its grasp of Ashtongue."))

--- a/modular_nova/modules/primitive_catgirls/code/clothing.dm
+++ b/modular_nova/modules/primitive_catgirls/code/clothing.dm
@@ -197,7 +197,7 @@
 	if(!ishuman(user))
 		return
 	if(slot & ITEM_SLOT_NECK)
-		user.grant_language(/datum/language/primitive_catgirl/, source = LANGUAGE_TRANSLATOR)
+		user.grant_language(/datum/language/siiktajr/, source = LANGUAGE_TRANSLATOR)
 		to_chat(user, span_boldnotice("Slipping the necklace on, you feel the insidious creep of a dark nature enter your bones, your very shadow and soul. You find yourself with an unnatural knowledge of the Hearthkin; but the amulet's eye stares back at you with a gleeful intent. Causing you to shiver with unease, you dont want to keep this on forever."))
 
 /obj/item/clothing/neck/necklace/hearthkin/dropped(mob/user)
@@ -206,5 +206,5 @@
 		return
 	var/mob/living/carbon/human/H = user
 	if(H.get_item_by_slot(ITEM_SLOT_NECK) == src && !QDELETED(src)) //This can be called as a part of destroy
-		user.remove_language(/datum/language/primitive_catgirl/, source = LANGUAGE_TRANSLATOR)
+		user.remove_language(/datum/language/siiktajr/, source = LANGUAGE_TRANSLATOR)
 		to_chat(user, span_boldnotice("You feel the alien unease lessen as the gem loses its interest in you after removing it. The eye closes, and your mind does as well, losing its grasp of Hearthkin."))

--- a/modular_nova/modules/primitive_catgirls/code/clothing.dm
+++ b/modular_nova/modules/primitive_catgirls/code/clothing.dm
@@ -198,7 +198,7 @@
 		return
 	if(slot & ITEM_SLOT_NECK)
 		user.grant_language(/datum/language/primitive_catgirl/, source = LANGUAGE_TRANSLATOR)
-		to_chat(user, span_boldnotice("Slipping the necklace on, you feel the insidious creep of a dark nature enter your bones, your very shadow and soul. You find yourself with an unnatural knowledge of the Hearthkin; but the amulet's eye stares back at you. Causing you to shiver with unease, you dont want to keep this on forever."))
+		to_chat(user, span_boldnotice("Slipping the necklace on, you feel the insidious creep of a dark nature enter your bones, your very shadow and soul. You find yourself with an unnatural knowledge of the Hearthkin; but the amulet's eye stares back at you with a gleeful intent. Causing you to shiver with unease, you dont want to keep this on forever."))
 
 /obj/item/clothing/neck/necklace/hearthkin/dropped(mob/user)
 	. = ..()

--- a/modular_nova/modules/xenoarch/code/modules/research/xenoarch/xenoarch_reward.dm
+++ b/modular_nova/modules/xenoarch/code/modules/research/xenoarch/xenoarch_reward.dm
@@ -68,6 +68,7 @@ GLOBAL_LIST_INIT(clothing_reward, list(
 	/obj/item/clothing/under/costume/gladiator/ash_walker/tribal = 1,
 	/obj/item/clothing/under/costume/gladiator/ash_walker/white = 1,
 	/obj/item/clothing/neck/necklace/ashwalker = 1,
+	/obj/item/clothing/neck/necklace/hearthkin = 1,
 	/obj/item/clothing/head/helmet/gladiator = 1,
 	/obj/item/clothing/under/costume/gladiator/ash_walker = 1,
 ))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This one's a QOL pass that i've been meaning to get to for a couple weeks:

Shuttle8532 - I hate having the fact you get a free syndicate modsuit without any effort, so i made it require effort. You now actually have to solve the puzzle of the ship instead of cheesing through the wall.

Icewalkers - nothing changed except i added in a gemmed necklace, it's an ashen necklace basically but for the cats. I was going to start respriting it but realize that the sprite itself can easily be changed

Cafe - added both the Ashen and Gemmed necklaces to their respective areas

## How This Contributes To The Nova Sector Roleplay Experience

Enables roleplay in the Cafe between tribals/non tribals
Enables a high-value item for the icewalkers - the gemmed necklace
Shuttle 8532 isnt a free syndie suit anymore

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  Ruins are now ruins! 
  
![image](https://github.com/NovaSector/NovaSector/assets/22140677/c879b220-fb68-4505-9f80-b8212493c5e5)


Call the press, the synths are speaking tongues
![image](https://github.com/NovaSector/NovaSector/assets/22140677/69d1749a-470b-4593-9fbd-73e974198f8b)
![image](https://github.com/NovaSector/NovaSector/assets/22140677/42acf212-b958-4059-bf59-4fbac016de1e)

![image](https://github.com/NovaSector/NovaSector/assets/22140677/cfcb81c1-2cb6-40ce-9a82-5f2994f8173e)

  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added a translator necklace for hearthkin, granting 1 to the map and 4 to the cafe
qol: Cafe now has the gemmed and ashen necklaces in their respective areas
balance: Shuttle 8532 actually requires thinking and skill to not die 
admin: Ruin names now have their identifier placed in the front, making it easier to pick them out of the massive list
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
