### PR TITLE
Makes wooden fences need a crowbar to deconstruct

### DIFF
--- a/modular_nova/modules/primitive_structures/code/fencing.dm
+++ b/modular_nova/modules/primitive_structures/code/fencing.dm
@@ -22,13 +22,13 @@
 	update_appearance()
 
 // formerly NO_DECONSTRUCTION
-/obj/structure/railing/wirecutter_act(mob/living/user, obj/item/I)
+/obj/structure/railing/wirecutter_act(mob/living/user, obj/item/tool)
 	return NONE
 
-/obj/structure/railing/crowbar_act(mob/living/user, obj/item/I)
+/obj/structure/railing/crowbar_act(mob/living/user, obj/item/tool)
 	. = ..()
 	to_chat(user, span_warning("You pry apart the railing."))
-	I.play_tool_sound(src, 100)
+	tool.play_tool_sound(src, 100)
 	deconstruct()
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

Tin. These formerly had the `NO_DECONSTRUCT` flag but it wasn't actually being checked so it still let you deconstruct them due to a bug.

When I fixed that bug I inadvertently removed the ability to take them apart at all.

Now you can do so with a crowbar, same as with most other wooden items.

<details><summary>Works</summary>

![dreamseeker_Q8UR7KIxmq](https://github.com/NovaSector/NovaSector/assets/13398309/e70f0a52-7726-4265-b9e4-17a6446b447b)

</details>

## Changelog

:cl:
fix: you can deconstruct wooden fences again, but now you have to use a crowbar
/:cl:
