### PR TITLE
Removes decaying waste as a pollutant

### DIFF
--- a/modular_nova/modules/pollution/code/pollutants_generic.dm
+++ b/modular_nova/modules/pollution/code/pollutants_generic.dm
@@ -45,14 +45,6 @@
 	descriptor = SCENT_DESC_SMELL
 	scent = "sulphur"
 
-///Organic waste and garbage makes this
-/datum/pollutant/decaying_waste
-	name = "Decaying Waste"
-	pollutant_flags = POLLUTANT_SMELL
-	smell_intensity = 3
-	descriptor = SCENT_DESC_ODOR
-	scent = "decaying waste"
-
 ///Splashing blood makes a tiny bit of this
 /datum/pollutant/metallic_scent
 	name = "Metallic Scent"

--- a/modular_nova/modules/pollution/code/pollution_initializations.dm
+++ b/modular_nova/modules/pollution/code/pollution_initializations.dm
@@ -2,26 +2,6 @@
 	. = ..()
 	AddElement(/datum/element/pollution_emitter, /datum/pollutant/chemical_vapors, 10)
 
-/obj/effect/decal/cleanable/vomit/Initialize(mapload)
-	. = ..()
-	AddElement(/datum/element/pollution_emitter, /datum/pollutant/decaying_waste, 10)
-
-/obj/effect/decal/cleanable/insectguts/Initialize(mapload)
-	. = ..()
-	AddElement(/datum/element/pollution_emitter, /datum/pollutant/decaying_waste, 10)
-
-/obj/effect/decal/cleanable/garbage/Initialize(mapload)
-	. = ..()
-	AddElement(/datum/element/pollution_emitter, /datum/pollutant/decaying_waste, 30)
-
-/obj/effect/decal/cleanable/blood/gibs/old/Initialize(mapload, list/datum/disease/diseases)
-	. = ..()
-	AddElement(/datum/element/pollution_emitter, /datum/pollutant/decaying_waste, 30)
-
-/obj/structure/moisture_trap/Initialize(mapload)
-	. = ..()
-	AddElement(/datum/element/pollution_emitter, /datum/pollutant/decaying_waste, 30)
-
 /obj/item/reagent_containers/cup/glass/coffee/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/temporary_pollution_emission, /datum/pollutant/food/coffee, 5, 3 MINUTES)


### PR DESCRIPTION
## About The Pull Request

Removes decaying waste as a pollutant. It provides no value to the station, and remains even when spaces are cleaned/renovated. Given maints spawn with garbage, it's impossible to eliminate and constantly spreads.

## How This Contributes To The Nova Sector Roleplay Experience

No more "The unmistakable odour of decaying waste bombards your nostrils." in spaces.

## Changelog

:cl: LT3
del: The unmistakable odour of decaying waste will no longer bombard your nostrils
/:cl: