### PR TITLE
Unapologetic Social Anxiety Nerfs Vol. 1 (feat. Feign Impairment)

### DIFF
--- a/code/datums/quirks/negative_quirks/social_anxiety.dm
+++ b/code/datums/quirks/negative_quirks/social_anxiety.dm
@@ -1,6 +1,6 @@
 /datum/quirk/social_anxiety
 	name = "Social Anxiety"
-	desc = "Talking to people is very difficult for you, and you often stutter or even lock up."
+	desc = "Talking to people is very difficult for you, and you often lock up, especially if blown kisses or if you happen upon eye contact." //NOVA EDIT - CHANGE- ORIGINAL: desc = "Talking to people is very difficult for you, and you often stutter or even lock up."
 	icon = FA_ICON_COMMENT_SLASH
 	value = -3
 	gain_text = span_danger("You start worrying about what you're saying.")
@@ -50,7 +50,7 @@
 					break
 			if(prob(max(5,(nearby_people*12.5*moodmod)))) //Minimum 1/20 chance of stutter
 				// Add a short stutter, THEN treat our word
-				quirker.adjust_stutter(0.5 SECONDS)
+				//quirker.adjust_stutter(0.5 SECONDS) //NOVA EDIT - REMOVAL - NO STUTTERING!
 				var/list/message_data = quirker.treat_message(word, capitalize_message = FALSE)
 				new_message += message_data["message"]
 			else
@@ -94,7 +94,8 @@
 		msg = "You make eye contact with [other_mob], "
 	else
 		msg = "[other_mob] makes eye contact with you, "
-
+	// NOVA EDIT CHANGE START
+	/* ORIGINAL:
 	switch(rand(1,3))
 		if(1)
 			quirk_holder.set_jitter_if_lower(20 SECONDS)
@@ -105,7 +106,18 @@
 		if(3)
 			quirk_holder.Stun(2 SECONDS)
 			msg += "causing you to freeze up!"
-
+	*/
+	// NOVA EDIT CHANGE END
+	switch(rand(1,3))
+		if(1)
+			quirk_holder.set_jitter_if_lower(20 SECONDS)
+			msg += "causing you to start fidgeting!"
+		if(2)
+			quirk_holder.set_confusion(2 SECONDS)
+			msg += "causing you to trip over your own feet!"
+		if(3)
+			quirk_holder.Stun(2 SECONDS)
+			msg += "causing you to freeze up!"
 	quirk_holder.add_mood_event("anxiety_eyecontact", /datum/mood_event/anxiety_eyecontact)
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), quirk_holder, span_userdanger("[msg]")), 3) // so the examine signal has time to fire and this will print after
 	return COMSIG_BLOCK_EYECONTACT

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -591,7 +591,7 @@
 			other_msg = "stammers softly for a moment before choking on something!"
 			self_msg = "You feel your tongue disappear down your throat as you fight to remember how to make words!"
 			addtimer(CALLBACK(living_target, TYPE_PROC_REF(/atom/movable, say), pick("Uhhh...", "O-oh, uhm...", "I- uhhhhh??", "You too!!", "What?")), rand(0.5 SECONDS, 1.5 SECONDS))
-			living_target.adjust_stutter(rand(10 SECONDS, 30 SECONDS))
+			living_target.adjust_stutter(rand(2 SECONDS, 5 SECONDS)) //NOVA EDIT - CHANGE - Original: living_target.adjust_stutter(rand(10 SECONDS, 30 SECONDS))
 		if(3)
 			other_msg = "locks up with a stunned look on [living_target.p_their()] face, staring at [firer ? firer : "the ceiling"]!"
 			self_msg = "Your brain completely fails to process what just happened, leaving you rooted in place staring at [firer ? "[firer]" : "the ceiling"] for what feels like an eternity!"

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/human.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/human.dm
@@ -211,7 +211,7 @@
 		to_chat(usr, span_warning("You can't do this right now..."))
 		return
 
-	var/static/list/choices = list("drunkenness", "stuttering", "jittering")
+	var/static/list/choices = list("drunkenness", "jittering")
 	var/impairment = tgui_input_list(src, "Select an impairment to perform:", "Impairments", choices)
 	if(!impairment)
 		return
@@ -223,8 +223,6 @@
 			if(istype(living_user))
 				living_user.add_mood_event("drunk", /datum/mood_event/drunk)
 			set_slurring_if_lower(duration SECONDS)
-		if("stuttering")
-			set_stutter_if_lower(duration SECONDS)
 		if("jittering")
 			set_jitter_if_lower(duration SECONDS)
 


### PR DESCRIPTION
## About The Pull Request
I post 'Vol. 1' like there's ever going to be a Vol. 2. Insane.

Anyway, how's it going.
After spending one of my first starting years here playing a character with a stutter, I found out that it's really not all that hard to do manually.
![image](https://github.com/NovaSector/NovaSector/assets/12636964/309a86e1-257e-4ed6-97c6-d52af1751d19)
But this isn't about me.

What this is about is what **is** really all that bad; the goddamn baked-in stutters in the code!
I have decided to strike at this problem where it's most commonly available and least well-treated, as ye olde alcohol stutters are kinda difficult to achieve and were also reworked: the social anxiety quirk.

Below, I have done two things.
One, removed the RNG stutters just from having people nearby.
Two, removed the RNG stutters just from making eye contact.
Three, nerfed the amount of time that kissing makes you stutter _severely._

![image](https://github.com/NovaSector/NovaSector/assets/12636964/3e17a0c8-6043-49b9-ab16-a3b5fa487d39)
![image](https://github.com/NovaSector/NovaSector/assets/12636964/e027d57a-c562-4789-a194-9e840dc0cb5d)
Here are my results.

But you're probably asking 'But, what else does Social Anxiety do if not stuttering?'

Glad you asked.

An underrated part of this quirk is that if you are above softcrit, not fucking blind, and without the fearless trait (and within a 50% probability,) if you get blown a kiss it has an effect on you.

On a roll of one, you stumble slightly and turn a bright red; "You lose control of your limbs for a moment as your blood rushes to your face, turning it bright red!"
This makes you stumble.

On a roll of two, you stammer softly for a moment before choking on something; "You feel your tongue disappear down your throat as you fight to remember how to make words!"
And you will either say.
"Uhhh..."
"O-oh, uhm...."
"I- uhhhh??"
"You too!!"
"What?"

On a roll of three, you lock up with a stunned look on [living_target.p_their()] face, staring at [firer ? firer : "the ceiling"]!; "Your brain completely fails to process what just happened, leaving you rooted in place staring at [firer ? "[firer]" : "the ceiling"] for what feels like an eternity!"
You are then stunned.

Otherwise, the bulk of Social Anxiety's actual fun stuff happens when you're making eye contact with someone, but I'm too lazy to continue writing this so I'll leave that stuff for you, the reader, to discover.

Lastly, I did take it out of Feign Impairment too. Sorry. Use the drunk one.

## How This Contributes To The Nova Sector Roleplay Experience
The baked-in code stutters are genuinely nearly impossible to comprehend and only become worse when combined with either long posts (which our server as an HRP server is all about,) or when combined with the random filler stuff from Social Anxiety. I genuinely think we should have as little of it as possible, especially considering typing out a stutter really isn't that hard.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
 In the OP.
</details>

## Changelog
:cl:
del: New advents in therapy, social apps for support networks, and speech consultation have resulted in people with social anxiety having less difficulty speaking.
del: Removed stuttering from Feign Impairment. I couldn't think of a funny caption for this.
/:cl: