### PR TITLE
[MISSED MIRROR] Adds colorblindness as a mild brain trauma (#76527)

### DIFF
--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -266,3 +266,18 @@
 			speak_dejavu += speech_args[SPEECH_MESSAGE]
 	else
 		speak_dejavu += speech_args[SPEECH_MESSAGE]
+
+/datum/brain_trauma/mild/color_blindness
+	name = "Achromatopsia"
+	desc = "Patient's occipital lobe is unable to recognize and interpret color, rendering the patient completely colorblind."
+	scan_desc = "colorblindness"
+	gain_text = span_warning("The world around you seems to lose its color.")
+	lose_text = span_notice("The world feels bright and colorful again.")
+
+/datum/brain_trauma/mild/color_blindness/on_gain()
+	owner.add_client_colour(/datum/client_colour/monochrome/colorblind)
+	return ..()
+
+/datum/brain_trauma/mild/color_blindness/on_lose(silent)
+	owner.remove_client_colour(/datum/client_colour/monochrome/colorblind)
+	return ..()

--- a/code/modules/client/client_colour.dm
+++ b/code/modules/client/client_colour.dm
@@ -211,6 +211,9 @@
 	fade_in = 20
 	fade_out = 20
 
+/datum/client_colour/monochrome/colorblind
+	priority = PRIORITY_HIGH
+
 /datum/client_colour/monochrome/trance
 	priority = PRIORITY_NORMAL
 


### PR DESCRIPTION
## ORIGINAL PR: https://github.com/tgstation/tgstation/pull/76527

## About The Pull Request

What the title says. 
The brain trauma makes the whole screen monochrome until cured.

![image](https://github.com/tgstation/tgstation/assets/82850673/442d24a8-6625-454c-bc28-64b786b03f49)

## Why It's Good For The Game

I feel like the current pool for mild brain traumas is quite lame, this helps spice it up a bit with something that is quite annoying and distracting but not game breaking (as mild brain traumas should generally be).

## Changelog

:cl:
add: Added colorblindness as a mild brain trauma.
/:cl:
