### PR TITLE
[NON-MODULAR] Buffs the desword to its (almost) former glory

### DIFF
--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -23,7 +23,7 @@
 	light_on = FALSE
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
-	block_chance = 45 //NOVA EDIT - Lowered ORIGINAL:75
+	block_chance = 65 //NOVA EDIT -FORMER:45
 	block_sound = 'sound/weapons/block_blade.ogg'
 	max_integrity = 200
 	armor_type = /datum/armor/item_dualsaber


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The desword was nerfed (https://github.com/Skyrat-SS13/Skyrat-tg/pull/11701) because 2022's Skyrat had too many antagonists going for it - it was easy to get and easy to use. At the same time, Skyrat was way more antagonist-driven at that time than what Nova is today. The way antagonists work has ultimately changed since then, and the desword was driven away from being a must-have tool, to being a rarely-seen weapon that's hard to get hands on, even if you're an antag. This PR increases the desword's block chance from 45 to 65 - a midterm.

## How This Contributes To The Nova Sector Roleplay Experience

RatFromTheJungle's PR served to decrease the continuous and abusive use of the desword over the years so SR/NS's antag policy could strenghten itself, solidify and become more strict on antagonist behavior so it can encourage roleplay. The time has passed and the tryhard mindset, which was almost always associated with the desword (and other OP items that got nerfed along with it) is long gone. I think it's time we give this a try.

Besides, the desword has become obsolete to modern weapons. It was supposed to be a feared antag item, but still balanced, and as of right now, you can easily take a wielder down with a laser carbine or anything that fires more than a shot per tick (screw guncargo)

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![imagem_2024-03-03_202334956](https://github.com/NovaSector/NovaSector/assets/64568243/75323961-5df6-4e7d-b108-9492cd096170)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Chelxox
balance: Increases the double-edged energy sword's block chance from 45 to 65.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
