### PR TITLE
Re-enables borg resizing for Tall/Wide with more aggressive limits

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -555,11 +555,12 @@
 	if(robot.model.model_select_icon == "nomod")
 		to_chat(usr, span_warning("Default models cannot take expand or shrink upgrades."))
 		return FALSE
-	if((TRAIT_R_WIDE in robot.model.model_features) || (TRAIT_R_TALL in robot.model.model_features))
-		to_chat(usr, span_warning("This unit's chassis cannot be enlarged any further."))
-		return FALSE
+	var/resize_amount = 1.5
+	if(TRAIT_R_WIDE in robot.model.model_features)
+		resize_amount = 1.25
+	if(TRAIT_R_TALL in robot.model.model_features)
+		resize_amount = 1.05
 	// NOVA EDIT END
-
 	ADD_TRAIT(robot, TRAIT_NO_TRANSFORM, REF(src))
 	var/prev_lockcharge = robot.lockcharge
 	robot.SetLockdown(TRUE)
@@ -576,7 +577,7 @@
 	robot.set_anchored(FALSE)
 	REMOVE_TRAIT(robot, TRAIT_NO_TRANSFORM, REF(src))
 	robot.hasExpanded = TRUE
-	robot.update_transform(1.5) // NOVA EDIT CHANGE - ORIGINAL: robot.update_transform(2)
+	robot.update_transform(resize_amount) // NOVA EDIT CHANGE - ORIGINAL: robot.update_transform(2)
 
 /obj/item/borg/upgrade/expand/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()

--- a/modular_nova/master_files/code/modules/research/techweb/all_nodes.dm
+++ b/modular_nova/master_files/code/modules/research/techweb/all_nodes.dm
@@ -232,6 +232,7 @@
 	design_ids += list(
 		"borg_upgrade_clamp",
 		"borg_upgrade_brush",
+		"borg_upgrade_shrink",
 	)
 	return ..()
 

--- a/modular_nova/modules/borgs/code/robot_upgrade.dm
+++ b/modular_nova/modules/borgs/code/robot_upgrade.dm
@@ -412,7 +412,6 @@
 		if(TRAIT_R_SMALL in borg.model.model_features)
 			to_chat(usr, span_warning("This unit's chassis cannot be shrunk any further."))
 			return FALSE
-
 		borg.hasShrunk = TRUE
 		ADD_TRAIT(borg, TRAIT_NO_TRANSFORM, REF(src))
 		var/prev_lockcharge = borg.lockcharge
@@ -429,7 +428,7 @@
 			borg.SetLockdown(FALSE)
 		borg.set_anchored(FALSE)
 		REMOVE_TRAIT(borg, TRAIT_NO_TRANSFORM, REF(src))
-		borg.update_transform(0.75)
+		borg.update_transform(0.90)
 
 /obj/item/borg/upgrade/shrink/deactivate(mob/living/silicon/robot/borg, user = usr)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The removal a while back was met with almost negatives across the board from borg players, so i'm re-introducing it but with more reasonable size changes. 

Wide Borgs (Quadsborgs):
Shrink module: 90%
Expand module: 125%

Ironically the quads had the opposite issue that tallborgs had where the small difference made them have really weird pixel bars show up.

Ordering in the pictures are top to bottom: Expand | Normal | Shrink

Tall Borgs (Nikas/Nikos/Mekas/CATTES):
Shrink: 95%
Expand: 105%
The scalers going on the Y axes give a much harsher and more dramatic change than the X axis like wides have, and given they're already fairly tall we're going to go with a tamer but still fairly noticable sprite difference.

Small_trait borgs (Default/Borgi)
Unchanged currently - they get the 125% increase but are locked from the decrease due to turning microscopic

Ordering in the pictures are left to right: Shrink | Normal | Expand

![image](https://github.com/NovaSector/NovaSector/assets/22140677/016f8448-3ca0-4303-8ba4-74a2b3cfcc56)

<details>
<summary>Other angles/with HUDS</summary>

![image](https://github.com/NovaSector/NovaSector/assets/22140677/b6f38baa-bf3e-4438-86e7-e55f429dfd94)

![image](https://github.com/NovaSector/NovaSector/assets/22140677/7eba9909-8d0a-40fd-aea5-8e8513d32bb6)

</details>

## How This Contributes To The Nova Sector Roleplay Experience

We have some rather dramatic size options now, from Oversized to dwarf, this brings back the ability to at-a-glance differentiate borgs who share the same skin within a shift if they choose to use one of these options. 

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  See Description
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: re-enabled Borg Resizing for wide and tall borgs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
