### PR TITLE
Fixes MSAY, MHELP, LOOC, and WALLPIERCE LOOC verbs

### DIFF
--- a/modular_nova/modules/mentor/code/mentorhelp.dm
+++ b/modular_nova/modules/mentor/code/mentorhelp.dm
@@ -1,4 +1,4 @@
-/client/verb/mentorhelp(msg as text|null)
+/client/verb/mentorhelp(msg as text)
 	set category = "Mentor"
 	set name = "Mentorhelp"
 

--- a/modular_nova/modules/mentor/code/mentorsay.dm
+++ b/modular_nova/modules/mentor/code/mentorsay.dm
@@ -1,4 +1,4 @@
-/client/proc/cmd_mentor_say(msg as text|null)
+/client/proc/cmd_mentor_say(msg as text)
 	set category = "Mentor"
 	set name = "Msay" //Gave this shit a shorter name so you only have to time out "msay" rather than "mentor say" to use it --NeoFite
 	set hidden = 1

--- a/modular_nova/modules/verbs/code/looc.dm
+++ b/modular_nova/modules/verbs/code/looc.dm
@@ -1,11 +1,11 @@
-/client/verb/looc(msg as text|null)
+/client/verb/looc(msg as text)
 	set name = "LOOC"
 	set desc = "Local OOC, seen only by those in view."
 	set category = "OOC"
 
 	looc_message(msg)
 
-/client/verb/looc_wallpierce(msg as text|null)
+/client/verb/looc_wallpierce(msg as text)
 	set name = "LOOC (Wallpierce)"
 	set desc = "Local OOC, seen by anyone within 7 tiles of you."
 	set category = "OOC"


### PR DESCRIPTION
## About The Pull Request

Something about these verbs broke recently, not exactly where they broke but this small change restores them to functionality (Fixes #1496)

## How This Contributes To The Nova Sector Roleplay Experience

Things work as expected

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_nHHpMySyi8](https://github.com/NovaSector/NovaSector/assets/2568378/d48b01d3-c8ea-4e1a-8ded-67fef4f1cd0c)

![dreamseeker_kLeMAl9gKS](https://github.com/NovaSector/NovaSector/assets/2568378/0c5f5ce1-f5c6-44b5-ad97-3c276d862c4f)


</details>

## Changelog

:cl:
fix: MSAY, MENTORHELP, LOOC, and WALLPIERCE LOOC verbs all now work again
/:cl: