### PR TITLE
Fixes lavaland chem master not having an apc

### DIFF
--- a/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1.dmm
@@ -1077,7 +1077,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/ruin/interdyne_planetary_base/med)
+/area/ruin/interdyne_planetary_base/med/pharm)
 "js" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/bookcase/random,
@@ -6803,7 +6803,7 @@ NW
 jY
 Un
 TH
-Pn
+Mv
 Ey
 uP
 GB
@@ -6844,7 +6844,7 @@ ea
 Uj
 Vf
 DF
-Pn
+Mv
 aA
 Ma
 Ma
@@ -6926,7 +6926,7 @@ vN
 IJ
 Vf
 ED
-Pn
+Mv
 ZE
 LJ
 AU
@@ -6967,7 +6967,7 @@ HB
 Zy
 gO
 LN
-Pn
+Mv
 BN
 aM
 aM
@@ -7008,7 +7008,7 @@ Pn
 Pn
 Pn
 MJ
-Pn
+Mv
 qm
 LC
 NM


### PR DESCRIPTION
## About The Pull Request

Fixes pharmacy area on lavaland interdyne base not having an apc

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![UzDtDczeOP](https://github.com/NovaSector/NovaSector/assets/13398309/05a40f3e-741d-42ad-be23-03d5b4768041)

</details>

## Changelog

:cl:
fix: lavaland interdyne base pharmacy now has an apc linked to it
/:cl: