### PR TITLE
[Semi-Modular]  Adds TGUI Chat Prefix Colors for various Faction Radios + Fixes Solfed Radios

### DIFF
--- a/code/__DEFINES/~nova_defines/mapping.dm
+++ b/code/__DEFINES/~nova_defines/mapping.dm
@@ -21,3 +21,9 @@
 #define RADIO_TOKEN_TARKON ":k"
 
 #define FREQ_TARKON 1243
+
+#define RADIO_CHANNEL_SOLFED "SolFed"
+#define RADIO_KEY_SOLFED "l"
+#define RADIO_TOKEN_SOLFED ":l"
+
+#define FREQ_SOLFED 1377

--- a/modular_nova/modules/goofsec/code/sol_fed.dm
+++ b/modular_nova/modules/goofsec/code/sol_fed.dm
@@ -392,6 +392,36 @@ GLOBAL_LIST_INIT(call911_do_and_do_not, list(
 	greyscale_config = /datum/greyscale_config/encryptionkey_medical
 	greyscale_colors = "#ebebeb#2b2793"
 
+/obj/item/radio/headset/headset_solfed/sec
+	name = "\improper SolFed adv. Security headset"
+	desc = "A headset used by the Solar Federation response teams."
+	icon_state = "med_headset"
+	keyslot = /obj/item/encryptionkey/headset_solfed/atmos
+	radiosound = 'modular_nova/modules/radiosound/sound/radio/security.ogg'
+
+/obj/item/encryptionkey/headset_solfed/sec
+	name = "\improper SolFed adv. Security encryption key"
+	icon_state = "cypherkey_medical"
+	independent = TRUE
+	channels = list(RADIO_CHANNEL_SOLFED = 1, RADIO_CHANNEL_SECURITY = 1, RADIO_CHANNEL_COMMAND = 1)
+	greyscale_config = /datum/greyscale_config/encryptionkey_medical
+	greyscale_colors = "#ebebeb#2b2793"
+
+/obj/item/radio/headset/headset_solfed/med
+	name = "\improper SolFed adv. Medical headset"
+	desc = "A headset used by the Solar Federation response teams."
+	icon_state = "med_headset"
+	keyslot = /obj/item/encryptionkey/headset_solfed/atmos
+	radiosound = 'modular_nova/modules/radiosound/sound/radio/security.ogg'
+
+/obj/item/encryptionkey/headset_solfed/med
+	name = "\improper SolFed adv. Medical encryption key"
+	icon_state = "cypherkey_medical"
+	independent = TRUE
+	channels = list(RADIO_CHANNEL_SOLFED = 1, RADIO_CHANNEL_MEDICAL = 1, RADIO_CHANNEL_COMMAND = 1)
+	greyscale_config = /datum/greyscale_config/encryptionkey_medical
+	greyscale_colors = "#ebebeb#2b2793"
+
 /*
 *	EMT
 */
@@ -407,7 +437,7 @@ GLOBAL_LIST_INIT(call911_do_and_do_not, list(
 	back = /obj/item/storage/backpack/medic
 	uniform = /obj/item/clothing/under/sol_emt
 	shoes = /obj/item/clothing/shoes/jackboots
-	ears = /obj/item/radio/headset/headset_med
+	ears = /obj/item/radio/headset/headset_solfed/med
 	mask = /obj/item/clothing/mask/gas/alt
 	head = /obj/item/clothing/head/helmet/toggleable/sf_hardened/emt
 	id = /obj/item/card/id/advanced/solfed
@@ -454,7 +484,7 @@ GLOBAL_LIST_INIT(call911_do_and_do_not, list(
 	uniform = /obj/item/clothing/under/sol_peacekeeper
 	shoes = /obj/item/clothing/shoes/jackboots
 	glasses = /obj/item/clothing/glasses/sunglasses
-	ears = /obj/item/radio/headset/headset_sec/alt
+	ears = /obj/item/radio/headset/headset_solfed/sec
 	head = /obj/item/clothing/head/helmet/sf_peacekeeper
 	belt = /obj/item/gun/energy/disabler
 	suit = /obj/item/clothing/suit/armor/sf_peacekeeper
@@ -505,7 +535,7 @@ GLOBAL_LIST_INIT(call911_do_and_do_not, list(
 
 	back = /obj/item/storage/backpack
 	glasses = /obj/item/clothing/glasses/sunglasses
-	ears = /obj/item/radio/headset/headset_sec/alt
+	ears = /obj/item/radio/headset/headset_solfed/sec
 	l_pocket = /obj/item/restraints/handcuffs
 	r_pocket = /obj/item/flashlight/seclite
 	id = /obj/item/card/id/advanced/solfed

--- a/tgui/packages/tgui-say/constants.ts
+++ b/tgui/packages/tgui-say/constants.ts
@@ -30,4 +30,11 @@ export const RADIO_PREFIXES = {
   ':u ': 'Supp',
   ':v ': 'Svc',
   ':y ': 'CCom',
+  // NOVA EDIT ADDITION START
+  ':w ': 'Dyne',
+  ':k ': 'Tark',
+  ':q ': 'Csun',
+  ':p ': 'Guild',
+  ':l ': 'SolFed',
+  // NOVA EDIT ADDITION END
 } as const;

--- a/tgui/packages/tgui-say/styles/colors.scss
+++ b/tgui/packages/tgui-say/styles/colors.scss
@@ -17,6 +17,11 @@ $_channel_map: (
   'io': #1e90ff,
   // NOVA EDIT ADDITION
   'LOOC': #ffceb6,
+  'Dyne': #67303c,
+  'Tark': #b69549,
+  'Csun': #b36033,
+  'Guild': #b3b3b3,
+  'SolFed': #cee152,
   'Me': #5975da,
   'Med': #57b8f0,
   'OOC': #cca300,


### PR DESCRIPTION
## About The Pull Request

This adds in TGUI chat box colors and proper prefixes for tarkon, interdyne, guild (which is present in a space ruin for NRI) Cybersun (which is present in the bitrunner simulation with proper player spawns) and SolFed.

As well as it properly adds in the SolFed Frequency that was present only in `modular_nova\modules\advanced_engineering\readme.md` but not actually added in code, as well as it properly outfits all of the solfed ERT teams with a headset that has the solfed frequency. 

## How This Contributes To The Nova Sector Roleplay Experience

Provides user feedback that they are properly talking on the correct channel on the radio to make it more recognizable the action they are about to send is going to go out in the proper radio frequency.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![ta815sDILw](https://github.com/NovaSector/NovaSector/assets/2568378/a13880e4-6a2a-43e4-b960-138fcdffef89)

![1Fp2jzMLtZ](https://github.com/NovaSector/NovaSector/assets/2568378/03323128-90fc-44ba-92fd-f6a0202a66ac)

![J2Aeu1fRun](https://github.com/NovaSector/NovaSector/assets/2568378/d5f9099b-4815-4efb-9519-f94371d39295)

![Fg9FKdScZD](https://github.com/NovaSector/NovaSector/assets/2568378/75462da1-a5d5-4fef-84d1-267316a27638)

![gRH72fcdcD](https://github.com/NovaSector/NovaSector/assets/2568378/c161c505-a732-48b7-ab5c-e6456f743da7)

</details>

## Changelog

:cl:
qol: Added TGUI color prefixes for Tarkon :k, Solfed :l, Guild :p, Interdyne :w and Cybersun :q
fix: Fixed a missing frequency for solfed radios that was in a readme but never actually defined in code...apparently nobody read that readme
add: Two radio headsets for the Solfed EMT team, and Solfed Marshel / SWAT / Marine teams
/:cl:
