### PR TITLE
[NO GBP] Changelogs an undocumented change in #1478

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Nova Sector (/tg/station Downstream)
+## Nova Sector (/tg/station Downstream) 
 
 [![CI Suite](https://github.com/NovaSector/NovaSector/workflows/CI%20Suite/badge.svg)](https://github.com/NovaSector/NovaSector/actions?query=workflow%3A%22CI+Suite%22)
 [![Percentage of issues still open](https://isitmaintained.com/badge/open/NovaSector/NovaSector.svg)](https://isitmaintained.com/project/NovaSector/NovaSector "Percentage of issues still open")


### PR DESCRIPTION
## About The Pull Request

For some reason the change to Security Belt size limitations went completely un-changelog'd in #1478 despite being a much larger change with a much larger scope of impact than resizing a single gun down to W_CLASS_NORMAL, so I'm adding it to the changelog.
![chrome_VtRXVNKSWM](https://github.com/NovaSector/NovaSector/assets/4081722/6b26feb4-0e29-445a-9946-7be8ea1339dd)

## How This Contributes To The Nova Sector Roleplay Experience

Accurate changelogs are good for the playerbase and helps them understand the changes being made. All changes in a PR should be appropriately changelogged so that they are visible to the players.

## Proof of Testing

It's a changelog entry, there's no code changes to the game.

## Changelog
:cl: JungleRat
balance: Security Belts now hold a max weight of 11, which is roughly 3 normal sized items, 5 small sized items, and 11 tiny sized items.
/:cl: