### PR TITLE
Ooey Gooey Slimegirl Buffs Vol. 1

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -133,6 +133,7 @@
 		drop_organs(phantom_owner) //Psuedoparts shouldn't have organs, but just in case
 		qdel(src)
 		return
+	//NOVA EDIT BEGIN - These just splatter, they don't fall off.
 	for(var/obj/item/bodypart/limb as anything in phantom_owner.bodyparts)
 		if(limb.limb_id == SPECIES_SLIMEPERSON)
 			phantom_owner.visible_message(span_notice("[phantom_owner]'s [limb] splatters with an unnerving squelch!"))
@@ -140,6 +141,7 @@
 			playsound(phantom_owner, 'sound/effects/blobattack.ogg', 60, TRUE)
 			qdel(src)
 			return
+	//NOVA EDIT END
 	if(move_to_floor)
 		if(!drop_loc) // drop_loc = null happens when a "dummy human" used for rendering icons on prefs screen gets its limbs replaced.
 			qdel(src)

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -133,12 +133,13 @@
 		drop_organs(phantom_owner) //Psuedoparts shouldn't have organs, but just in case
 		qdel(src)
 		return
-	if(limb_id & SPECIES_SLIMEPERSON)
-		phantom_owner.visible_message(span_notice("[phantom_owner]'s [src] splatters with an unnerving squelch!"))
-		to_chat(phantom_owner, span_warning("Your [src] splatters with an unnerving squelch!"))
-		playsound(phantom_owner, 'sound/effects/blobattack.ogg', 60, TRUE)
-		qdel(src)
-		return
+	for(var/obj/item/bodypart/limb as anything in phantom_owner.bodyparts)
+		if(limb.limb_id == SPECIES_SLIMEPERSON)
+			phantom_owner.visible_message(span_notice("[phantom_owner]'s [limb] splatters with an unnerving squelch!"))
+			to_chat(phantom_owner, span_warning("Your [src] splatters with an unnerving squelch!"))
+			playsound(phantom_owner, 'sound/effects/blobattack.ogg', 60, TRUE)
+			qdel(src)
+			return
 	if(move_to_floor)
 		if(!drop_loc) // drop_loc = null happens when a "dummy human" used for rendering icons on prefs screen gets its limbs replaced.
 			qdel(src)

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -133,7 +133,12 @@
 		drop_organs(phantom_owner) //Psuedoparts shouldn't have organs, but just in case
 		qdel(src)
 		return
-
+	if(limb_id & SPECIES_SLIMEPERSON)
+		phantom_owner.visible_message(span_notice("[phantom_owner]'s [src] splatters with an unnerving squelch!"))
+		to_chat(phantom_owner, span_warning("Your [src] splatters with an unnerving squelch!"))
+		playsound(phantom_owner, 'sound/effects/blobattack.ogg', 60, TRUE)
+		qdel(src)
+		return
 	if(move_to_floor)
 		if(!drop_loc) // drop_loc = null happens when a "dummy human" used for rendering icons on prefs screen gets its limbs replaced.
 			qdel(src)

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -5,6 +5,10 @@
 	hair_color = "mutcolor"
 	hair_alpha = 160 //a notch brighter so it blends better.
 	facial_hair_alpha = 160
+	mutantliver = /obj/item/organ/internal/liver/slime
+	mutantstomach = /obj/item/organ/internal/stomach/slime
+	mutantbrain = /obj/item/organ/internal/brain/slime
+	inherent_traits = (TRAIT_EASYDISMEMBER)
 
 /datum/species/jelly/get_default_mutant_bodyparts()
 	return list(
@@ -18,6 +22,55 @@
 		"spines" = list("None", FALSE),
 		"frills" = list("None", FALSE),
 	)
+
+/obj/item/organ/internal/eyes/jelly
+	zone = BODY_ZONE_CHEST
+	organ_flags = ORGAN_UNREMOVABLE
+
+/obj/item/organ/internal/tongue/jelly
+	zone = BODY_ZONE_CHEST
+	organ_flags = ORGAN_UNREMOVABLE
+
+/obj/item/organ/internal/lungs/slime
+	zone = BODY_ZONE_CHEST
+	organ_flags = ORGAN_UNREMOVABLE
+
+/obj/item/organ/internal/liver/slime
+	name = "endoplasmic reticulum"
+	zone = BODY_ZONE_CHEST
+	organ_flags = ORGAN_UNREMOVABLE
+
+/obj/item/organ/internal/stomach/slime
+	name = "golgi apparatus"
+	zone = BODY_ZONE_CHEST
+	organ_flags = ORGAN_UNREMOVABLE
+
+/obj/item/organ/internal/brain/slime
+	name = "nucleus"
+	zone = BODY_ZONE_CHEST
+	organ_flags = ORGAN_UNREMOVABLE
+
+/obj/item/bodypart/head/slime
+	can_dismember = TRUE //Their organs are in their chest now. It's okay.
+
+/datum/species/jelly/spec_life(mob/living/carbon/human/slime, seconds_per_tick, times_fired)
+	. = ..()
+	if(slime.stat != CONSCIOUS)
+		return
+
+	if(slime.blood_volume > BLOOD_VOLUME_NORMAL)
+		slime.heal_overall_damage(brute = 0.5 * seconds_per_tick, burn = 0.5 * seconds_per_tick, required_bodytype = BODYTYPE_ORGANIC)
+		slime.adjustOxyLoss(-0.5 * seconds_per_tick)
+
+/datum/species/jelly/handle_chemical(mob/living/carbon/slime, datum/reagent/chem, seconds_per_tick, times_fired)
+	. = ..()
+	// slimes use plasma to fix wounds, and if they have enough blood, organs
+	if(istype(chem, /datum/reagent/toxin/plasma) || istype(chem, /datum/reagent/toxin/hot_ice))
+		for(var/datum/wound/iter_wound as anything in slime.all_wounds)
+			iter_wound.on_xadone(4 * REM * seconds_per_tick)
+		if(slime.blood_volume < BLOOD_VOLUME_SLIME_SPLIT)
+			slime.fully_heal(HEAL_ORGANS)
+		return // Do normal metabolism
 
 /datum/species/jelly/get_species_description()
 	return placeholder_description
@@ -111,7 +164,7 @@
 
 /datum/action/innate/alter_form/New(Target)
 	. = ..()
-	
+
 	generate_radial_icons()
 
 	if(length(available_choices))


### PR DESCRIPTION
## About The Pull Request
Opening as a draft while I do some number tweaks tomorrow and also handle stuff on the other PR.

How's it going.
Long have slimepeople been boring as hell. I will make that no longer a thing.
I've been glancing at https://ss13polaris.com/index.php?title=Promethean and while I haven't quite been able to nail down most of this stuff because /tg/ simply doesn't have the finely tuned species code to manage it (let me know if anyone can help me with slimes cleaning stuff they touch and getting nutrition), I've managed to port some of it. Some of it.

To begin with, slimes now have all their organs in their chest where they belong. They are **unremovable,** which means you can't really upgrade them in the round unless for some reason you take that stuff in chargen (fair play,) but now decapitation isn't that much of a problem. Let me know in the comments if you'd like to see a buff to how efficient their stomach is as a trade offer. Fits in with the whole 'eats everything.' Additionally, I went ahead and gave them more interesting names. SURGERY DOES WORK JUST AS IT USED TO.

Secondly, slimes now have easily detachable limbs. Exact testing is still to-do, but they have the same easy dismember that the ligament surgery gives you. Their limbs splatter instead of falling off, so you will **have to** regenerate them. Additionally, they are now one of the only species in the game (besides zombies) that experience decapitation. Don't worry, **the hair grows back too.** 

Now let's get to the meat and potatoes. I've got bad news and good news.

The bad news is that slimes are now weak to water. I was going to put this on various drinks and juices, but I figured it would be enough for now to just do subtypes of water. Wetstacks drain blood volume and prevent damage regeneration (more on that later), enough of them will do toxin damage. Drinking water makes the problem even worse, but it does metabolize away at about the same rate a blood filter does. Do not drown.

In exchange, slimes now have the actual potent regenerative powers that you would expect a fucking slime to have. About -2 brute and burn a tick, along with -1 oxyloss. Plasma in particular will work as a panacea for their wounds much like blood works for hemophages and plasma works for plasmamen, and in high amounts of internal jelly (like, above what it takes to split) it will work as a panacea for their various organs. Let me know if I should disable it fixing their brain.

## How This Contributes To The Nova Sector Roleplay Experience
Much like my other PRs, this is to help bring these species out of regressive and restrictive modes of balance and start to make them more mechanically deep; especially slimepeople, who require xenobiology green extracts to be 'deep' to any degree.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
More on that later.
</details>

## Changelog
:cl:
add: Slimes now passively heal, heal better in response to plasma, but are weak to water. Don't drink that stuff!
add: Slimes now have all their organs in their chest.
add: Slimes, also, now have much more easily detachable limbs, which splatter when severed.
/:cl:
