### PR TITLE
[MODULAR] fix ATs on crash.dmm

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/crash.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/crash.dmm
@@ -7,7 +7,7 @@
 /area/ruin/unpowered/no_grav)
 "d" = (
 /obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating,
+/turf/open/indestructible/plating/airless,
 /area/ruin/unpowered/no_grav)
 "e" = (
 /obj/item/storage/toolbox/syndicate,
@@ -36,7 +36,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/up,
 /obj/effect/turf_decal/sand,
-/turf/open/floor/plating,
+/turf/open/indestructible/plating/airless,
 /area/ruin/unpowered/no_grav)
 "B" = (
 /obj/effect/decal/fakelattice,
@@ -90,7 +90,7 @@
 "U" = (
 /obj/effect/turf_decal/sand,
 /obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating,
+/turf/open/indestructible/plating/airless,
 /area/ruin/unpowered/no_grav)
 "V" = (
 /obj/structure/closet/crate,
@@ -100,7 +100,7 @@
 /area/ruin/unpowered/no_grav)
 "X" = (
 /obj/effect/turf_decal/sand,
-/turf/open/floor/plating,
+/turf/open/indestructible/plating/airless,
 /area/ruin/unpowered/no_grav)
 "Y" = (
 /obj/machinery/power/port_gen/pacman/super,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes ~10 or so rounstart Active Turfs

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/NovaSector/NovaSector/assets/28457065/fd82a110-04cd-458b-a7cc-b5dae5784faa)

  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: 10 less roundstart active turfs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
