### PR TITLE
Removes the hidden backdoor in Blueshift's command bunker

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -76904,10 +76904,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
 /turf/open/floor/iron,
 /area/station/medical/psychology)
-"oJY" = (
-/obj/structure/falsewall/reinforced,
-/turf/open/floor/plating,
-/area/station/command/secure_bunker)
 "oKf" = (
 /obj/structure/railing{
 	dir = 5
@@ -232245,7 +232241,7 @@ vur
 rcU
 uhZ
 uhZ
-xbB
+uhZ
 xSc
 yig
 nNn
@@ -232502,7 +232498,7 @@ iyR
 nFF
 jCK
 dTz
-xbB
+uhZ
 jzw
 tmU
 ijy
@@ -232759,7 +232755,7 @@ ske
 bgS
 ciM
 vhb
-xbB
+uhZ
 fCZ
 uLh
 aTj
@@ -233016,7 +233012,7 @@ bug
 uhZ
 uhZ
 nPM
-xbB
+uhZ
 mlN
 skJ
 kMJ
@@ -233273,7 +233269,7 @@ cAj
 gGr
 qit
 vhb
-xbB
+uhZ
 vzh
 tBI
 vzh
@@ -233530,7 +233526,7 @@ pUg
 dhs
 hyt
 vhb
-xbB
+uhZ
 mdx
 gVz
 qow
@@ -233787,7 +233783,7 @@ vzW
 kxk
 aFD
 vhb
-xbB
+uhZ
 rOD
 uJF
 hrN
@@ -234044,7 +234040,7 @@ jNU
 cab
 bpn
 rXy
-xbB
+uhZ
 mTZ
 skJ
 lYY
@@ -234301,7 +234297,7 @@ uhZ
 gdH
 uhZ
 uhZ
-xbB
+uhZ
 vzh
 boK
 vzh
@@ -234556,8 +234552,8 @@ uhZ
 xvI
 ePU
 cab
-oJY
-qZv
+uhZ
+uhZ
 uhZ
 bqb
 vRt
@@ -234815,7 +234811,7 @@ lJn
 req
 uhZ
 uhZ
-uhZ
+sZz
 gOw
 jyr
 uDb


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

did you know there was a secret path from the command bunker into perma that's only hidden by a single false r-wall?


https://github.com/NovaSector/NovaSector/assets/28007787/f32be079-73ce-4e3d-adae-376f46127a80


video courtesy of Orleans.

okay so it's not exactly that straightforward since it'd need gravity out or a north-direction staircase, but let's just tighten those bolts down.

## How This Contributes To The Nova Sector Roleplay Experience

prisoner's don't need easy access to buckshot.

## Proof of Testing

todo - after I sleep.

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: blueshift's command bunker is more secure
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
