### PR TITLE
Refactors how CI is handled and cleans up signals

### DIFF
--- a/code/__DEFINES/~nova_defines/signals.dm
+++ b/code/__DEFINES/~nova_defines/signals.dm
@@ -56,9 +56,6 @@
 //when someone pulls back their fishing rod
 #define COMSIG_FINISH_FISHING "finish_fishing"
 
-/// From mob/living/*/set_combat_mode(): (new_state)
-#define COMSIG_LIVING_COMBAT_MODE_TOGGLE "living_combat_mode_toggle"
-
 /// From /obj/item/organ/internal/stomach/after_eat(atom/edible)
 #define COMSIG_STOMACH_AFTER_EAT "stomach_after_eat"
 

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -134,7 +134,6 @@
 	stop_pulling()
 
 	cut_overlay(GLOB.combat_indicator_overlay) //NOVA EDIT ADDITION - COMBAT_INDICATOR
-	set_combat_indicator(FALSE) //NOVA EDIT ADDITION - COMBAT_INDICATOR
 	set_ssd_indicator(FALSE) //NOVA EDIT ADDITION - SSD_INDICATOR
 
 	SEND_SIGNAL(src, COMSIG_LIVING_DEATH, gibbed)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -151,7 +151,6 @@
 		return
 	. = combat_mode
 	combat_mode = new_mode
-	SEND_SIGNAL(src, COMSIG_LIVING_COMBAT_MODE_TOGGLE, new_mode) //NOVA EDIT ADDITION
 	if(hud_used?.action_intent)
 		hud_used.action_intent.update_appearance()
 	//NOVA EDIT ADDITION BEGIN

--- a/modular_nova/modules/indicators/code/combat_indicator.dm
+++ b/modular_nova/modules/indicators/code/combat_indicator.dm
@@ -47,12 +47,20 @@ GLOBAL_VAR_INIT(combat_indicator_overlay, GenerateCombatOverlay())
 	if(combat_indicator_vehicle)
 		. += GLOB.combat_indicator_overlay
 
-/mob/living/proc/combat_indicator_unconscious_signal()
+/**
+ * Called whenever a mob's stat changes.
+ * Checks if the mob's stat is greater than SOFT_CRIT, and if it is, it will disable CI.
+ *
+ * Arguments:
+ * * source -- The mob in question that toggled CI status.
+ * * new_stat -- The new stat of the mob.
+ */
+
+/mob/living/proc/ci_on_stat_change(mob/source, new_stat)
 	SIGNAL_HANDLER
-	if(stat < UNCONSCIOUS) // sanity check because something is calling this signal improperly -- it may be due to adjustconciousness()
-		stack_trace("Improper COMSIG_LIVING_STATUS_UNCONSCIOUS sent; mob is not unconscious")
+	if(new_stat <= SOFT_CRIT)
 		return
-	set_combat_indicator(FALSE)
+	disable_combat_indicator(TRUE)
 
 /**
  * Called whenever a mob's CI status changes for any reason.
@@ -67,46 +75,69 @@ GLOBAL_VAR_INIT(combat_indicator_overlay, GenerateCombatOverlay())
 	if(!CONFIG_GET(flag/combat_indicator))
 		return
 
-	if(stat == DEAD)
-		combat_indicator = FALSE
-
 	if(combat_indicator == state) // If the mob is dead (should not happen) or if the combat_indicator is the same as state (also shouldnt happen) kill the proc.
 		return
+
+	if(stat == DEAD)
+		disable_combat_indicator(TRUE)
 
 	combat_indicator = state
 
 	SEND_SIGNAL(src, COMSIG_MOB_CI_TOGGLED)
 
 	if(combat_indicator)
-		if(world.time > nextcombatpopup) // As of the time of writing, COMBAT_NOTICE_COOLDOWN is 10 secs, so this is asking "has 10 secs past between last activation of CI?"
-			nextcombatpopup = world.time + COMBAT_NOTICE_COOLDOWN
-			playsound(src, 'sound/machines/chime.ogg', vol = 10, vary = FALSE, extrarange = -6, falloff_exponent = 4, frequency = null, channel = 0, pressure_affected = FALSE, ignore_walls = FALSE, falloff_distance = 1)
-			flick_emote_popup_on_mob("combat", 20)
-			var/ciweapon
-			if(get_active_held_item())
-				ciweapon = get_active_held_item()
-				if(istype(ciweapon, /obj/item/gun))
-					visible_message(span_boldwarning("[src] raises \the [ciweapon] with their finger on the trigger, ready for combat!"))
-				else
-					visible_message(span_boldwarning("[src] readies \the [ciweapon] with a tightened grip and offensive stance, ready for combat!"))
-			else
-				if(issilicon(src))
-					visible_message(span_boldwarning("<b>[src] shifts its armour plating into a defensive stance, ready for combat!"))
-				if(ishuman(src))
-					visible_message(span_boldwarning("[src] raises [p_their()] fists in an offensive stance, ready for combat!"))
-				if(isalien(src))
-					visible_message(span_boldwarning("[src] hisses in a terrifying stance, claws raised and ready for combat!"))
-				else
-					visible_message(span_boldwarning("[src] gets ready for combat!"))
-		combat_indicator = TRUE
-		apply_status_effect(/datum/status_effect/grouped/surrender, src)
-		log_message("<font color='red'>has turned ON the combat indicator!</font>", LOG_ATTACK)
-		RegisterSignal(src, COMSIG_LIVING_STATUS_UNCONSCIOUS, PROC_REF(combat_indicator_unconscious_signal)) //From now on, whenever this mob falls unconcious, the referenced proc will fire.
+		enable_combat_indicator()
 	else
-		combat_indicator = FALSE
-		remove_status_effect(/datum/status_effect/grouped/surrender, src)
-		log_message("<font color='blue'>has turned OFF the combat indicator!</font>", LOG_ATTACK)
-		UnregisterSignal(src, COMSIG_LIVING_STATUS_UNCONSCIOUS) //combat_indicator_unconcious_signal will no longer be fired if this mob is unconcious.
+		disable_combat_indicator()
+
+/**
+ * Called whenever a mob enables CI.
+ *
+ * Plays a sound, sents a message to chat, updates their overlay, and sets the mob's CI status to true.
+ */
+
+/mob/living/proc/enable_combat_indicator()
+	if(world.time > nextcombatpopup) // As of the time of writing, COMBAT_NOTICE_COOLDOWN is 10 secs, so this is asking "has 10 secs past between last activation of CI?"
+		nextcombatpopup = world.time + COMBAT_NOTICE_COOLDOWN
+		playsound(src, 'sound/machines/chime.ogg', vol = 10, vary = FALSE, extrarange = -6, falloff_exponent = 4, frequency = null, channel = 0, pressure_affected = FALSE, ignore_walls = FALSE, falloff_distance = 1)
+		flick_emote_popup_on_mob("combat", 20)
+		var/ciweapon
+		if(get_active_held_item())
+			ciweapon = get_active_held_item()
+			if(istype(ciweapon, /obj/item/gun))
+				visible_message(span_boldwarning("[src] raises \the [ciweapon] with their finger on the trigger, ready for combat!"))
+			else
+				visible_message(span_boldwarning("[src] readies \the [ciweapon] with a tightened grip and offensive stance, ready for combat!"))
+		else
+			if(issilicon(src))
+				visible_message(span_boldwarning("<b>[src] shifts its armour plating into a defensive stance, ready for combat!"))
+			if(ishuman(src))
+				visible_message(span_boldwarning("[src] raises [p_their()] fists in an offensive stance, ready for combat!"))
+			if(isalien(src))
+				visible_message(span_boldwarning("[src] hisses in a terrifying stance, claws raised and ready for combat!"))
+			else
+				visible_message(span_boldwarning("[src] gets ready for combat!"))
+	combat_indicator = TRUE
+	apply_status_effect(/datum/status_effect/grouped/surrender, src)
+	log_message("<font color='red'>[src] has turned ON the combat indicator!</font>", LOG_ATTACK)
+	RegisterSignal(src, COMSIG_MOB_STATCHANGE , PROC_REF(ci_on_stat_change))
+	update_appearance(UPDATE_ICON|UPDATE_OVERLAYS)
+
+/**
+ * Called whenever a mob disables CI. Or when they die or fall unconscious.
+ *
+ * Arguments:
+ * * involuntary -- Boolean. If true, the mob is dead or unconscious, and the log will reflect that.
+ */
+
+/mob/living/proc/disable_combat_indicator(involuntary = FALSE)
+	combat_indicator = FALSE
+	remove_status_effect(/datum/status_effect/grouped/surrender, src)
+	if(involuntary)
+		log_message("<font color='cyan'>[src] has fallen unconsious or has died and lost their combat indicator!</font>", LOG_ATTACK)
+	else
+		log_message("<font color='cyan'>[src] has turned OFF the combat indicator!</font>", LOG_ATTACK)
+	UnregisterSignal(src, COMSIG_MOB_STATCHANGE)
 	update_appearance(UPDATE_ICON|UPDATE_OVERLAYS)
 
 /**


### PR DESCRIPTION
## About The Pull Request

This splits the proc for how CI is set into three procs, as well as it cleans up the signal handlers for CI. The signal handlers before where never executing, this fix makes them properly fire. This also fixes the surrender button not being removed upon death. (Fixes #1205)

As well as it cleans up and adds additional logging for admins, it also changes the color for the logs making them a little more readable (dark blue on gray was really hard to read sometimes)

## How This Contributes To The Nova Sector Roleplay Experience

This is mostly code based, but it does clean up the hud when someone goes unconscious removing the surrender button when it wasn't before

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

https://github.com/NovaSector/NovaSector/assets/2568378/3f0224b6-1396-4c1d-8d82-13503f8f9ed9

![nLLtfFglVN](https://github.com/NovaSector/NovaSector/assets/2568378/b1b2384b-e43f-4780-bbe8-a2418c28137b)

</details>

## Changelog

:cl:
fix: If you die or fall unconscious with Combat Indicator turned on, you will properly lose CI and the surrender button
refactor: Refactored how Combat Indicator is handled in the backend
admin: Added additional logging for when someone dies / falls unconscious with CI on, as well as changed the color of the logs for readability. 
/:cl:

