### PR TITLE
Fixes span for silicon/simplemob temp flavor text

### DIFF
--- a/modular_nova/modules/customization/modules/mob/living/silicon/examine.dm
+++ b/modular_nova/modules/customization/modules/mob/living/silicon/examine.dm
@@ -25,7 +25,7 @@
 			. += span_notice("Antag Opt-in Status: <b><font color='[GLOB.antag_opt_in_colors[stringified_optin]]'>[stringified_optin]</font></b>")
 
 	if(temporary_flavor_text)
-		if(length_char(temporary_flavor_text) <= 40)
-			. += span_notice("<b>They look different than usual:</b> [temporary_flavor_text]")
+		if(length_char(temporary_flavor_text) < TEMPORARY_FLAVOR_PREVIEW_LIMIT)
+			. += span_revennotice("<br>They look different than usual: [temporary_flavor_text]")
 		else
-			. += span_notice("<b>They look different than usual:</b> [copytext_char(temporary_flavor_text, 1, 37)]... <a href='?src=[REF(src)];temporary_flavor=1'>More...</a>")
+			. += span_revennotice("<br>They look different than usual: [copytext_char(temporary_flavor_text, 1, TEMPORARY_FLAVOR_PREVIEW_LIMIT)]... <a href='?src=[REF(src)];temporary_flavor=1'>More...</a>")

--- a/modular_nova/modules/customization/modules/mob/living/simple_mob/examine.dm
+++ b/modular_nova/modules/customization/modules/mob/living/simple_mob/examine.dm
@@ -2,7 +2,7 @@
 	. = ..()
 	//Temporary flavor text addition:
 	if(temporary_flavor_text)
-		if(length_char(temporary_flavor_text) <= 40)
-			. += span_notice("[temporary_flavor_text]")
+		if(length_char(temporary_flavor_text) < TEMPORARY_FLAVOR_PREVIEW_LIMIT)
+			. += span_revennotice("<br>They look different than usual: [temporary_flavor_text]")
 		else
-			. += span_notice("[copytext_char(temporary_flavor_text, 1, 37)]... <a href='?src=[REF(src)];temporary_flavor=1'>More...</a>")
+			. += span_revennotice("<br>They look different than usual: [copytext_char(temporary_flavor_text, 1, TEMPORARY_FLAVOR_PREVIEW_LIMIT)]... <a href='?src=[REF(src)];temporary_flavor=1'>More...</a>")


### PR DESCRIPTION
## Changelog

:cl: LT3
fix: Silicon and simplemob temporary flavor text is now displayed in the same length and style as everyone else
/:cl: