### PR TITLE
Remove modular fire alarm lighting override

### DIFF
--- a/modular_nova/modules/aesthetics/lights/code/lighting.dm
+++ b/modular_nova/modules/aesthetics/lights/code/lighting.dm
@@ -4,8 +4,6 @@
 
 /obj/machinery/light
 	brightness = 7.5
-	fire_brightness = 6
-	fire_colour = COLOR_FIRE_LIGHT_RED
 	bulb_colour = COLOR_OFF_WHITE
 	bulb_power = 0.9
 	nightshift_light_color = null // Let the dynamic night shift color code handle this.


### PR DESCRIPTION
## About The Pull Request

Removes Nova's modular override of fire alarm lighting, as TG has since upstreamed to be similar enough.

## How This Contributes To The Nova Sector Roleplay Experience

Remove needless overrides.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
 
![firelights](https://github.com/NovaSector/NovaSector/assets/83487515/7a6ef6c7-a7f7-49a8-a01c-1db4ab654a5a)

</details>

## Changelog

:cl: LT3
del: Removed modular override of fire alarm lighting
/:cl: