### PR TITLE
Ghost faction aligments

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
@@ -26,6 +26,32 @@
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/nova/des_two/cargo)
+"ag" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/door/airlock/vault{
+	id_tag = "syndie_ds2_vault"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/nova/des_two/bridge/vault)
 "ah" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -50,20 +76,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/nova/des_two/bridge/cl)
-"an" = (
-/obj/machinery/button/door/directional/west{
-	desc = "Used to open the security checkpoint bypass shutters.";
-	id = "ds2bayaccess";
-	name = "Checkpoint Bypass Shutters Control";
-	req_access = list("syndicate")
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/nova/des_two/halls)
 "at" = (
 /obj/effect/turf_decal/siding/dark/end,
 /obj/machinery/light/cold/directional/south,
@@ -326,6 +338,12 @@
 	},
 /turf/open/floor/circuit/red,
 /area/ruin/space/has_grav/nova/des_two/research/robotics)
+"bO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/nova/des_two/halls)
 "bP" = (
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/red/line{
@@ -519,12 +537,31 @@
 	},
 /area/ruin/space/has_grav/nova/des_two/cargo)
 "cs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/structure/cable,
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/mineral/silver{
+	pixel_x = -4;
+	amount = 10
 	},
-/obj/structure/chair/office,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/nova/des_two/halls)
+/obj/item/stack/sheet/mineral/gold{
+	pixel_x = 4;
+	amount = 10
+	},
+/obj/item/stack/sheet/mineral/diamond{
+	amount = 3
+	},
+/obj/item/stack/sheet/bluespace_crystal{
+	amount = 3;
+	pixel_y = -7
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 10
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/nova/des_two/bridge/vault)
 "ct" = (
 /obj/effect/turf_decal/bot_white,
 /obj/structure/table,
@@ -556,35 +593,19 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/nova/des_two/research)
 "cB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/apc/syndicate_access,
-/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/computer/security{
+	dir = 1;
+	network = list("ds2")
+	},
 /obj/structure/cable,
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/mineral/silver{
-	pixel_x = -4;
-	amount = 10
-	},
-/obj/item/stack/sheet/mineral/gold{
-	pixel_x = 4;
-	amount = 10
-	},
-/obj/item/stack/sheet/mineral/diamond{
-	amount = 3
-	},
-/obj/item/stack/sheet/bluespace_crystal{
-	amount = 3;
-	pixel_y = -7
-	},
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 10
-	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/nova/des_two/halls)
+"cC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/nova/des_two/bridge/vault)
-"cC" = (
-/obj/structure/closet/secure_closet/des_two/brig_officer_locker,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/nova/des_two/halls)
 "cD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -710,12 +731,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/nova/des_two/service/dorms)
-"di" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/nova/des_two/halls)
 "dl" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/mod/core/standard,
@@ -2220,6 +2235,11 @@
 	dir = 1
 	},
 /area/ruin/space/has_grav/nova/des_two/research/robotics)
+"jB" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/nova/des_two/bridge/vault)
 "jC" = (
 /obj/effect/turf_decal/nova_decals/syndicate/middle/right,
 /obj/structure/cable,
@@ -2817,6 +2837,14 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/nova/des_two/cargo)
+"lT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/chair/office,
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/nova/des_two/halls)
 "lU" = (
 /obj/effect/turf_decal/trimline/dark_blue/corner{
 	dir = 4
@@ -3116,11 +3144,12 @@
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/nova/des_two/service/dorms)
 "nx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/filingcabinet,
-/obj/item/folder/syndicate/red,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/nova/des_two/bridge/vault)
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/nova/des_two/halls)
 "ny" = (
 /obj/machinery/light/warm/directional/south,
 /turf/open/floor/carpet/blue,
@@ -3508,6 +3537,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/machinery/button/door/directional/south{
+	id = "syndie_ds2_vault";
+	name = "Vault Bolt Control";
+	req_access = list("syndicate");
+	specialfunctions = 4;
+	normaldoorcontrol = 1
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/nova/des_two/halls)
 "pb" = (
@@ -3704,12 +3740,6 @@
 	},
 /turf/open/floor/iron/small,
 /area/ruin/space/has_grav/nova/des_two/service/diner)
-"pK" = (
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/nova/des_two/halls)
 "pO" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
@@ -4713,6 +4743,24 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/nova/des_two/security/prison)
+"uO" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Security Checkpoint"
+	},
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/nova/des_two/halls)
 "uS" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -4753,6 +4801,20 @@
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/nova/des_two/security/prison)
+"vh" = (
+/obj/machinery/button/door/directional/west{
+	desc = "Used to open the security checkpoint bypass shutters.";
+	id = "ds2bayaccess";
+	name = "Checkpoint Bypass Shutters Control";
+	req_access = list("syndicate_leader")
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/nova/des_two/halls)
 "vj" = (
 /obj/effect/turf_decal/trimline/dark_red/filled/line,
 /obj/structure/chair/plastic{
@@ -5008,13 +5070,6 @@
 /obj/structure/sign/poster/contraband/icebox_moment/directional/south,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/nova/des_two/security)
-"wD" = (
-/obj/machinery/computer/security{
-	dir = 1;
-	network = list("ds2")
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/nova/des_two/halls)
 "wE" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5602,23 +5657,6 @@
 	dir = 4
 	},
 /area/ruin/space/has_grav/nova/des_two/service/diner)
-"zu" = (
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
-/obj/effect/turf_decal/stripes/red/line,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery/red,
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/security/old/glass{
-	name = "Security Checkpoint"
-	},
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/open/floor/iron/dark/textured_large,
-/area/ruin/space/has_grav/nova/des_two/halls)
 "zv" = (
 /obj/effect/turf_decal/vg_decals/numbers/zero{
 	dir = 4
@@ -5954,32 +5992,6 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/nova/des_two/security)
-"Bf" = (
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/obj/machinery/door/airlock/vault{
-	id_tag = "syndie_ds2_vault"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery/red,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/ruin/space/has_grav/nova/des_two/bridge/vault)
 "Bj" = (
 /obj/structure/sink/kitchen/directional/west,
 /obj/machinery/firealarm/directional/east,
@@ -6392,6 +6404,9 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/nova/des_two/engineering)
+"Db" = (
+/turf/open/space/basic,
+/area/space)
 "Dc" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -6929,9 +6944,12 @@
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/nova/des_two/security/prison)
 "Fq" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/nova/des_two/bridge/vault)
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/closet/secure_closet/des_two/brig_officer_locker,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/nova/des_two/halls)
 "Fx" = (
 /obj/machinery/chem_dispenser/mutagensaltpeter,
 /turf/open/floor/iron/white/diagonal,
@@ -7034,6 +7052,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/button/door/directional/east{
+	name = "Checkpoint Bypass Shutters Control";
+	id = "ds2bayaccess"
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/nova/des_two/halls)
 "FW" = (
@@ -7723,7 +7745,6 @@
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/nova/des_two/halls)
 "IC" = (
@@ -8435,7 +8456,7 @@
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/nova/des_two/halls)
 "LK" = (
@@ -8658,6 +8679,22 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/nova/des_two/service/dorms/fitness)
+"MY" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
+/obj/machinery/airalarm/directional/west,
+/obj/structure/filingcabinet,
+/obj/item/folder/syndicate/red,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/nova/des_two/bridge/vault)
 "MZ" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
@@ -8893,13 +8930,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/button/door/directional/west{
-	id = "syndie_ds2_vault";
-	name = "Vault Bolt Control";
-	normaldoorcontrol = 1;
-	req_access = list("syndicate_leader");
-	specialfunctions = 4
-	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/nova/des_two/cargo)
 "NW" = (
@@ -9655,6 +9685,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/nova/des_two/halls)
@@ -10275,20 +10307,6 @@
 /obj/item/reagent_containers/blood/o_minus,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/nova/des_two/cargo)
-"Ud" = (
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/south,
-/obj/effect/mapping_helpers/airalarm/syndicate_access,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/nova/des_two/bridge/vault)
 "Ue" = (
 /obj/item/reagent_containers/cup/bucket/wooden,
 /obj/effect/turf_decal/trimline/dark_red/filled/line{
@@ -10902,8 +10920,6 @@
 /area/ruin/space/has_grav/nova/des_two/engineering)
 "Xg" = (
 /obj/effect/turf_decal/stripes/red/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
@@ -13056,16 +13072,16 @@ yz
 bN
 yu
 pQ
-HH
-HH
-HH
-HH
-HH
 vl
 vl
 vl
 vl
 vl
+HH
+HH
+HH
+HH
+HH
 WV
 mD
 fQ
@@ -13111,16 +13127,16 @@ KR
 bN
 So
 Xg
-zu
-pK
-an
-fD
-Zl
-Fq
+jB
 pj
 xq
-Ud
-vl
+MY
+jB
+Fq
+vh
+fD
+Zl
+tB
 bf
 cy
 rB
@@ -13166,16 +13182,16 @@ ls
 Zx
 So
 Rw
-tB
+ag
 cC
-di
-cs
-wD
-Fq
-nx
 wb
+cs
+jB
+bO
+nx
+lT
 cB
-vl
+tB
 vj
 FG
 mJ
@@ -13221,15 +13237,15 @@ AS
 Wa
 yi
 pa
-HH
-tB
+vl
+vl
+vl
+vl
+vl
+uO
 Wy
 uK
 zO
-vl
-vl
-Bf
-vl
 VG
 my
 KC
@@ -13969,7 +13985,7 @@ wg
 wg
 EJ
 kx
-vl
+NB
 bw
 zV
 Un
@@ -14173,11 +14189,11 @@ wg
 kx
 wg
 wg
-wg
-wg
-wg
-wg
-wg
+Db
+Db
+Db
+Db
+Db
 wg
 wg
 wg
@@ -14228,11 +14244,11 @@ wg
 EJ
 wg
 wg
-wg
-wg
-wg
-wg
-wg
+Db
+Db
+Db
+Db
+Db
 wg
 wg
 wg
@@ -14283,11 +14299,11 @@ wg
 wg
 wg
 wg
-wg
-wg
-wg
-wg
-wg
+Db
+Db
+Db
+Db
+Db
 wg
 wg
 wg
@@ -14338,11 +14354,11 @@ wg
 wg
 wg
 wg
-wg
-wg
-wg
-wg
-wg
+Db
+Db
+Db
+Db
+Db
 wg
 wg
 wg

--- a/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
@@ -184,7 +184,8 @@
 /area/ruin/space/has_grav/nova/des_two/bridge)
 "aW" = (
 /obj/machinery/porta_turret/syndicate/energy{
-	dir = 6
+	dir = 6;
+	faction = list("Syndicate DS-2 Crew","Interdyne Lavaland Personnel")
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/nova/des_two/bridge/vault)
@@ -1474,12 +1475,6 @@
 "go" = (
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/nova/des_two/cargo)
-"gv" = (
-/obj/machinery/porta_turret/syndicate/energy{
-	dir = 5
-	},
-/turf/closed/wall/r_wall/syndicate,
-/area/ruin/space/has_grav/nova/des_two/bridge/vault)
 "gw" = (
 /obj/item/circuitboard/machine/component_printer,
 /obj/effect/turf_decal/trimline/dark_red/filled/line{
@@ -3235,7 +3230,8 @@
 /area/ruin/space/has_grav/nova/des_two/engineering)
 "nO" = (
 /obj/machinery/porta_turret/syndicate/energy{
-	dir = 9
+	dir = 9;
+	faction = list("Syndicate DS-2 Crew","Interdyne Lavaland Personnel")
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/nova/des_two/bridge/vault)
@@ -3381,7 +3377,7 @@
 "oG" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 5;
-	faction = list("Syndicate","neutral")
+	faction = list("Syndicate DS-2 Crew","neutral")
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/nova/des_two/security/armory)
@@ -4896,7 +4892,9 @@
 /turf/open/floor/iron/pool,
 /area/ruin/space/has_grav/nova/des_two/engineering)
 "vS" = (
-/obj/machinery/porta_turret/syndicate/energy,
+/obj/machinery/porta_turret/syndicate/energy{
+	faction = list("Syndicate DS-2 Crew","Interdyne Lavaland Personnel")
+	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/nova/des_two/bridge/vault)
 "vU" = (
@@ -8559,7 +8557,8 @@
 /area/ruin/space/has_grav/nova/des_two/research)
 "Mt" = (
 /obj/machinery/porta_turret/syndicate/energy{
-	dir = 5
+	dir = 5;
+	faction = list("Syndicate DS-2 Crew","Interdyne Lavaland Personnel")
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/nova/des_two/bridge/vault)
@@ -10555,7 +10554,8 @@
 /area/ruin/space/has_grav/nova/des_two/security/lawyer)
 "VG" = (
 /obj/machinery/porta_turret/syndicate/energy{
-	dir = 4
+	dir = 4;
+	faction = list("Syndicate DS-2 Crew","Interdyne Lavaland Personnel")
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/nova/des_two/bridge/vault)
@@ -13969,7 +13969,7 @@ wg
 wg
 EJ
 kx
-Mt
+vl
 bw
 zV
 Un
@@ -14143,7 +14143,7 @@ wg
 wg
 wg
 wg
-gv
+gn
 bw
 bw
 bw

--- a/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
@@ -8419,7 +8419,6 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/nova/des_two/bridge/admiral)
 "LJ" = (
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -8436,6 +8435,7 @@
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/nova/des_two/halls)
 "LK" = (

--- a/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
@@ -6404,9 +6404,6 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/nova/des_two/engineering)
-"Db" = (
-/turf/open/space/basic,
-/area/space)
 "Dc" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -14189,11 +14186,11 @@ wg
 kx
 wg
 wg
-Db
-Db
-Db
-Db
-Db
+wg
+wg
+wg
+wg
+wg
 wg
 wg
 wg
@@ -14244,11 +14241,11 @@ wg
 EJ
 wg
 wg
-Db
-Db
-Db
-Db
-Db
+wg
+wg
+wg
+wg
+wg
 wg
 wg
 wg
@@ -14299,11 +14296,11 @@ wg
 wg
 wg
 wg
-Db
-Db
-Db
-Db
-Db
+wg
+wg
+wg
+wg
+wg
 wg
 wg
 wg
@@ -14354,11 +14351,11 @@ wg
 wg
 wg
 wg
-Db
-Db
-Db
-Db
-Db
+wg
+wg
+wg
+wg
+wg
 wg
 wg
 wg

--- a/code/__DEFINES/~nova_defines/factions.dm
+++ b/code/__DEFINES/~nova_defines/factions.dm
@@ -1,10 +1,3 @@
-// Black Mesa away mission factions
-
-#define FACTION_XEN "xen"
-#define FACTION_HECU "hecu"
-#define FACTION_BLACKOPS "blackops"
-#define FACTION_BLACKMESA "blackmesa"
-
 // ERT faction
 #define FACTION_ERT "ert"
 

--- a/modular_nova/master_files/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/modular_nova/master_files/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -143,7 +143,7 @@
 	var/jobtype = /datum/job/interdyne_planetary_base
 
 /datum/outfit/interdyne_planetary_base/post_equip(mob/living/carbon/human/syndicate, visualsOnly = FALSE)
-	syndicate.faction |= ROLE_SYNDICATE
+	syndicate.faction |= ROLE_INTERDYNE_PLANETARY_BASE
 
 	var/obj/item/card/id/id_card = syndicate.wear_id
 	if(istype(id_card))

--- a/modular_nova/modules/mapping/code/interdyne_mining.dm
+++ b/modular_nova/modules/mapping/code/interdyne_mining.dm
@@ -31,4 +31,4 @@
 
 /mob/living/basic/mining_drone/interdyne
 	name = "\improper Interdyne minebot"
-	faction = list(FACTION_NEUTRAL, ROLE_SYNDICATE)
+	faction = list(FACTION_NEUTRAL, ROLE_INTERDYNE_PLANETARY_BASE)

--- a/modular_nova/modules/mapping/code/mob_spawns.dm
+++ b/modular_nova/modules/mapping/code/mob_spawns.dm
@@ -274,7 +274,7 @@
 	ears = /obj/item/radio/headset/interdyne
 
 /datum/outfit/ds2/syndicate/post_equip(mob/living/carbon/human/syndicate)
-	syndicate.faction |= ROLE_SYNDICATE
+	syndicate.faction |= ROLE_DS2
 	return ..()
 
 //DS-2 Command
@@ -336,7 +336,7 @@
 	id_trim = /datum/id_trim/syndicom/nova/ds2/stationadmiral
 
 /datum/outfit/ds2/syndicate_command/post_equip(mob/living/carbon/human/syndicate)
-	syndicate.faction |= ROLE_SYNDICATE
+	syndicate.faction |= ROLE_DS2
 	return ..()
 
 /datum/outfit/hotelstaff


### PR DESCRIPTION
## About The Pull Request

Interdyne and DS2 have piggybacked off the Syndicate faction for a while and have had some unintended consequences as such. This just assigns the spawners their correct faction role that exists already as well as ensures everything behaves so the players aren't impacted at all.

I also adjusted the access to the control areas around the dock itself, this is aimed towards letting general DS2 crew be soloplay instead of having to hack the door open just to be able to go into the door/turn the turrets off.

I swapped the vault and the security post to facilitate this change without general interdyne crew being able to easily access the vault/unlock the shutters as well.

Security post shutters are now set to Leader

## How This Contributes To The Nova Sector Roleplay Experience

Some of our highest threat ruins are syndicate themed, and being able to walk in and get the high tier loot without consequence really isnt fair to everyone.

<details>
<Summary> Example </Summary>

![image](https://github.com/NovaSector/NovaSector/assets/22140677/8015f3de-ae23-48d9-a754-9fa16c967312)

</details>

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
  Turrets go :  )
![image](https://github.com/NovaSector/NovaSector/assets/22140677/524bf1e5-03a6-4c10-ace1-fa1b3dd035f3)

  Syndies go > :  (

![image](https://github.com/NovaSector/NovaSector/assets/22140677/16ac080b-c2d0-428d-b315-fa87d81c379f)

![image](https://github.com/NovaSector/NovaSector/assets/22140677/e919ef37-7828-4ec2-aa5a-ee2010181ad0)

Normal DS2 crew can now open the shutter to the dock, the security post now needs Leader access in order to use the same shutter button

![image](https://github.com/NovaSector/NovaSector/assets/22140677/2a5f67bb-1889-4036-8187-3e383d8c0401)
![image](https://github.com/NovaSector/NovaSector/assets/22140677/b661ee28-5123-4ffb-9577-e3df24140322)

The Vault can now be unbolted by regular DS2 crew, the interior access was already set to general as was the door 

![image](https://github.com/NovaSector/NovaSector/assets/22140677/9274a742-3606-4962-b8bb-9579e37299da)
![image](https://github.com/NovaSector/NovaSector/assets/22140677/0a495108-86a7-40df-a5fa-f7cc875915a0)


  
</details>

## Changelog
:cl:
code: removed the faction defines for Black Mesa as they dont exist anymore
balance: DS2 and Interdyne factions are properly assigned, syndicate ruins will not retaliate
qol: DS2 general crew can now open the shutters to go to the docking area as well as unbolt the vault for turret control
/:cl:
