### PR TITLE
Fixes synths spilling brains when gibbed in deathmatch

### DIFF
--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -133,6 +133,11 @@
 	if (global_chat)
 		ADD_TRAIT(new_player, TRAIT_SIXTHSENSE, INNATE_TRAIT)
 		ADD_TRAIT(new_player, TRAIT_XRAY_HEARING, INNATE_TRAIT)
+	// NOVA EDIT ADDITION START - Synth brains don't drop here - let them delete with the mob
+	var/obj/item/organ/internal/brain/synth/synth_brain = new_player.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(istype(synth_brain))
+		synth_brain.drop_when_organ_spilling = FALSE
+	// NOVA EDIT ADDITION END
 
 /datum/deathmatch_lobby/proc/game_took_too_long()
 	if (!location || QDELING(src))

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -133,11 +133,6 @@
 	if (global_chat)
 		ADD_TRAIT(new_player, TRAIT_SIXTHSENSE, INNATE_TRAIT)
 		ADD_TRAIT(new_player, TRAIT_XRAY_HEARING, INNATE_TRAIT)
-	// NOVA EDIT ADDITION START - Synth brains don't drop here - let them delete with the mob
-	var/obj/item/organ/internal/brain/synth/synth_brain = new_player.get_organ_slot(ORGAN_SLOT_BRAIN)
-	if(istype(synth_brain))
-		synth_brain.drop_when_organ_spilling = FALSE
-	// NOVA EDIT ADDITION END
 
 /datum/deathmatch_lobby/proc/game_took_too_long()
 	if (!location || QDELING(src))

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -19,7 +19,7 @@
 		death(TRUE)
 
 	ghostize()
-	spill_organs(issynthetic(src) ? drop_bitflags|DROP_BRAIN : drop_bitflags) // NOVA EDIT CHANGE - Synths always drop brains - ORIGINAL: spill_organs(drop_bitflags)
+	spill_organs(drop_bitflags)
 
 	if(drop_bitflags & DROP_BODYPARTS)
 		spread_bodyparts(drop_bitflags)

--- a/modular_nova/master_files/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/modular_nova/master_files/code/modules/deathmatch/deathmatch_lobby.dm
@@ -1,5 +1,5 @@
 // Synth brains don't drop in deathmatch
-/datum/deathmatch_lobby/proc/spawn_observer_as_player(ckey, loc)
+/datum/deathmatch_lobby/spawn_observer_as_player(ckey, loc)
 	. = ..()
 	var/obj/item/organ/internal/brain/synth/synth_brain = new_player.get_organ_slot(ORGAN_SLOT_BRAIN)
 	if(istype(synth_brain))

--- a/modular_nova/master_files/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/modular_nova/master_files/code/modules/deathmatch/deathmatch_lobby.dm
@@ -1,7 +1,0 @@
-// Synth brains don't drop in deathmatch
-/datum/deathmatch_lobby/spawn_observer_as_player(ckey, loc)
-	. = ..()
-	var/obj/item/organ/internal/brain/synth/synth_brain = new_player.get_organ_slot(ORGAN_SLOT_BRAIN)
-	if(istype(synth_brain))
-		synth_brain.drop_when_organ_spilling = FALSE
-

--- a/modular_nova/master_files/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/modular_nova/master_files/code/modules/deathmatch/deathmatch_lobby.dm
@@ -1,0 +1,7 @@
+// Synth brains don't drop in deathmatch
+/datum/deathmatch_lobby/proc/spawn_observer_as_player(ckey, loc)
+	. = ..()
+	var/obj/item/organ/internal/brain/synth/synth_brain = new_player.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(istype(synth_brain))
+		synth_brain.drop_when_organ_spilling = FALSE
+

--- a/modular_nova/master_files/code/modules/mob/living/carbon/death.dm
+++ b/modular_nova/master_files/code/modules/mob/living/carbon/death.dm
@@ -6,6 +6,11 @@
 			held_organs.Add(organ)
 			organs.Remove(organ)
 
+	// synth brains always drop when gibbed, by default
+	var/obj/item/organ/internal/brain/synth/synth_brain = get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(istype(synth_brain))
+		drop_bitflags |= DROP_BRAIN
+
 	. = ..()
 
 	// put the unspillable organs back

--- a/modular_nova/master_files/code/modules/mob/living/carbon/human/human.dm
+++ b/modular_nova/master_files/code/modules/mob/living/carbon/human/human.dm
@@ -1,0 +1,11 @@
+/mob/living/carbon/human/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/interactable)
+	//Removing ERP IC verbs depending on config
+	if(CONFIG_GET(flag/disable_erp_preferences))
+		verbs -= /mob/living/carbon/human/verb/toggle_genitals
+		verbs -= /mob/living/carbon/human/verb/toggle_arousal
+	if(CONFIG_GET(flag/disable_erp_preferences))
+		verbs -= /mob/living/carbon/human/verb/climax_verb
+	if(CONFIG_GET(flag/disable_lewd_items))
+		verbs -= /mob/living/carbon/human/verb/safeword

--- a/modular_nova/modules/customization/modules/surgery/organs/genitals.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/genitals.dm
@@ -500,7 +500,6 @@
 			return text2num(key)
 	return 0
 
-
 /mob/living/carbon/human/verb/toggle_genitals()
 	set category = "IC"
 	set name = "Expose/Hide genitals"
@@ -529,13 +528,6 @@
 			picked_organ.visibility_preference = gen_vis_trans[picked_visibility]
 			update_body()
 	return
-
-//Removing ERP IC verb depending on config
-/mob/living/carbon/human/Initialize(mapload)
-	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
-		verbs -= /mob/living/carbon/human/verb/toggle_genitals
-		verbs -= /mob/living/carbon/human/verb/toggle_arousal
 
 /mob/living/carbon/human/verb/toggle_arousal()
 	set category = "IC"
@@ -566,4 +558,3 @@
 			picked_organ.aroused = gen_arous_trans[picked_arousal]
 			picked_organ.update_sprite_suffix()
 			update_body()
-	return

--- a/modular_nova/modules/interaction_menu/code/interaction_datum.dm
+++ b/modular_nova/modules/interaction_menu/code/interaction_datum.dm
@@ -84,7 +84,7 @@ GLOBAL_LIST_EMPTY_TYPED(interaction_instances, /datum/interaction)
 			if(INTERACTION_REQUIRE_TARGET_HAND)
 				if(!target.get_active_hand())
 					return FALSE
-			
+
 			else
 				CRASH("Unimplemented interaction requirement '[requirement]'")
 	return TRUE
@@ -226,10 +226,6 @@ GLOBAL_LIST_EMPTY_TYPED(interaction_instances, /datum/interaction)
 	var/file = file(fpath)
 	WRITE_FILE(file, json_encode(json))
 	return TRUE
-
-/mob/living/carbon/human/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/interactable)
 
 /// Global loading procs
 /proc/populate_interaction_instances()

--- a/modular_nova/modules/modular_items/lewd_items/code/verbs.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/verbs.dm
@@ -34,13 +34,6 @@
 /mob/living/silicon/get_reflexes_lose_text()
 	return "Our systems will allow platonic contact."
 
-/mob/living/carbon/human/Initialize(mapload)
-	. = ..()
-	if(CONFIG_GET(flag/disable_erp_preferences))
-		verbs -= /mob/living/carbon/human/verb/climax_verb
-	if(CONFIG_GET(flag/disable_lewd_items))
-		verbs -= /mob/living/carbon/human/verb/safeword
-
 /mob/living/carbon/human/verb/safeword()
 	set name = "Remove Lewd Items"
 	set category = "OOC"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6419,7 +6419,6 @@
 #include "modular_nova\master_files\code\modules\clothing\under\jobs\security.dm"
 #include "modular_nova\master_files\code\modules\clothing\under\jobs\civilian\civilian.dm"
 #include "modular_nova\master_files\code\modules\clothing\under\jobs\civilian\suits.dm"
-#include "modular_nova\master_files\code\modules\deathmatch\deathmatch_lobby.dm"
 #include "modular_nova\master_files\code\modules\entombed_quirk\code\entombed.dm"
 #include "modular_nova\master_files\code\modules\entombed_quirk\code\entombed_mod.dm"
 #include "modular_nova\master_files\code\modules\events\_event.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6488,6 +6488,7 @@
 #include "modular_nova\master_files\code\modules\mob\living\carbon\death.dm"
 #include "modular_nova\master_files\code\modules\mob\living\carbon\human_helpers.dm"
 #include "modular_nova\master_files\code\modules\mob\living\carbon\human\death.dm"
+#include "modular_nova\master_files\code\modules\mob\living\carbon\human\human.dm"
 #include "modular_nova\master_files\code\modules\mob\living\carbon\human\species.dm"
 #include "modular_nova\master_files\code\modules\mob\living\carbon\human\species_type\lizardpeople.dm"
 #include "modular_nova\master_files\code\modules\mob\living\carbon\human\species_type\podpeople.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6419,6 +6419,7 @@
 #include "modular_nova\master_files\code\modules\clothing\under\jobs\security.dm"
 #include "modular_nova\master_files\code\modules\clothing\under\jobs\civilian\civilian.dm"
 #include "modular_nova\master_files\code\modules\clothing\under\jobs\civilian\suits.dm"
+#include "modular_nova\master_files\code\modules\deathmatch\deathmatch_lobby.dm"
 #include "modular_nova\master_files\code\modules\entombed_quirk\code\entombed.dm"
 #include "modular_nova\master_files\code\modules\entombed_quirk\code\entombed_mod.dm"
 #include "modular_nova\master_files\code\modules\events\_event.dm"


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/1260

Also cleans up some unrelated code. `mob/living/carbon/human/Initialize()` was needlessly overridden three times adding unnecessary overhead.

## How This Contributes To The Nova Sector Roleplay Experience

Fixes a bug/oversight.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_AhI8LSUtze](https://github.com/NovaSector/NovaSector/assets/13398309/23020515-92c9-45a7-a2b9-7c8ecdbfb662)

</details>

## Changelog

:cl:
fix: synths gibbed in deathmatch do not drop their brains any longer
/:cl:
