### PR TITLE
Some Table flipping fixes

### DIFF
--- a/modular_nova/modules/tableflip/code/flipped_table.dm
+++ b/modular_nova/modules/tableflip/code/flipped_table.dm
@@ -48,7 +48,7 @@
 
 /obj/structure/flippedtable/CtrlShiftClick(mob/living/user)
 	. = ..()
-	if(!istype(user) || !user.can_interact_with(src) || iscorticalborer(user))
+	if(!istype(user) || iscorticalborer(user) || !user.can_perform_action(src, NEED_DEXTERITY))
 		return FALSE
 	user.balloon_alert_to_viewers("flipping table upright...")
 	if(do_after(user, max_integrity * 0.25))
@@ -70,7 +70,7 @@
 
 /obj/structure/table/CtrlShiftClick(mob/living/user)
 	. = ..()
-	if(!istype(user) || !user.can_interact_with(src) || iscorticalborer(user))
+	if(!istype(user) || iscorticalborer(user) || !user.can_perform_action(src, NEED_DEXTERITY))
 		return
 	if(!can_flip)
 		return


### PR DESCRIPTION
## About The Pull Request

Some bugs that were brought to my attention.
-Ghosts can no longer unflip tables
-Borgs can no longer remotely flip tables

## How This Contributes To The Nova Sector Roleplay Experience

Fixes some bugs/exploits.

## Proof of Testing

<details>
<summary>No more remote tableflipping form borgs</summary>
  
![dreamseeker_Ky0uKsCKQL](https://github.com/NovaSector/NovaSector/assets/13398309/a56334ce-0baf-4f32-9af0-ed37f3cb7f54)

</details>

<details>
<summary>No more ghost tableflips</summary>
 
![dreamseeker_974nwD83uQ](https://github.com/NovaSector/NovaSector/assets/13398309/c1c86b63-e4bd-4827-8b78-ee52bf71e60f)

</details>

## Changelog

:cl:
fix: the station is now slightly less haunted - ghosts can no longer unflip tables.
fix: the remote flipping mechanisms have been removed from all the tables. borgs can no longer remotely tableflip.
/:cl:
