### PR TITLE
Adds more fake Syndicate clothing to the loadout list, fixes and balances the existing ones

### DIFF
--- a/modular_nova/master_files/code/modules/clothing/under/syndicate.dm
+++ b/modular_nova/master_files/code/modules/clothing/under/syndicate.dm
@@ -31,7 +31,7 @@
 	inhand_icon_state = "b_suit"
 	can_adjust = TRUE
 	has_sensor = HAS_SENSORS
-	armor_type = /datum/armor/clothing_under/none
+	armor_type = /datum/armor/clothing_under
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
 	unique_reskin = list(
 		RESKIN_NT = "tactifool_blue",
@@ -49,19 +49,15 @@
 	name = "tacticool skirtleneck"
 	desc = "A snug skirtleneck, in fabulous Nanotrasen-blue. Just looking at it makes you want to buy a NT-certifed coffee, go into the office, and -work-."
 	icon_state = "tactifool_blue_skirt"
-	armor_type = /datum/armor/clothing_under/none
+	gets_cropped_on_taurs = FALSE
 	body_parts_covered = CHEST|GROIN|ARMS
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	dying_key = DYE_REGISTRY_JUMPSKIRT
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
-	unique_reskin = list(
-		RESKIN_NT = "tactifool_blue_skirt",
-		RESKIN_CHARCOAL = "tactifool_skirt"
-	)
 
 /obj/item/clothing/under/syndicate/bloodred/sleepytime/sensors //Halloween-only
 	has_sensor = HAS_SENSORS
-	armor_type = /datum/armor/clothing_under/none
+	armor_type = /datum/armor/clothing_under
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
 
 /obj/item/clothing/under/syndicate/nova/baseball
@@ -69,18 +65,55 @@
 	desc = "Aaand the Syndicate Snakes are up to bat, ready for one of their signature nuclear home-runs! Lets show these corpos a good time." //NT pitches their plasma/bluespace(something)
 	icon_state = "syndicate_baseball"
 
+/obj/item/clothing/under/syndicate/unarmoured
+	name = "cheap Syndicate tactical turtleneck"
+	desc = "A non-descript and slightly suspicious looking turtleneck with digital camouflage cargo pants... The armor has been removed from the fabric."
+	icon_state = "syndicate"
+	inhand_icon_state = "bl_suit"
+	has_sensor = HAS_SENSORS
+	armor_type = /datum/armor/clothing_under
+
+/obj/item/clothing/under/syndicate/unarmoured/skirt
+	name = "cheap Syndicate tactical skirtleneck"
+	desc = "A non-descript and slightly suspicious looking skirtleneck... The armor has been removed from the fabric."
+	icon_state = "syndicate_skirt"
+	inhand_icon_state = "bl_suit"
+	gets_cropped_on_taurs = FALSE
+	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
+	dying_key = DYE_REGISTRY_JUMPSKIRT
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+
+/obj/item/clothing/under/syndicate/nova/tactical/unarmoured
+	name = "cheap Syndicate tactical turtleneck"
+	desc = "A snug syndicate-red turtleneck with charcoal-black cargo pants... The armor has been removed from the fabric."
+	icon_state = "syndicate_red"
+	inhand_icon_state = "r_suit"
+	has_sensor = HAS_SENSORS
+	armor_type = /datum/armor/clothing_under
+	unique_reskin = null
+
+/obj/item/clothing/under/syndicate/nova/tactical/unarmoured/skirt
+	name = "cheap Syndicate tactical skirtleneck"
+	desc = "A pair of spiffy overalls with a turtleneck underneath, this one is a skirt instead, breezy... The armor has been removed from the fabric."
+	icon_state = "syndicate_red_skirt"
+	gets_cropped_on_taurs = FALSE
+	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
+	dying_key = DYE_REGISTRY_JUMPSKIRT
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+
 /obj/item/clothing/under/syndicate/nova/overalls/unarmoured
-	name = "tacticool utility overalls turtleneck"
-	desc = "A pair of spiffy overalls with a turtleneck underneath, useful for both engineering and botanical work."
+	name = "cheap Syndicate utility overalls turtleneck"
+	desc = "A pair of spiffy overalls with a turtleneck underneath, useful for both engineering and botanical work... The armor has been removed from the fabric."
 	icon_state = "syndicate_overalls"
-	armor_type = /datum/armor/clothing_under/none
+	armor_type = /datum/armor/clothing_under
 	has_sensor = HAS_SENSORS
 	can_adjust = TRUE
 
 /obj/item/clothing/under/syndicate/nova/overalls/unarmoured/skirt
-	name = "tacticool utility overalls skirtleneck"
-	desc = "A pair of spiffy overalls with a turtleneck underneath, this one is a skirt instead, breezy."
+	name = "cheap Syndicate utility overalls skirtleneck"
+	desc = "A pair of spiffy overalls with a turtleneck underneath, this one is a skirt instead, breezy... The armor has been removed from the fabric."
 	icon_state = "syndicate_overallskirt"
+	gets_cropped_on_taurs = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	dying_key = DYE_REGISTRY_JUMPSKIRT
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
@@ -149,7 +182,7 @@
 	desc = "Throughout the stars, rumors of mad scientists and angry drill sergeants run rampant; of creatures in armor black as night, being led by men or women wearing this uniform. They share one thing: a deep, natonalistic zeal of the dream of America."
 	icon_state = "enclave"
 	can_adjust = TRUE
-	armor_type = /datum/armor/clothing_under/none
+	armor_type = /datum/armor/clothing_under
 
 /obj/item/clothing/under/syndicate/nova/enclave/officer
 	name = "neo-American officer uniform"

--- a/modular_nova/modules/loadouts/loadout_items/under/loadout_datum_under.dm
+++ b/modular_nova/modules/loadouts/loadout_items/under/loadout_datum_under.dm
@@ -523,19 +523,35 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 
 /datum/loadout_item/under/miscellaneous/tacticool_turtleneck
 	name = "Tacticool Turtleneck"
-	item_path = /obj/item/clothing/under/syndicate/tacticool //This has been rebalanced in modular_nova\master_files\code\modules\clothing\under\syndicate.dm
+	item_path = /obj/item/clothing/under/syndicate/tacticool
 
 /datum/loadout_item/under/miscellaneous/tactical_skirt
 	name = "Tacticool Skirtleneck"
-	item_path = /obj/item/clothing/under/syndicate/tacticool/skirt //This has been rebalanced in modular_nova\master_files\code\modules\clothing\under\syndicate.dm
+	item_path = /obj/item/clothing/under/syndicate/tacticool/skirt
+
+/datum/loadout_item/under/miscellaneous/syndicate_unarmoured
+	name = "Cheap Syndicate Tactical Turtleneck (Grey)"
+	item_path = /obj/item/clothing/under/syndicate/unarmoured
+
+/datum/loadout_item/under/miscellaneous/syndicate_unarmoured_skirt
+	name = "Cheap Syndicate Tactical Skirtleneck (Grey)"
+	item_path = /obj/item/clothing/under/syndicate/unarmoured/skirt
+
+/datum/loadout_item/under/miscellaneous/syndicate_nova_unarmoured
+	name = "Cheap Syndicate Tactical Turtleneck (Red)"
+	item_path = /obj/item/clothing/under/syndicate/nova/tactical/unarmoured
+
+/datum/loadout_item/under/miscellaneous/syndicate_nova_unarmoured_skirt
+	name = "Cheap Syndicate Tactical Skirtleneck (Red)"
+	item_path = /obj/item/clothing/under/syndicate/nova/tactical/unarmoured/skirt
 
 /datum/loadout_item/under/miscellaneous/syndicate_nova_overalls_unarmoured
-	name = "Tacticool Utility Overalls Turtleneck"
-	item_path = /obj/item/clothing/under/syndicate/nova/overalls/unarmoured //This has been rebalanced in modular_nova\master_files\code\modules\clothing\under\syndicate.dm :3
+	name = "Cheap Syndicate Utility Overalls Turtleneck"
+	item_path = /obj/item/clothing/under/syndicate/nova/overalls/unarmoured
 
 /datum/loadout_item/under/miscellaneous/syndicate_nova_overalls_unarmoured_skirt
-	name = "Tacticool Overalls Skirtleneck"
-	item_path = /obj/item/clothing/under/syndicate/nova/overalls/unarmoured/skirt //This has been rebalanced in modular_nova\master_files\code\modules\clothing\under\syndicate.dm :3
+	name = "Cheap Syndicate Overalls Skirtleneck"
+	item_path = /obj/item/clothing/under/syndicate/nova/overalls/unarmoured/skirt
 
 /datum/loadout_item/under/miscellaneous/tactical_pants
 	name = "Tactical Pants"


### PR DESCRIPTION
## About The Pull Request

The tacticool clothing set is a series, these new ported clothing aren't part of that series. So I fixed that, and added the rest of the clothing that the port neglected. I also updated the armour, there's no reason for these items to have less armour than a jumpsuit. There's also a slight amount of code cleanup, subtypes don't need to have code repeated that their parent already carries.

Oh and they display properly on taurs, since everyone always forgets to remove the crop-code from skirt versions.

## How This Contributes To The Nova Sector Roleplay Experience

This port https://github.com/NovaSector/NovaSector/pull/1264 only did half the job. In this PR I add the items appropriately.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/77534246/c5ca2d00-3718-431e-86e4-ef37a77de22c)

</details>

## Changelog
:cl:
add: Adds all versions of the Syndie clothing as fake, loadout-able gear instead of just the Overalls
balance: Fake Syndie clothing now isn't completely armourless, it has the same armor as jumpsuits
fix: The fake Syndie clothing display properly on Taur characters
/:cl: