### PR TITLE
[MODULAR] Removes the vetlock from pet owner and shapeshifter

### DIFF
--- a/modular_nova/modules/pet_owner/pet_owner.dm
+++ b/modular_nova/modules/pet_owner/pet_owner.dm
@@ -4,7 +4,6 @@
 	icon = FA_ICON_HORSE
 	value = 4
 	mob_trait = TRAIT_PET_OWNER
-	veteran_only = TRUE
 	gain_text = span_notice("You brought your pet with you to work.")
 	lose_text = span_danger("You feel lonely, as if leaving somebody behind...")
 	medical_record_text = "Patient mentions their fondness for their pet."

--- a/modular_nova/modules/shapeshifter_quirk/code/shapeshifter_quirk.dm
+++ b/modular_nova/modules/shapeshifter_quirk/code/shapeshifter_quirk.dm
@@ -6,7 +6,6 @@
 	lose_text = span_notice("Your body loses its alterable feeling.")
 	medical_record_text = "Patient has an unusual physiology that allows them to physically transform their body."
 	value = 8
-	veteran_only = TRUE
 	quirk_flags = QUIRK_HUMAN_ONLY
 
 /datum/quirk/shapeshifter/add(client/client_source)


### PR DESCRIPTION

## About The Pull Request

Title.
## How This Contributes To The Nova Sector Roleplay Experience

Shapeshifter was arbitrarily vetlocked as it was "designed as a veteran quirk" in https://github.com/NovaSector/NovaSector/pull/1065, and pet owner was vetlocked out of paranoia in https://github.com/Skyrat-SS13/Skyrat-tg/pull/25142. 

Firstly, I havent actually seen an argument as to why shapeshifter is vetlocked, so let me rebutt a few arguments that I think might crop up.

1. "People will use it to make weird looking characters" - already doable in char creation
2. "People will use it to hide their identities" - Already doable via shapeshift disk and slimepeople (One of which is undetectable and unpredictable, you can go "oh that slime person will look different" with slimes, not with shapechanger NIF or quirk)
3. "It serves as a incentive to be a veteran" - Absolutely horrible justification. From what I understand, veteran exists as a way to give people access to funkier things that we might not be able to trust the general playerbase with (ex. why clown is vetlocked) - Things should not be vetlocked arbitrarily to get people to be veteran, and I can easily make counterarguments such as, it _also_ clogs the application process more, or, more importantly, _deprives people of fun mechanics_ they _can_ be trusted with just because they didnt _apply_. Being a vet should be a status of _trust_, not a status of _"heightened citizenship"_.

As for pet owner, the PR author themselves said they arent too attached to it being a pet owner. Let me break down some arguments for its vet locking and say why theyre false.
1. "Veteran incentive" - See above
2. "People will spam pets and flood the interlink" - Do you see people en masse getting skub and just flooding the interlink with it? Do you see people flooding the station with monkeys _en masse_? People do this, yes, but the keyword is en masse, as thats when it gets really disruptive. SOME people might just drop their pets for no reason, but certainly not the entire playerbase - they arent a dedicated grief machine.
3. "Some pets like horses can be overpowered" - If the animal is mountable, we can compromise by vetlocking those animals only 
4. "Some pets like horses are _stupid_" - See above, I agree but I also think it isnt an issue since people wouldnt be doing it en masse

For 2 and 4 unfortunately I cant conclusively prove myself right as the only way to do so is to test. Doubly unfortunately, this isnt exactly the PR that would get conclusive results on a TM, its one of those long term issues.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
localhost lets you take all quirks so i cant lmao

</details>

## Changelog
:cl:
add: Shapeshifter is no longer vetlocked
add: Pet owner is no longer v etlocked
/:cl:
