### PR TITLE
Expands Interaction Preferences To Fit More People Under Them (& One New One)

### DIFF
--- a/modular_nova/master_files/code/modules/client/preferences/erp_preferences.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/erp_preferences.dm
@@ -128,10 +128,13 @@
 	savefile_key = "erp_status_pref"
 
 /datum/preference/choiced/erp_status/init_possible_values()
-	return list("Yes - Switch", "Yes - Sub", "Yes - Dom", "Check OOC", "Ask", "No", "Yes")
+	return list (
+	"Top - Dom", "Top - Switch", "Top - Sub", "Verse-Top - Dom", "Verse-Top - Switch", "Verse-Top - Sub", "Verse - Dom", "Verse - Switch", "Verse - Sub",
+	"Verse-Bottom - Dom", "Verse-Bottom - Switch", "Verse-Bottom - Sub", "Bottom - Dom", "Bottom- Switch", "Bottom - Sub", "Check OOC", "Ask (L)OOC", "No", "Yes"
+	)
 
 /datum/preference/choiced/erp_status/create_default_value()
-	return "Ask"
+	return "Check OOC"
 
 /datum/preference/choiced/erp_status/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))
@@ -158,10 +161,10 @@
 	savefile_key = "erp_status_pref_nc"
 
 /datum/preference/choiced/erp_status_nc/init_possible_values()
-	return list("Yes - Switch", "Yes - Sub", "Yes - Dom", "Check OOC", "Ask", "No", "Yes")
+	return list ("Yes", "Check OOC", "No")
 
 /datum/preference/choiced/erp_status_nc/create_default_value()
-	return "Ask"
+	return "Check OOC"
 
 /datum/preference/choiced/erp_status_nc/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))
@@ -191,7 +194,7 @@
 	return list("Yes - Switch", "Yes - Prey", "Yes - Pred", "Check OOC", "Ask", "No", "Yes")
 
 /datum/preference/choiced/erp_status_v/create_default_value()
-	return "Ask"
+	return "No"
 
 /datum/preference/choiced/erp_status_v/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))
@@ -270,4 +273,35 @@
 	. = ..()
 
 /datum/preference/choiced/erp_sexuality/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return FALSE
+
+/datum/preference/choiced/erp_status_hypno
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "erp_status_pref_hypnosis"
+
+/datum/preference/choiced/erp_status_hypno/init_possible_values()
+	return list("Always/Whenever", "Gameplay Only", "Ask (L)OOC", "Check OOC", "No")
+
+/datum/preference/choiced/erp_status_hypno/create_default_value()
+	return "No"
+
+/datum/preference/choiced/erp_status_hypno/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	if(CONFIG_GET(flag/disable_erp_preferences))
+		return FALSE
+
+	return preferences.read_preference(/datum/preference/toggle/master_erp_preferences)
+
+/datum/preference/choiced/erp_status_hypno/deserialize(input, datum/preferences/preferences)
+	if(CONFIG_GET(flag/disable_erp_preferences))
+		return "No"
+
+	if(!preferences.read_preference(/datum/preference/toggle/master_erp_preferences))
+		return "No"
+	. = ..()
+
+/datum/preference/choiced/erp_status_hypno/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	return FALSE

--- a/modular_nova/master_files/code/modules/mob/living/examine_tgui.dm
+++ b/modular_nova/master_files/code/modules/mob/living/examine_tgui.dm
@@ -62,13 +62,15 @@
 	if(preferences)
 		if(preferences.read_preference(/datum/preference/toggle/master_erp_preferences))
 			var/e_prefs = preferences.read_preference(/datum/preference/choiced/erp_status)
-			var/e_prefs_nc = preferences.read_preference(/datum/preference/choiced/erp_status_nc)
-			var/e_prefs_v = preferences.read_preference(/datum/preference/choiced/erp_status_v)
+			var/e_prefs_hypno = preferences.read_preference(/datum/preference/choiced/erp_status_hypno)
 			var/e_prefs_mechanical = preferences.read_preference(/datum/preference/choiced/erp_status_mechanics)
+			var/e_prefs_v = preferences.read_preference(/datum/preference/choiced/erp_status_v)
+			var/e_prefs_nc = preferences.read_preference(/datum/preference/choiced/erp_status_nc)
 			ooc_notes += "ERP: [e_prefs]\n"
-			ooc_notes += "Non-Con: [e_prefs_nc]\n"
-			ooc_notes += "Vore: [e_prefs_v]\n"
+			ooc_notes += "Hypnosis: [e_prefs_hypno]\n"
 			ooc_notes += "ERP Mechanics: [e_prefs_mechanical]\n"
+			ooc_notes += "Vore: [e_prefs_v]\n"
+			ooc_notes += "Non-Con: [e_prefs_nc]\n"
 			ooc_notes += "\n"
 
 		if(!CONFIG_GET(flag/disable_antag_opt_in_preferences))

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/genitals.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/genitals.tsx
@@ -217,6 +217,11 @@ export const erp_status_pref_v: FeatureChoiced = {
   component: FeatureDropdownInput,
 };
 
+export const erp_status_pref_hypnosis: FeatureChoiced = {
+  name: 'ERP Hypnosis Status',
+  component: FeatureDropdownInput,
+};
+
 export const erp_status_pref_mechanics: FeatureChoiced = {
   name: 'ERP Mechanical Status',
   component: FeatureDropdownInput,


### PR DESCRIPTION
## About The Pull Request
Hi.
This PR adds some preferences for illicit meetups.
Let's go over them.
For clarification, verse refers to 'okay with either bottoming or topping' and switch corresponds with domming and subbing. Jsyk.

For midnight meetings,
Top - Dom
Top - Switch
Top - Sub
Verse-Top - Dom
Verse-Top - Switch
Verse-Top - Sub
Verse - Dom
Verse - Switch
Verse - Sub
Verse-Bottom - Dom 
Verse-Bottom - Switch
Verse-Bottom - Sub
Bottom - Dom
Bottom - Switch 
Bottom - Sub

I am willing to put 'Yes -' infront of each of those, but I don't really think it's needed? It's sort of implied.
I also changed some of the other ones.
'Ask' is now 'Ask (L)OOC.' Of course you ask ICly, it came free with your 'playing a social interaction game,' and I don't know why we'd have a preference *just* for Ask ICly? So instead, ask in LOOC if it's a go or not.

As for assault and consumption, I have made the default be 'no,' and slimmed down the options for assault. This sort of assault is implicitly tied with conception, you should go off the preference readout for that.

I have added another preference for hypnosis.
Always/Whenever - Corresponding to just 'yeah whenever's fine even if it's just for trivial RP stuff.'
Gameplay Only - For stuff like hypnobangs or traitor stuff, not for "woohoo."
Ask (L)OOC - We've been over this.
Check OOC - Check the notes.
No - Means no.

![image](https://github.com/NovaSector/NovaSector/assets/12636964/1e7c0193-19b4-43b0-84a5-a1b0bfac4c88)
![image](https://github.com/NovaSector/NovaSector/assets/12636964/25958643-23bd-4845-8d90-2910180d8862)


## How This Contributes To The Nova Sector Roleplay Experience
This allows you to get a more granular experience and allows for a wider array of display of identity, and there have been situations where, say, a sub person being engaged with and being expected to bottom when they don't want to.
Additionally, it really, really shouldn't default to 'ask' for extreme content like the other two.

As to the hypnosis preference, I am self-serving; but more importantly, this stuff is surprisingly accessible nowadays (thru the NIFsoft and Hypno Goggles) and there's been more people around with it as kind of a central theme.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
 Desc. 
</details>

## Changelog
:cl:
qol: Interaction preferences have been expanded to make a wider array of characters more comfortable.
/:cl:
