### PR TITLE
[Bugfix] Worn lolipops properly consume reagents

### DIFF
--- a/code/game/objects/items/food/sweets.dm
+++ b/code/game/objects/items/food/sweets.dm
@@ -307,11 +307,18 @@
 	var/mutable_appearance/head
 	var/head_color = rgb(0, 0, 0)
 
+	/// NOVA ADDITION BEGIN
+	//Copies regent metabolization from bubblegum so that you cant get infinite reagents from wearing lolipops
+	var/metabolization_ammount = REAGENTS_METABOLISM / 2
+	// Nova ADDITION END
+
 /obj/item/food/lollipop/Initialize(mapload)
 	. = ..()
 	head = mutable_appearance('icons/obj/food/lollipop.dmi', "lollipop_head")
 	change_head_color(rgb(rand(0, 255), rand(0, 255), rand(0, 255)))
-	AddElement(/datum/element/chewable)
+	// NOVA EDIT BEGIN: Original: AddElement(/datum/element/chewable)
+	AddElement(/datum/element/chewable, metabolization_ammount)
+	// NOVA EDIT END
 
 /obj/item/food/lollipop/proc/change_head_color(C)
 	head_color = C
@@ -351,9 +358,16 @@
 	slot_flags = ITEM_SLOT_MASK
 	crafting_complexity = FOOD_COMPLEXITY_1
 
+	/// NOVA ADDITION BEGIN
+	//Copies regent metabolization from bubblegum so that you cant get infinite reagents from wearing lolipops
+	var/metabolization_ammount = REAGENTS_METABOLISM / 2
+	// Nova ADDITION END
+
 /obj/item/food/spiderlollipop/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/chewable)
+	// NOVA EDIT BEGIN: Original: AddElement(/datum/element/chewable)
+	AddElement(/datum/element/chewable, metabolization_ammount)
+	// NOVA EDIT END
 
 /obj/item/food/swirl_lollipop
 	name = "swirl lollipop"
@@ -372,6 +386,13 @@
 	slot_flags = ITEM_SLOT_MASK
 	crafting_complexity = FOOD_COMPLEXITY_1
 
+	/// NOVA ADDITION BEGIN
+	//Copies regent metabolization from bubblegum so that you cant get infinite reagents from wearing lolipops
+	var/metabolization_ammount = REAGENTS_METABOLISM / 2
+	// Nova ADDITION END
+
 /obj/item/food/swirl_lollipop/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/chewable)
+	// NOVA EDIT BEGIN: Original: AddElement(/datum/element/chewable)
+	AddElement(/datum/element/chewable, metabolization_ammount)
+	// NOVA EDIT END


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The lolipops now properly lose reagents when worn in the face slot instead of infinitely giving you its reagents (leading to you inevitably gaining weight.)

This was done by adding a second argument to an AddElement() on lolipops that was missing.

Made primarily because someone requested it in feature requests. I will not lose sleep if this is deemed unnecessary

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Allows you to cosmetically wear a lolipop for entire shifts without "becoming fat" from the endless stream of nutrient that lolipops could give you. Also the absurdity that it gave infinite omnizine is no more.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
I really dont know how to show this, so have a 250% sped up clip of me refreshing the reagents variable till it empites. (clip unedited is ~140ish seconds.
https://github.com/NovaSector/NovaSector/assets/161195966/21eddea2-0cb6-4733-a395-58fcd8abbfcb


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Worn lolipops now properly consume their reagents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
