### PR TITLE
[MODULAR] Makes Tajarans able to land on their feet

### DIFF
--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
@@ -107,3 +107,15 @@
 	cat.dna.mutant_bodyparts["ears"] = list(MUTANT_INDEX_NAME = "Cat, normal", MUTANT_INDEX_COLOR_LIST = list(main_color, second_color, second_color))
 	regenerate_organs(cat, src, visual_only = TRUE)
 	cat.update_body(TRUE)
+
+/datum/species/tajaran/create_pref_unique_perks()
+	var/list/to_add = list()
+
+	to_add += list(list(
+		SPECIES_PERK_TYPE = SPECIES_NEUTRAL_PERK,
+		SPECIES_PERK_ICON = FA_ICON_PERSON_FALLING,
+		SPECIES_PERK_NAME = "Soft Landing",
+		SPECIES_PERK_DESC = "Tajarans are unhurt by high falls, and land on their feet.",
+	))
+
+	return to_add


### PR DESCRIPTION

## About The Pull Request

This PR makes Tajarans able to land on their feet if they fall through z-levels by giving them the TRAIT_CATLIKE_GRACE. It also adds the according perk on the species list page (as shown in the video).

## How This Contributes To The Nova Sector Roleplay Experience

Because they're lowkey cats and it'd make sense - and because [apparently this is what the code intended](https://github.com/NovaSector/NovaSector/blob/cf1f1e2e8bb3b579b85a0b7ccc9aae932943f001/code/modules/mob/living/living.dm#L90) (kind of?) It offers variety and makes the trait (that's gatekept to felinids) available to other species that share, even if slightly, the same concept.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
forgive the 506p ^_^

https://github.com/NovaSector/NovaSector/assets/64568243/11bc1dab-3c54-42de-9f00-0122e359c441
</details>

## Changelog
:cl: Chelxox
balance: Tajarans are able to land on their feet (like felinids).
/:cl:
