### PR TITLE
Tesla coil input multiplier balance

### DIFF
--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -42,6 +42,7 @@
 		return ITEM_INTERACT_BLOCKING
 	return ..()
 
+/* NOVA EDIT CHANGE BEGIN - MOVED TO modular_nova/master_files/code/modules/power/tesla/coil.dm
 /obj/machinery/power/energy_accumulator/tesla_coil/RefreshParts()
 	. = ..()
 	var/power_multiplier = 0
@@ -50,6 +51,7 @@
 		power_multiplier += capacitor.tier
 		zap_cooldown -= (capacitor.tier * 20)
 	input_power_multiplier = max(1 * (power_multiplier / 8), 0.25) //Max out at 50% efficency.
+*/// NOVA EDIT CHANGE END
 
 /obj/machinery/power/energy_accumulator/tesla_coil/examine(mob/user)
 	. = ..()

--- a/modular_nova/master_files/code/modules/power/tesla/coil.dm
+++ b/modular_nova/master_files/code/modules/power/tesla/coil.dm
@@ -1,0 +1,9 @@
+/obj/machinery/power/energy_accumulator/tesla_coil/RefreshParts()
+	. = ..()
+	var/new_power_multiplier = 0.44
+	zap_cooldown = 10 SECONDS
+	for(var/datum/stock_part/capacitor/capacitor in component_parts)
+		new_power_multiplier += capacitor.tier * 0.12
+		zap_cooldown -= (capacitor.tier * 2 SECONDS)
+
+	input_power_multiplier = clamp(new_power_multiplier, 0.44, 0.92)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6629,6 +6629,7 @@
 #include "modular_nova\master_files\code\modules\power\powernet.dm"
 #include "modular_nova\master_files\code\modules\power\lighting\light_mapping_helpers.dm"
 #include "modular_nova\master_files\code\modules\power\singularity\containment_field.dm"
+#include "modular_nova\master_files\code\modules\power\tesla\coil.dm"
 #include "modular_nova\master_files\code\modules\projectiles\boxes_magazines\external\shotgun.dm"
 #include "modular_nova\master_files\code\modules\projectiles\boxes_magazines\external\smg.dm"
 #include "modular_nova\master_files\code\modules\projectiles\guns\ballistic.dm"


### PR DESCRIPTION
## About The Pull Request

Gives a boost to tesla coil input multiplier, particularly focusing on roundstart. This will allow engineers to collect a bit more extra power roundstart using their default SM setup. Returns it to a bit below pre-2022 TG levels.

This does not change the amount of energy generated by the crystal/emitters, only the ability for the tesla coils to collect the energy.

## How This Contributes To The Nova Sector Roleplay Experience

With the increased power consumption post-TG refactor combined with Nova's higher player count, this will allow engineers (particularly those who don't have the skill/desire to run an experimental engine setup, which is supposed to get CE or admin approval anyways per the rules) to provide more roundstart power and less screaming at them about low power brownouts despite following how they're "supposed" to set up the engine.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![novasector](https://github.com/NovaSector/NovaSector/assets/83487515/07efccab-04de-4e72-a002-c7cdd7613981)

</details>

## Changelog

:cl: LT3
balance: Increased tesla coil zap conversion capacity
/:cl:
