### PR TITLE
[Modular] Makes the Possessive and Kleptomaniac brain trumas into quirks

### DIFF
--- a/modular_nova/modules/trauma_quirks/trauma_quirks.dm
+++ b/modular_nova/modules/trauma_quirks/trauma_quirks.dm
@@ -1,0 +1,37 @@
+/datum/quirk/possessive
+	name = "Possessive"
+	desc = "You feel a strong attachment over any item you own, often times you feel like you cant drop them."
+	value = 0
+	gain_text = span_danger("You feel like everything you own is too precious to drop.")
+	lose_text = span_notice("Suddenly you feel like your stuff isnt that inportant anymore.")
+	medical_record_text = "Subject has exhibits a possessive tendencey with objects."
+	icon = FA_ICON_HANDS_HOLDING
+
+/datum/quirk/possessive/post_add()
+	. = ..()
+	var/mob/living/carbon/human/affected_human = quirk_holder
+	affected_human.gain_trauma(/datum/brain_trauma/mild/possessive, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/possessive/remove()
+	. = ..()
+	var/mob/living/carbon/human/affected_human = quirk_holder
+	affected_human?.cure_trauma_type(/datum/brain_trauma/mild/possessive, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/kleptomaniac
+	name = "Kleptomaniac"
+	desc = "You feel a the strong urge to pickup anything around often times without your awareness."
+	value = 0
+	gain_text = span_danger("You feel a sudden urge to take that. Surely no one will notice.")
+	lose_text = span_notice("You no longer feel the urge to take things.")
+	medical_record_text = "Subject has exhibits kleptomania"
+	icon = FA_ICON_HAND_HOLDING
+
+/datum/quirk/kleptomaniac/post_add()
+	. = ..()
+	var/mob/living/carbon/human/affected_human = quirk_holder
+	affected_human.gain_trauma(/datum/brain_trauma/severe/kleptomaniac, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/kleptomaniac/remove()
+	. = ..()
+	var/mob/living/carbon/human/affected_human = quirk_holder
+	affected_human?.cure_trauma_type(/datum/brain_trauma/severe/kleptomaniac, TRAUMA_RESILIENCE_ABSOLUTE)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8155,6 +8155,7 @@
 #include "modular_nova\modules\traitor-uplinks\code\categories\stealthy_tools.dm"
 #include "modular_nova\modules\traitor-uplinks\code\categories\stealthy_weapons.dm"
 #include "modular_nova\modules\traitor-uplinks\code\categories\suits.dm"
+#include "modular_nova\modules\trauma_quirks\trauma_quirks.dm"
 #include "modular_nova\modules\tribal_extended\code\crafting.dm"
 #include "modular_nova\modules\tribal_extended\code\recipes.dm"
 #include "modular_nova\modules\tribal_extended\code\ammo\caseless\arrow.dm"


### PR DESCRIPTION
## About The Pull Request

This was mostly a passive remark that another maint requested but i took it seriously because it was a good idea, this makes these two brain traumas into quirks.

## How This Contributes To The Nova Sector Roleplay Experience

These are two real world medical conditions that people CAN suffer from it only make sense to give people the option to make characters that use these quirks to make characters that suffers from these conditions

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![dreamseeker_mn7242HsKX](https://github.com/NovaSector/NovaSector/assets/2568378/79861787-42ef-44d4-bebe-28fee6ff4afe)

![dreamseeker_RMAEoHf7J8](https://github.com/NovaSector/NovaSector/assets/2568378/1f38490f-8219-4949-9da3-06a92d8cf80a)
  
</details>

## Changelog

:cl:
add: Added two new quirks, Kleptomaniac, and Possessive 
/:cl: