### PR TITLE
Improving (very) small details on Blueshift

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -45047,17 +45047,6 @@
 /obj/machinery/photocopier,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
-"iFh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/secure_safe/caps_spare{
-	base_icon_state = "floorsafe";
-	icon_state = "floorsafe";
-	pixel_x = -1
-	},
-/turf/open/floor/iron,
-/area/station/command/bridge)
 "iFl" = (
 /obj/structure/sign/painting/library,
 /turf/closed/wall/mineral/wood,
@@ -225508,7 +225497,7 @@ nca
 xmO
 dEJ
 idB
-iFh
+wFN
 maG
 mrZ
 jiu

--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -72354,14 +72354,14 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engineering/atmos_aux_port)
 "nSQ" = (
-/obj/machinery/firealarm/directional/west{
-	pixel_x = -35;
-	pixel_y = -10
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
+	},
+/obj/machinery/firealarm/directional/west{
+	pixel_x = -27;
+	pixel_y = 24
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 1

--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -6095,7 +6095,6 @@
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/firealarm/directional/west,
 /obj/structure/disposalpipe/trunk{
 	dir = 2
 	},
@@ -7339,6 +7338,10 @@
 	pixel_y = -8
 	},
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/firealarm/directional/west{
+	pixel_x = -34;
+	pixel_y = -7
+	},
 /turf/open/floor/iron/stairs{
 	dir = 1
 	},
@@ -45044,6 +45047,17 @@
 /obj/machinery/photocopier,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
+"iFh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/secure_safe/caps_spare{
+	base_icon_state = "floorsafe";
+	icon_state = "floorsafe";
+	pixel_x = -1
+	},
+/turf/open/floor/iron,
+/area/station/command/bridge)
 "iFl" = (
 /obj/structure/sign/painting/library,
 /turf/closed/wall/mineral/wood,
@@ -49693,7 +49707,8 @@
 /obj/structure/secure_safe/caps_spare{
 	base_icon_state = "floorsafe";
 	icon_state = "floorsafe";
-	pixel_x = -1
+	pixel_x = -1;
+	density = 0
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
@@ -72340,8 +72355,8 @@
 /area/station/maintenance/department/engineering/atmos_aux_port)
 "nSQ" = (
 /obj/machinery/firealarm/directional/west{
-	pixel_x = -27;
-	pixel_y = 24
+	pixel_x = -35;
+	pixel_y = -10
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -225493,7 +225508,7 @@ nca
 xmO
 dEJ
 idB
-wFN
+iFh
 maG
 mrZ
 jiu


### PR DESCRIPTION

## About The Pull Request

This PR repositions the Blueshift's warden's office fire alarm (that was inside a display screen and couldn't be interacted with) and disables the bridge's spare ID card safe's density, making it possible to walk over it.

## How This Contributes To The Nova Sector Roleplay Experience

These were annoying me as much as they were annoying other players (and because it's really convenient).

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![imagem_2024-04-13_055225216](https://github.com/NovaSector/NovaSector/assets/64568243/40d2a0e3-b002-421a-b4e2-1282c6fa5b20)
![imagem_2024-04-13_055356555](https://github.com/NovaSector/NovaSector/assets/64568243/6291a7c3-8d4b-4bb3-b8a6-502b9f897bbc)

![imagem_2024-04-13_055313424](https://github.com/NovaSector/NovaSector/assets/64568243/fdd89ac1-2cc3-4b3c-9b9a-0c736bf68fa5)
![imagem_2024-04-13_055421414](https://github.com/NovaSector/NovaSector/assets/64568243/7ed2b48f-1e46-42ec-af89-5da872ca12cb)
</details>

## Changelog
:cl: Chelxox
qol: The Blueshift's warden's office fire alarm was repositioned so it can actually be interacted with.
qol: The bridge's spare ID safe on Blueshift can be walked on and doesn't block the path anymore.
/:cl:
