### PR TITLE
[Modular] Adds a verb that lets you toggle if a mask hides your face (and flavortext)

### DIFF
--- a/modular_nova/modules/customization/modules/clothing/masks/gasmask.dm
+++ b/modular_nova/modules/customization/modules/clothing/masks/gasmask.dm
@@ -216,3 +216,24 @@
 	clothing_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS | GAS_FILTERING
 	visor_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS | GAS_FILTERING
 	starting_filter_type = /obj/item/gas_filter/vox
+
+/// Adds a proc to all masks to toggle the flag that that hides your face and adds a action button for it
+/obj/item/clothing/mask/proc/toggle_hide_face()
+	if(src.flags_inv & HIDEFACE)
+		src.flags_inv &= ~HIDEFACE
+		to_chat(usr, "You've revealed your face!")
+	else
+		src.flags_inv |= HIDEFACE
+		to_chat(usr, "You've hidden your face!")
+
+	return TRUE
+
+/// Adds a mob proc under the object category that checks if theres a worn mask and if so runs the toggle_hide_face proc
+/mob/living/carbon/verb/toggle_mask_hide()
+	set name = "Toggle Mask Face Hiding"
+	set category = "Object"
+
+	if(src.wear_mask)
+		src.wear_mask.toggle_hide_face()
+	else
+		to_chat(usr, "You're not wearing a mask!")

--- a/modular_nova/modules/customization/modules/clothing/masks/gasmask.dm
+++ b/modular_nova/modules/customization/modules/clothing/masks/gasmask.dm
@@ -233,7 +233,9 @@
 	set name = "Toggle Mask Face Hiding"
 	set category = "Object"
 
-	if(src.wear_mask)
+	if(src.wear_mask && src.wear_mask.flags_inv && src.wear_mask.flags_inv & HIDEFACE)
 		src.wear_mask.toggle_hide_face()
+	else if(src.wear_mask)
+		to_chat(src, "The mask you're wearing doesn't hide your face!")
 	else
-		to_chat(usr, "You're not wearing a mask!")
+		to_chat(src, "You're not wearing a mask!")


### PR DESCRIPTION
## About The Pull Request

Simply put this adds a verb to the object tab that lets you toggle a mask your wearing HIDEFACE flag so that it no longer hides your face and thus lets people see flavor text

## How This Contributes To The Nova Sector Roleplay Experience

This lets people who make characters who exclusively wear masks still have the ability to show flavor text without having to shove that flavor text into OOC notes

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_ITpjlKolhP](https://github.com/NovaSector/NovaSector/assets/2568378/2cd58563-ba38-447d-bc3c-825a75820e03)

![dreamseeker_OlbKDYgZJn](https://github.com/NovaSector/NovaSector/assets/2568378/5713f62f-041d-4aad-9dc7-49f7c039a239)

</details>

## Changelog

:cl:
qol: Masks that hide your characters face (and flavor text) has a new verb in the object tab to toggle hiding your face (and thus show your flavor text)
/:cl:
