### PR TITLE
Fix "Overweight" trait unintended interaction

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -799,9 +799,11 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/splash)
 		state = HUNGER_STATE_FINE
 		return
 
+	/*
 	if(HAS_TRAIT(hungry, TRAIT_FAT))
 		state = HUNGER_STATE_FAT
 		return
+	*/
 
 	switch(hungry.nutrition)
 		if(NUTRITION_LEVEL_FULL to INFINITY)

--- a/code/datums/mood.dm
+++ b/code/datums/mood.dm
@@ -116,9 +116,11 @@
 		clear_mood_event(MOOD_CATEGORY_NUTRITION)
 		return FALSE
 
+/*
 	if(HAS_TRAIT(mob_parent, TRAIT_FAT) && !HAS_TRAIT(mob_parent, TRAIT_VORACIOUS))
 		add_mood_event(MOOD_CATEGORY_NUTRITION, /datum/mood_event/fat)
 		return TRUE
+*/
 
 	switch(mob_parent.nutrition)
 		if(NUTRITION_LEVEL_FULL to INFINITY)

--- a/code/modules/mob/living/carbon/human/init_signals.dm
+++ b/code/modules/mob/living/carbon/human/init_signals.dm
@@ -46,12 +46,12 @@
 	SIGNAL_HANDLER
 	hud_used?.hunger?.update_appearance()
 	mob_mood?.update_nutrition_moodlets()
-
+/*
 	if(HAS_TRAIT(src, TRAIT_FAT))
 		add_movespeed_modifier(/datum/movespeed_modifier/obesity)
 	else
 		remove_movespeed_modifier(/datum/movespeed_modifier/obesity)
-
+*/
 /mob/living/carbon/human/proc/on_nohunger(datum/source)
 	SIGNAL_HANDLER
 	// When gaining NOHUNGER, we restore nutrition to normal levels, since we no longer interact with the hunger system


### PR DESCRIPTION
## About The Pull Request
The hunger hud update changed how the Overweight trait is handled, making it give any character using it the speed malus that the trait already gives, but also giving them an extra speed malus as if they were overfed at all times. Currently there's no way to get rid of the permanently overfed state without manually removing the "Overweight" trait directly from the mob that has it, this PR removes that permanent overfed state.

## How This Contributes To The Nova Sector Roleplay Experience
TG code doesn't have the "Overweight" trait, so this bit of code isn't a problem on their codebase, this problem is specific to Nova. All that said, this solves the problem for Nova and doesn't cause any issues otherwise.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Overweight trait no longer permanently makes a character overfed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
