### PR TITLE
fixes some minor oddities in blueshift

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -82078,7 +82078,7 @@
 	icon_state = "dirt-flat-1"
 	},
 /obj/structure/cable,
-/obj/machinery/power/energy_accumulator/grounding_rod,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "pKM" = (

--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -18045,7 +18045,6 @@
 /obj/effect/turf_decal/stripes{
 	dir = 5
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "dts" = (
@@ -19981,7 +19980,6 @@
 	dir = 4;
 	name = "Output Release"
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "dLW" = (
@@ -25826,14 +25824,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
-"eRH" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Engineering Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engineering/atmos_aux_port)
 "eRN" = (
 /obj/structure/chair{
 	dir = 8
@@ -34767,7 +34757,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "gEe" = (
@@ -37672,7 +37661,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "hiz" = (
@@ -40700,7 +40688,6 @@
 /obj/effect/turf_decal/stripes{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "hOe" = (
@@ -60140,7 +60127,6 @@
 	c_tag = "Engineering - Supermatter Room";
 	name = "engineering camera"
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "lzq" = (
@@ -75217,7 +75203,6 @@
 	dir = 9
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "osN" = (
@@ -108982,13 +108967,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"uLS" = (
-/obj/effect/turf_decal/stripes{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "uMb" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -115352,7 +115330,6 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "vVI" = (
@@ -117431,11 +117408,6 @@
 	dir = 8
 	},
 /area/station/common/wrestling/arena)
-"wpi" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engineering/atmos_aux_port)
 "wpl" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -160695,7 +160667,7 @@ hrj
 jJU
 weC
 jJU
-lvh
+eLg
 wFq
 xtd
 hVF
@@ -160705,9 +160677,9 @@ xtd
 xtd
 ryb
 dSf
-aKB
-eRH
-wpi
+psI
+fpY
+eFZ
 ipQ
 eFZ
 eFZ
@@ -160954,15 +160926,15 @@ lIS
 wIk
 dto
 osE
-mmz
+jzs
 hNZ
-mmz
+jzs
 lzn
-mmz
-mmz
+jzs
+jzs
 vVE
 dLQ
-uLS
+dUl
 jrA
 xOi
 yjp

--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -18045,6 +18045,7 @@
 /obj/effect/turf_decal/stripes{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "dts" = (
@@ -19980,6 +19981,7 @@
 	dir = 4;
 	name = "Output Release"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "dLW" = (
@@ -25824,6 +25826,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
+"eRH" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Engineering Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engineering/atmos_aux_port)
 "eRN" = (
 /obj/structure/chair{
 	dir = 8
@@ -34681,7 +34691,6 @@
 /turf/open/floor/iron/dark/side,
 /area/station/security/prison/workout)
 "gDp" = (
-/obj/machinery/light_switch/directional/south,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/stairs/old{
@@ -34758,6 +34767,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "gEe" = (
@@ -37662,6 +37672,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "hiz" = (
@@ -40689,6 +40700,7 @@
 /obj/effect/turf_decal/stripes{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "hOe" = (
@@ -43443,6 +43455,7 @@
 /area/station/command/teleporter)
 "ipQ" = (
 /obj/effect/decal/cleanable/glass,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engineering/atmos_aux_port)
 "ipR" = (
@@ -52393,6 +52406,7 @@
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
+/obj/item/airlock_painter/decal,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "jYW" = (
@@ -60126,6 +60140,7 @@
 	c_tag = "Engineering - Supermatter Room";
 	name = "engineering camera"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "lzq" = (
@@ -66143,7 +66158,13 @@
 /area/station/security/prison)
 "mHA" = (
 /obj/structure/table/reinforced,
-/obj/item/airlock_painter/decal,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser{
+	pixel_y = -8
+	},
+/obj/item/pipe_dispenser{
+	pixel_y = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "mHB" = (
@@ -75196,6 +75217,7 @@
 	dir = 9
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "osN" = (
@@ -88597,7 +88619,6 @@
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
-/obj/item/tank/internals/plasma,
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
@@ -101491,6 +101512,7 @@
 /area/station/hallway/secondary/construction)
 "trE" = (
 /obj/structure/cable,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "trG" = (
@@ -107968,7 +107990,6 @@
 /obj/effect/turf_decal/siding/purple/end{
 	dir = 1
 	},
-/obj/machinery/door/window/left/directional/west,
 /turf/open/floor/glass/reinforced,
 /area/station/science)
 "uBR" = (
@@ -108961,6 +108982,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"uLS" = (
+/obj/effect/turf_decal/stripes{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "uMb" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -115324,6 +115352,7 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "vVI" = (
@@ -117403,14 +117432,10 @@
 	},
 /area/station/common/wrestling/arena)
 "wpi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/window/brigdoor/left/directional/north{
-	name = "Creature Pen";
-	req_access = list("research")
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engineering/atmos_aux_port)
 "wpl" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -121409,13 +121434,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "xcO" = (
-/obj/machinery/atmospherics/components/tank/plasma{
-	initialize_directions = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/tank/plasma,
 /obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/bridge_pipe/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/test_chambers)
 "xcP" = (
@@ -160672,7 +160695,7 @@ hrj
 jJU
 weC
 jJU
-eLg
+lvh
 wFq
 xtd
 hVF
@@ -160682,9 +160705,9 @@ xtd
 xtd
 ryb
 dSf
-psI
-fpY
-eFZ
+aKB
+eRH
+wpi
 ipQ
 eFZ
 eFZ
@@ -160931,15 +160954,15 @@ lIS
 wIk
 dto
 osE
-jzs
+mmz
 hNZ
-jzs
+mmz
 lzn
-jzs
-jzs
+mmz
+mmz
 vVE
 dLQ
-dUl
+uLS
 jrA
 xOi
 yjp
@@ -223107,7 +223130,7 @@ euU
 xRi
 tft
 bOU
-wpi
+mya
 eMR
 mlr
 euU


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
changed/fixed some things with blueshift,
removed misplaced windoors in or around science
gave the spare chambers around the supermatter an airalarm
changed a pipe under a plasma pressure tank in atmos, so that the pressure pump that was supposed to connect to the tank, didn't connect to the pipe under it
gave engineering a more visible RPD placement, along with the ones already in the radlockers
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
idk
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/59183821/6937950e-9931-43d8-9575-626fa371903a)
new RPD placement
![image](https://github.com/NovaSector/NovaSector/assets/59183821/8d6e69c3-eec6-425d-b3cb-57b33550050f)
~~new wired APC~~ along with an airalarm
![image](https://github.com/NovaSector/NovaSector/assets/59183821/18783e4b-7035-43ab-aec6-97357da779e3)
![image](https://github.com/NovaSector/NovaSector/assets/59183821/0ef96d97-5573-4bc3-8178-b35fe81cba23)
there isn't a windoor in these spots anymore

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: the misplaced windoors around science on blueshift are gone
qol: blueshift engineers have a more visible RPD placement for the supermatter
fix: the chambers surrounding the supermatter on blueshift have an accessible airalarm near them now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
