### PR TITLE
Removes Syndicate Bombs (the gargantuan one) from Syndicate Uplink.

### DIFF
--- a/code/modules/uplink/uplink_items/explosive.dm
+++ b/code/modules/uplink/uplink_items/explosive.dm
@@ -86,7 +86,7 @@
 	..()
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_CYBERNETIC_REVOLUTION))
 		cost *= 2
-
+/* // NOVA EDIT REMOVAL START
 /datum/uplink_item/explosives/syndicate_bomb
 	name = "Syndicate Bomb"
 	desc = "The Syndicate bomb is a fearsome device capable of massive destruction. It has an adjustable timer, \
@@ -102,3 +102,4 @@
 /datum/uplink_item/explosives/syndicate_bomb/New()
 	. = ..()
 	desc = replacetext(desc, "%MIN_BOMB_TIMER", SYNDIEBOMB_MIN_TIMER_SECONDS)
+*/ // NOVA EDIT REMOVAL END


### PR DESCRIPTION
## About The Pull Request

We can't even use these things so why keep em' in? Feels like newbie traps for policy-unsuspecting traitors.
## How This Contributes To The Nova Sector Roleplay Experience

yes

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/109750345/8f5b31ae-6f77-4107-b0e1-53bb0e0fb984)

</details>

## Changelog
:cl:
del: Removed Syndicate Bomb (LARGE, 11 TC) from Syndicate Uplink.
/:cl:
