### PR TITLE
Cuts out the spreading of yawns back down once again

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -565,7 +565,7 @@
 	message = "smiles weakly."
 
 /// The base chance for your yawn to propagate to someone else if they're on the same tile as you
-#define YAWN_PROPAGATE_CHANCE_BASE 16 // NOVA EDIT - Group yawn no more - ORIGINAL: #define YAWN_PROPAGATE_CHANCE_BASE 20
+#define YAWN_PROPAGATE_CHANCE_BASE 0 // NOVA EDIT - Group yawn no more - ORIGINAL: #define YAWN_PROPAGATE_CHANCE_BASE 20
 /// The amount the base chance to propagate yawns falls for each tile of distance
 #define YAWN_PROPAGATE_CHANCE_DECAY 4
 


### PR DESCRIPTION
## About The Pull Request
Yawns no longer spread, again.

## How This Contributes To The Nova Sector Roleplay Experience
The arguments I had against it still stand. It's annoying, there's no control over it, I'm not interested in keeping it.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  I already tested it in the past, I'm returning it to what it used to be.
</details>

## Changelog

:cl: GoldenAlpharex
fix: Yawns no longer spread, once again.
/:cl: