### PR TITLE
[MODULAR] Character Headshots via files.byondhome.com

### DIFF
--- a/modular_nova/master_files/code/modules/client/preferences/headshot.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/headshot.dm
@@ -7,7 +7,7 @@
 	maximum_value_length = MAX_MESSAGE_LEN
 	/// Assoc list of ckeys and their link, used to cut down on chat spam
 	var/list/stored_link = list()
-	var/static/link_regex = regex("i.gyazo.com|media.discordapp.net|cdn.discordapp.com")
+	var/static/link_regex = regex("i.gyazo.com|media.discordapp.net|cdn.discordapp.com|files.byondhome.com")
 	var/static/list/valid_extensions = list("jpg", "png", "jpeg") // Regex works fine, if you know how it works
 
 /datum/preference/text/headshot/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
@@ -36,7 +36,7 @@
 
 	find_index = findtext(value, link_regex)
 	if(find_index != 9)
-		to_chat(usr, span_warning("The image must be hosted on one of the following sites: 'Gyazo, Discord'"))
+		to_chat(usr, span_warning("The image must be hosted on one of the following sites: 'Gyazo, Discord, Byond'"))
 		return
 
 	apply_headshot(value)


### PR DESCRIPTION
## About The Pull Request

This PR changes the character headshot preference to allow for URLs via `files.byondhome.com`, which is Byond's built-in file uploader for Byond members only.

## How This Contributes To The Nova Sector Roleplay Experience

With the changes in this PR, players with a Byond membership can take advantage of their 20MB of hot-linkable online storage space for headshots. The file uploader can be accessed via logging into [Byond.com](https://www.byond.com/), then click "Manage Account" (https://secure.byond.com/members/-/account), then click "Files" in the top row.

See the circled link:
![image](https://github.com/NovaSector/NovaSector/assets/17753498/cee72a1c-4556-4818-9aa2-4f7321861eb8)

## Proof of Testing

Tested locally ok!

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/NovaSector/NovaSector/assets/17753498/af53f933-8252-42d0-90d9-62dbff2cd2aa)

![image](https://github.com/NovaSector/NovaSector/assets/17753498/b64d127e-2363-4852-8fb5-d391ed0df72d)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: A.C.M.O.
qol: Added support for adding Character Headshots via files.byondhome.com, for Byond members only.
/:cl: