### PR TITLE
Fixes null faction causing tons of runtimes

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/shuttle8532.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/shuttle8532.dmm
@@ -1591,7 +1591,7 @@
 /area/ruin/space/has_grav/shuttle8532cargohall)
 "FW" = (
 /mob/living/basic/trooper/syndicate/melee/space/anthro/lizard{
-	faction = null
+	faction = list()
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532bridge)
@@ -1864,7 +1864,7 @@
 /area/ruin/space/has_grav/shuttle8532engineering)
 "MM" = (
 /mob/living/basic/trooper/syndicate/melee/sword/space/stormtrooper{
-	faction = null
+	faction = list()
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532engineering)
@@ -1997,7 +1997,7 @@
 /area/ruin/space/has_grav/shuttle8532researchbay)
 "Pn" = (
 /mob/living/basic/trooper/syndicate/ranged/shotgun/space/stormtrooper/anthro/fox{
-	faction = null
+	faction = list()
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532bridge)


### PR DESCRIPTION
## About The Pull Request

Fixes this runtime 

![image](https://github.com/NovaSector/NovaSector/assets/13398309/884e36fc-3834-4b7a-a9bc-d4cafe85d346)

Ultimately caused by some `faction` lists that were varedited to be null. For mobs these should be a list (even an empty one).

## How This Contributes To The Nova Sector Roleplay Experience

Clears some runtime spam.

## Changelog

Nothing player facing