### PR TITLE
[Modular] Cryo tubes now announce on department channels when heads of staff cryo.

### DIFF
--- a/modular_nova/modules/cryosleep/code/jobs.dm
+++ b/modular_nova/modules/cryosleep/code/jobs.dm
@@ -1,0 +1,20 @@
+/datum/job
+	var/default_radio_channel = null
+/datum/job/chief_medical_officer
+	default_radio_channel = RADIO_CHANNEL_MEDICAL
+/datum/job/chief_engineer
+	default_radio_channel = RADIO_CHANNEL_ENGINEERING
+/datum/job/head_of_security
+	default_radio_channel = RADIO_CHANNEL_SECURITY
+/datum/job/head_of_personnel
+	default_radio_channel = RADIO_CHANNEL_SERVICE
+/datum/job/research_director
+	default_radio_channel = RADIO_CHANNEL_SCIENCE
+/datum/job/quartermaster
+	default_radio_channel = RADIO_CHANNEL_SUPPLY
+/datum/job/captain
+	default_radio_channel = RADIO_CHANNEL_COMMAND
+/datum/job/blueshield
+	default_radio_channel = RADIO_CHANNEL_COMMAND
+/datum/job/nanotrasen_consultant
+	default_radio_channel = RADIO_CHANNEL_COMMAND

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6977,6 +6977,7 @@
 #include "modular_nova\modules\cryosleep\code\cryo_console_return.dm"
 #include "modular_nova\modules\cryosleep\code\cryopod.dm"
 #include "modular_nova\modules\cryosleep\code\job.dm"
+#include "modular_nova\modules\cryosleep\code\jobs.dm"
 #include "modular_nova\modules\cryosleep\code\mind.dm"
 #include "modular_nova\modules\cryosleep\code\mood.dm"
 #include "modular_nova\modules\curatorbundle\Mushy.dm"


### PR DESCRIPTION
## About The Pull Request

This makes the cryogenics computer announce on the respective department head's department radio channel, this was a suggestion on the discord as well.

## How This Contributes To The Nova Sector Roleplay Experience

It provides IC information to players when their boss is no longer around and makes it a bit more visible.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_TiwKvAAGWz](https://github.com/NovaSector/NovaSector/assets/2568378/a165526d-bef8-4223-899b-0801f040c306)

![dreamseeker_MsvKZeM0aO](https://github.com/NovaSector/NovaSector/assets/2568378/16bc528f-5c7a-45ef-9762-c7d68716d6b1)

</details>

## Changelog

:cl:
add: The cryogenics computer now will announce on the relevant department channels when a head of staff cryo's
/:cl:

