### PR TITLE
[MISSED MIRROR] Actually Caches The BYOND Installation in CI (#82364)

### DIFF
--- a/.github/workflows/autowiki.yml
+++ b/.github/workflows/autowiki.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/BYOND
-        key: ${{ runner.os }}-byond-${{ secrets.CACHE_PURGE_KEY }}
+        key: ${{ runner.os }}-byond-${{ hashFiles('dependencies.sh') }}
     - name: Install rust-g
       if: steps.secrets_set.outputs.SECRETS_ENABLED
       run: |

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -128,7 +128,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/BYOND
-          key: ${{ runner.os }}-byond
+          key: ${{ runner.os }}-byond-${{ hashFiles('dependencies.sh') }}
       - name: Compile All Maps
         run: |
           bash tools/ci/install_byond.sh

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/BYOND
-          key: ${{ runner.os }}-byond-${{ secrets.CACHE_PURGE_KEY }}
+          key: ${{ runner.os }}-byond-${{ hashFiles('dependencies.sh') }}
       - name: Setup database
         run: |
           sudo systemctl start mysql


### PR DESCRIPTION
## ORIGINAL PR: https://github.com/tgstation/tgstation/pull/82364

## About The Pull Request

Fun fact, nothing ever hashbanged this, so we've been using the same weeks-old cache which has been necessitating that we use the same old versions of BYOND until someone cleaned the cache. Let's tie to `dependencies.sh` like everything else (which we already did in #78307 (5e1c8bdebd610d82c4a9f7254342e7f299db0e19)) so we don't have to keep wasting time in CI compilations having to reinstall the needed BYOND version from scratch (and have caches date and auto-clear themselves when outdated)

the advantage is that we spend less time downloading/installing BYOND in CI runs and can actually run CI