### PR TITLE
Fix thing buy wiht no nif

### DIFF
--- a/modular_nova/modules/modular_implants/code/nifsoft_catalog.dm
+++ b/modular_nova/modules/modular_implants/code/nifsoft_catalog.dm
@@ -109,6 +109,11 @@ GLOBAL_LIST_INIT(purchasable_nifsofts, list(
 
 			var/amount_to_charge = (params["product_cost"])
 			var/rewards_purchase = (params["rewards_purchase"])
+			
+			if(!target_nif)
+				paying_account.bank_card_talk("You need a NIF implant to purchase this.")
+				return FALSE
+			
 			var/obj/item/organ/internal/cyberimp/brain/nif/buyer_nif = target_nif.resolve()
 
 			if(rewards_purchase)


### PR DESCRIPTION
this would runtime before and fail with no user-facing error message

:cl:
fix: Trying to buy a NIFsoft without a NIF implant will now tell you why it failed.
/:cl: