### PR TITLE
Fixes runtime with taur_body

### DIFF
--- a/modular_nova/modules/customization/modules/surgery/organs/taur_body.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/taur_body.dm
@@ -63,6 +63,9 @@
 
 
 /obj/item/organ/external/taur_body/Remove(mob/living/carbon/organ_owner, special, moving)
+	if(QDELETED(owner))
+		return
+
 	var/obj/item/bodypart/leg/left/left_leg = organ_owner.get_bodypart(BODY_ZONE_L_LEG)
 	var/obj/item/bodypart/leg/right/right_leg = organ_owner.get_bodypart(BODY_ZONE_R_LEG)
 


### PR DESCRIPTION
## About The Pull Request

We don't have to do all this if the `owner` was qdeleted, since all that will go away to begin with. It was causing a lot of runtimes since it was trying to `update_body_parts()` on parts whose `owner` was `null`.

## How This Contributes To The Nova Sector Roleplay Experience

Less runtime log spam.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![MfRNdSeuM0](https://github.com/NovaSector/NovaSector/assets/13398309/ac90925d-4972-4cf9-bdb3-7d4bd415753e)

</details>

## Changelog

Nothing player facing