### PR TITLE
[MODULAR] Fixing unconnected modular consoles and not dir 2 any consoles

### DIFF
--- a/modular_nova/modules/connecting_computer/code/_computer.dm
+++ b/modular_nova/modules/connecting_computer/code/_computer.dm
@@ -8,7 +8,7 @@
 	if(connectable)
 		AddComponent(/datum/component/connectable_computer)
 
-/obj/machinery/modular_computer/console/Initialize(mapload)
+/obj/machinery/modular_computer/Initialize(mapload)
 	. = ..()
 
 	// Modular consoles all have the same case.

--- a/modular_nova/modules/connecting_computer/code/connectable_component.dm
+++ b/modular_nova/modules/connecting_computer/code/connectable_component.dm
@@ -10,11 +10,13 @@
 
 /datum/component/connectable_computer/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(on_update_overlays))
+	RegisterSignal(parent, COMSIG_ATOM_POST_DIR_CHANGE, PROC_REF(update_neighbors))
 
 	update_neighbors()
 
 /datum/component/connectable_computer/UnregisterFromParent()
 	UnregisterSignal(parent, COMSIG_ATOM_UPDATE_OVERLAYS)
+	UnregisterSignal(parent, COMSIG_ATOM_POST_DIR_CHANGE)
 
 	update_neighbors()
 
@@ -42,6 +44,24 @@
 			return target
 
 	return null
+
+/**
+ * Handles COMSIG_ATOM_POST_DIR_CHANGE for machines.
+ * 
+ * Because ingame construction sets dir after Initialize and LateInitialize
+ * And changing dir doesn't trigger appearance updates
+ *
+ * Arguments:
+ * * dir - old dir
+ * * newdir - new dir
+ */
+/datum/component/connectable_computer/proc/on_dir_change(dir, newdir)
+	SIGNAL_HANDLER
+
+	// Call uppereance update on us and our neighbors
+	var/obj/machinery/parent_machine = parent
+	parent_machine.update_appearance()
+	update_neighbors()
 
 /**
  * Handles COMSIG_ATOM_UPDATE_OVERLAYS for machines.


### PR DESCRIPTION
## Proof of Testing

Under spoiler.
Huh.. That also means that changing dir caused by shuttle movement, will also reconnect them... Neat!

<details>
<summary>Screenshots/Videos</summary>
Computers on other dirs:
![image](https://github.com/NovaSector/NovaSector/assets/32466328/52dc6347-2713-4318-9f07-c612f81d8e31)
Modular PCs
![image](https://github.com/NovaSector/NovaSector/assets/32466328/532bbb73-c315-4a98-9d3d-ccce1a61a4aa)
![Uploading image.png…]()

</details>

## Changelog

:cl:
fix: Consoles connecting their spites again on any dir. And modular PC connects with them too!
/:cl:
