### PR TITLE
Adds Gun Boots and some Baseball Bats to the DM Mystery Boxes

### DIFF
--- a/modular_nova/master_files/code/modules/clothing/shoes/boots.dm
+++ b/modular_nova/master_files/code/modules/clothing/shoes/boots.dm
@@ -1,3 +1,6 @@
 /obj/item/clothing/shoes/workboots/mining
 	icon = 'modular_nova/master_files/icons/obj/clothing/shoes.dmi' // To keep the old version before #8911
 	worn_icon = 'modular_nova/master_files/icons/mob/clothing/feet.dmi' // To keep the old version before #8911
+
+/obj/item/clothing/shoes/gunboots/dm
+	projectile_type = /obj/projectile/beam/laser

--- a/modular_nova/modules/modular_weapons/code/overrides/mystery_box_additions.dm
+++ b/modular_nova/modules/modular_weapons/code/overrides/mystery_box_additions.dm
@@ -45,6 +45,9 @@ GLOBAL_LIST_INIT(nova_funny_mystery_box_items, list(
 	/obj/item/autosurgeon/syndicate/sandy,
 	/obj/item/autosurgeon/syndicate/razorwire,
 	/obj/item/shield/ballistic,
+	/obj/item/melee/baseball_bat/ablative,
+	/obj/item/melee/baseball_bat/homerun,
+	/obj/item/clothing/shoes/gunboots/dm
 ))
 
 /obj/structure/mystery_box/guns/generate_valid_types()


### PR DESCRIPTION
## About The Pull Request

Tin! The gun boots are a new subtype that shoot normal lasers instead of big bullets.

## How This Contributes To The Nova Sector Roleplay Experience

Fun DM items. :)

## Proof of Testing

![image](https://github.com/NovaSector/NovaSector/assets/77534246/e5675e14-e399-479d-aee9-ba79999f3774)

![image](https://github.com/NovaSector/NovaSector/assets/77534246/5b4404a8-7bc9-473d-b108-410a4e0a2a79)

## Changelog

:cl:
add: Adds Gun Botos and some Baseball Bats to the DM Mystery Boxes
/:cl:
