### PR TITLE
Gives Lavadyne the new micro reactor

### DIFF
--- a/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1.dmm
@@ -55,7 +55,7 @@
 "aG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/engine/o2,
+/turf/open/floor/engine/n2,
 /area/ruin/interdyne_planetary_base/eng)
 "aI" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -73,16 +73,8 @@
 "aM" = (
 /turf/open/floor/iron/dark/small,
 /area/ruin/interdyne_planetary_base/med/pharm)
-"aO" = (
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "aS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/engine/n2,
+/turf/open/floor/iron/diagonal,
 /area/ruin/interdyne_planetary_base/eng)
 "aU" = (
 /obj/machinery/light/floor{
@@ -670,13 +662,6 @@
 	dir = 4
 	},
 /area/ruin/interdyne_planetary_base/serv/kitchen)
-"gl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/interdyne_planetary_base/eng)
 "gr" = (
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
@@ -933,14 +918,6 @@
 	},
 /obj/structure/drain/big,
 /turf/open/floor/iron/pool,
-/area/ruin/interdyne_planetary_base/eng)
-"iu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/meter/layer2,
-/turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "iz" = (
 /obj/effect/turf_decal/siding/dark{
@@ -1445,6 +1422,12 @@
 "lU" = (
 /turf/template_noop,
 /area/template_noop)
+"lX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/interdyne_planetary_base/eng)
 "lY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1852,6 +1835,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/interdyne_planetary_base/cargo)
+"px" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/engine/o2,
+/area/ruin/interdyne_planetary_base/eng)
 "py" = (
 /obj/effect/turf_decal/siding/white,
 /obj/effect/turf_decal/siding/white/corner{
@@ -1909,7 +1897,9 @@
 /turf/open/floor/iron/herringbone,
 /area/ruin/interdyne_planetary_base/cargo)
 "pT" = (
-/turf/open/floor/iron/diagonal,
+/obj/effect/turf_decal/siding/thinplating,
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "pX" = (
 /obj/effect/turf_decal/delivery,
@@ -2274,6 +2264,12 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/wood/tile,
 /area/ruin/interdyne_planetary_base/serv/bar)
+"to" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "tq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -2315,6 +2311,11 @@
 	dir = 8
 	},
 /area/ruin/interdyne_planetary_base/main)
+"tL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/effect/turf_decal/siding/thinplating,
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "tN" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access"
@@ -2377,10 +2378,11 @@
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "ug" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/eng)
 "ui" = (
 /obj/structure/drain,
@@ -3034,6 +3036,7 @@
 	default_raw_text = "<h1>Note from Interdyne Engineering:</h1><p>As the shuttle is significantly more power hungry than the previous installation, auxiliary power setup is required for whenever it's planetside. A stock of radiation emitting RTGs has been provided for your convenience, as well as the PPE needed to set them up. These are located on the balcony in engineering.<p></p>Lay wires on the catwalks, then stand in front of where you'd like the RTGs to be unpacked to and press the button on the flatpacked equipment to deploy it. It will immediately begin producing power and radiation. If you take too many rads, administer toxin-healing medication.</p>";
 	name = "paper- 'Note from Interdyne Engineering'"
 	},
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/eng)
 "Ao" = (
@@ -3074,6 +3077,17 @@
 	},
 /turf/open/floor/iron/herringbone,
 /area/ruin/interdyne_planetary_base/cargo)
+"Aw" = (
+/obj/machinery/light/cold/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital/layer2{
+	dir = 4;
+	name = "Waste Valve"
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "Az" = (
 /obj/machinery/door/window/survival_pod/left/directional/south{
 	req_access = list("syndicate")
@@ -3452,6 +3466,14 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/interdyne_planetary_base/science/xeno)
+"Dh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/space_heater,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "Dl" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -3521,11 +3543,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/ruin/interdyne_planetary_base/cargo)
-"DP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/effect/turf_decal/siding/thinplating,
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "DT" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/lavaland_atmos,
@@ -3801,6 +3818,13 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/interdyne_planetary_base/science/xeno)
+"Fs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/interdyne_planetary_base/eng)
 "Fv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -4132,12 +4156,6 @@
 "Ih" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/interdyne_planetary_base/cargo)
-"Ii" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/interdyne_planetary_base/eng)
 "Io" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
@@ -4255,14 +4273,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/interdyne_planetary_base/main)
-"Jd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/space_heater,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "Jr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -4462,6 +4472,13 @@
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/cargo)
+"Lp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "Lw" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -5201,22 +5218,6 @@
 "RY" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/interdyne_planetary_base/serv/bar)
-"RZ" = (
-/obj/machinery/light/cold/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/valve/digital/layer2{
-	dir = 4;
-	name = "Waste Valve"
-	},
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
-"Sf" = (
-/obj/effect/turf_decal/siding/thinplating,
-/obj/machinery/light/cold/directional/east,
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "Sg" = (
 /obj/effect/turf_decal/tile/dark_green/half{
 	dir = 1
@@ -5650,13 +5651,6 @@
 /obj/machinery/recharger,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/med)
-"UD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "UE" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/syndicate/red/secretformula,
@@ -5869,14 +5863,26 @@
 /obj/structure/rack/gunrack,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/main/vault)
-"Wk" = (
+"Wg" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
+"Wk" = (
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "Wn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
+"Wu" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "Wx" = (
@@ -5986,6 +5992,14 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/interdyne_planetary_base/science/xeno)
+"Xa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/meter/layer2,
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "Xd" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -6058,13 +6072,6 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/ruin/interdyne_planetary_base/main)
-"Xt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/interdyne_planetary_base/eng)
 "Xv" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/effect/turf_decal/bot_red,
@@ -6240,12 +6247,6 @@
 /obj/effect/turf_decal/siding/thinplating,
 /turf/open/floor/iron/checker,
 /area/ruin/interdyne_planetary_base/serv/bar)
-"Zt" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "Zy" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/delivery/white,
@@ -7863,8 +7864,8 @@ fm
 pq
 is
 uf
-ug
-Jd
+to
+Dh
 Ih
 vO
 oT
@@ -7905,7 +7906,7 @@ pq
 RT
 qV
 wu
-RZ
+Aw
 Ih
 vO
 oT
@@ -7945,8 +7946,8 @@ Tc
 pq
 jf
 cL
-Wk
-iu
+Wg
+Xa
 Ih
 Io
 Tx
@@ -8027,12 +8028,12 @@ Tc
 pq
 pq
 pq
-aO
+Wk
 Ra
 jx
-Xt
-gl
-Ii
+ug
+Fs
+lX
 Hy
 pq
 oW
@@ -8107,7 +8108,7 @@ fm
 Gj
 Tc
 pq
-aG
+px
 ct
 tq
 wu
@@ -8152,8 +8153,8 @@ pq
 pq
 BJ
 cK
-UD
-Zt
+Lp
+Wu
 At
 xe
 HS
@@ -8189,12 +8190,12 @@ fm
 Gj
 RR
 pq
-aS
+aG
 UN
 dk
-DP
-pT
-pT
+tL
+aS
+aS
 qv
 ZU
 Wx
@@ -8233,9 +8234,9 @@ pq
 DW
 cq
 fn
-Sf
 pT
-pT
+aS
+aS
 Vr
 Fh
 VQ

--- a/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1.dmm
@@ -74,7 +74,11 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/interdyne_planetary_base/med/pharm)
 "aS" = (
-/turf/open/floor/iron/diagonal,
+/obj/effect/turf_decal/siding/thinplating/corner,
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "aU" = (
 /obj/machinery/light/floor{
@@ -296,10 +300,8 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/med/pharm)
 "cK" = (
-/obj/effect/turf_decal/siding/thinplating/corner,
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/effect/turf_decal/siding/thinplating,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "cL" = (
@@ -949,9 +951,9 @@
 /area/ruin/interdyne_planetary_base)
 "iO" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/eng)
 "iP" = (
@@ -1370,6 +1372,12 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/ruin/interdyne_planetary_base/serv/bar)
+"lt" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "lw" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /obj/machinery/door/window/survival_pod/left/directional/south{
@@ -1422,12 +1430,6 @@
 "lU" = (
 /turf/template_noop,
 /area/template_noop)
-"lX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/interdyne_planetary_base/eng)
 "lY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1460,6 +1462,12 @@
 /obj/structure/closet/secure_closet/interdynefob/deckofficer_locker,
 /turf/open/floor/wood,
 /area/ruin/interdyne_planetary_base/cargo/deck)
+"mm" = (
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "mp" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
 	dir = 4
@@ -1835,11 +1843,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/interdyne_planetary_base/cargo)
-"px" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/engine/o2,
-/area/ruin/interdyne_planetary_base/eng)
 "py" = (
 /obj/effect/turf_decal/siding/white,
 /obj/effect/turf_decal/siding/white/corner{
@@ -1897,9 +1900,10 @@
 /turf/open/floor/iron/herringbone,
 /area/ruin/interdyne_planetary_base/cargo)
 "pT" = (
-/obj/effect/turf_decal/siding/thinplating,
-/obj/machinery/light/cold/directional/east,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/eng)
 "pX" = (
 /obj/effect/turf_decal/delivery,
@@ -2090,6 +2094,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/interdyne_planetary_base/med)
+"ri" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/interdyne_planetary_base/eng)
 "rj" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
@@ -2124,6 +2135,12 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/interdyne_planetary_base/main/dorms)
+"rJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "rR" = (
 /turf/open/floor/iron/dark/herringbone,
 /area/ruin/interdyne_planetary_base/serv/hydr)
@@ -2264,12 +2281,6 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/wood/tile,
 /area/ruin/interdyne_planetary_base/serv/bar)
-"to" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "tq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -2311,11 +2322,6 @@
 	dir = 8
 	},
 /area/ruin/interdyne_planetary_base/main)
-"tL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/effect/turf_decal/siding/thinplating,
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "tN" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access"
@@ -2378,11 +2384,9 @@
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "ug" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_dark,
+/obj/effect/turf_decal/siding/thinplating,
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "ui" = (
 /obj/structure/drain,
@@ -3077,17 +3081,6 @@
 	},
 /turf/open/floor/iron/herringbone,
 /area/ruin/interdyne_planetary_base/cargo)
-"Aw" = (
-/obj/machinery/light/cold/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/valve/digital/layer2{
-	dir = 4;
-	name = "Waste Valve"
-	},
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "Az" = (
 /obj/machinery/door/window/survival_pod/left/directional/south{
 	req_access = list("syndicate")
@@ -3373,6 +3366,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/interdyne_planetary_base/main)
+"Cx" = (
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "CF" = (
 /obj/machinery/atmospherics/components/binary/volume_pump,
 /turf/open/floor/iron/dark/smooth_large,
@@ -3466,14 +3465,6 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/interdyne_planetary_base/science/xeno)
-"Dh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/space_heater,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "Dl" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -3683,6 +3674,13 @@
 "Eu" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/interdyne_planetary_base/main)
+"Ew" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/interdyne_planetary_base/eng)
 "Ex" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/iron/dark/smooth_large,
@@ -3816,15 +3814,9 @@
 	dir = 1
 	},
 /obj/machinery/light_switch/directional/north,
+/obj/item/xenoarch/handheld_recoverer,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/interdyne_planetary_base/science/xeno)
-"Fs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/interdyne_planetary_base/eng)
 "Fv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -4435,6 +4427,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/med)
+"KL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "KN" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -4472,13 +4471,6 @@
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/cargo)
-"Lp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "Lw" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -4854,6 +4846,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/ruin/interdyne_planetary_base/serv/hydr)
+"Ox" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/meter/layer2,
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "OB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4954,6 +4954,11 @@
 	},
 /turf/open/floor/plating/lavaland_atmos,
 /area/ruin/interdyne_planetary_base)
+"Pt" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/engine/o2,
+/area/ruin/interdyne_planetary_base/eng)
 "Pu" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/siding/wood{
@@ -5009,7 +5014,6 @@
 /area/ruin/interdyne_planetary_base/med)
 "PH" = (
 /obj/machinery/light/cold/directional/west,
-/obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/tile/dark_green/half{
 	dir = 8
 	},
@@ -5315,6 +5319,14 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/main)
+"SO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/space_heater,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "SP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5818,6 +5830,17 @@
 /obj/machinery/light/warm/directional/south,
 /turf/open/floor/engine,
 /area/ruin/interdyne_planetary_base/eng)
+"VR" = (
+/obj/machinery/light/cold/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital/layer2{
+	dir = 4;
+	name = "Waste Valve"
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "VV" = (
 /obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5863,26 +5886,11 @@
 /obj/structure/rack/gunrack,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/main/vault)
-"Wg" = (
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "Wk" = (
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/diagonal,
 /area/ruin/interdyne_planetary_base/eng)
 "Wn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
-"Wu" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "Wx" = (
@@ -5992,14 +6000,6 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/interdyne_planetary_base/science/xeno)
-"Xa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/meter/layer2,
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "Xd" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -7864,8 +7864,8 @@ fm
 pq
 is
 uf
-to
-Dh
+rJ
+SO
 Ih
 vO
 oT
@@ -7906,7 +7906,7 @@ pq
 RT
 qV
 wu
-Aw
+VR
 Ih
 vO
 oT
@@ -7946,8 +7946,8 @@ Tc
 pq
 jf
 cL
-Wg
-Xa
+Cx
+Ox
 Ih
 Io
 Tx
@@ -7987,7 +7987,7 @@ XM
 pb
 FL
 cQ
-iO
+Ew
 MV
 pq
 pq
@@ -8028,12 +8028,12 @@ Tc
 pq
 pq
 pq
-Wk
+mm
 Ra
 jx
-ug
-Fs
-lX
+iO
+ri
+pT
 Hy
 pq
 oW
@@ -8108,7 +8108,7 @@ fm
 Gj
 Tc
 pq
-px
+Pt
 ct
 tq
 wu
@@ -8152,9 +8152,9 @@ pq
 pq
 pq
 BJ
-cK
-Lp
-Wu
+aS
+KL
+lt
 At
 xe
 HS
@@ -8193,9 +8193,9 @@ pq
 aG
 UN
 dk
-tL
-aS
-aS
+cK
+Wk
+Wk
 qv
 ZU
 Wx
@@ -8234,9 +8234,9 @@ pq
 DW
 cq
 fn
-pT
-aS
-aS
+ug
+Wk
+Wk
 Vr
 Fh
 VQ

--- a/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1.dmm
@@ -55,7 +55,7 @@
 "aG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/engine/n2,
+/turf/open/floor/engine/o2,
 /area/ruin/interdyne_planetary_base/eng)
 "aI" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -73,10 +73,16 @@
 "aM" = (
 /turf/open/floor/iron/dark/small,
 /area/ruin/interdyne_planetary_base/med/pharm)
+"aO" = (
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "aS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/engine/o2,
+/turf/open/floor/engine/n2,
 /area/ruin/interdyne_planetary_base/eng)
 "aU" = (
 /obj/machinery/light/floor{
@@ -282,12 +288,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
-"cx" = (
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "cD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/space_heater,
@@ -316,6 +316,9 @@
 	},
 /obj/structure/railing{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
@@ -667,6 +670,13 @@
 	dir = 4
 	},
 /area/ruin/interdyne_planetary_base/serv/kitchen)
+"gl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/interdyne_planetary_base/eng)
 "gr" = (
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
@@ -798,13 +808,6 @@
 /obj/structure/sink/kitchen/directional/west,
 /turf/open/floor/iron/dark/small,
 /area/ruin/interdyne_planetary_base/serv/hydr)
-"hI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "hL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/light/small/directional/east,
@@ -905,12 +908,6 @@
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /turf/open/floor/plating/airless,
 /area/ruin/interdyne_planetary_base)
-"ii" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/interdyne_planetary_base/eng)
 "im" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor{
@@ -937,6 +934,14 @@
 /obj/structure/drain/big,
 /turf/open/floor/iron/pool,
 /area/ruin/interdyne_planetary_base/eng)
+"iu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/meter/layer2,
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "iz" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -950,11 +955,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/ruin/interdyne_planetary_base/cargo)
-"iE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/effect/turf_decal/siding/thinplating,
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "iK" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -972,7 +972,10 @@
 /area/ruin/interdyne_planetary_base)
 "iO" = (
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/eng)
 "iP" = (
 /obj/effect/turf_decal/siding/dark_green{
@@ -1050,6 +1053,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/structure/drain/big,
 /turf/open/floor/iron/pool,
 /area/ruin/interdyne_planetary_base/eng)
 "jh" = (
@@ -2063,6 +2067,9 @@
 "qV" = (
 /obj/item/circuitboard/machine/stacking_machine,
 /obj/structure/frame/machine/secured,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "qX" = (
@@ -2071,13 +2078,6 @@
 /obj/machinery/recharger,
 /turf/open/floor/iron/dark/textured,
 /area/ruin/interdyne_planetary_base/cargo)
-"rd" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/interdyne_planetary_base/eng)
 "rf" = (
 /obj/machinery/light/cold/directional/south,
 /obj/machinery/light_switch/directional/south,
@@ -2203,10 +2203,6 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/ruin/interdyne_planetary_base/main)
-"sK" = (
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/interdyne_planetary_base/eng)
 "sM" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
@@ -2307,12 +2303,6 @@
 /obj/effect/turf_decal/siding/brown,
 /turf/open/floor/iron/dark/diagonal,
 /area/ruin/interdyne_planetary_base/cargo)
-"tF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "tI" = (
 /obj/effect/turf_decal/tile/dark_green/half{
 	dir = 8
@@ -2381,14 +2371,15 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "ug" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8
+	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/meter/layer2,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "ui" = (
@@ -2536,19 +2527,6 @@
 "vu" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/interdyne_planetary_base)
-"vv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/space_heater,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
-"vA" = (
-/obj/effect/turf_decal/siding/thinplating,
-/obj/machinery/light/cold/directional/east,
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "vB" = (
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/interdyne_planetary_base/science/xeno)
@@ -2969,13 +2947,6 @@
 /obj/item/reagent_containers/cup/rag,
 /turf/open/floor/wood/tile,
 /area/ruin/interdyne_planetary_base/serv/bar)
-"zt" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "zB" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/delivery,
@@ -3093,6 +3064,7 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/interdyne_planetary_base/science/xeno)
 "At" = (
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/eng)
 "Av" = (
@@ -3549,6 +3521,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/ruin/interdyne_planetary_base/cargo)
+"DP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/effect/turf_decal/siding/thinplating,
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "DT" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/lavaland_atmos,
@@ -4155,6 +4132,12 @@
 "Ih" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/interdyne_planetary_base/cargo)
+"Ii" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/interdyne_planetary_base/eng)
 "Io" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
@@ -4272,6 +4255,14 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/interdyne_planetary_base/main)
+"Jd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/space_heater,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "Jr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -5210,6 +5201,22 @@
 "RY" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/interdyne_planetary_base/serv/bar)
+"RZ" = (
+/obj/machinery/light/cold/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital/layer2{
+	dir = 4;
+	name = "Waste Valve"
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
+"Sf" = (
+/obj/effect/turf_decal/siding/thinplating,
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "Sg" = (
 /obj/effect/turf_decal/tile/dark_green/half{
 	dir = 1
@@ -5643,6 +5650,13 @@
 /obj/machinery/recharger,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/med)
+"UD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "UE" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/syndicate/red/secretformula,
@@ -5810,13 +5824,6 @@
 /obj/machinery/light/warm/directional/south,
 /turf/open/floor/engine,
 /area/ruin/interdyne_planetary_base/eng)
-"VS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/interdyne_planetary_base/eng)
 "VV" = (
 /obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5863,13 +5870,8 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/main/vault)
 "Wk" = (
-/obj/machinery/light/cold/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/valve/digital/layer2{
-	dir = 4;
-	name = "Waste Valve"
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
@@ -5984,12 +5986,6 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/interdyne_planetary_base/science/xeno)
-"WY" = (
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "Xd" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -6062,6 +6058,13 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/ruin/interdyne_planetary_base/main)
+"Xt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/interdyne_planetary_base/eng)
 "Xv" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/effect/turf_decal/bot_red,
@@ -6237,6 +6240,12 @@
 /obj/effect/turf_decal/siding/thinplating,
 /turf/open/floor/iron/checker,
 /area/ruin/interdyne_planetary_base/serv/bar)
+"Zt" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "Zy" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/delivery/white,
@@ -7854,8 +7863,8 @@ fm
 pq
 is
 uf
-tF
-vv
+ug
+Jd
 Ih
 vO
 oT
@@ -7896,7 +7905,7 @@ pq
 RT
 qV
 wu
-Wk
+RZ
 Ih
 vO
 oT
@@ -7936,8 +7945,8 @@ Tc
 pq
 jf
 cL
-WY
-ug
+Wk
+iu
 Ih
 Io
 Tx
@@ -7977,7 +7986,7 @@ XM
 pb
 FL
 cQ
-rd
+iO
 MV
 pq
 pq
@@ -8018,12 +8027,12 @@ Tc
 pq
 pq
 pq
-cx
+aO
 Ra
 jx
-VS
-ii
-ii
+Xt
+gl
+Ii
 Hy
 pq
 oW
@@ -8062,7 +8071,7 @@ cq
 bB
 wu
 mp
-iO
+wu
 At
 wu
 bN
@@ -8098,12 +8107,12 @@ fm
 Gj
 Tc
 pq
-aS
+aG
 ct
 tq
 wu
 kX
-iO
+wu
 At
 wu
 Am
@@ -8143,9 +8152,9 @@ pq
 pq
 BJ
 cK
-hI
-zt
-sK
+UD
+Zt
+At
 xe
 HS
 pq
@@ -8180,10 +8189,10 @@ fm
 Gj
 RR
 pq
-aG
+aS
 UN
 dk
-iE
+DP
 pT
 pT
 qv
@@ -8224,7 +8233,7 @@ pq
 DW
 cq
 fn
-vA
+Sf
 pT
 pT
 Vr

--- a/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1.dmm
@@ -54,7 +54,8 @@
 /area/ruin/interdyne_planetary_base/med)
 "aG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
-/turf/open/floor/engine/o2,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/engine/n2,
 /area/ruin/interdyne_planetary_base/eng)
 "aI" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -73,10 +74,9 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/interdyne_planetary_base/med/pharm)
 "aS" = (
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/engine/o2,
 /area/ruin/interdyne_planetary_base/eng)
 "aU" = (
 /obj/machinery/light/floor{
@@ -194,16 +194,11 @@
 /turf/open/floor/iron/dark/smooth_edge,
 /area/ruin/interdyne_planetary_base/main)
 "bN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/meter/layer2,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/mapping_helpers/apc/syndicate_access,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/eng)
 "bO" = (
 /obj/effect/turf_decal/tile/dark_green/half{
@@ -287,6 +282,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
+"cx" = (
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "cD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/space_heater,
@@ -303,8 +304,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/med/pharm)
 "cK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/effect/turf_decal/siding/thinplating,
+/obj/effect/turf_decal/siding/thinplating/corner,
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "cL" = (
@@ -373,7 +376,7 @@
 /obj/effect/turf_decal/trimline/dark_red/filled/warning{
 	dir = 8
 	},
-/turf/open/floor/engine/o2,
+/turf/open/floor/engine,
 /area/ruin/interdyne_planetary_base/eng)
 "df" = (
 /obj/effect/turf_decal/stripes/line{
@@ -795,6 +798,13 @@
 /obj/structure/sink/kitchen/directional/west,
 /turf/open/floor/iron/dark/small,
 /area/ruin/interdyne_planetary_base/serv/hydr)
+"hI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "hL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/light/small/directional/east,
@@ -895,6 +905,12 @@
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /turf/open/floor/plating/airless,
 /area/ruin/interdyne_planetary_base)
+"ii" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/interdyne_planetary_base/eng)
 "im" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor{
@@ -934,6 +950,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/ruin/interdyne_planetary_base/cargo)
+"iE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/effect/turf_decal/siding/thinplating,
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "iK" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -1115,7 +1136,10 @@
 	network = list("intd13")
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/eng)
 "jG" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -1292,8 +1316,10 @@
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/med)
 "kX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Air to Distro"
+	},
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "lc" = (
@@ -1448,8 +1474,9 @@
 /turf/open/floor/wood,
 /area/ruin/interdyne_planetary_base/cargo/deck)
 "mp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/meter/layer2,
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "mz" = (
@@ -1878,11 +1905,7 @@
 /turf/open/floor/iron/herringbone,
 /area/ruin/interdyne_planetary_base/cargo)
 "pT" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Air to Distro"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron/diagonal,
 /area/ruin/interdyne_planetary_base/eng)
 "pX" = (
 /obj/effect/turf_decal/delivery,
@@ -2048,6 +2071,13 @@
 /obj/machinery/recharger,
 /turf/open/floor/iron/dark/textured,
 /area/ruin/interdyne_planetary_base/cargo)
+"rd" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/interdyne_planetary_base/eng)
 "rf" = (
 /obj/machinery/light/cold/directional/south,
 /obj/machinery/light_switch/directional/south,
@@ -2173,6 +2203,10 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/ruin/interdyne_planetary_base/main)
+"sK" = (
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/interdyne_planetary_base/eng)
 "sM" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
@@ -2273,6 +2307,12 @@
 /obj/effect/turf_decal/siding/brown,
 /turf/open/floor/iron/dark/diagonal,
 /area/ruin/interdyne_planetary_base/cargo)
+"tF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "tI" = (
 /obj/effect/turf_decal/tile/dark_green/half{
 	dir = 8
@@ -2340,15 +2380,17 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "ug" = (
-/obj/machinery/conveyor{
-	dir = 6;
-	id = "interdynedisp"
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/turf/open/lava/smooth/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/meter/layer2,
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "ui" = (
 /obj/structure/drain,
 /obj/effect/turf_decal/siding/thinplating{
@@ -2415,10 +2457,6 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/ruin/interdyne_planetary_base/cargo)
-"uI" = (
-/obj/effect/turf_decal/siding/thinplating,
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "uN" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/dark_green{
@@ -2498,6 +2536,19 @@
 "vu" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/interdyne_planetary_base)
+"vv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/space_heater,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
+"vA" = (
+/obj/effect/turf_decal/siding/thinplating,
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "vB" = (
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/interdyne_planetary_base/science/xeno)
@@ -2556,9 +2607,6 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /turf/open/floor/iron/white,
 /area/ruin/interdyne_planetary_base/cargo)
-"we" = (
-/turf/open/floor/iron/diagonal,
-/area/ruin/interdyne_planetary_base/eng)
 "wf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -2667,19 +2715,9 @@
 /turf/open/floor/iron/checker,
 /area/ruin/interdyne_planetary_base/serv/bar)
 "xe" = (
-/obj/machinery/power/terminal,
-/obj/machinery/computer/monitor{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/item/paper{
-	default_raw_text = "<h1>Note from Interdyne Engineering:</h1><p>As the shuttle is significantly more power hungry than the previous installation, auxiliary power setup is required for whenever it's planetside. A stock of radiation emitting RTGs has been provided for your convenience, as well as the PPE needed to set them up. These are located on the balcony in engineering.<p></p>Lay wires on the catwalks, then stand in front of where you'd like the RTGs to be unpacked to and press the button on the flatpacked equipment to deploy it. It will immediately begin producing power and radiation. If you take too many rads, administer toxin-healing medication.</p>";
-	name = "paper- 'Note from Interdyne Engineering'"
-	},
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/obj/machinery/power/terminal,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/eng)
 "xk" = (
 /obj/structure/railing/corner,
@@ -2691,13 +2729,6 @@
 	},
 /turf/open/floor/iron/checker,
 /area/ruin/interdyne_planetary_base/serv/bar)
-"xp" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "xq" = (
 /obj/structure/table/wood,
 /obj/item/pai_card{
@@ -2938,6 +2969,13 @@
 /obj/item/reagent_containers/cup/rag,
 /turf/open/floor/wood/tile,
 /area/ruin/interdyne_planetary_base/serv/bar)
+"zt" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "zB" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/delivery,
@@ -3017,12 +3055,15 @@
 /turf/open/floor/engine,
 /area/ruin/interdyne_planetary_base/science/xeno)
 "Am" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/machinery/computer/monitor{
+	dir = 8
+	},
+/obj/item/paper{
+	default_raw_text = "<h1>Note from Interdyne Engineering:</h1><p>As the shuttle is significantly more power hungry than the previous installation, auxiliary power setup is required for whenever it's planetside. A stock of radiation emitting RTGs has been provided for your convenience, as well as the PPE needed to set them up. These are located on the balcony in engineering.<p></p>Lay wires on the catwalks, then stand in front of where you'd like the RTGs to be unpacked to and press the button on the flatpacked equipment to deploy it. It will immediately begin producing power and radiation. If you take too many rads, administer toxin-healing medication.</p>";
+	name = "paper- 'Note from Interdyne Engineering'"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/eng)
 "Ao" = (
 /obj/structure/sign/poster/contraband/moffuchis_pizza/directional/south,
@@ -3052,8 +3093,7 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/interdyne_planetary_base/science/xeno)
 "At" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/eng)
 "Av" = (
 /obj/effect/turf_decal/siding/thinplating,
@@ -3177,12 +3217,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ruin/interdyne_planetary_base/main)
-"Bo" = (
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "By" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/interdyne_planetary_base/cargo/deck)
@@ -3248,6 +3282,7 @@
 	pixel_y = -4;
 	pixel_x = 2
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "BL" = (
@@ -3546,7 +3581,7 @@
 /area/ruin/interdyne_planetary_base/science/xeno)
 "DW" = (
 /obj/machinery/atmospherics/miner/nitrogen,
-/turf/open/floor/engine/o2,
+/turf/open/floor/engine/n2,
 /area/ruin/interdyne_planetary_base/eng)
 "DZ" = (
 /turf/closed/wall/mineral/titanium,
@@ -3764,7 +3799,7 @@
 "Fh" = (
 /obj/structure/cable,
 /obj/machinery/power/micro_reactor,
-/turf/open/floor/engine/o2,
+/turf/open/floor/engine,
 /area/ruin/interdyne_planetary_base/eng)
 "Fj" = (
 /obj/machinery/camera/directional/east{
@@ -3781,13 +3816,6 @@
 	},
 /turf/open/floor/iron/herringbone,
 /area/ruin/interdyne_planetary_base/cargo)
-"Fl" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "Fq" = (
 /obj/structure/closet/xenoarch,
 /obj/effect/turf_decal/tile/dark_green/half{
@@ -4055,13 +4083,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/meter/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/eng)
 "HB" = (
 /obj/structure/reagent_dispensers/plumbed,
@@ -4109,10 +4137,7 @@
 	output_level = 60000
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/eng)
 "HV" = (
 /obj/structure/dresser,
@@ -4618,12 +4643,12 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/interdyne_planetary_base/science/xeno)
 "MV" = (
-/obj/machinery/atmospherics/components/binary/valve/digital/layer2{
-	dir = 4;
-	name = "Waste Valve"
-	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/eng)
 "MY" = (
 /obj/machinery/door/airlock/virology/glass,
@@ -5065,13 +5090,10 @@
 "Ra" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
-"Re" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/eng)
 "Ri" = (
 /obj/effect/turf_decal/siding/dark_green{
@@ -5159,11 +5181,6 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/interdyne_planetary_base/main/dorms)
-"RJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/effect/turf_decal/siding/thinplating/corner,
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "RR" = (
 /obj/item/geiger_counter,
 /obj/item/clothing/head/utility/radiation,
@@ -5263,12 +5280,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/med/pharm)
-"SB" = (
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "SF" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -5770,7 +5781,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark_red/filled/warning,
 /obj/machinery/door/window/survival_pod/left/directional/north,
-/turf/open/floor/engine/o2,
+/turf/open/floor/engine,
 /area/ruin/interdyne_planetary_base/eng)
 "VA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -5797,7 +5808,14 @@
 	dir = 1
 	},
 /obj/machinery/light/warm/directional/south,
-/turf/open/floor/engine/o2,
+/turf/open/floor/engine,
+/area/ruin/interdyne_planetary_base/eng)
+"VS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/eng)
 "VV" = (
 /obj/effect/turf_decal/siding/thinplating,
@@ -5845,7 +5863,14 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/main/vault)
 "Wk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/cold/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital/layer2{
+	dir = 4;
+	name = "Waste Valve"
+	},
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "Wn" = (
@@ -5959,6 +5984,12 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/interdyne_planetary_base/science/xeno)
+"WY" = (
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "Xd" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -6276,7 +6307,7 @@
 	},
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /obj/structure/cable,
-/turf/open/floor/engine/o2,
+/turf/open/floor/engine,
 /area/ruin/interdyne_planetary_base/eng)
 "ZV" = (
 /turf/open/floor/iron/dark/side{
@@ -7823,8 +7854,8 @@ fm
 pq
 is
 uf
-wu
-cD
+tF
+vv
 Ih
 vO
 oT
@@ -7865,7 +7896,7 @@ pq
 RT
 qV
 wu
-Wn
+Wk
 Ih
 vO
 oT
@@ -7905,8 +7936,8 @@ Tc
 pq
 jf
 cL
-Bo
-Wn
+WY
+ug
 Ih
 Io
 Tx
@@ -7946,7 +7977,7 @@ XM
 pb
 FL
 cQ
-Fl
+rd
 MV
 pq
 pq
@@ -7987,12 +8018,12 @@ Tc
 pq
 pq
 pq
-SB
+cx
 Ra
 jx
-iO
-wu
-wu
+VS
+ii
+ii
 Hy
 pq
 oW
@@ -8029,11 +8060,11 @@ pq
 EG
 cq
 bB
-Wn
+wu
 mp
-Ra
-Wn
-Wn
+iO
+At
+wu
 bN
 pq
 jv
@@ -8067,14 +8098,14 @@ fm
 Gj
 Tc
 pq
-aG
+aS
 ct
 tq
-aS
+wu
 kX
-pT
+iO
 At
-Wk
+wu
 Am
 pq
 nY
@@ -8111,10 +8142,10 @@ pq
 pq
 pq
 BJ
-RJ
-Re
-xp
-xp
+cK
+hI
+zt
+sK
 xe
 HS
 pq
@@ -8152,9 +8183,9 @@ pq
 aG
 UN
 dk
-cK
-we
-we
+iE
+pT
+pT
 qv
 ZU
 Wx
@@ -8193,9 +8224,9 @@ pq
 DW
 cq
 fn
-uI
-we
-we
+vA
+pT
+pT
 Vr
 Fh
 VQ
@@ -8396,7 +8427,7 @@ ja
 ja
 fm
 fm
-ug
+fm
 fm
 EZ
 sg

--- a/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1.dmm
@@ -53,14 +53,8 @@
 /turf/open/floor/iron/white,
 /area/ruin/interdyne_planetary_base/med)
 "aG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "interdynedisp"
-	},
-/turf/open/floor/iron/pool,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
+/turf/open/floor/engine/o2,
 /area/ruin/interdyne_planetary_base/eng)
 "aI" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -79,15 +73,10 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/interdyne_planetary_base/med/pharm)
 "aS" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "interdynedisp"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
 	dir = 1
 	},
-/obj/structure/drain/big,
-/turf/open/floor/iron/pool,
+/turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "aU" = (
 /obj/machinery/light/floor{
@@ -192,22 +181,7 @@
 /turf/open/floor/iron/textured_large,
 /area/ruin/interdyne_planetary_base/med)
 "bB" = (
-/obj/machinery/conveyor_switch/oneway{
-	dir = 4;
-	id = "interdynedisp";
-	name = "disposal conveyor";
-	pixel_y = 8
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/vg_decals/atmos/oxygen,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "bJ" = (
@@ -220,14 +194,15 @@
 /turf/open/floor/iron/dark/smooth_edge,
 /area/ruin/interdyne_planetary_base/main)
 "bN" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/meter/layer2,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/mapping_helpers/apc/syndicate_access,
 /obj/structure/disposalpipe/segment{
-	dir = 9
+	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "bO" = (
@@ -313,10 +288,8 @@
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "cD" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "cE" = (
@@ -330,19 +303,18 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/med/pharm)
 "cK" = (
-/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
-/obj/machinery/light/warm/directional/east,
-/obj/structure/cable,
-/obj/machinery/door/window/survival_pod/left/directional/west{
-	req_access = list("syndicate");
-	pixel_x = -4
-	},
-/obj/machinery/power/rtg/advanced,
-/turf/open/floor/catwalk_floor/iron_dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/effect/turf_decal/siding/thinplating,
+/turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "cL" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_centre,
-/turf/open/floor/iron/diagonal,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "cO" = (
 /obj/machinery/hydroponics/constructable,
@@ -353,7 +325,7 @@
 /turf/open/floor/grass,
 /area/ruin/interdyne_planetary_base/serv/hydr)
 "cQ" = (
-/obj/effect/turf_decal/tile/dark_green/diagonal_centre,
+/obj/structure/cable,
 /turf/open/floor/iron/diagonal,
 /area/ruin/interdyne_planetary_base/eng)
 "cR" = (
@@ -395,8 +367,13 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/interdyne_planetary_base/med)
 "de" = (
-/obj/machinery/atmospherics/miner/nitrogen,
-/turf/open/floor/engine/n2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/engine/o2,
 /area/ruin/interdyne_planetary_base/eng)
 "df" = (
 /obj/effect/turf_decal/stripes/line{
@@ -409,10 +386,9 @@
 /turf/open/floor/plating/airless,
 /area/ruin/interdyne_planetary_base)
 "dk" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_centre,
-/obj/structure/railing,
-/obj/machinery/space_heater,
-/turf/open/floor/iron/diagonal,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "dn" = (
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -432,11 +408,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/ruin/interdyne_planetary_base/main/dorms)
-"dz" = (
-/obj/structure/cable,
-/obj/structure/lattice/catwalk,
-/turf/open/lava/smooth/lava_land_surface,
-/area/ruin/interdyne_planetary_base)
 "dB" = (
 /obj/machinery/door/window/survival_pod/left/directional/east{
 	req_access = list("syndicate")
@@ -590,9 +561,7 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "fn" = (
-/obj/machinery/airalarm/directional/east,
-/obj/effect/mapping_helpers/airalarm/syndicate_access,
-/obj/structure/reagent_dispensers/fueltank/large,
+/obj/effect/turf_decal/vg_decals/atmos/nitrogen,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "fo" = (
@@ -945,13 +914,12 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/ruin/interdyne_planetary_base/med/viro)
 "is" = (
-/obj/effect/turf_decal/tile/dark_green/diagonal_centre,
-/obj/structure/closet/secure_closet/ds2atmos{
-	anchorable = 0;
-	anchored = 1
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "interdynedisp"
 	},
-/obj/item/wrench/bolter,
-/turf/open/floor/iron/diagonal,
+/obj/structure/drain/big,
+/turf/open/floor/iron/pool,
 /area/ruin/interdyne_planetary_base/eng)
 "iz" = (
 /obj/effect/turf_decal/siding/dark{
@@ -982,8 +950,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/interdyne_planetary_base)
 "iO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/firealarm/directional/west,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "iP" = (
@@ -1054,10 +1021,15 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/interdyne_planetary_base/science/xeno)
 "jf" = (
-/obj/effect/turf_decal/tile/dark_green/diagonal_centre,
-/obj/machinery/light/small/directional/north,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/iron/diagonal,
+/obj/effect/turf_decal/tile/neutral/diagonal_centre,
+/obj/machinery/conveyor{
+	dir = 6;
+	id = "interdynedisp"
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron/pool,
 /area/ruin/interdyne_planetary_base/eng)
 "jh" = (
 /obj/machinery/door/window/survival_pod/left/directional/south{
@@ -1071,7 +1043,6 @@
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 1
 	},
-/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/turf_decal/tile/dark_green/half,
 /turf/open/floor/iron/dark/smooth_large,
@@ -1140,11 +1111,10 @@
 /turf/open/floor/iron/herringbone,
 /area/ruin/interdyne_planetary_base/cargo)
 "jx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/meter,
 /obj/machinery/camera/autoname/directional/west{
 	network = list("intd13")
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "jG" = (
@@ -1322,8 +1292,8 @@
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/med)
 "kX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/meter,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "lc" = (
@@ -1478,10 +1448,8 @@
 /turf/open/floor/wood,
 /area/ruin/interdyne_planetary_base/cargo/deck)
 "mp" = (
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/meter/layer2,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "mz" = (
@@ -1562,24 +1530,13 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/interdyne_planetary_base/science/xeno)
 "nb" = (
-/obj/effect/turf_decal/tile/dark_green/diagonal_centre,
-/obj/structure/table/reinforced,
-/obj/item/grenade/chem_grenade/smart_metal_foam{
-	pixel_y = 5;
-	pixel_x = 4
+/obj/machinery/conveyor_switch/oneway{
+	dir = 4;
+	id = "interdynedisp";
+	name = "disposal conveyor";
+	pixel_y = 8
 	},
-/obj/item/grenade/chem_grenade/smart_metal_foam{
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/obj/item/storage/toolbox/syndicate,
-/obj/item/storage/toolbox/electrical{
-	pixel_y = -4;
-	pixel_x = 1
-	},
-/obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/tile/dark_green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
+/turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "nd" = (
 /obj/docking_port/stationary{
@@ -1790,7 +1747,6 @@
 /area/ruin/interdyne_planetary_base/eng)
 "pd" = (
 /obj/machinery/smartfridge/extract/preloaded,
-/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
 /obj/effect/turf_decal/tile/dark_green/half,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/interdyne_planetary_base/science/xeno)
@@ -1837,11 +1793,6 @@
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /turf/open/floor/iron/dark/small,
 /area/ruin/interdyne_planetary_base/med/viro)
-"pp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "pq" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/interdyne_planetary_base/eng)
@@ -1927,8 +1878,10 @@
 /turf/open/floor/iron/herringbone,
 /area/ruin/interdyne_planetary_base/cargo)
 "pT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Air to Distro"
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "pX" = (
@@ -1937,8 +1890,20 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/cargo)
 "pZ" = (
-/obj/machinery/atmospherics/miner/oxygen,
-/turf/open/floor/engine/o2,
+/obj/structure/table/reinforced,
+/obj/item/construction/rtd{
+	pixel_y = 8
+	},
+/obj/item/construction/rld{
+	pixel_x = -5
+	},
+/obj/item/construction/rcd{
+	pixel_y = -3
+	},
+/obj/item/inducer{
+	pixel_y = -4
+	},
+/turf/open/floor/iron/diagonal,
 /area/ruin/interdyne_planetary_base/eng)
 "ql" = (
 /obj/effect/turf_decal/trimline/dark_green/warning{
@@ -2000,10 +1965,14 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/interdyne_planetary_base/med)
 "qv" = (
-/obj/effect/turf_decal/tile/dark_green/diagonal_centre,
-/obj/structure/railing,
-/obj/machinery/space_heater,
-/turf/open/floor/iron/diagonal,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/marker_beacon/burgundy,
+/obj/effect/turf_decal/trimline/dark_red/filled/corner,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/turf/open/floor/plating/reinforced,
 /area/ruin/interdyne_planetary_base/eng)
 "qw" = (
 /obj/structure/table/reinforced/rglass,
@@ -2276,8 +2245,8 @@
 /turf/open/floor/wood/tile,
 /area/ruin/interdyne_planetary_base/serv/bar)
 "tq" = (
-/obj/machinery/light/small/directional/east,
-/obj/effect/turf_decal/box,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "tt" = (
@@ -2365,16 +2334,21 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/interdyne_planetary_base/med)
 "uf" = (
-/turf/open/floor/engine/o2,
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "ug" = (
-/obj/structure/railing{
-	dir = 4
+/obj/machinery/conveyor{
+	dir = 6;
+	id = "interdynedisp"
 	},
-/obj/effect/turf_decal/tile/dark_green/diagonal_centre,
-/obj/structure/cable,
-/turf/open/floor/iron/diagonal,
-/area/ruin/interdyne_planetary_base/eng)
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "ui" = (
 /obj/structure/drain,
 /obj/effect/turf_decal/siding/thinplating{
@@ -2441,6 +2415,10 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/ruin/interdyne_planetary_base/cargo)
+"uI" = (
+/obj/effect/turf_decal/siding/thinplating,
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "uN" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/dark_green{
@@ -2578,12 +2556,19 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /turf/open/floor/iron/white,
 /area/ruin/interdyne_planetary_base/cargo)
+"we" = (
+/turf/open/floor/iron/diagonal,
+/area/ruin/interdyne_planetary_base/eng)
 "wf" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_centre,
-/obj/structure/railing/corner{
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/marker_beacon/burgundy,
+/obj/effect/turf_decal/trimline/dark_red/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/iron/diagonal,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/turf/open/floor/plating/reinforced,
 /area/ruin/interdyne_planetary_base/eng)
 "wi" = (
 /obj/machinery/door/airlock{
@@ -2682,13 +2667,19 @@
 /turf/open/floor/iron/checker,
 /area/ruin/interdyne_planetary_base/serv/bar)
 "xe" = (
-/obj/structure/cable,
-/obj/machinery/door/window/survival_pod/left/directional/west{
-	req_access = list("syndicate");
-	pixel_x = -4
+/obj/machinery/power/terminal,
+/obj/machinery/computer/monitor{
+	dir = 8
 	},
-/obj/machinery/power/rtg/advanced,
-/turf/open/floor/catwalk_floor/iron_dark,
+/obj/structure/cable,
+/obj/item/paper{
+	default_raw_text = "<h1>Note from Interdyne Engineering:</h1><p>As the shuttle is significantly more power hungry than the previous installation, auxiliary power setup is required for whenever it's planetside. A stock of radiation emitting RTGs has been provided for your convenience, as well as the PPE needed to set them up. These are located on the balcony in engineering.<p></p>Lay wires on the catwalks, then stand in front of where you'd like the RTGs to be unpacked to and press the button on the flatpacked equipment to deploy it. It will immediately begin producing power and radiation. If you take too many rads, administer toxin-healing medication.</p>";
+	name = "paper- 'Note from Interdyne Engineering'"
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "xk" = (
 /obj/structure/railing/corner,
@@ -2700,6 +2691,13 @@
 	},
 /turf/open/floor/iron/checker,
 /area/ruin/interdyne_planetary_base/serv/bar)
+"xp" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "xq" = (
 /obj/structure/table/wood,
 /obj/item/pai_card{
@@ -2894,7 +2892,6 @@
 /turf/open/floor/iron/white,
 /area/ruin/interdyne_planetary_base/med)
 "yY" = (
-/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
 /obj/effect/turf_decal/tile/dark_green/anticorner{
 	dir = 8
 	},
@@ -3020,16 +3017,12 @@
 /turf/open/floor/engine,
 /area/ruin/interdyne_planetary_base/science/xeno)
 "Am" = (
-/obj/item/circuitboard/machine/recycler,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "interdynedisp"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/frame/machine/secured,
-/turf/open/floor/iron/pool,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "Ao" = (
 /obj/structure/sign/poster/contraband/moffuchis_pizza/directional/south,
@@ -3184,6 +3177,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/ruin/interdyne_planetary_base/main)
+"Bo" = (
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "By" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/interdyne_planetary_base/cargo/deck)
@@ -3240,16 +3239,16 @@
 /turf/open/floor/wood,
 /area/ruin/interdyne_planetary_base/main/dorms)
 "BJ" = (
+/obj/structure/table/reinforced,
 /obj/item/pipe_dispenser{
 	pixel_y = 8
 	},
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/dark_green/diagonal_centre,
-/obj/item/construction/rcd{
-	pixel_y = -3
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/syndicate{
+	pixel_y = -4;
+	pixel_x = 2
 	},
-/obj/structure/railing,
-/turf/open/floor/iron/diagonal,
+/turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "BL" = (
 /obj/machinery/door/airlock/external{
@@ -3546,17 +3545,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/interdyne_planetary_base/science/xeno)
 "DW" = (
-/obj/machinery/conveyor{
-	dir = 6;
-	id = "interdynedisp"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/pool,
+/obj/machinery/atmospherics/miner/nitrogen,
+/turf/open/floor/engine/o2,
 /area/ruin/interdyne_planetary_base/eng)
 "DZ" = (
 /turf/closed/wall/mineral/titanium,
@@ -3705,16 +3695,8 @@
 /turf/open/floor/iron/white,
 /area/ruin/interdyne_planetary_base/med)
 "EG" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "interdynedisp"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/botanical_waste,
-/obj/structure/drain/big,
-/turf/open/floor/iron/pool,
+/obj/machinery/atmospherics/miner/oxygen,
+/turf/open/floor/engine/o2,
 /area/ruin/interdyne_planetary_base/eng)
 "EH" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -3780,7 +3762,9 @@
 /turf/open/floor/plating/lavaland_atmos,
 /area/ruin/interdyne_planetary_base)
 "Fh" = (
-/turf/open/floor/engine/n2,
+/obj/structure/cable,
+/obj/machinery/power/micro_reactor,
+/turf/open/floor/engine/o2,
 /area/ruin/interdyne_planetary_base/eng)
 "Fj" = (
 /obj/machinery/camera/directional/east{
@@ -3797,6 +3781,13 @@
 	},
 /turf/open/floor/iron/herringbone,
 /area/ruin/interdyne_planetary_base/cargo)
+"Fl" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "Fq" = (
 /obj/structure/closet/xenoarch,
 /obj/effect/turf_decal/tile/dark_green/half{
@@ -3834,8 +3825,8 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/med)
 "FL" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_centre,
-/obj/machinery/button/door/directional/north{
+/obj/structure/cable,
+/obj/machinery/button/door/directional/east{
 	id = "syndie_lavaland_construction";
 	specialfunctions = 4;
 	req_access = list("syndicate");
@@ -4063,11 +4054,13 @@
 "Hy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/meter/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/south,
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "HB" = (
@@ -4110,14 +4103,16 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/interdyne_planetary_base/med)
 "HS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/machinery/door/window/survival_pod/left/directional/west{
-	req_access = list("syndicate");
-	pixel_x = -4
+/obj/machinery/power/smes/engineering{
+	charge = 4.5e+006;
+	input_level = 150000;
+	output_level = 60000
 	},
-/obj/machinery/power/rtg/advanced,
-/turf/open/floor/catwalk_floor/iron_dark,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "HV" = (
 /obj/structure/dresser,
@@ -4366,14 +4361,6 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
-"KC" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/ruin/interdyne_planetary_base/eng)
 "KD" = (
 /obj/effect/turf_decal/siding/dark_green{
 	dir = 1
@@ -4487,13 +4474,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/med/pharm)
-"LE" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Air to Distro"
-	},
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "LF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -4561,16 +4541,6 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/ruin/interdyne_planetary_base/med/pharm)
-"Mb" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/computer/monitor,
-/obj/item/paper{
-	default_raw_text = "<h1>Note from Interdyne Engineering:</h1><p>As the shuttle is significantly more power hungry than the previous installation, auxiliary power setup is required for whenever it's planetside. A stock of radiation emitting RTGs has been provided for your convenience, as well as the PPE needed to set them up. These are located on the balcony in engineering.<p></p>Lay wires on the catwalks, then stand in front of where you'd like the RTGs to be unpacked to and press the button on the flatpacked equipment to deploy it. It will immediately begin producing power and radiation. If you take too many rads, administer toxin-healing medication.</p>";
-	name = "paper- 'Note from Interdyne Engineering'"
-	},
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "Mc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4648,13 +4618,11 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/interdyne_planetary_base/science/xeno)
 "MV" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/binary/valve/digital/layer2{
 	dir = 4;
 	name = "Waste Valve"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "MY" = (
@@ -4815,11 +4783,14 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/cargo)
 "Oo" = (
-/obj/effect/turf_decal/vg_decals/atmos/nitrogen{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/obj/machinery/light/warm/directional/east,
-/turf/open/floor/engine/n2,
+/obj/structure/marker_beacon/burgundy,
+/obj/effect/turf_decal/trimline/dark_red/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/reinforced,
 /area/ruin/interdyne_planetary_base/eng)
 "Os" = (
 /obj/effect/turf_decal/tile/dark_green/half/contrasted{
@@ -5041,18 +5012,6 @@
 /obj/machinery/door/window/survival_pod/left/directional/east,
 /turf/open/floor/grass,
 /area/ruin/interdyne_planetary_base/serv/hydr)
-"Qa" = (
-/obj/structure/disposaloutlet{
-	dir = 1
-	},
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk,
-/obj/structure/drain/big,
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "Qd" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/interdyne_planetary_base/main/vault)
@@ -5106,6 +5065,12 @@
 "Ra" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
+"Re" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "Ri" = (
@@ -5173,16 +5138,6 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/cargo/ware)
-"RB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/door/window/survival_pod/left/directional/west{
-	req_access = list("syndicate");
-	pixel_x = -4
-	},
-/obj/machinery/power/rtg/advanced,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/interdyne_planetary_base/eng)
 "RD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5204,6 +5159,11 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/interdyne_planetary_base/main/dorms)
+"RJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/effect/turf_decal/siding/thinplating/corner,
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "RR" = (
 /obj/item/geiger_counter,
 /obj/item/clothing/head/utility/radiation,
@@ -5213,9 +5173,13 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/ruin/interdyne_planetary_base)
 "RT" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/tile/neutral/diagonal_centre,
-/turf/open/floor/iron/diagonal,
+/obj/item/circuitboard/machine/recycler,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "interdynedisp"
+	},
+/obj/structure/frame/machine/secured,
+/turf/open/floor/iron/pool,
 /area/ruin/interdyne_planetary_base/eng)
 "RX" = (
 /obj/effect/turf_decal/siding/dark_green{
@@ -5299,6 +5263,12 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/med/pharm)
+"SB" = (
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/interdyne_planetary_base/eng)
 "SF" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -5795,12 +5765,12 @@
 /turf/open/floor/iron/dark,
 /area/ruin/interdyne_planetary_base/cargo/obs)
 "Vr" = (
-/obj/effect/turf_decal/siding/thinplating{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/dark_red/filled/warning,
+/obj/machinery/door/window/survival_pod/left/directional/north,
+/turf/open/floor/engine/o2,
 /area/ruin/interdyne_planetary_base/eng)
 "VA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -5822,10 +5792,12 @@
 /turf/closed/wall/mineral/titanium,
 /area/ruin/interdyne_planetary_base/main/dorms)
 "VQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 8
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/dark_red/filled/warning{
+	dir = 1
 	},
-/turf/open/floor/engine/n2,
+/obj/machinery/light/warm/directional/south,
+/turf/open/floor/engine/o2,
 /area/ruin/interdyne_planetary_base/eng)
 "VV" = (
 /obj/effect/turf_decal/siding/thinplating,
@@ -5873,31 +5845,23 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/main/vault)
 "Wk" = (
-/obj/structure/cable,
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "Wn" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/smes/engineering{
-	charge = 4.5e+006;
-	input_level = 150000;
-	output_level = 60000
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "Wx" = (
-/obj/structure/railing/corner{
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/marker_beacon/burgundy,
+/obj/effect/turf_decal/trimline/dark_red/filled/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/dark_green/diagonal_centre,
-/obj/structure/cable,
-/turf/open/floor/iron/diagonal,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/turf/open/floor/plating/reinforced,
 /area/ruin/interdyne_planetary_base/eng)
 "Wy" = (
 /obj/structure/cable,
@@ -6112,33 +6076,24 @@
 /turf/open/floor/iron/dark/smooth_edge,
 /area/ruin/interdyne_planetary_base/main)
 "XK" = (
-/obj/effect/turf_decal/vg_decals/atmos/oxygen{
-	dir = 8
+/obj/structure/closet/secure_closet/ds2atmos{
+	anchorable = 0;
+	anchored = 1
 	},
-/obj/machinery/light/warm/directional/east,
-/turf/open/floor/engine/o2,
+/obj/item/wrench/bolter,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
+/turf/open/floor/iron/diagonal,
 /area/ruin/interdyne_planetary_base/eng)
 "XL" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark/diagonal,
 /area/ruin/interdyne_planetary_base/cargo)
 "XM" = (
-/obj/item/construction/rtd{
-	pixel_y = 8
-	},
-/obj/structure/table/reinforced,
-/obj/item/construction/rld{
-	pixel_x = -5
-	},
-/obj/item/inducer{
-	pixel_x = 12;
-	pixel_y = -4
-	},
-/obj/structure/railing,
-/obj/effect/turf_decal/tile/neutral/diagonal_centre,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/diagonal,
-/area/ruin/interdyne_planetary_base/eng)
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/interdyne_planetary_base)
 "XU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6146,15 +6101,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/stairs/right,
 /area/ruin/interdyne_planetary_base/main)
-"XV" = (
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/interdyne_planetary_base/eng)
 "XZ" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -6322,9 +6268,14 @@
 /turf/open/floor/iron/dark,
 /area/ruin/interdyne_planetary_base/med)
 "ZU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/dark_red/filled/warning{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/structure/cable,
 /turf/open/floor/engine/o2,
 /area/ruin/interdyne_planetary_base/eng)
 "ZV" = (
@@ -7831,7 +7782,7 @@ fm
 kk
 pq
 nb
-XM
+Wn
 cD
 Ih
 iQ
@@ -7871,8 +7822,8 @@ fm
 fm
 pq
 is
-cL
-BJ
+uf
+wu
 cD
 Ih
 vO
@@ -7912,9 +7863,9 @@ sy
 gL
 pq
 RT
-cQ
-dk
-cD
+qV
+wu
+Wn
 Ih
 vO
 oT
@@ -7954,8 +7905,8 @@ Tc
 pq
 jf
 cL
-qv
-cD
+Bo
+Wn
 Ih
 Io
 Tx
@@ -7991,11 +7942,11 @@ ja
 ja
 fm
 Gj
-Tc
-pq
+XM
+pb
 FL
 cQ
-wf
+Fl
 MV
 pq
 pq
@@ -8032,16 +7983,16 @@ ja
 ja
 fm
 Gj
-dz
-pb
-ug
-KC
-Wx
-Vr
+Tc
+pq
+pq
+pq
+SB
+Ra
 jx
 iO
-LE
-At
+wu
+wu
 Hy
 pq
 oW
@@ -8076,13 +8027,13 @@ Gj
 Tc
 pq
 EG
-Qa
+cq
 bB
-XV
-mp
-pp
 Wn
-Mb
+mp
+Ra
+Wn
+Wn
 bN
 pq
 jv
@@ -8116,15 +8067,15 @@ fm
 Gj
 Tc
 pq
+aG
+ct
+tq
 aS
-wu
-wu
-Ra
 kX
 pT
+At
 Wk
-pT
-pT
+Am
 pq
 nY
 Ai
@@ -8157,13 +8108,13 @@ fm
 Gj
 pJ
 pq
-Am
-qV
-wu
-cK
-RB
-xe
-xe
+pq
+pq
+BJ
+RJ
+Re
+xp
+xp
 xe
 HS
 pq
@@ -8199,14 +8150,14 @@ Gj
 RR
 pq
 aG
-wu
-wu
-pq
-ct
-cq
-pq
-cq
 UN
+dk
+cK
+we
+we
+qv
+ZU
+Wx
 pq
 fW
 fW
@@ -8240,12 +8191,12 @@ Gj
 Tc
 pq
 DW
-tq
+cq
 fn
-pq
-ZU
-uf
-pq
+uI
+we
+we
+Vr
 Fh
 VQ
 pq
@@ -8286,7 +8237,7 @@ pq
 pq
 XK
 pZ
-pq
+wf
 de
 Oo
 pq
@@ -8445,7 +8396,7 @@ ja
 ja
 fm
 fm
-fm
+ug
 fm
 EZ
 sg


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Extending #1929 to Lavadyne, woo. Engineering gets a remap.

## How This Contributes To The Nova Sector Roleplay Experience

More QOL. Also fixes a couple small things here and there. Extra light switches, windows, etc.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/28007787/7efbf6c4-cbc3-4b23-a341-0def7716a107)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: lavadyne now has the micro reactor for power support.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
