### PR TITLE
suboptimal - hoshi is bulky, still onehand only

### DIFF
--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/saibasan/laser_guns.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/saibasan/laser_guns.dm
@@ -266,7 +266,6 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/cybersun_small_hellfire)
 	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_BELT
 	SET_BASE_PIXEL(0, 0)
-	w_class = WEIGHT_CLASS_NORMAL
 	weapon_weight = WEAPON_MEDIUM
 	weapon_mode_options = list(
 		/datum/laser_weapon_mode/hellfire,


### PR DESCRIPTION
## About The Pull Request
![image](https://github.com/NovaSector/NovaSector/assets/31829017/8ac5db0e-77c6-4cae-ae86-602aa23ab8ed)
(hoshi is bulky now. however it still only needs 1 hand)

## How This Contributes To The Nova Sector Roleplay Experience

![image](https://github.com/NovaSector/NovaSector/assets/31829017/3bd236ac-7391-42da-bc10-f1de879b4b44)


## Proof of Testing
dude trust me
## Changelog
:cl:
balance: Cybersun Industries is now rolling out larger Hoshi chassis in order to mitigate a heatsink issue, at the cost of making them unable to be stored quite so easily.
/:cl: