### PR TITLE
[MODULAR] Expands character customization by adding all species limbs to the augments tab.

### DIFF
--- a/modular_nova/modules/customization/modules/client/augment/limbs.dm
+++ b/modular_nova/modules/customization/modules/client/augment/limbs.dm
@@ -3,6 +3,8 @@
 	allowed_biotypes = MOB_ORGANIC|MOB_ROBOTIC
 	///Hardcoded styles that can be chosen from and apply to limb, if it's true
 	var/uses_robotic_styles = TRUE
+	///Should we draw these greyscale?
+	var/uses_greyscale = FALSE
 
 /datum/augment_item/limb/apply(mob/living/carbon/human/augmented, character_setup = FALSE, datum/preferences/prefs)
 	if(character_setup)
@@ -20,8 +22,11 @@
 			old_limb.set_icon_static(chosen_style)
 			old_limb.current_style = prefs.augment_limb_styles[slot]
 		else
-			old_limb.set_icon_static(initial(new_limb.icon))
-		old_limb.should_draw_greyscale = FALSE
+			if(!uses_greyscale)
+				old_limb.set_icon_static(initial(new_limb.icon))
+			else
+				old_limb.set_icon_greyscale(UNLINT(initial(new_limb.icon_greyscale))) // stupid var_protected memes
+		old_limb.should_draw_greyscale = uses_greyscale
 
 		return body_zone
 	else

--- a/modular_nova/modules/customization/modules/client/augment/species_limbs.dm
+++ b/modular_nova/modules/customization/modules/client/augment/species_limbs.dm
@@ -1,0 +1,648 @@
+/datum/augment_item/limb/head/mutant
+	name = "anthromorph head"
+	path = /obj/item/bodypart/head/mutant
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/chest/mutant
+	name = "anthromorph chest"
+	path = /obj/item/bodypart/chest/mutant
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_arm/mutant
+	name = "anthromorph left arm"
+	path = /obj/item/bodypart/arm/left/mutant
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_arm/mutant
+	name = "anthromorph right arm"
+	path = /obj/item/bodypart/arm/right/mutant
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_leg/mutant
+	name = "anthromorph left leg"
+	path = /obj/item/bodypart/leg/left/mutant
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_leg/mutant
+	name = "anthromorph right leg"
+	path = /obj/item/bodypart/leg/right/mutant
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/head/akula
+	name = "akula head"
+	path = /obj/item/bodypart/head/mutant/akula
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/chest/akula
+	name = "akula chest"
+	path = /obj/item/bodypart/chest/mutant/akula
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_arm/akula
+	name = "akula left arm"
+	path = /obj/item/bodypart/arm/left/mutant/akula
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_arm/akula
+	name = "akula right arm"
+	path = /obj/item/bodypart/arm/right/mutant/akula
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_leg/akula
+	name = "akula left leg"
+	path = /obj/item/bodypart/leg/left/mutant/akula
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_leg/akula
+	name = "akula right leg"
+	path = /obj/item/bodypart/leg/right/mutant/akula
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/head/aquatic
+	name = "aquatic head"
+	path = /obj/item/bodypart/head/mutant/aquatic
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/chest/aquatic
+	name = "aquatic chest"
+	path = /obj/item/bodypart/chest/mutant/aquatic
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_arm/aquatic
+	name = "aquatic left arm"
+	path = /obj/item/bodypart/arm/left/mutant/aquatic
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_arm/aquatic
+	name = "aquatic right arm"
+	path = /obj/item/bodypart/arm/right/mutant/aquatic
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_leg/aquatic
+	name = "aquatic left leg"
+	path = /obj/item/bodypart/leg/left/mutant/aquatic
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_leg/aquatic
+	name = "aquatic right leg"
+	path = /obj/item/bodypart/leg/right/mutant/aquatic
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_arm/ghoul
+	name = "ghoul left arm"
+	path = /obj/item/bodypart/arm/left/mutant/ghoul
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_arm/ghoul
+	name = "ghoul right arm"
+	path = /obj/item/bodypart/arm/right/mutant/ghoul
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/head/ghoul
+	name = "ghoul head"
+	path = /obj/item/bodypart/head/mutant/ghoul
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_leg/ghoul
+	name = "ghoul left leg"
+	path = /obj/item/bodypart/leg/left/mutant/ghoul
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_leg/ghoul
+	name = "ghoul right leg"
+	path = /obj/item/bodypart/leg/right/mutant/ghoul
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/chest/ghoul
+	name = "ghoul chest"
+	path = /obj/item/bodypart/chest/mutant/ghoul
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/head/insect
+	name = "insect head"
+	path = /obj/item/bodypart/head/mutant/insect
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/chest/insect
+	name = "insect chest"
+	path = /obj/item/bodypart/chest/mutant/insect
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_arm/insect
+	name = "insect left arm"
+	path = /obj/item/bodypart/arm/left/mutant/insect
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_arm/insect
+	name = "insect right arm"
+	path = /obj/item/bodypart/arm/right/mutant/insect
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_leg/insect
+	name = "insect left leg"
+	path = /obj/item/bodypart/leg/left/mutant/insect
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_leg/insect
+	name = "insect right leg"
+	path = /obj/item/bodypart/leg/right/mutant/insect
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/head/lizard
+	name = "lizard head"
+	path = /obj/item/bodypart/head/lizard
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/chest/lizard
+	name = "lizard chest"
+	path = /obj/item/bodypart/chest/lizard
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_arm/lizard
+	name = "lizard left arm"
+	path = /obj/item/bodypart/arm/left/lizard
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_arm/lizard
+	name = "lizard right arm"
+	path = /obj/item/bodypart/arm/right/lizard
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_leg/lizard
+	name = "lizard left leg"
+	path = /obj/item/bodypart/leg/left/lizard
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_leg/lizard
+	name = "lizard right leg"
+	path = /obj/item/bodypart/leg/right/lizard
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_arm/fly
+	name = "fly left arm"
+	path = /obj/item/bodypart/arm/left/fly
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_arm/fly
+	name = "fly right arm"
+	path = /obj/item/bodypart/arm/right/fly
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/head/fly
+	name = "fly head"
+	path = /obj/item/bodypart/head/fly
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_leg/fly
+	name = "fly left leg"
+	path = /obj/item/bodypart/leg/left/fly
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_leg/fly
+	name = "fly right leg"
+	path = /obj/item/bodypart/leg/right/fly
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/chest/fly
+	name = "fly chest"
+	path = /obj/item/bodypart/chest/fly
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_arm/golem
+	name = "golem left arm"
+	path = /obj/item/bodypart/arm/left/golem
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_arm/golem
+	name = "golem right arm"
+	path = /obj/item/bodypart/arm/right/golem
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/head/golem
+	name = "golem head"
+	path = /obj/item/bodypart/head/golem
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_leg/golem
+	name = "golem left leg"
+	path = /obj/item/bodypart/leg/left/golem
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_leg/golem
+	name = "golem right leg"
+	path = /obj/item/bodypart/leg/right/golem
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/chest/golem
+	name = "golem chest"
+	path = /obj/item/bodypart/chest/golem
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_arm/slime
+	name = "slime left arm"
+	path = /obj/item/bodypart/arm/left/slime/roundstart
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_arm/slime
+	name = "slime right arm"
+	path = /obj/item/bodypart/arm/right/slime/roundstart
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/head/slime
+	name = "slime head"
+	path = /obj/item/bodypart/head/slime/roundstart
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_leg/slime
+	name = "slime left leg"
+	path = /obj/item/bodypart/leg/left/slime/roundstart
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_leg/slime
+	name = "slime right leg"
+	path = /obj/item/bodypart/leg/right/slime/roundstart
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/chest/slime
+	name = "slime chest"
+	path = /obj/item/bodypart/chest/slime/roundstart
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/head/moth
+	name = "moth head"
+	path = /obj/item/bodypart/head/moth
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/chest/moth
+	name = "moth chest"
+	path = /obj/item/bodypart/chest/moth
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_arm/moth
+	name = "moth left arm"
+	path = /obj/item/bodypart/arm/left/moth
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_arm/moth
+	name = "moth right arm"
+	path = /obj/item/bodypart/arm/right/moth
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_leg/moth
+	name = "moth left leg"
+	path = /obj/item/bodypart/leg/left/moth
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_leg/moth
+	name = "moth right leg"
+	path = /obj/item/bodypart/leg/right/moth
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_arm/mushroom
+	name = "mushroom left arm"
+	path = /obj/item/bodypart/arm/left/mushroom
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_arm/mushroom
+	name = "mushroom right arm"
+	path = /obj/item/bodypart/arm/right/mushroom
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/head/mushroom
+	name = "mushroom head"
+	path = /obj/item/bodypart/head/mushroom
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_leg/mushroom
+	name = "mushroom left leg"
+	path = /obj/item/bodypart/leg/left/mushroom
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_leg/mushroom
+	name = "mushroom right leg"
+	path = /obj/item/bodypart/leg/right/mushroom
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/chest/mushroom
+	name = "mushroom chest"
+	path = /obj/item/bodypart/chest/mushroom
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_arm/pod
+	name = "pod left arm"
+	path = /obj/item/bodypart/arm/left/pod
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_arm/pod
+	name = "pod right arm"
+	path = /obj/item/bodypart/arm/right/pod
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/head/pod
+	name = "pod head"
+	path = /obj/item/bodypart/head/pod
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_leg/pod
+	name = "pod left leg"
+	path = /obj/item/bodypart/leg/left/pod
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_leg/pod
+	name = "pod right leg"
+	path = /obj/item/bodypart/leg/right/pod
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/chest/pod
+	name = "pod chest"
+	path = /obj/item/bodypart/chest/pod
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_arm/skeleton
+	name = "skeleton left arm"
+	path = /obj/item/bodypart/arm/left/skeleton
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_arm/skeleton
+	name = "skeleton right arm"
+	path = /obj/item/bodypart/arm/right/skeleton
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/head/skeleton
+	name = "skeleton head"
+	path = /obj/item/bodypart/head/skeleton
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_leg/skeleton
+	name = "skeleton left leg"
+	path = /obj/item/bodypart/leg/left/skeleton
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_leg/skeleton
+	name = "skeleton right leg"
+	path = /obj/item/bodypart/leg/right/skeleton
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/chest/skeleton
+	name = "skeleton chest"
+	path = /obj/item/bodypart/chest/skeleton
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_arm/ethereal
+	name = "ethereal left arm"
+	path = /obj/item/bodypart/arm/left/ethereal
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_arm/ethereal
+	name = "ethereal right arm"
+	path = /obj/item/bodypart/arm/right/ethereal
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/head/ethereal
+	name = "ethereal head"
+	path = /obj/item/bodypart/head/ethereal
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_leg/ethereal
+	name = "ethereal left leg"
+	path = /obj/item/bodypart/leg/left/ethereal
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_leg/ethereal
+	name = "ethereal right leg"
+	path = /obj/item/bodypart/leg/right/ethereal
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/chest/ethereal
+	name = "ethereal chest"
+	path = /obj/item/bodypart/chest/ethereal
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/head/abductor
+	name = "abductor head"
+	path = /obj/item/bodypart/head/abductor
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/chest/abductor
+	name = "abductor chest"
+	path = /obj/item/bodypart/chest/abductor
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_arm/abductor
+	name = "abductor left arm"
+	path = /obj/item/bodypart/arm/left/abductor
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_arm/abductor
+	name = "abductor right arm"
+	path = /obj/item/bodypart/arm/right/abductor
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_leg/abductor
+	name = "abductor left leg"
+	path = /obj/item/bodypart/leg/left/abductor
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_leg/abductor
+	name = "abductor right leg"
+	path = /obj/item/bodypart/leg/right/abductor
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/head/skrell
+	name = "skrell head"
+	path = /obj/item/bodypart/head/mutant/skrell
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/chest/skrell
+	name = "skrell chest"
+	path = /obj/item/bodypart/chest/mutant/skrell
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_arm/skrell
+	name = "skrell left arm"
+	path = /obj/item/bodypart/arm/left/mutant/skrell
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_arm/skrell
+	name = "skrell right arm"
+	path = /obj/item/bodypart/arm/right/mutant/skrell
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_leg/skrell
+	name = "skrell left leg"
+	path = /obj/item/bodypart/leg/left/mutant/skrell
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_leg/skrell
+	name = "skrell right leg"
+	path = /obj/item/bodypart/leg/right/mutant/skrell
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/head/vox
+	name = "vox head"
+	path = /obj/item/bodypart/head/mutant/vox
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/chest/vox
+	name = "vox chest"
+	path = /obj/item/bodypart/chest/mutant/vox
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_arm/vox
+	name = "vox left arm"
+	path = /obj/item/bodypart/arm/left/mutant/vox
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_arm/vox
+	name = "vox right arm"
+	path = /obj/item/bodypart/arm/right/mutant/vox
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_leg/vox
+	name = "vox left leg"
+	path = /obj/item/bodypart/leg/left/mutant/vox
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_leg/vox
+	name = "vox right leg"
+	path = /obj/item/bodypart/leg/right/mutant/vox
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/head/xenohybrid
+	name = "xenohybrid head"
+	path = /obj/item/bodypart/head/mutant/xenohybrid
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/chest/xenohybrid
+	name = "xenohybrid chest"
+	path = /obj/item/bodypart/chest/mutant/xenohybrid
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_arm/xenohybrid
+	name = "xenohybrid left arm"
+	path = /obj/item/bodypart/arm/left/mutant/xenohybrid
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_arm/xenohybrid
+	name = "xenohybrid right arm"
+	path = /obj/item/bodypart/arm/right/mutant/xenohybrid
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/l_leg/xenohybrid
+	name = "xenohybrid left leg"
+	path = /obj/item/bodypart/leg/left/digitigrade/xenohybrid
+	cost = 0
+	uses_robotic_styles = FALSE
+
+/datum/augment_item/limb/r_leg/xenohybrid
+	name = "xenohybrid right leg"
+	path = /obj/item/bodypart/leg/right/digitigrade/xenohybrid
+	cost = 0
+	uses_robotic_styles = FALSE
+

--- a/modular_nova/modules/customization/modules/client/augment/species_limbs.dm
+++ b/modular_nova/modules/customization/modules/client/augment/species_limbs.dm
@@ -3,216 +3,252 @@
 	path = /obj/item/bodypart/head/mutant
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/chest/mutant
 	name = "anthromorph chest"
 	path = /obj/item/bodypart/chest/mutant
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_arm/mutant
 	name = "anthromorph left arm"
 	path = /obj/item/bodypart/arm/left/mutant
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_arm/mutant
 	name = "anthromorph right arm"
 	path = /obj/item/bodypart/arm/right/mutant
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_leg/mutant
 	name = "anthromorph left leg"
 	path = /obj/item/bodypart/leg/left/mutant
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_leg/mutant
 	name = "anthromorph right leg"
 	path = /obj/item/bodypart/leg/right/mutant
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/head/akula
 	name = "akula head"
 	path = /obj/item/bodypart/head/mutant/akula
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/chest/akula
 	name = "akula chest"
 	path = /obj/item/bodypart/chest/mutant/akula
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_arm/akula
 	name = "akula left arm"
 	path = /obj/item/bodypart/arm/left/mutant/akula
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_arm/akula
 	name = "akula right arm"
 	path = /obj/item/bodypart/arm/right/mutant/akula
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_leg/akula
 	name = "akula left leg"
 	path = /obj/item/bodypart/leg/left/mutant/akula
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_leg/akula
 	name = "akula right leg"
 	path = /obj/item/bodypart/leg/right/mutant/akula
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/head/aquatic
 	name = "aquatic head"
 	path = /obj/item/bodypart/head/mutant/aquatic
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/chest/aquatic
 	name = "aquatic chest"
 	path = /obj/item/bodypart/chest/mutant/aquatic
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_arm/aquatic
 	name = "aquatic left arm"
 	path = /obj/item/bodypart/arm/left/mutant/aquatic
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_arm/aquatic
 	name = "aquatic right arm"
 	path = /obj/item/bodypart/arm/right/mutant/aquatic
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_leg/aquatic
 	name = "aquatic left leg"
 	path = /obj/item/bodypart/leg/left/mutant/aquatic
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_leg/aquatic
 	name = "aquatic right leg"
 	path = /obj/item/bodypart/leg/right/mutant/aquatic
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_arm/ghoul
 	name = "ghoul left arm"
 	path = /obj/item/bodypart/arm/left/mutant/ghoul
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_arm/ghoul
 	name = "ghoul right arm"
 	path = /obj/item/bodypart/arm/right/mutant/ghoul
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/head/ghoul
 	name = "ghoul head"
 	path = /obj/item/bodypart/head/mutant/ghoul
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_leg/ghoul
 	name = "ghoul left leg"
 	path = /obj/item/bodypart/leg/left/mutant/ghoul
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_leg/ghoul
 	name = "ghoul right leg"
 	path = /obj/item/bodypart/leg/right/mutant/ghoul
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/chest/ghoul
 	name = "ghoul chest"
 	path = /obj/item/bodypart/chest/mutant/ghoul
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/head/insect
 	name = "insect head"
 	path = /obj/item/bodypart/head/mutant/insect
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/chest/insect
 	name = "insect chest"
 	path = /obj/item/bodypart/chest/mutant/insect
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_arm/insect
 	name = "insect left arm"
 	path = /obj/item/bodypart/arm/left/mutant/insect
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_arm/insect
 	name = "insect right arm"
 	path = /obj/item/bodypart/arm/right/mutant/insect
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_leg/insect
 	name = "insect left leg"
 	path = /obj/item/bodypart/leg/left/mutant/insect
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_leg/insect
 	name = "insect right leg"
 	path = /obj/item/bodypart/leg/right/mutant/insect
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/head/lizard
 	name = "lizard head"
 	path = /obj/item/bodypart/head/lizard
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/chest/lizard
 	name = "lizard chest"
 	path = /obj/item/bodypart/chest/lizard
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_arm/lizard
 	name = "lizard left arm"
 	path = /obj/item/bodypart/arm/left/lizard
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_arm/lizard
 	name = "lizard right arm"
 	path = /obj/item/bodypart/arm/right/lizard
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_leg/lizard
 	name = "lizard left leg"
 	path = /obj/item/bodypart/leg/left/lizard
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_leg/lizard
 	name = "lizard right leg"
 	path = /obj/item/bodypart/leg/right/lizard
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_arm/fly
 	name = "fly left arm"
@@ -291,144 +327,168 @@
 	path = /obj/item/bodypart/arm/left/slime/roundstart
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_arm/slime
 	name = "slime right arm"
 	path = /obj/item/bodypart/arm/right/slime/roundstart
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/head/slime
 	name = "slime head"
 	path = /obj/item/bodypart/head/slime/roundstart
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_leg/slime
 	name = "slime left leg"
 	path = /obj/item/bodypart/leg/left/slime/roundstart
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_leg/slime
 	name = "slime right leg"
 	path = /obj/item/bodypart/leg/right/slime/roundstart
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/chest/slime
 	name = "slime chest"
 	path = /obj/item/bodypart/chest/slime/roundstart
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/head/moth
 	name = "moth head"
 	path = /obj/item/bodypart/head/moth
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/chest/moth
 	name = "moth chest"
 	path = /obj/item/bodypart/chest/moth
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_arm/moth
 	name = "moth left arm"
 	path = /obj/item/bodypart/arm/left/moth
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_arm/moth
 	name = "moth right arm"
 	path = /obj/item/bodypart/arm/right/moth
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_leg/moth
 	name = "moth left leg"
 	path = /obj/item/bodypart/leg/left/moth
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_leg/moth
 	name = "moth right leg"
 	path = /obj/item/bodypart/leg/right/moth
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_arm/mushroom
 	name = "mushroom left arm"
 	path = /obj/item/bodypart/arm/left/mushroom
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_arm/mushroom
 	name = "mushroom right arm"
 	path = /obj/item/bodypart/arm/right/mushroom
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/head/mushroom
 	name = "mushroom head"
 	path = /obj/item/bodypart/head/mushroom
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_leg/mushroom
 	name = "mushroom left leg"
 	path = /obj/item/bodypart/leg/left/mushroom
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_leg/mushroom
 	name = "mushroom right leg"
 	path = /obj/item/bodypart/leg/right/mushroom
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/chest/mushroom
 	name = "mushroom chest"
 	path = /obj/item/bodypart/chest/mushroom
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_arm/pod
 	name = "pod left arm"
 	path = /obj/item/bodypart/arm/left/pod
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_arm/pod
 	name = "pod right arm"
 	path = /obj/item/bodypart/arm/right/pod
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/head/pod
 	name = "pod head"
 	path = /obj/item/bodypart/head/pod
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_leg/pod
 	name = "pod left leg"
 	path = /obj/item/bodypart/leg/left/pod
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_leg/pod
 	name = "pod right leg"
 	path = /obj/item/bodypart/leg/right/pod
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/chest/pod
 	name = "pod chest"
 	path = /obj/item/bodypart/chest/pod
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_arm/skeleton
 	name = "skeleton left arm"
@@ -471,36 +531,42 @@
 	path = /obj/item/bodypart/arm/left/ethereal
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_arm/ethereal
 	name = "ethereal right arm"
 	path = /obj/item/bodypart/arm/right/ethereal
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/head/ethereal
 	name = "ethereal head"
 	path = /obj/item/bodypart/head/ethereal
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_leg/ethereal
 	name = "ethereal left leg"
 	path = /obj/item/bodypart/leg/left/ethereal
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_leg/ethereal
 	name = "ethereal right leg"
 	path = /obj/item/bodypart/leg/right/ethereal
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/chest/ethereal
 	name = "ethereal chest"
 	path = /obj/item/bodypart/chest/ethereal
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/head/abductor
 	name = "abductor head"
@@ -543,106 +609,124 @@
 	path = /obj/item/bodypart/head/mutant/skrell
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/chest/skrell
 	name = "skrell chest"
 	path = /obj/item/bodypart/chest/mutant/skrell
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_arm/skrell
 	name = "skrell left arm"
 	path = /obj/item/bodypart/arm/left/mutant/skrell
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_arm/skrell
 	name = "skrell right arm"
 	path = /obj/item/bodypart/arm/right/mutant/skrell
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_leg/skrell
 	name = "skrell left leg"
 	path = /obj/item/bodypart/leg/left/mutant/skrell
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_leg/skrell
 	name = "skrell right leg"
 	path = /obj/item/bodypart/leg/right/mutant/skrell
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/head/vox
 	name = "vox head"
 	path = /obj/item/bodypart/head/mutant/vox
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/chest/vox
 	name = "vox chest"
 	path = /obj/item/bodypart/chest/mutant/vox
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_arm/vox
 	name = "vox left arm"
 	path = /obj/item/bodypart/arm/left/mutant/vox
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_arm/vox
 	name = "vox right arm"
 	path = /obj/item/bodypart/arm/right/mutant/vox
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_leg/vox
 	name = "vox left leg"
 	path = /obj/item/bodypart/leg/left/mutant/vox
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_leg/vox
 	name = "vox right leg"
 	path = /obj/item/bodypart/leg/right/mutant/vox
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/head/xenohybrid
 	name = "xenohybrid head"
 	path = /obj/item/bodypart/head/mutant/xenohybrid
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/chest/xenohybrid
 	name = "xenohybrid chest"
 	path = /obj/item/bodypart/chest/mutant/xenohybrid
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_arm/xenohybrid
 	name = "xenohybrid left arm"
 	path = /obj/item/bodypart/arm/left/mutant/xenohybrid
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_arm/xenohybrid
 	name = "xenohybrid right arm"
 	path = /obj/item/bodypart/arm/right/mutant/xenohybrid
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/l_leg/xenohybrid
 	name = "xenohybrid left leg"
 	path = /obj/item/bodypart/leg/left/digitigrade/xenohybrid
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 
 /datum/augment_item/limb/r_leg/xenohybrid
 	name = "xenohybrid right leg"
 	path = /obj/item/bodypart/leg/right/digitigrade/xenohybrid
 	cost = 0
 	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
 

--- a/modular_nova/modules/customization/modules/surgery/bodyparts/_bodyparts.dm
+++ b/modular_nova/modules/customization/modules/surgery/bodyparts/_bodyparts.dm
@@ -31,3 +31,16 @@
 	var/state_to_verify = "[limb_id]_[body_zone][is_dimorphic ? "_[limb_gender]" : ""]"
 	if(icon_exists(new_icon, state_to_verify, scream = TRUE))
 		icon_static = new_icon
+
+/**
+ * # This should only be ran by augments, if you don't know what you're doing, you shouldn't be touching this.
+ * A setter for the `icon_greyscale` variable of the bodypart. Runs through `icon_exists()` for sanity, and it won't
+ * change anything in the event that the check fails.
+ *
+ * Arguments:
+ * * new_icon - The new icon filepath that you want to replace `icon_greyscale` with.
+ */
+/obj/item/bodypart/proc/set_icon_greyscale(new_icon)
+	var/state_to_verify = "[limb_id]_[body_zone][is_dimorphic ? "_[limb_gender]" : ""]"
+	if(icon_exists(new_icon, state_to_verify, scream = TRUE))
+		icon_greyscale = new_icon

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7055,6 +7055,7 @@
 #include "modular_nova\modules\customization\modules\client\augment\implants.dm"
 #include "modular_nova\modules\customization\modules\client\augment\limbs.dm"
 #include "modular_nova\modules\customization\modules\client\augment\organs.dm"
+#include "modular_nova\modules\customization\modules\client\augment\species_limbs.dm"
 #include "modular_nova\modules\customization\modules\clothing\accessories.dm"
 #include "modular_nova\modules\customization\modules\clothing\toggle_base.dm"
 #include "modular_nova\modules\customization\modules\clothing\ears\ears.dm"


### PR DESCRIPTION
## About The Pull Request
![CPrhPpTrWL](https://github.com/NovaSector/NovaSector/assets/4081722/46e57ef5-29e4-4816-8d56-072623916e4d)

Expands character customization by adding all species limbs to the augments tab.

## How This Contributes To The Nova Sector Roleplay Experience

This is something that was on my todo list during the new character customization menu but I scrapped it for time because head/chest augments didn't work at the time.

This expands character customization to allow you to use the full assortment of limb options we've got for species without being locked into a specific set of limbs. Wanna have a kickass skeleton arm on your right hand but a rock golem arm on your left? Go for it.

This will let you gamers cut back on the volume of species that exist just to change the sprites as people can just assemble it 

Can probably put the unique species organs in the organ augs pool too, but that'd require some additional boilerplate to ensure you get nitrogen/plasma tanks if you took vox/plasmaman lungs.

## Proof of Testing
![shEDUXkhgb](https://github.com/NovaSector/NovaSector/assets/4081722/d0fc5239-5154-4ae0-8da3-2ca207c540a5)
he walks the station

## Changelog

:cl:
add: Expands character customization by adding all species limbs to the augments tab.
fix: Fixes augments that use icon_greyscale not rendering properly on character creation.
/:cl: