### PR TITLE
[SEMI MODULAR] Syndicate Sleeper Agent now polls people when it runs

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -272,7 +272,14 @@
 			candidates -= player // We don't autotator people with roles already
 
 /datum/dynamic_ruleset/midround/from_living/autotraitor/execute()
-	var/mob/M = pick(candidates)
+	// NOVA EDIT ADDITION START
+	var/list/mob/living/pruned = optin(candidates)
+	if(!pruned || !pruned.len)
+		message_admins("No valid candidates found for the [name] ruleset. Nobody Signed up.")
+		log_dynamic("No valid candidates found for the [name] ruleset. Nobody Signed up.")
+		return FALSE
+	// NOVA EDIT ADDITION END
+	var/mob/M = pick(pruned) // NOVA EDIT CHANGE - ORIGINALLY pick(candidates)
 	assigned += M
 	candidates -= M
 	var/datum/antagonist/traitor/infiltrator/sleeper_agent/newTraitor = new

--- a/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
+++ b/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
@@ -1,0 +1,19 @@
+/datum/dynamic_ruleset/midround/from_living/autotraitor/proc/optin(candidates)
+	var/list/mob/living/candidates_pruned = SSpolling.poll_candidates(
+		question = "Do you want to be a syndicate sleeper agent?",
+		group = candidates,
+		poll_time = 30 SECONDS,
+		flash_window = FALSE,
+		start_signed_up = FALSE,
+		alert_pic = /obj/structure/sign/poster/contraband/gorlex_recruitment,
+		custom_response_messages = list(
+			POLL_RESPONSE_SIGNUP = "You have signed up to be a traitor!",
+			POLL_RESPONSE_ALREADY_SIGNED = "You are already signed up to be a traitor.",
+			POLL_RESPONSE_NOT_SIGNED = "You aren't signed up to be a traitor.",
+			POLL_RESPONSE_TOO_LATE_TO_UNREGISTER = "It's too late to decide against being a traitor.",
+			POLL_RESPONSE_UNREGISTERED = "You decide against being a traitor.",
+		),
+		chat_text_border_icon = /obj/structure/sign/poster/contraband/gorlex_recruitment,
+	)
+
+	return candidates_pruned

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6239,6 +6239,7 @@
 #include "modular_nova\master_files\code\_onclick\cyborg.dm"
 #include "modular_nova\master_files\code\controllers\configuration\entries\config_entries.dm"
 #include "modular_nova\master_files\code\controllers\subsystem\dbcore.dm"
+#include "modular_nova\master_files\code\controllers\subsystem\dynamic_rulesets_midround.dm"
 #include "modular_nova\master_files\code\controllers\subsystem\events.dm"
 #include "modular_nova\master_files\code\controllers\subsystem\language.dm"
 #include "modular_nova\master_files\code\datums\ai_laws.dm"


### PR DESCRIPTION
## About The Pull Request

This was a request by a headmin, but they requested that when syndicate sleeper agent rolls it will do a poll on valid people for the role and ask them if they do or do not want to be a agent, if they don't want to be they wont be picked for the role.

## How This Contributes To The Nova Sector Roleplay Experience

Less traitors caught with their pants literally down

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  

https://github.com/NovaSector/NovaSector/assets/2568378/0c1c62e5-8b5d-4765-b998-53f270db2aad

Ok the full video is sliiiigthly too long to put on git so heres a screenshot of me getting traitor

![jE3ZcrkfcZ](https://github.com/NovaSector/NovaSector/assets/2568378/080fcb61-516d-4284-b191-0cd4106a52a6)

</details>

## Changelog

:cl:
add: Syndicate Sleeper Agent now has a popup poll for all valid players to get sleeper agent asking if they want to be traitor.
/:cl: