### PR TITLE
Unapologetic Teshari Buffs Vol. 1

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -120,8 +120,8 @@
 	if(..())
 		return
 	// NOVA EDIT BEGIN
-	if(owner.dna.features["body_size"] < 1)
-		to_chat(owner, "You feel your body shrinking even further, but your organs aren't! Uh oh!")
+	if(owner.dna.features["body_size"] < 1 || isteshari(owner))
+		to_chat(owner, "You feel your body try to shrink, but your organs don't! Uh oh!")
 		owner.adjustBruteLoss(25)
 		return
 	// NOVA EDIT END
@@ -132,9 +132,8 @@
 	if(..())
 		return
 	// NOVA EDIT BEGIN
-	if(owner.dna.features["body_size"] < 1)
+	if(owner.dna.features["body_size"] < 1 || isteshari(owner))
 		to_chat(owner, "You feel relief as your organs cease to strain against your insides.")
-		REMOVE_TRAIT(owner, TRAIT_DWARF, GENETIC_MUTATION)
 		return
 	// NOVA EDIT END
 	REMOVE_TRAIT(owner, TRAIT_DWARF, GENETIC_MUTATION)

--- a/code/datums/quirks/positive_quirks/settler.dm
+++ b/code/datums/quirks/positive_quirks/settler.dm
@@ -19,7 +19,10 @@
 	give_item_to_holder(/obj/item/storage/box/papersack/wheat, list(LOCATION_BACKPACK = ITEM_SLOT_BACKPACK, LOCATION_HANDS = ITEM_SLOT_HANDS))
 	give_item_to_holder(/obj/item/storage/toolbox/fishing/small, list(LOCATION_BACKPACK = ITEM_SLOT_BACKPACK, LOCATION_HANDS = ITEM_SLOT_HANDS))
 	var/mob/living/carbon/human/human_quirkholder = quirk_holder
-	human_quirkholder.set_mob_height(HUMAN_HEIGHT_SHORTEST)
+	//NOVA EDIT BEGIN - This is so Teshari don't get the height decrease.
+	if(!isteshari(human_quirkholder))
+		human_quirkholder.set_mob_height(HUMAN_HEIGHT_SHORTEST)\
+	//NOVA EDIT END
 	human_quirkholder.add_movespeed_modifier(/datum/movespeed_modifier/settler)
 	human_quirkholder.physiology.hunger_mod *= 0.5 //good for you, shortass, you don't get hungry nearly as often
 

--- a/code/datums/quirks/positive_quirks/settler.dm
+++ b/code/datums/quirks/positive_quirks/settler.dm
@@ -21,7 +21,7 @@
 	var/mob/living/carbon/human/human_quirkholder = quirk_holder
 	//NOVA EDIT BEGIN - This is so Teshari don't get the height decrease.
 	if(!isteshari(human_quirkholder))
-		human_quirkholder.set_mob_height(HUMAN_HEIGHT_SHORTEST)\
+		human_quirkholder.set_mob_height(HUMAN_HEIGHT_SHORTEST)
 	//NOVA EDIT END
 	human_quirkholder.add_movespeed_modifier(/datum/movespeed_modifier/settler)
 	human_quirkholder.physiology.hunger_mod *= 0.5 //good for you, shortass, you don't get hungry nearly as often

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -452,7 +452,7 @@
 		check_break(M)
 
 /obj/structure/table/glass/proc/check_break(mob/living/M)
-	if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL && !(M.movement_type & MOVETYPES_NOT_TOUCHING_GROUND))
+	if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL && !(M.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) && (!isteshari(M))) //NOVA EDIT ADDITION - Allows Teshari to climb on glassies safely.
 		table_shatter(M)
 
 /obj/structure/table/glass/proc/table_shatter(mob/living/victim)

--- a/modular_nova/modules/bodyparts/code/teshari_bodyparts.dm
+++ b/modular_nova/modules/bodyparts/code/teshari_bodyparts.dm
@@ -112,6 +112,7 @@
 	base_limb_id = SPECIES_TESHARI
 	brute_modifier = TESHARI_BRUTE_MODIFIER
 	burn_modifier = TESHARI_BURN_MODIFIER
+	speed_modifier = -0.2
 
 /obj/item/bodypart/leg/right/digitigrade/teshari
 	icon_greyscale = BODYPART_ICON_TESHARI
@@ -119,6 +120,7 @@
 	base_limb_id = SPECIES_TESHARI
 	brute_modifier = TESHARI_BRUTE_MODIFIER
 	burn_modifier = TESHARI_BURN_MODIFIER
+	speed_modifier = -0.2
 
 #undef TESHARI_PUNCH_LOW
 #undef TESHARI_PUNCH_HIGH

--- a/modular_nova/modules/organs/code/ears.dm
+++ b/modular_nova/modules/organs/code/ears.dm
@@ -1,0 +1,12 @@
+/obj/item/organ/internal/ears/teshari
+	name = "teshari ears"
+	desc = "A set of four long rabbit-like ears, a Teshari's main tool while hunting."
+	damage_multiplier = 2
+
+/obj/item/organ/internal/ears/teshari/on_mob_insert(mob/living/carbon/ear_owner)
+	. = ..()
+	ADD_TRAIT(ear_owner, TRAIT_GOOD_HEARING, ORGAN_TRAIT)
+
+/obj/item/organ/internal/ears/teshari/on_mob_remove(mob/living/carbon/ear_owner)
+	. = ..()
+	REMOVE_TRAIT(ear_owner, TRAIT_GOOD_HEARING, ORGAN_TRAIT)

--- a/modular_nova/modules/teshari/code/_teshari.dm
+++ b/modular_nova/modules/teshari/code/_teshari.dm
@@ -39,6 +39,7 @@
 	bodytemp_heat_damage_limit = (BODYTEMP_HEAT_DAMAGE_LIMIT + TESHARI_TEMP_OFFSET)
 	bodytemp_cold_damage_limit = (BODYTEMP_COLD_DAMAGE_LIMIT + TESHARI_TEMP_OFFSET)
 	species_language_holder = /datum/language_holder/teshari
+	mutantears = /obj/item/organ/internal/ears/teshari
 	body_size_restricted = TRUE
 	bodypart_overrides = list(
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/mutant/teshari,
@@ -57,7 +58,7 @@
 	)
 
 /obj/item/organ/internal/tongue/teshari
-	liked_foodtypes = MEAT
+	liked_foodtypes = MEAT | GORE | RAW
 	disliked_foodtypes = GROSS | GRAIN
 
 /datum/species/teshari/random_name(gender, unique, lastname)
@@ -80,3 +81,12 @@
 	tesh.dna.mutant_bodyparts["tail"] = list(MUTANT_INDEX_NAME = "Teshari (Default)", MUTANT_INDEX_COLOR_LIST = list(base_color, base_color, ear_color))
 	regenerate_organs(tesh, src, visual_only = TRUE)
 	tesh.update_body(TRUE)
+
+/datum/species/teshari/on_species_gain(mob/living/carbon/human/new_teshari, datum/species/old_species, pref_load)
+	. = ..()
+	passtable_on(new_teshari, SPECIES_TRAIT)
+
+/datum/species/teshari/on_species_loss(mob/living/carbon/C, datum/species/new_species, pref_load)
+	. = ..()
+	passtable_off(C, SPECIES_TRAIT)
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7886,6 +7886,7 @@
 #include "modular_nova\modules\opposing_force\code\equipment\modsuit.dm"
 #include "modular_nova\modules\opposing_force\code\equipment\spells.dm"
 #include "modular_nova\modules\opposing_force\code\equipment\uplink.dm"
+#include "modular_nova\modules\organs\code\ears.dm"
 #include "modular_nova\modules\organs\code\heart.dm"
 #include "modular_nova\modules\organs\code\liver.dm"
 #include "modular_nova\modules\organs\code\lungs.dm"


### PR DESCRIPTION
## About The Pull Request
New lore new me.

This does a few things.
One, this is actually a burf PR. You'll see right away the first part I did here was ensure that Teshari can't get _even smaller._ This blocks Settler, Dwarfism, and that's about it. I've tested both of those, and it's absolutely agonizing how narrow you can make the sprite. Spacer is available, however.

Two, the actual meat and potatoes. I've made Teshari a _pinch_ faster and allowed them to cross tables. There's a modular edit in there that lets them cross glass tables. You might be asking why I did that instead of simply making them MOB_SIZE_SMALL.
The good part of being small is that 
![image](https://github.com/NovaSector/NovaSector/assets/12636964/33a544a7-8871-441b-9455-882749615dee)
you can fit in a minifridge.

The downside is
![image](https://github.com/NovaSector/NovaSector/assets/12636964/035807cd-b99b-4c2d-bde3-c25aef4937b3)
you can fit in a pet carrier, which is genuinely awful and I'd die if I had to witness this.

So instead, the edit.

Third, I've given Teshari whisper-sensitive ears. I was going to do whisper-sensitive x-ray ears with 4x damage multiplier, but that would be fucking crazy, wouldn't it? I found it in concept to be pretty strong, but let me know what you think.

Lastly, Teshari now enjoy raw and gore to fit the lore. Yippee.

Further, more tangible content might come later.

## How This Contributes To The Nova Sector Roleplay Experience
I think this species is kind of mechanically a nothingburger despite the potential, and they're currently a fat list of debuffs for a very narrow list of perks. Why?

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
Over in the desc.  
</details>

## Changelog
:cl:
add: Teshari are now more agile, better at hearing stuff, and can feast on carrion!
/:cl: