### PR TITLE
Robo knowledge for RD

### DIFF
--- a/code/modules/library/skill_learning/job_skillchips/research_director.dm
+++ b/code/modules/library/skill_learning/job_skillchips/research_director.dm
@@ -1,7 +1,7 @@
 /obj/item/skillchip/job/research_director
 	name = "R.D.S.P.L.X. skillchip"
 	desc = "Knowledge of how to solve the ancient conumdrum; what happens when an unstoppable force meets an immovable object."
-	auto_traits = list(TRAIT_ROD_SUPLEX)
+	auto_traits = list(TRAIT_ROD_SUPLEX,TRAIT_KNOW_ROBO_WIRES) // NOVA ADDITION: Added robotics wiring knowledge
 	skill_name = "True Strength"
 	skill_description = "The knowledge and strength to resolve the most ancient conumdrum; what happens when an unstoppable force meets an immovable object."
 	skill_icon = "dumbbell"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds robo wiring knowledge for RD's Rod Suplex skillchip. 

## How This Contributes To The Nova Sector Roleplay Experience

Research Director is literally Silicon's supervisor and the most skilled scientist and roboticist. He MUST know how to maintain silicons, synths and MODsuits

## Proof of Testing

It adds literally one deffinition. Do you really think it needs a testing?

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: RD got roboticist's wiring knowledge trait.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
