### PR TITLE
live shotgun reaction, somewhat - buyable doublebarrel/.38 revolver, 12g revolver now has reload CD

### DIFF
--- a/modular_nova/master_files/code/modules/cargo/goodies.dm
+++ b/modular_nova/master_files/code/modules/cargo/goodies.dm
@@ -12,7 +12,6 @@
 
 /datum/supply_pack/goody/mars_single
 	access_view = FALSE
-	special = TRUE
 
 /datum/supply_pack/goody/Survivalknives_single
 	access_view = FALSE
@@ -46,5 +45,4 @@
 	special = TRUE
 
 /datum/supply_pack/goody/double_barrel
-	special = TRUE
 	access_view = FALSE

--- a/modular_nova/modules/modular_weapons/code/overrides/ballistic_master.dm
+++ b/modular_nova/modules/modular_weapons/code/overrides/ballistic_master.dm
@@ -13,18 +13,21 @@
 */
 
 /obj/item/gun/ballistic/revolver
-	box_reload_delay = CLICK_CD_RAPID // honestly this is negligible because of the inherent delay of having to switch hands
+	box_reload_delay = NONE // honestly this is negligible because of the inherent delay of having to switch hands
+
+/obj/item/gun/ballistic/revolver/shotgun_revolver
+	box_reload_delay = CLICK_CD_MELEE // unfortunately this is a shotgun
 
 /obj/item/gun/ballistic/rifle/boltaction // slightly less negligible than a revolver, since this is mostly for fairly powerful but crew-accessible stuff like mosins
-	box_reload_delay = CLICK_CD_RANGE
+	box_reload_delay = NONE
 
 /// Reloading with ammo box can incur penalty with some guns
 /obj/item/gun/ballistic/proc/handle_box_reload(mob/user, obj/item/ammo_box/ammobox, num_loaded)
 	var/box_load = FALSE // if you're reloading with an ammo box, inflicts a cooldown
-	if(istype(ammobox, /obj/item/ammo_box) && box_reload_penalty)
+	if(istype(ammobox, /obj/item/ammo_box) && box_reload_penalty && box_reload_delay)
 		box_load = TRUE
 		user.changeNext_move(box_reload_delay) // cooldown to simulate having to fumble for another round
-		balloon_alert(user, "reload encumbered!")
+		balloon_alert(user, "reload encumbered ([box_reload_delay * DECISECONDS]s)!")
 	to_chat(user, span_notice("You load [num_loaded] [cartridge_wording]\s into [src][box_load ?  ", but it takes some extra effort" : ""]."))
 
 /obj/effect/temp_visual/dir_setting/firing_effect


### PR DESCRIPTION
## About The Pull Request
- double barrel shotgun returned to goodies tab (from upstream)
- .38 revolver returned to goodies tab (from upstream)
- Bobr 12g shotgun revolver now has proper shotgun reload delay if using an ammo box
- bolt-actions and revolvers no longer have ammo box delay because at this point i don't think it's that offensive anymore (shotguns still have it, though)
- reloading a weapon with reload encumbrance now shows the delay in seconds
## How This Contributes To The Nova Sector Roleplay Experience
- double barrel and .38 are inoffensive enough that i don't think they need to be admin-locked/irreplacable from cargo
- the bobr having mostly uncapped shotgun reload delay was unintentional and only happened from subtyping shenanigans
## Proof of Testing


<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/31829017/fca7909f-5cbb-471d-8318-c0ca7da8b48f)
![image](https://github.com/NovaSector/NovaSector/assets/31829017/cfbb6f69-249f-490c-9448-e38be6d0cda4)

</details>

## Changelog

:cl:
balance: Double-barrel shotguns and the Colt Detective Special .38 revolver are back in Cargo's goodies tab.
balance: The Bobr 12g shotgun revolver no longer has basically instant reload delay.
balance: Bolt-action rifles and revolvers no longer delay your next hand use after using an ammo box to reload them.
qol: Reloading a weapon in a way that encumbers you now says how long your handedness is impaired for in seconds.
/:cl:
