### PR TITLE
Discord links for headshots are no longer allowed

### DIFF
--- a/modular_nova/master_files/code/modules/client/preferences/headshot.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/headshot.dm
@@ -7,7 +7,7 @@
 	maximum_value_length = MAX_MESSAGE_LEN
 	/// Assoc list of ckeys and their link, used to cut down on chat spam
 	var/list/stored_link = list()
-	var/static/link_regex = regex("i.gyazo.com|media.discordapp.net|cdn.discordapp.com|files.byondhome.com")
+	var/static/link_regex = regex("i.gyazo.com|files.byondhome.com")
 	var/static/list/valid_extensions = list("jpg", "png", "jpeg") // Regex works fine, if you know how it works
 
 /datum/preference/text/headshot/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
@@ -36,7 +36,7 @@
 
 	find_index = findtext(value, link_regex)
 	if(find_index != 9)
-		to_chat(usr, span_warning("The image must be hosted on one of the following sites: 'Gyazo, Discord, Byond'"))
+		to_chat(usr, span_warning("The image must be hosted on one of the following sites: 'Gyazo, Byond'"))
 		return
 
 	apply_headshot(value)


### PR DESCRIPTION
## About The Pull Request

Closes https://github.com/NovaSector/NovaSector/issues/1199

## Changelog

:cl:
del: Due to a backend update, using discord for hosting headshots no longer works. Please use Gyazo or files.byondhome.com instead.
/:cl: