### PR TITLE
[MODULAR] removes (?) the stun from getting EMP'd with a NIF.

### DIFF
--- a/modular_nova/modules/modular_implants/code/nifs.dm
+++ b/modular_nova/modules/modular_implants/code/nifs.dm
@@ -405,6 +405,11 @@
 
 /obj/item/organ/internal/cyberimp/brain/nif/emp_act(severity)
 	. = ..()
+	if(!owner || . & EMP_PROTECT_SELF)
+		return
+	var/stun_amount = 0
+	owner.Stun(stun_amount)
+	to_chat(owner, span_warning("You feel a stinging pain in your head!"))
 	if(!durability_loss_vulnerable)
 		return FALSE
 


### PR DESCRIPTION

## About The Pull Request
NIFs are primarily roleplay focused, and slapping people with a 2s hardstun for having it on-emp makes it a flat detriment to have, for little mechanical gain.

## How This Contributes To The Nova Sector Roleplay Experience
see above

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  i'm gonna do it l8ter big promise
</details>

## Changelog


:cl:
balance: made it so EMPs don't hardstun people who have nifs. (doesn't affect other implants)

/:cl:


