### PR TITLE
Delam scram counter penalty

### DIFF
--- a/modular_nova/modules/delam_emergency_stop/code/delam.dm
+++ b/modular_nova/modules/delam_emergency_stop/code/delam.dm
@@ -59,3 +59,11 @@
 		return FALSE
 
 	return TRUE
+
+/obj/machinery/power/supermatter_crystal/engine/Destroy()
+	if(is_main_engine && GLOB.main_supermatter_engine == src)
+		SSpersistence.delam_highscore = SSpersistence.rounds_since_engine_exploded
+		SSpersistence.rounds_since_engine_exploded = -1
+		for(var/obj/machinery/incident_display/sign as anything in GLOB.map_delamination_counters)
+			sign.update_delam_count(SSpersistence.rounds_since_engine_exploded)
+	..()

--- a/modular_nova/modules/delam_emergency_stop/code/scram.dm
+++ b/modular_nova/modules/delam_emergency_stop/code/scram.dm
@@ -157,6 +157,9 @@
 			notify_volume = 75,
 		)
 	else
+		SSpersistence.rounds_since_engine_exploded = round(SSpersistence.rounds_since_engine_exploded * 0.75)
+		for(var/obj/machinery/incident_display/sign as anything in GLOB.map_delamination_counters)
+			sign.update_delam_count(SSpersistence.rounds_since_engine_exploded)
 		var/reason
 		switch(trigger_reason)
 			if(AUTOMATIC_SAFETIES)


### PR DESCRIPTION
## About The Pull Request

Delam scram will now put a 25% penalty on the delam counter, if the crystal is destroyed in a failed attempt, the counter resets.

## How This Contributes To The Nova Sector Roleplay Experience

The question of if it'd be too easy to rack up the counter if the system didn't impact the score has been answered. It's not an overly punishing penalty, but will allow the counter to get back to being an actual counter and something to work at rather than being perpetually stuck at 199.

## Changelog

:cl: LT3
balance: Using the delam panic button now costs 25% of your current score. A failed save and consequent delam wipes the counter as usual
/:cl:
