### PR TITLE
Power related fixes for flatpacked stirlings, ore thumpers and both sizes of station batteries

### DIFF
--- a/modular_nova/modules/colony_fabricator/code/machines/power_storage_unit.dm
+++ b/modular_nova/modules/colony_fabricator/code/machines/power_storage_unit.dm
@@ -5,9 +5,9 @@
 		<b>higher maximum output</b> than some larger units. Most commonly seen being used not for their ability to store \
 		power, but rather for use in regulating power input and output."
 	icon = 'modular_nova/modules/colony_fabricator/icons/power_storage_unit/small_battery.dmi'
-	capacity = 750 * 1000
-	input_level_max = 400 * 1000
-	output_level_max = 400 * 1000
+	capacity = 7.5 * STANDARD_CELL_CHARGE
+	input_level_max = 400 KILO WATTS
+	output_level_max = 400 KILO WATTS
 	circuit = null
 	obj_flags = CAN_BE_HIT | NO_DECONSTRUCTION
 	/// The item we turn into when repacked
@@ -71,9 +71,9 @@
 		<b>low maximum output</b> compared to smaller units. Most commonly seen as large backup batteries, or simply \
 		for large power storage where throughput is not a concern."
 	icon = 'modular_nova/modules/colony_fabricator/icons/power_storage_unit/large_battery.dmi'
-	capacity = 10000 * 1000
-	input_level_max = 50 * 1000
-	output_level_max = 50 * 1000
+	capacity = 100 * STANDARD_CELL_CHARGE
+	input_level_max = 50 KILO WATTS
+	output_level_max = 50 KILO WATTS
 	repacked_type = /obj/item/flatpacked_machine/large_station_battery
 
 // Automatically set themselves to be completely charged on init

--- a/modular_nova/modules/colony_fabricator/code/machines/rtg.dm
+++ b/modular_nova/modules/colony_fabricator/code/machines/rtg.dm
@@ -7,7 +7,7 @@
 	icon = 'modular_nova/modules/colony_fabricator/icons/machines.dmi'
 	circuit = null
 	obj_flags = CAN_BE_HIT | NO_DECONSTRUCTION
-	power_gen = 7500
+	power_gen = 7.5 KILO WATTS
 	/// What we turn into when we are repacked
 	var/repacked_type = /obj/item/flatpacked_machine/rtg
 

--- a/modular_nova/modules/colony_fabricator/code/machines/stirling_generator.dm
+++ b/modular_nova/modules/colony_fabricator/code/machines/stirling_generator.dm
@@ -22,7 +22,7 @@
 	/// Maximum efficient heat difference, at what heat difference does more difference stop meaning anything for power?
 	var/max_efficient_heat_difference = 8000
 	/// Maximum power output from this machine
-	var/max_power_output = 100 * 1000
+	var/max_power_output = 100 KILO WATTS
 	/// How much power the generator is currently making
 	var/current_power_generation
 	/// Our looping fan sound that we play when turned on
@@ -39,13 +39,12 @@
 	// This is just to make sure our atmos connection spawns facing the right way
 	setDir(dir)
 
-
 /obj/machinery/power/stirling_generator/examine(mob/user)
 	. = ..()
 	. += span_notice("You can use a <b>wrench</b> with <b>Left-Click</b> to rotate the generator.")
 	. += span_notice("It will not work in a <b>vacuum</b> as it must be cooled by the gas around it.")
-	. += span_notice("It is currently generating <b>[current_power_generation / 1000] kW</b> of power.")
-	. += span_notice("It has a maximum power output of <b>[max_power_output / 1000] kW</b> at a temperature difference of <b>[max_efficient_heat_difference] K</b>.")
+	. += span_notice("It is currently generating <b>[display_power(current_power_generation, convert = FALSE)]</b> of power.")
+	. += span_notice("It has a maximum power output of <b>[display_power(max_power_output, convert = FALSE)]</b> at a temperature difference of <b>[max_efficient_heat_difference] K</b>.")
 
 
 /obj/machinery/power/stirling_generator/Destroy()

--- a/modular_nova/modules/colony_fabricator/code/machines/stirling_generator.dm
+++ b/modular_nova/modules/colony_fabricator/code/machines/stirling_generator.dm
@@ -85,7 +85,7 @@
 
 /obj/machinery/power/stirling_generator/process()
 	var/power_output = round(current_power_generation)
-	add_avail(power_output)
+	add_avail(power_to_energy(power_output))
 	var/new_icon_state = (power_output ? "stirling_on" : "stirling")
 	icon_state = new_icon_state
 	if(soundloop.is_active() && !power_output)

--- a/modular_nova/modules/kahraman_equipment/code/ore_thumper.dm
+++ b/modular_nova/modules/kahraman_equipment/code/ore_thumper.dm
@@ -88,7 +88,7 @@
 		. += span_notice("Its must be constructed <b>outdoors</b> to function.")
 	if(!istype(get_turf(src), /turf/open/misc))
 		. += span_notice("It must be constructed on <b>suitable terrain</b>, like ash, snow, or sand.")
-	. += span_notice("It must have a powered, <b>wired connection</b> running beneath it with <b>[active_power_usage / BASE_MACHINE_ACTIVE_CONSUMPTION] kW</b> of excess power to function.")
+	. += span_notice("It must have a powered, <b>wired connection</b> running beneath it with <b>[display_power(active_power_usage, convert = FALSE)]</b> of excess power to function.")
 	. += span_notice("It will produce a box of materials after it has slammed [slam_jams_needed] times.")
 	. += span_notice("Currently, it has slammed [slam_jams] / [slam_jams_needed] times needed.")
 	. += span_notice("It will stop producing resources if there are <b>too many piles of ore</b> near it.")
@@ -98,6 +98,7 @@
 /obj/machinery/power/colony_ore_thumper/process()
 	var/turf/our_turf = get_turf(src)
 	var/obj/structure/cable/cable_under_us = locate() in our_turf
+	var/energy_needed = power_to_energy(active_power_usage)
 	if(!cable_under_us && powernet)
 		disconnect_from_network()
 	else if(cable_under_us && !powernet)
@@ -107,8 +108,8 @@
 			balloon_alert_to_viewers("invalid location!")
 			cut_that_out()
 			return
-		if(avail(active_power_usage))
-			add_load(active_power_usage)
+		if(avail(energy_needed))
+			add_load(energy_needed)
 		else
 			balloon_alert_to_viewers("not enough power!")
 			cut_that_out()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I don't know why we should convert POWER to ENERGY to get correct amount of POWER in powernet. But it is what it is. Now sitrlings produce twice as much power and could do it's work in a new dark age of 1 MW loads of cell chargers.

Same problem happened to ore thumpers. Free ore is ended, they are once again eating theirs 50 kW as their description saying.

And while i'm at it, i have changed some plain numbers to TG defines increasing capacity of both flatpack SMESes. They are now back in line with regular SMESes: 15% for small battery and 2x for large.

Power generation machinery got their description changed slightly by adding new `display_power` proc. Nothing visually changed, but it is nice to have it this way.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Another fix for https://github.com/NovaSector/NovaSector/issues/1678
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/8430839/547c8c3a-d42b-4ae1-ad42-a517d4a0431a)

![image](https://github.com/NovaSector/NovaSector/assets/8430839/623aec18-f696-4485-aa35-caf6f0d90c8b)

![image](https://github.com/NovaSector/NovaSector/assets/8430839/0cbc8aa5-7b0d-4d37-a000-5ea39e2f4384)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed stirlings outputting only half the power they show on display
fix: fixed thumpers consuming half as much power as they need
code: some or even all colony machinery should be dependent on TG defines for power
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
