### PR TITLE
Fixes ghosts not being able to check records

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -277,29 +277,30 @@
 						sec_record_message += "\nAdded by [crime.author] at [crime.time]"
 				to_chat(human_or_ghost_user, examine_block(sec_record_message))
 				return
+			// NOVA EDIT ADDITION START- EXAMINE RECORDS
+			if(href_list["genrecords"])
+				if(ishuman(usr))
+					var/mob/living/carbon/human/human_user = usr
+					if(!human_user.canUseHUD())
+						return
+					if(!HAS_TRAIT(human_user, TRAIT_SECURITY_HUD))
+						return
+				else if(!isobserver(usr))
+					return
+				to_chat(usr, "<b>General Record:</b> [target_record.past_general_records]")
+			if(href_list["secrecords"])
+				if(ishuman(usr))
+					var/mob/living/carbon/human/human_user = usr
+					if(!human_user.canUseHUD())
+						return
+					if(!HAS_TRAIT(human_user, TRAIT_SECURITY_HUD))
+						return
+				else if(!isobserver(usr))
+					return
+				to_chat(usr, "<b>Security Record:</b> [target_record.past_security_records]")
+			// NOVA EDIT ADDITION END - EXAMINE RECORDS
 			if(ishuman(human_or_ghost_user))
 				var/mob/living/carbon/human/human_user = human_or_ghost_user
-				//NOVA EDIT ADDITION BEGIN - EXAMINE RECORDS
-				if(href_list["genrecords"])
-					if(istype(human_user))
-						if(!human_user.canUseHUD())
-							return
-						if(!HAS_TRAIT(human_user, TRAIT_SECURITY_HUD))
-							return
-					else if(!isobserver(human_or_ghost_user))
-						return
-					to_chat(human_user, "<b>General Record:</b> [target_record.past_general_records]")
-
-				if(href_list["secrecords"])
-					if(istype(human_user))
-						if(!human_user.canUseHUD())
-							return
-						if(!HAS_TRAIT(human_user, TRAIT_SECURITY_HUD))
-							return
-					else if(!isobserver(human_or_ghost_user))
-						return
-					to_chat(human_user, "<b>Security Record:</b> [target_record.past_security_records]")
-				//NOVA EDIT ADDITION END
 				if(href_list["add_citation"])
 					var/max_fine = CONFIG_GET(number/maxfine)
 					var/citation_name = tgui_input_text(human_user, "Citation crime", "Security HUD")


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/1684

## How This Contributes To The Nova Sector Roleplay Experience

Bugfix

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![dreamseeker_aWlp9nJyOT](https://github.com/NovaSector/NovaSector/assets/13398309/44fc61aa-7646-46ed-8258-13075e0a496b)


</details>

## Changelog

:cl:
fix: ghosts can now view general and security records once again
/:cl:
