### PR TITLE
Disables the Drifting Contractor random event in favor of using dynamic only to spawn them

### DIFF
--- a/modular_nova/modules/contractor/code/datums/midround/event.dm
+++ b/modular_nova/modules/contractor/code/datums/midround/event.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/ghost_role/contractor
 	weight = 8
 	max_occurrences = 1
+	dynamic_should_hijack = TRUE
 	category = EVENT_CATEGORY_INVASION
 	description = "A pre-equipped contractor floats towards the station to fulfill contracts."
 

--- a/modular_nova/modules/contractor/code/datums/midround/event.dm
+++ b/modular_nova/modules/contractor/code/datums/midround/event.dm
@@ -2,7 +2,7 @@
 	name = "Drifting Contractor"
 	typepath = /datum/round_event/ghost_role/contractor
 	weight = 8
-	max_occurrences = 1
+	max_occurrences = 0
 	dynamic_should_hijack = TRUE
 	category = EVENT_CATEGORY_INVASION
 	description = "A pre-equipped contractor floats towards the station to fulfill contracts."


### PR DESCRIPTION
## About The Pull Request
This variant (which only spawns one contractor at a time) was using the event system, which meant that it wasn't following the dynamic config.

## How This Contributes To The Nova Sector Roleplay Experience
This allows for proper control over an antag through dynamic.

## Proof of Testing

I didn't want to spend two hours waiting for this to not run.

## Changelog

:cl: GoldenAlpharex
fix: Drifting Contractors now respects the dynamic config, by no longer running in the event system on top of the dynamic system.
/:cl: