### PR TITLE
hoshi back to normal sized, sec belt has a storage limit

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -359,6 +359,7 @@
 	. = ..()
 	atom_storage.max_slots = 5
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
+	atom_storage.max_total_storage = 11 // NOVA EDIT - ADDITION
 	atom_storage.set_holdable(list(
 		/obj/item/ammo_box,
 		/obj/item/ammo_casing/shotgun,
@@ -368,7 +369,7 @@
 		/obj/item/flashlight/seclite,
 		/obj/item/food/donut,
 		/obj/item/grenade,
-		/obj/item/gun, //NOVA EDIT ADDITION
+		/obj/item/gun, //NOVA EDIT - ADDITION
 		/obj/item/holosign_creator/security,
 		/obj/item/knife/combat,
 		/obj/item/melee/baton,

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/saibasan/laser_guns.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/saibasan/laser_guns.dm
@@ -267,6 +267,7 @@
 	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_BELT
 	SET_BASE_PIXEL(0, 0)
 	weapon_weight = WEAPON_MEDIUM
+	w_class = WEIGHT_CLASS_NORMAL
 	weapon_mode_options = list(
 		/datum/laser_weapon_mode/hellfire,
 		/datum/laser_weapon_mode/sword,


### PR DESCRIPTION

## About The Pull Request

Makes the hoshi carbine normal sized again, because making it bulky essentially made it into a case of "why would you pick this over the bigger rifle that's the same size' it also shot the one decently-usable energy gun dead in the streets, over it fitting in sec belts.

tiny = 1
small = 2 
normal = 3

total - 11

## How This Contributes To The Nova Sector Roleplay Experience

Energy guns are already hit pretty hard in usability (no reload, low charge counts) compared to ballistics, and being locked to 'belt slot or nothing' is a real nail in the coffin for the first 'convenient' one (not counting mini-egun)

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
   god told me it would work
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The Hoshi is once more, reduced in size, because it turns out bigger, does not always equal better with heatsinks!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
