### PR TITLE
Add additional config checks for antag opt-in system

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -114,7 +114,7 @@
 		if(possible_target.current.stat == DEAD)
 			continue
 		// NOVA EDIT ADDITION BEGIN - Antag opt-in (Only security and command can be targetted)
-		if (!possible_target.assigned_role?.heretic_sac_target)
+		if (!CONFIG_GET(flag/disable_antag_opt_in_preferences) && !possible_target.assigned_role?.heretic_sac_target)
 			continue
 		// NOVA EDIT ADDITION END
 
@@ -146,14 +146,15 @@
 			valid_targets -= sec_mind
 			break
 
-	/* NOVA EDIT REMOVAL -- Antag Opt In (Only sec and command may be targetted)
+	// NOVA EDIT REMOVAL -- Antag Opt In (Only sec and command may be targetted if config is set as 0)
 	// Third target, someone in their department.
-	for(var/datum/mind/department_mind as anything in shuffle(valid_targets))
-		if(department_mind.assigned_role?.departments_bitflags & user.mind.assigned_role?.departments_bitflags)
-			final_targets += department_mind
-			valid_targets -= department_mind
-			break
-	*/ // NOVA EDIT REMOVAL END
+	if(CONFIG_GET(flag/disable_antag_opt_in_preferences))
+		for(var/datum/mind/department_mind as anything in shuffle(valid_targets))
+			if(department_mind.assigned_role?.departments_bitflags & user.mind.assigned_role?.departments_bitflags)
+				final_targets += department_mind
+				valid_targets -= department_mind
+				break
+	// NOVA EDIT REMOVAL END
 
 	// Now grab completely random targets until we'll full
 	var/target_sanity = 0

--- a/modular_nova/modules/antag_opt_in/code/mind.dm
+++ b/modular_nova/modules/antag_opt_in/code/mind.dm
@@ -35,7 +35,8 @@ GLOBAL_LIST_INIT(optin_forcing_on_spawn_antag_categories, list(
 
 /mob/living/Login()
 	. = ..()
-
+	if(CONFIG_GET(flag/disable_antag_opt_in_preferences)) //lets not annoy our fellow players with useless info if we don't use this system at all
+		return
 	if (isnull(mind))
 		return
 	if (isnull(client?.prefs))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fix for a problem with heretics not getting their targets when antag opt-in disabled. Also removes this somewhat annoying message about "i want to get killed" pref getting changed because of be-antag button.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

![image](https://github.com/NovaSector/NovaSector/assets/8430839/ef2e7bc6-1fcf-4cf1-af2f-a8444fe02cda)

Turns out, it doesn't disables opt-in system completely. Now it does.

In actuality, it shouldn't be noticeable on Nova. But it does fixes something that any downstream would encounter if the choos not to use antag opt-in.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
Keep in mind, my ability to check if it does indeed work is kinda limited, but here are some screenshots
<details>
<summary>Screenshots/Videos</summary>
  opt-in enabled
  non-sec player does not appear as target

![image](https://github.com/NovaSector/NovaSector/assets/8430839/cf628c8f-8f2e-497f-b7e0-4f2a1088665c)

sec player appears as target
![image](https://github.com/NovaSector/NovaSector/assets/8430839/577a7a4c-5099-4d13-b9fb-f54fc2b6942f)

annoying message is shown
![image](https://github.com/NovaSector/NovaSector/assets/8430839/883740f6-d2e6-4536-8fe3-12994c7cdbe6)

Now - same things with opt-in turned off
![image](https://github.com/NovaSector/NovaSector/assets/8430839/9d92e81a-e3e8-4ff2-ae68-51c4ff96f4e9)

no message on spawn
![image](https://github.com/NovaSector/NovaSector/assets/8430839/58a4de5d-a727-456a-8fea-bd5f17e0224c)

random people gets targeted by heretics
![image](https://github.com/NovaSector/NovaSector/assets/8430839/3c7e71c0-f8cb-41db-80e5-e72fbd4fd402)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixes heretics not getting their targets when antag opt-in disabled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
