### PR TITLE
[Modular] Fixes Telepathy quirk sending empty messages

### DIFF
--- a/modular_nova/modules/telepathy_quirk/code/telepathy_action.dm
+++ b/modular_nova/modules/telepathy_quirk/code/telepathy_action.dm
@@ -44,7 +44,7 @@
 	if(. & SPELL_CANCEL_CAST || blocked)
 		return
 
-	message = autopunct_bare(capitalize(tgui_input_text(owner, "What do you wish to whisper to [cast_on]?", "[src]")))
+	message = autopunct_bare(capitalize(tgui_input_text(owner, "What do you wish to whisper to [cast_on]?", "[src]", null)))
 	if(QDELETED(src) || QDELETED(owner) || QDELETED(cast_on) || !can_cast_spell())
 		return . | SPELL_CANCEL_CAST
 
@@ -52,7 +52,7 @@
 		owner.balloon_alert(owner, "they're too far!")
 		return . | SPELL_CANCEL_CAST
 
-	if(!message)
+	if(!message || length(message) == 0)
 		reset_spell_cooldown()
 		return . | SPELL_CANCEL_CAST
 


### PR DESCRIPTION
## About The Pull Request

This fixes the telepathy quirk specifically to not send an empty message if the user hits cancel, the x, or just enter with a empty message.

Before the tgui_text_imput didnt have its default value set to null. tgui_text_input sends that default value whenever the user hits the x or cancel. Without it it just becomes a empty string, which before was valid for the message to be sent to people.

This also checks now for if the message has a length of 0 and will refuse to send it too as its a empty message

## How This Contributes To The Nova Sector Roleplay Experience

Less bugs, more indecisive psychics. 

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

Hard for me to test by myself, as it requires to have two clients. I did test this change with a friend i just kinda forgot to record evidence, and don't wana pester them to rejoin my local server to test it more. It works and I have tested it
  
</details>

## Changelog

:cl:
fix: Telepathy quirk no longer sends empty messages on hitting the cancel button or closing the window.
/:cl:
