### PR TITLE
Shuttle8352 Tweak 

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/shuttle8532.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/shuttle8532.dmm
@@ -730,9 +730,6 @@
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532bridge)
-"pu" = (
-/turf/closed/wall/r_wall/syndicate,
-/area/ruin/space/has_grav/shuttle8532bridge)
 "py" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -2217,9 +2214,6 @@
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/shuttle8532bridge)
-"Uy" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/space/has_grav/shuttle8532bridge)
 "UN" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -2962,8 +2956,8 @@ qb
 qb
 "}
 (8,1,1) = {"
-pu
-Uy
+xO
+xO
 XQ
 fp
 HK
@@ -3025,7 +3019,7 @@ qb
 qb
 "}
 (9,1,1) = {"
-pu
+xO
 zA
 ZU
 Vi


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The last PR I made was to sort of cheese-proof the ruin, however i appear to have missed 2 of the walls by accident

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
 Once I load it locally
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixes a missed section of indestructible walls on the Shuttle8352 Ruin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
