### PR TITLE
Blueshift - No more roundstart Gravity Blackouts

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -90,6 +90,7 @@
 /obj/item/bedsheet{
 	pixel_y = 8
 	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "abA" = (
@@ -313,14 +314,11 @@
 /turf/open/floor/carpet/purple,
 /area/station/science/breakroom)
 "aea" = (
-/obj/machinery/camera{
-	c_tag = "Security - Brig Far Starboard";
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "aed" = (
@@ -684,6 +682,15 @@
 "ahn" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/entry)
+"ahx" = (
+/obj/structure/window/spawner/directional/east,
+/obj/structure/chair/sofa/corp/left{
+	color = "#DE3A3A";
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen/diner)
 "ahz" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
@@ -845,11 +852,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 2
 	},
-/obj/machinery/camera{
-	c_tag = "Recreation - Arcade Upper";
-	dir = 9;
-	name = "hallway camera"
-	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/wood,
 /area/station/hallway/primary/port)
 "aiU" = (
@@ -1504,11 +1507,6 @@
 "apa" = (
 /obj/machinery/vending/coffee,
 /obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Departures Customs";
-	dir = 9;
-	name = "customs camera"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
@@ -3134,6 +3132,7 @@
 /obj/machinery/computer/atmos_control,
 /obj/machinery/light/directional/north,
 /obj/machinery/light_switch/directional/north,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/office)
 "aGj" = (
@@ -3740,12 +3739,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "aMl" = (
-/obj/machinery/camera{
-	c_tag = "Recreation - Barbershop backroom";
-	dir = 6;
-	name = "hallway camera"
-	},
 /obj/item/kirbyplants/random,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/wood,
 /area/station/service/barber)
 "aMt" = (
@@ -5825,12 +5820,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
 	},
-/obj/machinery/camera{
-	c_tag = "Medbay - Virology Ward 2";
-	dir = 9;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "bio" = (
@@ -5847,6 +5837,7 @@
 	},
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/captain)
 "biv" = (
@@ -6168,17 +6159,12 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Medbay - Virology";
-	dir = 10;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /obj/structure/cable,
 /obj/machinery/newscaster/directional/west,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "blx" = (
@@ -8335,6 +8321,7 @@
 	},
 /obj/structure/rack/shelf,
 /obj/machinery/light/directional/north,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/smooth_edge{
 	dir = 4
 	},
@@ -9029,11 +9016,7 @@
 /obj/item/assembly/prox_sensor,
 /obj/item/assembly/prox_sensor,
 /obj/item/assembly/prox_sensor,
-/obj/machinery/camera/directional/south{
-	c_tag = "Science - Robotics Lab";
-	name = "science camera";
-	network = list("ss13","rd")
-	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/mineral/plastitanium/red,
 /area/station/science/robotics/lab)
 "bMr" = (
@@ -10546,13 +10529,9 @@
 /turf/open/floor/grass,
 /area/station/science/research)
 "cbm" = (
-/obj/machinery/camera{
-	c_tag = "Central Hallway - Fore Port Bow";
-	dir = 6;
-	name = "hallway camera"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "cbs" = (
@@ -10697,6 +10676,18 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
+"ccw" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering - Engine Foyer";
+	dir = 1;
+	name = "engineering camera"
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "ccx" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -11888,20 +11879,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/test_chambers)
 "cnZ" = (
-/obj/machinery/camera{
-	c_tag = "Medbay - Ward Cell 3";
-	dir = 5;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/stripes{
 	dir = 1
 	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/mineral/titanium/tiled/white{
-	name = "Padded tile"
-	},
-/area/station/medical/aslyum)
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/engine,
+/area/station/science/explab)
 "cob" = (
 /obj/structure/ore_box,
 /obj/effect/decal/cleanable/dirt{
@@ -12042,11 +12025,6 @@
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/storage/toolbox/electrical,
 /obj/item/stack/cable_coil,
-/obj/machinery/camera{
-	c_tag = "Engineering - Bottom Central";
-	dir = 6;
-	name = "engineering camera"
-	},
 /obj/machinery/light_switch/directional/south,
 /obj/item/airlock_painter,
 /turf/open/floor/iron/dark,
@@ -12808,12 +12786,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "cvn" = (
-/obj/machinery/camera{
-	c_tag = "Leisure Hallway - Central Aft";
-	dir = 6;
-	name = "hallway camera"
-	},
 /obj/machinery/light/directional/east,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -13080,6 +13054,7 @@
 /obj/machinery/door/window/left/directional/east{
 	req_access = list("eva")
 	},
+/obj/machinery/camera/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "cxZ" = (
@@ -13348,11 +13323,6 @@
 /area/station/cargo/sorting)
 "czR" = (
 /obj/machinery/modular_computer/preset/engineering,
-/obj/machinery/camera/directional/south{
-	c_tag = "Atmospherics - Desk";
-	dir = 1;
-	name = "atmospherics camera"
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/office)
 "czZ" = (
@@ -15413,6 +15383,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/auxiliary)
 "cSf" = (
@@ -15594,6 +15565,12 @@
 /obj/structure/drain,
 /turf/open/floor/iron/freezer,
 /area/station/commons/dorms/room6)
+"cUm" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/turf_decal/bot,
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/commons/dorms)
 "cUu" = (
 /obj/structure/window/spawner/directional/south,
 /obj/structure/chair/sofa/middle/brown{
@@ -15638,6 +15615,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
+"cUI" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "cUJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/railing/corner/end{
@@ -16320,6 +16302,7 @@
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "dbZ" = (
@@ -16900,30 +16883,14 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "dhT" = (
-/obj/machinery/camera{
-	c_tag = "Medbay - Ward Cell 1";
-	dir = 5;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/mineral/titanium/tiled/white{
-	name = "Padded tile"
-	},
-/area/station/medical/aslyum)
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "dhU" = (
 /obj/machinery/shower/directional/west{
 	name = "emergency shower"
 	},
 /obj/structure/drain,
-/obj/machinery/camera/directional/south{
-	c_tag = "Engineering - Engine Foyer";
-	dir = 1;
-	name = "engineering camera"
-	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/checker,
 /area/station/engineering/main)
@@ -17449,16 +17416,12 @@
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/west,
-/obj/machinery/camera{
-	c_tag = "Dorm Hallway - Port Central Left";
-	dir = 10;
-	name = "hallway camera"
-	},
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "dmO" = (
@@ -17941,12 +17904,8 @@
 /area/station/command/bridge)
 "dsn" = (
 /obj/effect/turf_decal/stripes,
-/obj/machinery/camera{
-	c_tag = "Engineering - Supermatter Room";
-	dir = 5;
-	name = "engineering camera"
-	},
 /obj/machinery/status_display/ai/directional/south,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "dsr" = (
@@ -19440,12 +19399,9 @@
 /obj/machinery/computer/prisoner/management{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Security Post - Arrivals";
-	dir = 10
-	},
 /obj/machinery/light/directional/west,
 /obj/machinery/status_display/ai/directional/west,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint)
 "dHU" = (
@@ -20184,6 +20140,13 @@
 	dir = 4
 	},
 /area/station/security/prison/workout)
+"dOp" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
+	},
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron/dark/small,
+/area/station/cargo/miningdock)
 "dOX" = (
 /obj/structure/disposalpipe/trunk/multiz{
 	dir = 1
@@ -21503,15 +21466,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Science - Xenobio Port";
-	dir = 5;
-	name = "science camera";
-	network = list("ss13","rd")
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "edc" = (
@@ -22198,6 +22156,7 @@
 /obj/machinery/dryer{
 	pixel_y = 14
 	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/carpet/black,
 /area/station/service/barber)
 "ekg" = (
@@ -22873,6 +22832,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/status_display/ai/directional/south,
 /obj/item/storage/medkit/regular,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "erB" = (
@@ -23057,6 +23017,7 @@
 	},
 /obj/machinery/light_switch/directional/south,
 /obj/machinery/light/directional/south,
+/obj/machinery/camera/directional/south,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/blueshield)
 "etj" = (
@@ -23310,13 +23271,10 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/abandon_diner)
 "euZ" = (
-/obj/machinery/camera{
-	c_tag = "Command Hallway - Central Port";
-	dir = 10
-	},
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/stairs/left,
 /area/station/hallway/secondary/command)
 "evb" = (
@@ -25759,6 +25717,7 @@
 	pixel_y = 8
 	},
 /obj/machinery/status_display/evac/directional/east,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "eQF" = (
@@ -25934,11 +25893,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/camera{
-	c_tag = "Engineering - Port Engineering Hub Deck 3";
-	dir = 6;
-	name = "engineering camera"
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "eSx" = (
@@ -27481,19 +27435,9 @@
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
 "fhg" = (
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
-	},
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering - Starboard Engineering Hub Deck 2";
-	dir = 9;
-	name = "engineering camera"
-	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/area/station/construction/mining/aux_base)
 "fhh" = (
 /turf/open/floor/plating,
 /area/station/science/auxlab/firing_range)
@@ -27551,8 +27495,10 @@
 	},
 /area/station/command/heads_quarters/ce)
 "fhD" = (
-/obj/machinery/power/smes,
 /obj/structure/cable,
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "fhE" = (
@@ -30063,6 +30009,7 @@
 /obj/item/computer_disk/maintenance/theme{
 	pixel_y = -10
 	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/smooth_edge{
 	dir = 1
 	},
@@ -30223,6 +30170,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering - Engine Foyer";
+	dir = 1;
+	name = "engineering camera"
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "fKP" = (
@@ -34510,6 +34462,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/engine,
 /area/station/science/explab)
 "gBb" = (
@@ -34877,6 +34830,7 @@
 "gFb" = (
 /obj/item/radio/intercom/directional/east,
 /obj/effect/landmark/start/barber,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/carpet/black,
 /area/station/service/barber)
 "gFg" = (
@@ -36823,11 +36777,6 @@
 /area/station/science/ordnance)
 "gZw" = (
 /obj/item/kirbyplants/organic/plant21,
-/obj/machinery/camera{
-	c_tag = "Engineering - Tcomms Controll 2";
-	dir = 10;
-	name = "engineering camera"
-	},
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "gZx" = (
@@ -37174,6 +37123,7 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/prison_upper)
 "hcO" = (
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "hcY" = (
@@ -38035,6 +37985,7 @@
 /obj/item/toy/figure/janitor,
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "hlQ" = (
@@ -38324,6 +38275,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hoE" = (
@@ -38480,6 +38432,11 @@
 /obj/machinery/firealarm/directional/north,
 /obj/item/pipe_dispenser,
 /obj/structure/sign/delam_procedure/directional/east,
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering - Engine Foyer";
+	dir = 1;
+	name = "engineering camera"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "hqF" = (
@@ -38641,6 +38598,20 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
+"hsu" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/structure/cable,
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "hsF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -39028,6 +38999,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/smooth_edge{
 	dir = 8
 	},
@@ -39453,11 +39425,6 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva/upper)
 "hCi" = (
-/obj/machinery/camera{
-	c_tag = "Chapel - Funeral Hall";
-	dir = 5;
-	name = "chapel camera"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -39465,6 +39432,7 @@
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/carpet,
 /area/station/service/chapel/funeral)
 "hCn" = (
@@ -39591,11 +39559,7 @@
 /obj/item/analyzer{
 	pixel_y = -4
 	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Engineering - Tech storage";
-	dir = 6;
-	name = "engineering camera"
-	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "hDp" = (
@@ -39699,6 +39663,11 @@
 /obj/item/clothing/glasses/meson,
 /obj/item/radio/intercom/directional/north,
 /obj/item/pipe_dispenser,
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering - Engine Foyer";
+	dir = 1;
+	name = "engineering camera"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "hDW" = (
@@ -40108,6 +40077,7 @@
 "hId" = (
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "hIe" = (
@@ -40332,11 +40302,7 @@
 /obj/item/pen,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/status_display/ai/directional/south,
-/obj/machinery/camera{
-	c_tag = "Departures Hallway - Fore";
-	dir = 5;
-	name = "hallway camera"
-	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hKi" = (
@@ -41436,11 +41402,7 @@
 /turf/open/floor/engine/vacuum,
 /area/station/maintenance/department/engineering/atmos_aux_port)
 "hUD" = (
-/obj/machinery/camera{
-	c_tag = "Leisure Hallway - Port Center";
-	dir = 10;
-	name = "hallway camera"
-	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/wood,
 /area/station/hallway/primary/port)
 "hUE" = (
@@ -43212,6 +43174,7 @@
 	pixel_y = 6
 	},
 /obj/item/food/burger/superbite,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/captain_dining)
 "imD" = (
@@ -43386,6 +43349,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/digital_clock/directional/east,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "iol" = (
@@ -43730,11 +43694,7 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology/control)
 "irJ" = (
-/obj/machinery/camera{
-	c_tag = "Leisure Hallway - Lowest Aft";
-	dir = 9;
-	name = "hallway camera"
-	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -49357,12 +49317,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/console_room)
 "jwh" = (
-/obj/machinery/camera/motion/directional/south{
-	c_tag = "Vault";
-	dir = 1;
-	network = list("vault")
-	},
 /obj/machinery/newscaster/directional/north,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/command/nuke_storage)
 "jwi" = (
@@ -51039,6 +50995,7 @@
 	},
 /obj/structure/window/spawner/directional/north,
 /obj/machinery/newscaster/directional/west,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "jME" = (
@@ -51992,6 +51949,7 @@
 "jUQ" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /mob/living/simple_animal/pet/poppy,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "jUS" = (
@@ -52605,11 +52563,6 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden/abandoned)
 "jZJ" = (
-/obj/machinery/camera{
-	c_tag = "Kitchen Diner Port";
-	dir = 10;
-	name = "service camera"
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
@@ -53896,6 +53849,7 @@
 /obj/item/stock_parts/cell/high,
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/cell_charger,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "kmc" = (
@@ -54172,12 +54126,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Central Hallway - Port Fore Central";
-	dir = 10;
-	name = "hallway camera"
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "koc" = (
@@ -54338,6 +54288,7 @@
 	dir = 10
 	},
 /obj/machinery/light/directional/east,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -54670,6 +54621,7 @@
 /area/station/hallway/primary/starboard)
 "kts" = (
 /obj/machinery/light_switch/directional/north,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "ktu" = (
@@ -55620,6 +55572,7 @@
 "kBG" = (
 /obj/structure/fans/tiny/forcefield,
 /obj/machinery/light/directional/east,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "kBM" = (
@@ -55827,6 +55780,7 @@
 "kDP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light_switch/directional/south,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/starboard/fore)
 "kDV" = (
@@ -55919,6 +55873,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
+"kEK" = (
+/obj/effect/turf_decal/stripes,
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/plating,
+/area/station/cargo/storage)
 "kEQ" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
@@ -56420,15 +56379,11 @@
 	dir = 4
 	},
 /obj/machinery/newscaster/directional/north,
-/obj/machinery/camera{
-	c_tag = "Dorm Hallway - Upper Fore Port";
-	dir = 9;
-	name = "hallway camera"
-	},
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/vg_decals/numbers/two,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "kKI" = (
@@ -56727,6 +56682,7 @@
 	dir = 4;
 	pixel_x = -5
 	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/wood,
 /area/station/service/barber)
 "kNR" = (
@@ -59614,14 +59570,10 @@
 	},
 /obj/structure/cable,
 /obj/machinery/light/directional/east,
-/obj/machinery/camera{
-	c_tag = "Dorm Hallway - Aft Port";
-	dir = 6;
-	name = "hallway camera"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "lsc" = (
@@ -60944,10 +60896,6 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/engine_access,
-/obj/machinery/camera/directional/east{
-	c_tag = "Engineering - Supermatter Airlock";
-	name = "engineering camera"
-	},
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Gas to Chamber"
 	},
@@ -61497,12 +61445,7 @@
 	pixel_y = 0
 	},
 /obj/effect/mapping_helpers/requests_console/ore_update,
-/obj/machinery/camera{
-	c_tag = "Medbay - Virology Upper";
-	dir = 10;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/virology/isolation)
 "lLC" = (
@@ -62142,14 +62085,10 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
 "lRG" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Security - Brig Cell 3"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "lRK" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/spawner/random/trash/mopbucket,
@@ -62306,6 +62245,7 @@
 /obj/effect/turf_decal/stripes{
 	dir = 8
 	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "lTe" = (
@@ -62918,6 +62858,7 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/item/ai_module/core/full/armadyne_safeguard,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "lYV" = (
@@ -63561,10 +63502,7 @@
 /area/station/security/lockers)
 "mfE" = (
 /obj/machinery/light_switch/directional/north,
-/obj/machinery/camera{
-	c_tag = "Security - Outpost Entrance";
-	dir = 1
-	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "mfI" = (
@@ -64638,6 +64576,7 @@
 /obj/structure/flora/bush/flowers_br,
 /obj/structure/window/spawner/directional/south,
 /obj/structure/sign/poster/random/directional/north,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/grass,
 /area/station/common/cryopods)
 "mrn" = (
@@ -64963,14 +64902,10 @@
 /turf/closed/wall,
 /area/station/maintenance/central)
 "mvl" = (
-/obj/machinery/camera{
-	c_tag = "Central Hallway - Port Bow";
-	dir = 10;
-	name = "hallway camera"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "mvo" = (
@@ -65574,15 +65509,11 @@
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/delivery,
 /obj/structure/noticeboard/directional/south,
-/obj/machinery/camera{
-	c_tag = "Kitchen Lower";
-	dir = 5;
-	name = "service camera"
-	},
 /obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "mBw" = (
@@ -66354,6 +66285,7 @@
 "mIv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light_switch/directional/south,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/fore)
 "mIw" = (
@@ -66448,6 +66380,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science)
+"mJy" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack/shelf,
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/cargo/warehouse)
 "mJC" = (
 /obj/item/radio/intercom/chapel{
 	pixel_y = 22
@@ -67685,20 +67623,12 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/obj/machinery/camera{
-	c_tag = "Central Hallway - Law Office Entrance";
-	dir = 5;
-	name = "hallway camera"
-	},
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/wood,
 /area/station/hallway/primary/central)
 "mVt" = (
-/obj/machinery/camera{
-	c_tag = "Central Hallway - Fore Starboard Bow";
-	dir = 10;
-	name = "hallway camera"
-	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "mVv" = (
@@ -68837,9 +68767,6 @@
 "nha" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/cable,
-/obj/machinery/camera/directional/west{
-	c_tag = "Security - Brig Cell 1"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -69395,10 +69322,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/noticeboard/directional/east,
-/obj/machinery/camera/directional/west{
-	c_tag = "Engineering - Tcomms Controll";
-	name = "engineering camera"
-	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "nnG" = (
@@ -70088,14 +70012,10 @@
 /turf/open/floor/iron,
 /area/station/science/tele_sci)
 "nvW" = (
-/obj/machinery/camera{
-	c_tag = "Central Hallway - Whiteship Dock";
-	dir = 5;
-	name = "hallway camera"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/south,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/secondary/exit)
 "nwc" = (
@@ -71229,6 +71149,7 @@
 	pixel_y = -25
 	},
 /obj/machinery/light/small/red/dim/directional/south,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "nGF" = (
@@ -72139,17 +72060,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "nQo" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/stripes{
+	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Central Hallway - Port Foremost Central";
-	dir = 10;
-	name = "hallway camera"
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering - Engine Foyer";
+	dir = 1;
+	name = "engineering camera"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "nQt" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
@@ -72614,6 +72534,7 @@
 	},
 /obj/machinery/light/directional/north,
 /obj/item/radio/intercom/directional/north,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/command/captain_dining)
 "nUn" = (
@@ -73558,10 +73479,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/lesser)
 "odS" = (
-/obj/machinery/camera{
-	c_tag = "Command Hallway - Upper Port";
-	dir = 10
-	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -73855,6 +73773,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "ogv" = (
@@ -75610,6 +75529,12 @@
 "owf" = (
 /turf/closed/wall,
 /area/station/engineering/break_room)
+"owm" = (
+/obj/machinery/camera/autoname/directional/east,
+/turf/open/floor/iron/smooth_edge{
+	dir = 4
+	},
+/area/station/engineering/atmos/hfr_room)
 "owp" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
@@ -76260,11 +76185,7 @@
 /area/station/maintenance/port/upper)
 "oCb" = (
 /obj/machinery/telecomms/receiver/preset_left,
-/obj/machinery/camera{
-	c_tag = "Engineering - Tcomms Lower";
-	dir = 10;
-	name = "engineering camera"
-	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "oCd" = (
@@ -76936,6 +76857,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "oJc" = (
@@ -77591,11 +77513,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Central Hallway - Lower Port Central";
-	dir = 10;
-	name = "hallway camera"
-	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -78871,11 +78789,6 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
-/obj/machinery/camera/directional/north{
-	c_tag = "AI - Upload";
-	name = "motion-sensitive ai camera";
-	network = list("aiupload")
-	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "pcy" = (
@@ -78985,11 +78898,6 @@
 /area/station/common/laser_tag)
 "pep" = (
 /obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Kitchen Diner Starboard";
-	dir = 6;
-	name = "service camera"
-	},
 /obj/machinery/airalarm/directional/east,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/kitchen,
@@ -79563,11 +79471,7 @@
 /area/station/commons/storage/primary)
 "pjA" = (
 /obj/machinery/telecomms/receiver/preset_right,
-/obj/machinery/camera/directional/west{
-	c_tag = "Engineering - Tcomms Upper";
-	dir = 6;
-	name = "engineering camera"
-	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "pjB" = (
@@ -80209,12 +80113,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "pre" = (
-/obj/machinery/camera{
-	c_tag = "Security - Interrogation Monitoring";
-	dir = 10
-	},
 /obj/machinery/light_switch/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -81169,6 +81070,7 @@
 /area/station/medical/morgue)
 "pzN" = (
 /obj/structure/sink/kitchen/directional/south,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "pzS" = (
@@ -81408,6 +81310,13 @@
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"pCL" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "pCO" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -82450,23 +82359,18 @@
 /turf/open/floor/iron/shuttle/arrivals/airless,
 /area/space/nearstation)
 "pMQ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/bed{
+	dir = 1;
+	pixel_y = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/item/bedsheet{
+	dir = 1;
+	pixel_y = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Dorm Hallway - Lower Aft Port";
-	dir = 10;
-	name = "hallway camera"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "pMR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/curtain/bounty,
@@ -82705,6 +82609,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "pPJ" = (
@@ -83361,6 +83266,7 @@
 	dir = 4;
 	pixel_x = -5
 	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "pWp" = (
@@ -83949,11 +83855,6 @@
 /area/station/maintenance/department/medical)
 "qcc" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/camera{
-	c_tag = "Departures Hallway - Airlock";
-	dir = 6;
-	name = "hallway camera"
-	},
 /obj/effect/turf_decal/tile/red{
 	color = "#DE3A3A";
 	dir = 8
@@ -83962,6 +83863,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
 "qce" = (
@@ -84165,6 +84067,11 @@
 /obj/effect/turf_decal/siding/thinplating/dark/end,
 /obj/structure/drain,
 /obj/structure/sign/poster/official/safety_internals/directional/north,
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering - Engine Foyer";
+	dir = 1;
+	name = "engineering camera"
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/test_chambers)
 "qdF" = (
@@ -84898,6 +84805,7 @@
 "qkH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/bci_implanter,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/science/circuits)
 "qkI" = (
@@ -85476,11 +85384,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/status_display/ai/directional/north,
 /obj/item/storage/dice,
-/obj/machinery/camera{
-	c_tag = "Departures Hallway - Lower";
-	dir = 9;
-	name = "hallway camera"
-	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "qqZ" = (
@@ -86677,10 +86581,6 @@
 "qBh" = (
 /obj/structure/cable,
 /obj/machinery/newscaster/directional/north,
-/obj/machinery/camera{
-	c_tag = "Security - Outpost";
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -87087,17 +86987,13 @@
 "qES" = (
 /obj/machinery/status_display/evac/directional/west,
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/camera{
-	c_tag = "Bridge - Head of Personnel's Office";
-	dir = 9;
-	name = "command camera"
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /obj/machinery/computer/accounting{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "qEU" = (
@@ -87375,6 +87271,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"qHs" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/upper)
 "qHx" = (
 /obj/structure/rack,
 /obj/item/electronics/airlock,
@@ -88192,15 +88095,9 @@
 /turf/open/floor/carpet,
 /area/station/service/library/printer)
 "qQh" = (
-/obj/machinery/camera{
-	c_tag = "Security - Brig Cell 6";
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
+/obj/machinery/camera/directional/east,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/test_chambers)
 "qQi" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -88650,6 +88547,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/light/directional/south,
+/obj/machinery/camera/directional/south,
 /turf/open/floor/iron/stairs/old{
 	dir = 8
 	},
@@ -88942,6 +88840,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/command)
 "qXk" = (
@@ -89394,6 +89293,15 @@
 "rbs" = (
 /turf/closed/wall,
 /area/station/medical/patients_rooms)
+"rbw" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible/layer2,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "rbD" = (
 /obj/effect/decal/cleanable/blood/innards,
 /mob/living/carbon/human/species/monkey/angry{
@@ -91822,6 +91730,7 @@
 /area/station/command/heads_quarters/captain/private)
 "ryz" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/security/checkpoint)
 "ryA" = (
@@ -92026,11 +91935,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Central Hallway - Port Central";
-	dir = 10;
-	name = "hallway camera"
-	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "rBT" = (
@@ -92418,14 +92323,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/porta_turret/ai,
-/obj/machinery/camera/directional/north{
-	c_tag = "AI Satellite - Antechamber";
-	name = "ai camera";
-	network = list("minisat");
-	start_active = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "rED" = (
@@ -94126,10 +94026,6 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "rXk" = (
-/obj/machinery/camera{
-	c_tag = "Security - Brig Cell 5";
-	dir = 6
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -94144,10 +94040,7 @@
 /turf/open/floor/iron/freezer,
 /area/station/science/xenobiology)
 "rXp" = (
-/obj/machinery/camera{
-	c_tag = "Command Hallway - Lower Port";
-	dir = 10
-	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "rXr" = (
@@ -94401,6 +94294,7 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/service/kitchen/diner)
 "rZN" = (
@@ -94640,15 +94534,10 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
 	},
-/obj/machinery/camera{
-	c_tag = "Medbay - Virology Ward 1";
-	dir = 9;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "scc" = (
@@ -95093,15 +94982,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
-/obj/machinery/camera{
-	c_tag = "Medbay - Pysch Ward Entrance";
-	dir = 6;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "sgz" = (
@@ -95632,11 +95516,6 @@
 /obj/structure/rack,
 /obj/item/storage/box/shipping,
 /obj/item/pushbroom,
-/obj/machinery/camera{
-	c_tag = "Cargo Bay - Sorting";
-	dir = 10;
-	name = "cargo camera"
-	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
@@ -96204,12 +96083,8 @@
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/west,
-/obj/machinery/camera{
-	c_tag = "Upper Central Hallway - Upper Port Aft";
-	dir = 10;
-	name = "hallway camera"
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper)
 "ssB" = (
@@ -96830,6 +96705,12 @@
 /obj/item/storage/photo_album,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"sxK" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/space_heater,
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/pumproom)
 "sxM" = (
 /turf/open/floor/iron/stairs/medium{
 	dir = 1
@@ -96993,16 +96874,11 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "sAc" = (
-/obj/machinery/camera{
-	c_tag = "Medbay - Ward Cell 2";
-	dir = 5;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/mineral/titanium/tiled/white{
 	name = "Padded tile"
 	},
@@ -97872,10 +97748,6 @@
 	dir = 4
 	},
 /obj/structure/window/spawner/directional/south,
-/obj/machinery/camera{
-	c_tag = "Security - Labor Shuttle Control";
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "sIk" = (
@@ -98469,6 +98341,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tcomms)
 "sNu" = (
@@ -99752,6 +99625,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "sZC" = (
@@ -99832,10 +99706,7 @@
 	},
 /area/station/security/prison)
 "tay" = (
-/obj/machinery/camera{
-	c_tag = "Courtroom - Center";
-	dir = 10
-	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "taF" = (
@@ -102291,14 +102162,10 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "tyO" = (
-/obj/machinery/camera{
-	c_tag = "Recreation - Barbershop Lower";
-	dir = 5;
-	name = "hallway camera"
-	},
 /obj/structure/chair/comfy/barber_chair{
 	dir = 8
 	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/wood/tile,
 /area/station/service/barber)
 "tyT" = (
@@ -102459,15 +102326,10 @@
 "tzR" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/machinery/camera{
-	c_tag = "Science - Xenobio Starboard";
-	dir = 5;
-	name = "science camera";
-	network = list("ss13","rd")
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "tzV" = (
@@ -102918,6 +102780,7 @@
 	dir = 8
 	},
 /obj/structure/displaycase/forsale,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/common/gaskiosk)
 "tDU" = (
@@ -103276,6 +103139,7 @@
 /area/station/medical/pharmacy)
 "tHQ" = (
 /obj/structure/sink/directional/north,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -104178,12 +104042,7 @@
 	dir = 5
 	},
 /obj/machinery/newscaster/directional/east,
-/obj/machinery/camera{
-	c_tag = "Medbay - Viro Entrance";
-	dir = 6;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "tQv" = (
@@ -105226,16 +105085,12 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics)
 "uck" = (
-/obj/machinery/camera{
-	c_tag = "Starboard Hallway - Info Kiosk";
-	dir = 10;
-	name = "hallway camera"
-	},
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "ucl" = (
@@ -105250,12 +105105,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "ucm" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Security - Brig Cell 2"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "ucn" = (
@@ -107635,12 +107488,6 @@
 "uxK" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/camera{
-	c_tag = "Medbay - Pharmacy";
-	dir = 10;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
 /obj/machinery/requests_console/directional/south{
 	department = "Pharmacy";
 	name = "Pharmacy Requests Console";
@@ -107652,6 +107499,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "uxO" = (
@@ -109961,11 +109809,6 @@
 	icon_state = "dirt-flat-1"
 	},
 /obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Engineering - Port Engineering Hub Deck 3";
-	dir = 6;
-	name = "engineering camera"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -110380,12 +110223,8 @@
 "uYQ" = (
 /obj/structure/closet/athletic_mixed,
 /obj/effect/turf_decal/bot,
-/obj/machinery/camera{
-	c_tag = "Recreation - Gym Lockers";
-	dir = 5;
-	name = "hallway camera"
-	},
 /obj/item/clothing/shoes/sports,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/common/locker_room_shower)
 "uYS" = (
@@ -111306,14 +111145,10 @@
 "viT" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Dorm Hallway - Central";
-	dir = 5;
-	name = "hallway camera"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "viU" = (
@@ -113540,6 +113375,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/service/bar/backroom)
+"vDp" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "vDx" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -113698,6 +113540,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom/directional/north,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "vEE" = (
@@ -114197,11 +114040,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "vIV" = (
-/obj/machinery/camera{
-	c_tag = "Recreation - Nightclub Lower";
-	dir = 5;
-	name = "hallway camera"
-	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/stairs{
 	dir = 8
 	},
@@ -114589,12 +114428,6 @@
 "vMy" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/spawner/random/trash/garbage,
-/obj/machinery/camera{
-	c_tag = "Disposal Driver";
-	dir = 6;
-	name = "Disposal Driver Camera";
-	network = list("Trash")
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "vMA" = (
@@ -115338,6 +115171,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"vUD" = (
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/iron/large,
+/area/station/ai_monitored/turret_protected/ai_upload)
 "vUH" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable,
@@ -115685,17 +115522,13 @@
 /area/station/maintenance/port/aft)
 "vYB" = (
 /obj/structure/table/wood,
-/obj/machinery/camera{
-	c_tag = "Bar - Fore 2";
-	dir = 6;
-	name = "service camera"
-	},
 /obj/item/radio/intercom/directional/east,
 /obj/structure/cable,
 /obj/machinery/pollution_scrubber{
 	pixel_x = 7;
 	pixel_y = -5
 	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
 "vYF" = (
@@ -116931,10 +116764,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/south,
 /obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Security - Genpop Lockers";
-	dir = 5
-	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark/side,
 /area/station/security/prison)
 "wjw" = (
@@ -117172,12 +117002,8 @@
 /area/station/engineering/supermatter/room)
 "wlJ" = (
 /obj/structure/bookcase/random/fiction,
-/obj/machinery/camera{
-	c_tag = "Bridge - Captain's Upper Office";
-	dir = 9;
-	name = "command camera"
-	},
 /obj/item/radio/intercom/directional/north,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
 "wlK" = (
@@ -118097,6 +117923,7 @@
 /obj/machinery/light/directional/east,
 /obj/machinery/light_switch/directional/east,
 /obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
 "wus" = (
@@ -118207,6 +118034,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/landmark/event_spawn,
 /obj/item/radio/intercom/directional/north,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/wood,
 /area/station/service/chapel/funeral)
 "wvg" = (
@@ -118414,10 +118242,6 @@
 /obj/item/clothing/head/cone,
 /obj/item/clothing/head/cone,
 /obj/item/clothing/head/cone,
-/obj/machinery/camera/directional/north{
-	c_tag = "Engineering - Fore Central";
-	name = "engineering camera"
-	},
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
@@ -118430,10 +118254,6 @@
 /area/station/service/chapel/funeral)
 "wyf" = (
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/camera{
-	c_tag = "Security - Brig Cell 4";
-	dir = 6
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -119109,11 +118929,6 @@
 /obj/structure/secure_safe/directional/east,
 /obj/structure/cable,
 /obj/machinery/light/directional/east,
-/obj/machinery/camera{
-	c_tag = "Bridge - Head of Personnel's Quarters";
-	dir = 6;
-	name = "command camera"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
@@ -119129,6 +118944,7 @@
 "wDy" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "wDB" = (
@@ -119668,10 +119484,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Security - Labor Shuttle Dock";
-	dir = 10
-	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "wJj" = (
@@ -122517,6 +122330,7 @@
 	dir = 1;
 	name = "Gas to Filter"
 	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "xnt" = (
@@ -123732,13 +123546,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/eva)
 "xzu" = (
-/obj/machinery/camera{
-	c_tag = "Departures Hallway - Staircase";
-	dir = 5;
-	name = "hallway camera"
-	},
 /obj/machinery/light/directional/south,
 /obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "xzv" = (
@@ -124674,13 +124484,9 @@
 	},
 /area/station/hallway/primary/upper)
 "xJi" = (
-/obj/machinery/camera{
-	c_tag = "Leisure Hallway - Lower Center";
-	dir = 10;
-	name = "hallway camera"
-	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -124723,12 +124529,8 @@
 "xJN" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/bot,
-/obj/machinery/camera{
-	c_tag = "Engineering - Gravgen Airlock";
-	dir = 6;
-	name = "engineering camera"
-	},
 /obj/machinery/light/small/directional/north,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "xJP" = (
@@ -125189,13 +124991,9 @@
 /area/station/service/abandoned_gambling_den)
 "xNW" = (
 /obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Chapel Office Hallway";
-	dir = 5;
-	name = "chapel camera"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "xOi" = (
@@ -125440,6 +125238,7 @@
 /area/station/security/interrogation)
 "xQS" = (
 /obj/machinery/light_switch/directional/south,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/command/nuke_storage)
 "xQY" = (
@@ -126108,12 +125907,9 @@
 /obj/item/clothing/head/bio_hood/security,
 /obj/item/clothing/head/bio_hood/security,
 /obj/item/clothing/head/bio_hood/security,
-/obj/machinery/camera{
-	c_tag = "Security - EVA Storage";
-	dir = 10
-	},
 /obj/machinery/light/directional/west,
 /obj/machinery/newscaster/directional/west,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -126813,6 +126609,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "ydM" = (
@@ -127070,14 +126867,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/upper)
 "ygl" = (
-/obj/machinery/camera{
-	c_tag = "Security - Brig Starboard";
-	dir = 10
-	},
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "ygn" = (
@@ -127634,11 +127428,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Bridge - Gateway Chamber";
-	dir = 9;
-	name = "command camera"
-	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/circuit,
 /area/station/command/gateway)
 "ylq" = (
@@ -151499,7 +151289,7 @@ vfU
 hyA
 hyA
 hyA
-phI
+vDp
 oXz
 feR
 qCP
@@ -152538,7 +152328,7 @@ dKA
 mIR
 mIR
 mIR
-mIR
+fhg
 mIR
 mIR
 mIR
@@ -157613,7 +157403,7 @@ csj
 uiE
 ceg
 mOg
-nQo
+knY
 mME
 ntd
 qGV
@@ -158230,7 +158020,7 @@ bgi
 jza
 bgi
 jJU
-mNE
+nQo
 eFF
 wnv
 lnX
@@ -158248,7 +158038,7 @@ kkg
 cmD
 sZC
 rhi
-rhi
+rbw
 rhi
 oeM
 szD
@@ -159743,7 +159533,7 @@ lLD
 inZ
 aYU
 tmp
-bJh
+sxK
 cuf
 inF
 cuf
@@ -160939,7 +160729,7 @@ cFp
 jUO
 wrN
 nha
-rfX
+pMQ
 vdZ
 vdZ
 vdZ
@@ -161199,7 +160989,7 @@ dMw
 ykG
 ucm
 rfX
-lRG
+ucm
 wjF
 hGf
 ekE
@@ -161311,7 +161101,7 @@ gpz
 gpz
 rcB
 jJU
-rAD
+ccw
 hAI
 rAD
 pOM
@@ -162741,7 +162531,7 @@ ien
 pJB
 rXk
 eQE
-qQh
+rXk
 wDy
 hGf
 sfn
@@ -163552,7 +163342,7 @@ cTZ
 nGY
 nGi
 prV
-jAZ
+ahx
 ftj
 eSN
 aUO
@@ -166452,7 +166242,7 @@ sQQ
 kfT
 sQQ
 sQQ
-sQQ
+qQh
 puX
 ued
 sQQ
@@ -167923,7 +167713,7 @@ fAl
 eWl
 dIK
 eFn
-erB
+mJy
 eGW
 nKK
 eFn
@@ -168722,7 +168512,7 @@ ukT
 bNR
 iBc
 mvD
-cve
+dOp
 cNn
 kxo
 rdt
@@ -169437,7 +169227,7 @@ cLX
 qgy
 hRu
 dVy
-fhg
+xgN
 baE
 dzs
 rtr
@@ -170509,7 +170299,7 @@ gfF
 gfF
 gfF
 gfF
-smi
+kEK
 qaC
 tpp
 eUy
@@ -171064,7 +170854,7 @@ aCz
 hhd
 nGa
 arA
-arA
+owm
 arA
 nGa
 arA
@@ -171579,7 +171369,7 @@ jfg
 bzG
 nux
 aqq
-aqq
+dhT
 bvA
 ivx
 tbz
@@ -213136,7 +212926,7 @@ xnw
 hOn
 sSX
 jLC
-qhW
+cUm
 qhW
 cXy
 dAB
@@ -215211,9 +215001,9 @@ rCV
 bcK
 rCV
 cKb
-pMQ
-bcK
 rCV
+bcK
+hsu
 fjj
 rCV
 bcK
@@ -217021,7 +216811,7 @@ aFP
 jda
 xkC
 acy
-sQD
+cnZ
 noh
 khi
 hpn
@@ -219316,7 +219106,7 @@ hhF
 xWy
 vhM
 gpu
-lvV
+pCL
 rCL
 wWd
 qSE
@@ -223755,7 +223545,7 @@ mya
 pWp
 mBe
 tyf
-tyf
+cUI
 fDT
 uJk
 ldA
@@ -224221,7 +224011,7 @@ ctE
 gyk
 xcT
 hCo
-xcK
+qHs
 xht
 mhL
 mhL
@@ -224417,7 +224207,7 @@ hiZ
 wlj
 vzV
 gJh
-lCL
+vUD
 jiu
 uKd
 vNL
@@ -225811,7 +225601,7 @@ kzI
 oxK
 xXm
 dNw
-dNw
+lRG
 fDT
 aQu
 ieW
@@ -231688,7 +231478,7 @@ rlK
 rvl
 udr
 jBZ
-cnZ
+sAc
 osg
 psl
 sob
@@ -233744,7 +233534,7 @@ rlK
 hFJ
 xxW
 jBZ
-dhT
+sAc
 pUQ
 sbR
 qwm

--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -682,15 +682,6 @@
 "ahn" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/entry)
-"ahx" = (
-/obj/structure/window/spawner/directional/east,
-/obj/structure/chair/sofa/corp/left{
-	color = "#DE3A3A";
-	dir = 8
-	},
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron/kitchen,
-/area/station/service/kitchen/diner)
 "ahz" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
@@ -5820,7 +5811,9 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
 	},
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "bio" = (
@@ -6164,7 +6157,9 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /obj/machinery/newscaster/directional/west,
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "blx" = (
@@ -7227,6 +7222,18 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/engine,
 /area/station/command/secure_bunker)
+"bui" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering - Engine Foyer";
+	dir = 1;
+	name = "engineering camera"
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "buC" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
@@ -7794,6 +7801,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
+"bzT" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","xeno","rd")
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "bzY" = (
 /obj/structure/plasticflaps/opaque,
 /obj/structure/disposalpipe/segment{
@@ -10676,18 +10690,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
-"ccw" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Engineering - Engine Foyer";
-	dir = 1;
-	name = "engineering camera"
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
 "ccx" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -11879,12 +11881,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/test_chambers)
 "cnZ" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/turf_decal/bot,
 /obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/engine,
-/area/station/science/explab)
+/turf/open/floor/iron/dark,
+/area/station/commons/dorms)
 "cob" = (
 /obj/structure/ore_box,
 /obj/effect/decal/cleanable/dirt{
@@ -13661,7 +13662,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Science - Xenobio Office";
 	name = "science camera";
-	network = list("ss13","rd")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology/control)
@@ -15565,12 +15566,6 @@
 /obj/structure/drain,
 /turf/open/floor/iron/freezer,
 /area/station/commons/dorms/room6)
-"cUm" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/effect/turf_decal/bot,
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/commons/dorms)
 "cUu" = (
 /obj/structure/window/spawner/directional/south,
 /obj/structure/chair/sofa/middle/brown{
@@ -15615,11 +15610,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
-"cUI" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "cUJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/railing/corner/end{
@@ -16504,6 +16494,10 @@
 /obj/structure/closet/secure_closet/injection,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
+"des" = (
+/obj/machinery/camera/directional/east,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/test_chambers)
 "det" = (
 /obj/machinery/porta_turret/lasertag/red,
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
@@ -16883,9 +16877,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "dhT" = (
-/obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/mineral/titanium/tiled/white{
+	name = "Padded tile"
+	},
+/area/station/medical/aslyum)
 "dhU" = (
 /obj/machinery/shower/directional/west{
 	name = "emergency shower"
@@ -20140,13 +20140,6 @@
 	dir = 4
 	},
 /area/station/security/prison/workout)
-"dOp" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
-/obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/iron/dark/small,
-/area/station/cargo/miningdock)
 "dOX" = (
 /obj/structure/disposalpipe/trunk/multiz{
 	dir = 1
@@ -21469,7 +21462,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","xeno","rd")
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "edc" = (
@@ -27435,9 +27430,12 @@
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
 "fhg" = (
-/obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/plating,
-/area/station/construction/mining/aux_base)
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/engine,
+/area/station/science/explab)
 "fhh" = (
 /turf/open/floor/plating,
 /area/station/science/auxlab/firing_range)
@@ -31252,6 +31250,19 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"fVN" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/bed{
+	dir = 1;
+	pixel_y = 8
+	},
+/obj/item/bedsheet{
+	dir = 1;
+	pixel_y = 8
+	},
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "fVQ" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/spawner/random/vending/colavend,
@@ -35806,7 +35817,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Science - Xenobio Starboard Pens";
 	name = "science camera";
-	network = list("ss13","rd")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
@@ -38598,20 +38609,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
-"hsu" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/obj/structure/cable,
-/obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "hsF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -42132,6 +42129,13 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/smooth_edge,
 /area/station/cargo/miningdock)
+"icc" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","xeno","rd")
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "icm" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -43112,7 +43116,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/directional/south,
+/obj/machinery/camera/directional/south{
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "ilW" = (
@@ -50560,6 +50566,17 @@
 	dir = 8
 	},
 /area/station/command/gateway)
+"jIh" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering - Engine Foyer";
+	dir = 1;
+	name = "engineering camera"
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "jIk" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
@@ -55873,11 +55890,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
-"kEK" = (
-/obj/effect/turf_decal/stripes,
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/plating,
-/area/station/cargo/storage)
 "kEQ" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
@@ -57648,7 +57660,7 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Science - Xenobio Port Pens";
 	name = "science camera";
-	network = list("ss13","rd")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
@@ -58174,6 +58186,15 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"ldL" = (
+/obj/structure/window/spawner/directional/east,
+/obj/structure/chair/sofa/corp/left{
+	color = "#DE3A3A";
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen/diner)
 "ldP" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/siding/wood,
@@ -59932,6 +59953,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"lvY" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "lwb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/green/visible,
@@ -61445,7 +61473,9 @@
 	pixel_y = 0
 	},
 /obj/effect/mapping_helpers/requests_console/ore_update,
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology/isolation)
 "lLC" = (
@@ -62085,10 +62115,12 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
 "lRG" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "lRK" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/spawner/random/trash/mopbucket,
@@ -64256,6 +64288,11 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"mnZ" = (
+/obj/effect/turf_decal/stripes,
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/plating,
+/area/station/cargo/storage)
 "moh" = (
 /obj/machinery/door/airlock/silver{
 	name = "Locker Room"
@@ -66380,12 +66417,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science)
-"mJy" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack/shelf,
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
 "mJC" = (
 /obj/item/radio/intercom/chapel{
 	pixel_y = 22
@@ -68359,7 +68390,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/camera/directional/north,
+/obj/machinery/camera/directional/north{
+	network = list("ss13","xeno","rd")
+	},
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "ndp" = (
@@ -71842,6 +71875,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/upper)
+"nNN" = (
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/plating,
+/area/station/construction/mining/aux_base)
 "nNP" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -72060,16 +72097,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "nQo" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
+/obj/machinery/camera/autoname/directional/east,
+/turf/open/floor/iron/smooth_edge{
+	dir = 4
 	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Engineering - Engine Foyer";
-	dir = 1;
-	name = "engineering camera"
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/atmos/hfr_room)
 "nQt" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
@@ -73773,7 +73805,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/camera/autoname/directional/north{
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "ogv" = (
@@ -75529,12 +75563,6 @@
 "owf" = (
 /turf/closed/wall,
 /area/station/engineering/break_room)
-"owm" = (
-/obj/machinery/camera/autoname/directional/east,
-/turf/open/floor/iron/smooth_edge{
-	dir = 4
-	},
-/area/station/engineering/atmos/hfr_room)
 "owp" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
@@ -81310,13 +81338,6 @@
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"pCL" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "pCO" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -82359,18 +82380,11 @@
 /turf/open/floor/iron/shuttle/arrivals/airless,
 /area/space/nearstation)
 "pMQ" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/bed{
-	dir = 1;
-	pixel_y = 8
-	},
-/obj/item/bedsheet{
-	dir = 1;
-	pixel_y = 8
-	},
-/obj/machinery/camera/autoname/directional/west,
+/obj/effect/turf_decal/bot,
+/obj/structure/rack/shelf,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/security/brig)
+/area/station/cargo/warehouse)
 "pMR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/curtain/bounty,
@@ -87271,13 +87285,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
-"qHs" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper)
 "qHx" = (
 /obj/structure/rack,
 /obj/item/electronics/airlock,
@@ -88095,9 +88102,9 @@
 /turf/open/floor/carpet,
 /area/station/service/library/printer)
 "qQh" = (
-/obj/machinery/camera/directional/east,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
-/area/station/engineering/atmos/test_chambers)
+/area/station/hallway/secondary/entry)
 "qQi" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -89293,15 +89300,6 @@
 "rbs" = (
 /turf/closed/wall,
 /area/station/medical/patients_rooms)
-"rbw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible/layer2,
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "rbD" = (
 /obj/effect/decal/cleanable/blood/innards,
 /mob/living/carbon/human/species/monkey/angry{
@@ -90312,7 +90310,9 @@
 /area/station/common/arcade)
 "rkS" = (
 /obj/effect/turf_decal/stripes/red/line,
-/obj/machinery/camera/directional/south,
+/obj/machinery/camera/directional/south{
+	network = list("ss13","xeno","rd")
+	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "rkT" = (
@@ -90961,7 +90961,9 @@
 /area/station/maintenance/department/crew_quarters/dorms)
 "rrK" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "rrO" = (
@@ -94537,7 +94539,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "scc" = (
@@ -94985,7 +94989,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "sgz" = (
@@ -96705,12 +96711,6 @@
 /obj/item/storage/photo_album,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"sxK" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/space_heater,
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
 "sxM" = (
 /turf/open/floor/iron/stairs/medium{
 	dir = 1
@@ -96874,15 +96874,11 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "sAc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/bot,
+/obj/machinery/space_heater,
 /obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/mineral/titanium/tiled/white{
-	name = "Padded tile"
-	},
-/area/station/medical/aslyum)
+/turf/open/floor/iron,
+/area/station/engineering/atmos/pumproom)
 "sAe" = (
 /obj/machinery/power/shuttle_engine/heater{
 	dir = 4
@@ -99625,7 +99621,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "sZC" = (
@@ -102329,7 +102327,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","xeno","rd")
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "tzV" = (
@@ -103846,6 +103846,13 @@
 	},
 /turf/open/floor/iron/white/side,
 /area/station/medical/aslyum)
+"tON" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
+	},
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron/dark/small,
+/area/station/cargo/miningdock)
 "tOP" = (
 /obj/item/flashlight/flare/candle/infinite{
 	pixel_x = -15;
@@ -104042,7 +104049,9 @@
 	dir = 5
 	},
 /obj/machinery/newscaster/directional/east,
-/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "tQv" = (
@@ -105105,12 +105114,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "ucm" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/structure/cable,
 /obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "ucn" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -107499,7 +107515,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "uxO" = (
@@ -111863,7 +111881,9 @@
 /area/station/maintenance/port/fore)
 "vpR" = (
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/camera/directional/east,
+/obj/machinery/camera/directional/east{
+	network = list("ss13","xeno","rd")
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "vpS" = (
@@ -113375,13 +113395,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/service/bar/backroom)
-"vDp" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "vDx" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -115171,10 +115184,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
-"vUD" = (
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron/large,
-/area/station/ai_monitored/turret_protected/ai_upload)
 "vUH" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable,
@@ -117257,6 +117266,15 @@
 	dir = 4
 	},
 /area/station/science/research)
+"wnJ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible/layer2,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "wnO" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/effect/decal/cleanable/dirt{
@@ -119401,6 +119419,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
+"wIv" = (
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/iron/large,
+/area/station/ai_monitored/turret_protected/ai_upload)
 "wIx" = (
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
@@ -119609,6 +119631,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
+"wKL" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/upper)
 "wKQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -124786,6 +124815,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"xMg" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "xMj" = (
 /obj/structure/railing/wooden_fencing{
 	dir = 8
@@ -151289,7 +151325,7 @@ vfU
 hyA
 hyA
 hyA
-vDp
+lvY
 oXz
 feR
 qCP
@@ -152328,7 +152364,7 @@ dKA
 mIR
 mIR
 mIR
-fhg
+nNN
 mIR
 mIR
 mIR
@@ -158020,7 +158056,7 @@ bgi
 jza
 bgi
 jJU
-nQo
+jIh
 eFF
 wnv
 lnX
@@ -158038,7 +158074,7 @@ kkg
 cmD
 sZC
 rhi
-rbw
+wnJ
 rhi
 oeM
 szD
@@ -159533,7 +159569,7 @@ lLD
 inZ
 aYU
 tmp
-sxK
+sAc
 cuf
 inF
 cuf
@@ -160729,7 +160765,7 @@ cFp
 jUO
 wrN
 nha
-pMQ
+fVN
 vdZ
 vdZ
 vdZ
@@ -160987,9 +161023,9 @@ pbC
 sum
 dMw
 ykG
-ucm
+lRG
 rfX
-ucm
+lRG
 wjF
 hGf
 ekE
@@ -161101,7 +161137,7 @@ gpz
 gpz
 rcB
 jJU
-ccw
+bui
 hAI
 rAD
 pOM
@@ -163342,7 +163378,7 @@ cTZ
 nGY
 nGi
 prV
-ahx
+ldL
 ftj
 eSN
 aUO
@@ -166242,7 +166278,7 @@ sQQ
 kfT
 sQQ
 sQQ
-qQh
+des
 puX
 ued
 sQQ
@@ -167713,7 +167749,7 @@ fAl
 eWl
 dIK
 eFn
-mJy
+pMQ
 eGW
 nKK
 eFn
@@ -168512,7 +168548,7 @@ ukT
 bNR
 iBc
 mvD
-dOp
+tON
 cNn
 kxo
 rdt
@@ -170299,7 +170335,7 @@ gfF
 gfF
 gfF
 gfF
-kEK
+mnZ
 qaC
 tpp
 eUy
@@ -170854,7 +170890,7 @@ aCz
 hhd
 nGa
 arA
-owm
+nQo
 arA
 nGa
 arA
@@ -171369,7 +171405,7 @@ jfg
 bzG
 nux
 aqq
-dhT
+qQh
 bvA
 ivx
 tbz
@@ -212926,7 +212962,7 @@ xnw
 hOn
 sSX
 jLC
-cUm
+cnZ
 qhW
 cXy
 dAB
@@ -215003,7 +215039,7 @@ rCV
 cKb
 rCV
 bcK
-hsu
+ucm
 fjj
 rCV
 bcK
@@ -216811,7 +216847,7 @@ aFP
 jda
 xkC
 acy
-cnZ
+fhg
 noh
 khi
 hpn
@@ -219106,7 +219142,7 @@ hhF
 xWy
 vhM
 gpu
-pCL
+xMg
 rCL
 wWd
 qSE
@@ -223545,7 +223581,7 @@ mya
 pWp
 mBe
 tyf
-cUI
+icc
 fDT
 uJk
 ldA
@@ -224011,7 +224047,7 @@ ctE
 gyk
 xcT
 hCo
-qHs
+wKL
 xht
 mhL
 mhL
@@ -224207,7 +224243,7 @@ hiZ
 wlj
 vzV
 gJh
-vUD
+wIv
 jiu
 uKd
 vNL
@@ -225601,7 +225637,7 @@ kzI
 oxK
 xXm
 dNw
-lRG
+bzT
 fDT
 aQu
 ieW
@@ -231478,7 +231514,7 @@ rlK
 rvl
 udr
 jBZ
-sAc
+dhT
 osg
 psl
 sob
@@ -232506,7 +232542,7 @@ foT
 hFJ
 hWC
 jBZ
-sAc
+dhT
 pUQ
 sbR
 sob
@@ -233534,7 +233570,7 @@ rlK
 hFJ
 xxW
 jBZ
-sAc
+dhT
 pUQ
 sbR
 qwm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The SMES in the grav room wasnt set to match other maps (why isnt a map helper made for this yet...) So i resolved that.

I also deleted 112 VV'd cameras and replaced them with proper ones


## How This Contributes To The Nova Sector Roleplay Experience

Gravity going out every single shift no matter what is kinda annoying, it gives pressure to engineers who may not be fully ready to 'rush' setting up an SM and given it happens before the 10 minute mark it's a bit cruel too.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
Happy Engine
![image](https://github.com/NovaSector/NovaSector/assets/22140677/6ac4766d-3c09-4068-9f9c-8e3c28573529) 

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Blueshift - Gravity will now not go out in 10 minutes every shift-start
fix: Blueshift - Numerous non-template cameras in blueshift have been moved to autoname and replaces the VV'd ones
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
