### PR TITLE
Fixes a runtime on food perfrences as well as a little QOL for invalid perfs

### DIFF
--- a/modular_nova/master_files/code/modules/client/preferences/middleware/food.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/middleware/food.dm
@@ -18,7 +18,10 @@ GLOBAL_DATUM_INIT(food_prefs_menu, /datum/food_prefs_menu, new)
 		return
 	qdel(species)
 
-	var/fail_reason = GLOB.food_prefs_menu.is_food_invalid(preferences)
+	var/counts = GLOB.food_prefs_menu.count_valid_perfs(preferences)
+
+	var/fail_reason = GLOB.food_prefs_menu.is_food_invalid(counts)
+
 	if(fail_reason)
 		to_chat(preferences.parent, span_announce("Your food preferences can't be set because of [fail_reason] choices! Please check your preferences!")) // Sorry, but I don't want folk sleeping on this.
 		return
@@ -113,6 +116,31 @@ GLOBAL_DATUM_INIT(food_prefs_menu, /datum/food_prefs_menu, new)
 
 	var/datum/species/species_type = preferences.read_preference(/datum/preference/choiced/species)
 	var/datum/species/species = new species_type
+
+	var/counts = count_valid_perfs(preferences)
+
+	var/list/data = list(
+		"selection" = preferences.food_preferences,
+		"enabled" = preferences.food_preferences["enabled"],
+		"invalid" = is_food_invalid(counts),
+		"race_disabled" = !species.allows_food_preferences(),
+		"limits" = list(
+			"max_liked" = MAXIMUM_LIKES,
+			"min_disliked" = MINIMUM_REQUIRED_DISLIKES,
+			"min_toxic" = MINIMUM_REQUIRED_TOXICS,
+		),
+		"counts" = counts,
+	)
+	qdel(species)
+	return data
+
+/**
+ * Counts the number of valid food preferences in the provided preferences datum.
+ *
+ * @param preferences The preferences datum to count the valid food preferences of.
+ * @return A list of counts for the valid food preferences.
+ */
+/datum/food_prefs_menu/proc/count_valid_perfs(datum/preferences/preferences)
 	var/counts = list(
 		"liked" = 0,
 		"disliked" = 0,
@@ -133,25 +161,12 @@ GLOBAL_DATUM_INIT(food_prefs_menu, /datum/food_prefs_menu, new)
 				counts["disliked"]++
 			if(FOOD_PREFERENCE_TOXIC)
 				counts["toxic"]++
-
-
-	var/list/data = list(
-		"selection" = preferences.food_preferences,
-		"enabled" = preferences.food_preferences["enabled"],
-		"invalid" = is_food_invalid(counts),
-		"race_disabled" = !species.allows_food_preferences(),
-		"limits" = list(
-			"max_liked" = MAXIMUM_LIKES,
-			"min_disliked" = MINIMUM_REQUIRED_DISLIKES,
-			"min_toxic" = MINIMUM_REQUIRED_TOXICS,
-		),
-		"counts" = counts,
-	)
-	qdel(species)
-	return data
+	return counts
 
 /// Checks the provided preferences datum to make sure the food pref values are valid. Does not check if the food preferences value is null.
 /datum/food_prefs_menu/proc/is_food_invalid(counts)
+	if(!islist(counts) && counts)
+		return
 	if(counts["liked"] > MAXIMUM_LIKES)
 		return "too many liked choices"
 	if(counts["disliked"] < MINIMUM_REQUIRED_DISLIKES)

--- a/tgui/packages/tgui/interfaces/FoodPreferences.tsx
+++ b/tgui/packages/tgui/interfaces/FoodPreferences.tsx
@@ -67,11 +67,14 @@ export const FoodPreferences = (props) => {
                     {invalid ? (
                       <Box as="span" color="#bd2020">
                         Prefrences are Invalid!{' '}
-                        {invalid.charAt(0).toUpperCase() + invalid.slice(1)}{' '}
+                        {invalid.charAt(0).toUpperCase() + invalid.slice(1)} |{' '}
+                        {counts.disliked < 2
+                          ? counts.disliked + '/2 Disliked'
+                          : counts.toxic + '/1 Toxic'}
                       </Box>
                     ) : (
                       <Box as="span" color="green">
-                        Prefrences are Valid!
+                        Prefrences are Valid! | {counts.liked}/3 Liked
                       </Box>
                     )}
                   </Box>


### PR DESCRIPTION
## About The Pull Request

This fixes a runtime that occurred whenever apply_to_human was called as it was passing a preferences datum into a proc that was expecting a list. This fixes this issue as well as uses that same list to provide a little more feedback to players if their preferences are valid or not

## How This Contributes To The Nova Sector Roleplay Experience

Less bugs, more QOL

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![dreamseeker_Ylxzax8cU7](https://github.com/NovaSector/NovaSector/assets/2568378/1229eefd-becc-4739-9895-844d8e74d04d)

![dreamseeker_htmmYASwnX](https://github.com/NovaSector/NovaSector/assets/2568378/943bc8c0-59b0-4c19-ab2b-c0152bcc721c)

![npmwVFCeCF](https://github.com/NovaSector/NovaSector/assets/2568378/04e2ba8c-b8b0-4de6-a4b4-9858d628a954)

</details>

## Changelog

:cl:
qol: Added additional user feedback to food preferences as to if preferences where valid or invalid
fix: Fixed a runtime in food preference that occurred whenever a player spawned in
/:cl: