### PR TITLE
[Non-modular] Disables cyborg expander

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -576,7 +576,7 @@
 	robot.set_anchored(FALSE)
 	REMOVE_TRAIT(robot, TRAIT_NO_TRANSFORM, REF(src))
 	robot.hasExpanded = TRUE
-	robot.update_transform(1.5) // NOVA EDIT CHANGE - ORIGINAL: robot.update_transform(2)
+	robot.update_transform(1) // NOVA EDIT CHANGE - ORIGINAL: robot.update_transform(2)
 
 /obj/item/borg/upgrade/expand/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tweaks a number.

## How This Contributes To The Nova Sector Roleplay Experience

There's code in place that prevents cyborgs with already big 64x32 sprites to install this upgrade. Unfortunately, people are aware of an exploit to do this anyway, and aren't very shy about it.
So I'm PRing it out, sorry to all the 32x32 cyborgs that liked this module.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed the ability for cyborgs to expand their size
/:cl:

