### PR TITLE
[NON-MODULAR] Physical Age & Chronological Age

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -461,7 +461,9 @@
 //MINOR TWEAKS/MISC
 //#define AGE_MIN 17	//youngest a character can be //ORIGINAL
 #define AGE_MIN	18	//youngest a character can be //NOVA EDIT CHANGE - age
-#define AGE_MAX 85 //oldest a character can be
+// #define AGE_MAX //oldest a character can be // ORIGINAL
+#define AGE_MAX 100 //oldest a character can be //NOVA EDIT CHANGE - Increase max character age to 100
+#define AGE_CHRONO_MAX 400 //NOVA EDIT ADDITION - Chronological age
 #define AGE_MINOR 20 //legal age of space drinking and smoking
 #define WIZARD_AGE_MIN 30 //youngest a wizard can be
 #define APPRENTICE_AGE_MIN 29 //youngest an apprentice can be

--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -121,6 +121,7 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 
 	var/datum/record/locked/lockfile = new(
 		age = person.age,
+		chrono_age = person.chrono_age, // NOVA EDIT ADDITION - Chronological age
 		blood_type = record_dna.blood_type,
 		character_appearance = character_appearance,
 		dna_string = record_dna.unique_enzymes,
@@ -138,6 +139,7 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 
 	new /datum/record/crew(
 		age = person.age,
+		chrono_age = person.chrono_age, // NOVA EDIT ADDITION - Chronological age
 		blood_type = record_dna.blood_type,
 		character_appearance = character_appearance,
 		dna_string = record_dna.unique_enzymes,

--- a/code/datums/records/record.dm
+++ b/code/datums/records/record.dm
@@ -27,8 +27,12 @@
 	/// The character's voice, if they have one.
 	var/voice
 
+	/// NOVA EDIT ADDITION - Chronological age of the character
+	var/chrono_age
+
 /datum/record/New(
 	age = 18,
+	chrono_age = 18, // NOVA EDIT ADDITION - Chronological age
 	blood_type = "?",
 	character_appearance,
 	dna_string = "Unknown",
@@ -42,6 +46,7 @@
 	voice = "?????",
 )
 	src.age = age
+	src.chrono_age = chrono_age // NOVA EDIT ADDITION - Chronological age
 	src.blood_type = blood_type
 	src.character_appearance = character_appearance
 	src.dna_string = dna_string
@@ -86,6 +91,7 @@
 
 /datum/record/crew/New(
 	age = 18,
+	chrono_age = 18, // NOVA EDIT ADDITION - Chronological age
 	blood_type = "?",
 	character_appearance,
 	dna_string = "Unknown",
@@ -149,6 +155,7 @@
 
 /datum/record/locked/New(
 	age = 18,
+	chrono_age = 18, // NOVA EDIT ADDITION - Chronological age
 	blood_type = "?",
 	character_appearance,
 	dna_string = "Unknown",
@@ -234,6 +241,7 @@
 	var/final_paper_text = "<center><b>SR-[print_count]: [header]</b></center><br>"
 
 	final_paper_text += "Name: [name]<br>Gender: [gender]<br>Age: [age]<br>"
+	final_paper_text += "Chronological Age: [chrono_age]<br>" // NOVA EDIT ADDITION - Chronological age
 	if(alias != name)
 		final_paper_text += "Alias: [alias]<br>"
 

--- a/code/game/machinery/computer/records/medical.dm
+++ b/code/game/machinery/computer/records/medical.dm
@@ -52,6 +52,7 @@
 
 		records += list(list(
 			age = target.age,
+			chrono_age = target.chrono_age, // NOVA EDIT ADDITION - Chronological age
 			blood_type = target.blood_type,
 			crew_ref = REF(target),
 			dna = target.dna_string,
@@ -79,6 +80,7 @@
 	var/list/data = list()
 	data["min_age"] = AGE_MIN
 	data["max_age"] = AGE_MAX
+	data["max_chrono_age"] = AGE_CHRONO_MAX // NOVA EDIT ADDITION - Chronological age
 	data["physical_statuses"] = PHYSICAL_STATUSES
 	data["mental_statuses"] = MENTAL_STATUSES
 	return data
@@ -144,6 +146,7 @@
 		return FALSE
 
 	target.age = 18
+	target.chrono_age = 18 // NOVA EDIT ADDITION - Chronological age
 	target.blood_type = pick(list("A+", "A-", "B+", "B-", "O+", "O-", "AB+", "AB-"))
 	target.dna_string = "Unknown"
 	target.gender = "Unknown"

--- a/code/game/machinery/computer/records/security.dm
+++ b/code/game/machinery/computer/records/security.dm
@@ -119,6 +119,7 @@
 
 		records += list(list(
 			age = target.age,
+			chrono_age = target.chrono_age, // NOVA EDIT ADDITION - Chronological age
 			citations = citations,
 			crew_ref = REF(target),
 			crimes = crimes,
@@ -143,6 +144,7 @@
 	var/list/data = list()
 	data["min_age"] = AGE_MIN
 	data["max_age"] = AGE_MAX
+	data["max_chrono_age"] = AGE_CHRONO_MAX // NOVA EDIT ADDITION - Chronological age
 	return data
 
 /obj/machinery/computer/records/security/ui_act(action, list/params, datum/tgui/ui)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -44,6 +44,8 @@
 
 	var/age = 30 //Player's age
 
+	var/chrono_age = 30 // NOVA EDIT ADDITION - Chronological age
+
 	/// Which body type to use
 	var/physique = MALE
 

--- a/code/modules/modular_computers/file_system/programs/records.dm
+++ b/code/modules/modular_computers/file_system/programs/records.dm
@@ -39,6 +39,7 @@
 				var/list/current_record = list()
 
 				current_record["age"] = person.age
+				current_record["chrono_age"] = person.chrono_age // NOVA EDIT ADDITION - Chronological age
 				current_record["fingerprint"] = person.fingerprint
 				current_record["gender"] = person.gender
 				current_record["name"] = person.name

--- a/modular_nova/master_files/code/modules/client/preferences/chronological_age.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/chronological_age.dm
@@ -1,0 +1,11 @@
+// Chronological age
+/datum/preference/numeric/chronological_age
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	savefile_key = "chrono_age"
+	savefile_identifier = PREFERENCE_CHARACTER
+
+	minimum = AGE_MIN
+	maximum = AGE_CHRONO_MAX
+
+/datum/preference/numeric/chronological_age/apply_to_human(mob/living/carbon/human/target, value)
+	target.chrono_age = value

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6340,6 +6340,7 @@
 #include "modular_nova\master_files\code\modules\client\preferences\be_antag.dm"
 #include "modular_nova\master_files\code\modules\client\preferences\body_size.dm"
 #include "modular_nova\master_files\code\modules\client\preferences\brain.dm"
+#include "modular_nova\master_files\code\modules\client\preferences\chronological_age.dm"
 #include "modular_nova\master_files\code\modules\client\preferences\clothing.dm"
 #include "modular_nova\master_files\code\modules\client\preferences\delete_sparks.dm"
 #include "modular_nova\master_files\code\modules\client\preferences\dontator_status.dm"

--- a/tgui/packages/tgui/interfaces/MedicalRecords/RecordView.tsx
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/RecordView.tsx
@@ -30,7 +30,7 @@ export const MedicalRecordView = (props) => {
 
   const { act, data } = useBackend<MedicalRecordData>();
   const { assigned_view, physical_statuses, mental_statuses, station_z } = data;
-
+  // const { min_age, max_age } = data; // ORIGINAL
   const { min_age, max_age, max_chrono_age } = data; // NOVA EDIT CHANGE - Chronological age
 
   const {
@@ -92,7 +92,10 @@ export const MedicalRecordView = (props) => {
             <LabeledList.Item label="Job">
               <EditableText field="job" target_ref={crew_ref} text={rank} />
             </LabeledList.Item>
-            <LabeledList.Item label="Age">
+            {/* <LabeledList.Item label="Age"> // ORIGINAL */}
+            {/* NOVA EDIT CHANGE BEGIN - Chronological age */}
+            <LabeledList.Item label="Physical Age">
+              {/* NOVA EDIT CHANGE END */}
               <RestrictedInput
                 minValue={min_age}
                 maxValue={max_age}
@@ -106,7 +109,7 @@ export const MedicalRecordView = (props) => {
                 value={age}
               />
             </LabeledList.Item>
-            {/* NOVA EDIT ADDITION BEGIN - CHRONOLOGICAL AGE */}
+            {/* NOVA EDIT ADDITION BEGIN - Chronological age */}
             <LabeledList.Item label="Chronological Age">
               <RestrictedInput
                 minValue={min_age}
@@ -121,7 +124,7 @@ export const MedicalRecordView = (props) => {
                 value={chrono_age}
               />
             </LabeledList.Item>
-            {/* NOVA EDIT ADDITION END - CHRONOLOGICAL AGE */}
+            {/* NOVA EDIT ADDITION END */}
             <LabeledList.Item label="Species">
               <EditableText
                 field="species"

--- a/tgui/packages/tgui/interfaces/MedicalRecords/RecordView.tsx
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/RecordView.tsx
@@ -31,10 +31,11 @@ export const MedicalRecordView = (props) => {
   const { act, data } = useBackend<MedicalRecordData>();
   const { assigned_view, physical_statuses, mental_statuses, station_z } = data;
 
-  const { min_age, max_age } = data;
+  const { min_age, max_age, max_chrono_age } = data; // NOVA EDIT CHANGE - Chronological age
 
   const {
     age,
+    chrono_age, // NOVA EDIT ADDITION - Chronological age
     blood_type,
     crew_ref,
     dna,
@@ -105,6 +106,22 @@ export const MedicalRecordView = (props) => {
                 value={age}
               />
             </LabeledList.Item>
+            {/* NOVA EDIT ADDITION BEGIN - CHRONOLOGICAL AGE */}
+            <LabeledList.Item label="Chronological Age">
+              <RestrictedInput
+                minValue={min_age}
+                maxValue={max_chrono_age}
+                onEnter={(event, value) =>
+                  act('edit_field', {
+                    field: 'chrono_age',
+                    ref: crew_ref,
+                    value: value,
+                  })
+                }
+                value={chrono_age}
+              />
+            </LabeledList.Item>
+            {/* NOVA EDIT ADDITION END - CHRONOLOGICAL AGE */}
             <LabeledList.Item label="Species">
               <EditableText
                 field="species"

--- a/tgui/packages/tgui/interfaces/MedicalRecords/types.ts
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/types.ts
@@ -9,10 +9,12 @@ export type MedicalRecordData = {
   records: MedicalRecord[];
   min_age: number;
   max_age: number;
+  max_chrono_age: number; // NOVA EDIT ADDITION - Chronological age
 };
 
 export type MedicalRecord = {
   age: number;
+  chrono_age: number; // NOVA EDIT ADDITION - Chronological age
   blood_type: string;
   crew_ref: string;
   dna: string;

--- a/tgui/packages/tgui/interfaces/NtosRecords.jsx
+++ b/tgui/packages/tgui/interfaces/NtosRecords.jsx
@@ -45,6 +45,10 @@ export const NtosRecords = (props) => {
                       ' ' +
                       record.age +
                       ' ' +
+                      /* NOVA EDIT ADDITION BEGIN - Chronological age */
+                      record.chrono_age +
+                      ' ' +
+                      /* NOVA EDIT ADDITION END */
                       record.fingerprint,
                   )
                 )
@@ -61,8 +65,14 @@ export const NtosRecords = (props) => {
               <br />
               Gender: {record.gender}
               <br />
-              Age: {record.age}
+              {/* NOVA EDIT CHANGE - Chronological age, ORIGINAL: Age: {record.age} */}
+              Physical Age: {record.age}
+              {/* NOVA EDIT CHANGE END */}
               <br />
+              {/* NOVA EDIT ADDITION BEGIN - Chronological age */}
+              Chronological Age: {record.chrono_age}
+              <br />
+              {/* NOVA EDIT ADDITION END */}
               Fingerprint Hash: {record.fingerprint}
               <br />
               <br />

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/age.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/age.tsx
@@ -1,6 +1,12 @@
 import { Feature, FeatureNumberInput } from '../base';
 
 export const age: Feature<number> = {
-  name: 'Age',
+  name: 'Age (Physical)', // NOVA EDIT CHANGE - Chronological age, ORIGINAL: name: 'Age',
+  // NOVA EDIT ADDITION BEGIN - Chronological age
+  description:
+    "Physical age represents how far your character has grown physically and mentally.\
+    Includes 'normal' aging, such as experiences which physically age the body, and 'anti-aging' medical procedures.\
+    Does not include time spent in cryo-sleep.",
+  // NOVA EDIT ADDITION END
   component: FeatureNumberInput,
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/age.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/age.tsx
@@ -1,7 +1,8 @@
 import { Feature, FeatureNumberInput } from '../base';
 
 export const age: Feature<number> = {
-  name: 'Age (Physical)', // NOVA EDIT CHANGE - Chronological age, ORIGINAL: name: 'Age',
+  // name: 'Age', // ORIGINAL
+  name: 'Age (Physical)', // NOVA EDIT CHANGE - Chronological age
   // NOVA EDIT ADDITION BEGIN - Chronological age
   description:
     "Physical age represents how far your character has grown physically and mentally.\

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/chronological_age.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/chronological_age.tsx
@@ -1,6 +1,6 @@
+// THIS IS A NOVA SECTOR UI FILE
 import { Feature, FeatureNumberInput } from '../../base';
 
-// Chronological age
 export const chrono_age: Feature<number> = {
   name: 'Age (Chronological)',
   description:

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/chronological_age.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/chronological_age.tsx
@@ -1,0 +1,10 @@
+import { Feature, FeatureNumberInput } from '../../base';
+
+// Chronological age
+export const chrono_age: Feature<number> = {
+  name: 'Age (Chronological)',
+  description:
+    'Chronological age represents how long your character has actually existed in the universe since birth.\
+    Includes time spent in cryo-sleep and/or in areas of gravity/speed-induced time dilation.',
+  component: FeatureNumberInput,
+};

--- a/tgui/packages/tgui/interfaces/SecurityRecords/RecordView.tsx
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/RecordView.tsx
@@ -53,10 +53,11 @@ const RecordInfo = (props) => {
   const { available_statuses } = data;
   const [open, setOpen] = useLocalState<boolean>('printOpen', false);
 
-  const { min_age, max_age } = data;
+  const { min_age, max_age, max_chrono_age } = data; // NOVA EDIT CHANGE - Chronological age
 
   const {
     age,
+    chrono_age, // NOVA EDIT ADDITION - Chronological age
     crew_ref,
     crimes,
     fingerprint,
@@ -164,6 +165,22 @@ const RecordInfo = (props) => {
                 value={age}
               />
             </LabeledList.Item>
+            {/* NOVA EDIT ADDITION BEGIN - CHRONOLOGICAL AGE */}
+            <LabeledList.Item label="Chronological Age">
+              <RestrictedInput
+                minValue={min_age}
+                maxValue={max_chrono_age}
+                onEnter={(event, value) =>
+                  act('edit_field', {
+                    crew_ref: crew_ref,
+                    field: 'chrono_age',
+                    value: value,
+                  })
+                }
+                value={chrono_age}
+              />
+            </LabeledList.Item>
+            {/* NOVA EDIT ADDITION END - CHRONOLOGICAL AGE */}
             <LabeledList.Item label="Species">
               <EditableText
                 field="species"

--- a/tgui/packages/tgui/interfaces/SecurityRecords/RecordView.tsx
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/RecordView.tsx
@@ -52,7 +52,7 @@ const RecordInfo = (props) => {
   const { act, data } = useBackend<SecurityRecordsData>();
   const { available_statuses } = data;
   const [open, setOpen] = useLocalState<boolean>('printOpen', false);
-
+  // const { min_age, max_age } = data; // ORIGINAL
   const { min_age, max_age, max_chrono_age } = data; // NOVA EDIT CHANGE - Chronological age
 
   const {
@@ -151,7 +151,10 @@ const RecordInfo = (props) => {
             <LabeledList.Item label="Job">
               <EditableText field="rank" target_ref={crew_ref} text={rank} />
             </LabeledList.Item>
-            <LabeledList.Item label="Age">
+            {/* <LabeledList.Item label="Age"> // ORIGINAL */}
+            {/* NOVA EDIT CHANGE BEGIN - Chronological age */}
+            <LabeledList.Item label="Physical Age">
+              {/* NOVA EDIT CHANGE END */}
               <RestrictedInput
                 minValue={min_age}
                 maxValue={max_age}
@@ -165,7 +168,7 @@ const RecordInfo = (props) => {
                 value={age}
               />
             </LabeledList.Item>
-            {/* NOVA EDIT ADDITION BEGIN - CHRONOLOGICAL AGE */}
+            {/* NOVA EDIT ADDITION BEGIN - Chronological age */}
             <LabeledList.Item label="Chronological Age">
               <RestrictedInput
                 minValue={min_age}
@@ -180,7 +183,7 @@ const RecordInfo = (props) => {
                 value={chrono_age}
               />
             </LabeledList.Item>
-            {/* NOVA EDIT ADDITION END - CHRONOLOGICAL AGE */}
+            {/* NOVA EDIT ADDITION END */}
             <LabeledList.Item label="Species">
               <EditableText
                 field="species"

--- a/tgui/packages/tgui/interfaces/SecurityRecords/types.ts
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/types.ts
@@ -9,10 +9,12 @@ export type SecurityRecordsData = {
   records: SecurityRecord[];
   min_age: number;
   max_age: number;
+  max_chrono_age: number; // NOVA EDIT ADDITION - Chronological age
 };
 
 export type SecurityRecord = {
   age: number;
+  chrono_age: number; // NOVA EDIT ADDITION - Chronological age
   citations: Crime[];
   crew_ref: string;
   crimes: Crime[];


### PR DESCRIPTION
## About The Pull Request

This PR adds a new field to Character Preferences and records windows, "Chronological Age", and changes the old "Age" fields to "Physical Age". New descriptions have been added to the Character Preferences window to differentiate the fields and explain their differences.

In-game description of Chronological Age:
"_Chronological age represents how long your character has actually existed in the universe since birth.
Includes time spent in cryo-sleep and/or in areas of gravity/speed-induced time dilation._"

In-game description of Physical Age:
"_Physical age represents how far your character has grown physically and mentally.
Includes 'normal' aging, such as experiences which physically age the body, and 'anti-aging' medical procedures.
Does not include time spent in cryo-sleep._"

## 🚧 Draft Status 🚧

Still testing to ensure that everything works as intended.

## How This Contributes To The Nova Sector Roleplay Experience

This feature was suggested by players in the Nova Sector Discord server.

![image](https://github.com/NovaSector/NovaSector/assets/17753498/822b0a14-e096-42ff-acfe-2fc3467afd45) ![image](https://github.com/NovaSector/NovaSector/assets/17753498/5a4d2f97-f8f1-4023-b174-eba75b643041)

## Proof of Testing

- Tested medical and security records consoles `/obj/machinery/computer/records/medical` and `/obj/machinery/computer/records/security`
- Tested the NTOS records apps `/datum/computer_file/program/records/medical` and `/datum/computer_file/program/records/security`

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/NovaSector/NovaSector/assets/17753498/09f457f6-6ec4-4ef3-90ae-cab6cffd8a56) ![image](https://github.com/NovaSector/NovaSector/assets/17753498/affb4d3d-d255-46bf-af9b-130406b8d5bd)

</details>

## Changelog

:cl:
add: Added new age field for Chronological Age. The original Age field is now renamed to Physical Age.
/:cl:
