### PR TITLE
Increase multi-cell charging rack max power to 1.5MW

### DIFF
--- a/modular_nova/modules/multicellcharger/code/multi_cell_charger.dm
+++ b/modular_nova/modules/multicellcharger/code/multi_cell_charger.dm
@@ -98,7 +98,7 @@
 	var/list/charging_queue = list()
 	for(var/obj/item/stock_parts/cell/battery_slot in charging_batteries)
 		if(battery_slot.percent() >= 100)
-			continue	
+			continue
 		LAZYADD(charging_queue, battery_slot)
 
 	if(!length(charging_queue))
@@ -109,7 +109,7 @@
 	var/charge_current = (charge_rate / length(charging_queue)) * seconds_per_tick
 	if(!charge_current)
 		return
-		
+
 	for(var/obj/item/stock_parts/cell/charging_cell in charging_queue)
 		use_energy(charge_current * 0.01) //use a small bit for the charger itself, but power usage scales up with the part tier
 		charge_cell(charge_current, charging_cell, grid_only = TRUE)
@@ -196,7 +196,7 @@
 	name = "Multi-Cell Charger (Machine Board)"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/cell_charger_multi
-	req_components = list(/datum/stock_part/capacitor = 4)
+	req_components = list(/datum/stock_part/capacitor = 6)
 	needs_anchored = FALSE
 
 


### PR DESCRIPTION
## About The Pull Request

Increases the multi-cell charging rack's max charge power from 1MW to 1.5MW

## How This Contributes To The Nova Sector Roleplay Experience

Charge those cells a bit faster, 1.5MW isn't too hard on the grid comparatively.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![multicell](https://github.com/NovaSector/NovaSector/assets/83487515/da9064c5-cd24-448d-8b71-79723bc6769a)

</details>

## Changelog

:cl: LT3
qol: Multi-cell charging rack cell charging power increased to 1.5MW
/:cl: