### PR TITLE
Clocking out opens your job slot

### DIFF
--- a/modular_nova/modules/cryosleep/code/job.dm
+++ b/modular_nova/modules/cryosleep/code/job.dm
@@ -6,3 +6,14 @@
 	if(!job)
 		return FALSE
 	job.current_positions = max(0, job.current_positions - 1)
+
+/// Used for clocking back in, re-claiming the previously freed role. Returns false if no slot is available.
+/datum/controller/subsystem/job/proc/OccupyRole(rank)
+	if(!rank)
+		return FALSE
+	JobDebug("Occupying role: [rank]")
+	var/datum/job/job = GetJob(rank)
+	if(!job || job.current_positions >= job.total_positions)
+		return FALSE
+	job.current_positions = job.current_positions + 1
+	return TRUE

--- a/modular_nova/modules/time_clock/code/console.dm
+++ b/modular_nova/modules/time_clock/code/console.dm
@@ -114,8 +114,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/time_clock, 28)
 	var/current_assignment = inserted_id.assignment
 	var/datum/id_trim/job/current_trim = inserted_id.trim
 	var/datum/job/clocked_out_job = current_trim.job
-	clocked_out_job.current_positions = max(0, clocked_out_job.current_positions - 1)
-
+	SSjob.FreeRole(clocked_out_job.title)
 	radio.talk_into(src, "[inserted_id.registered_name], [current_assignment] has gone off-duty.", announcement_channel)
 	update_static_data_for_all_viewers()
 
@@ -139,10 +138,10 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/time_clock, 28)
 		return FALSE
 
 	var/datum/job/clocked_in_job = id_component.stored_trim.job
-	if(!clocked_in_job || (clocked_in_job.total_positions <= clocked_in_job.current_positions))
+	if(!SSjob.OccupyRole(clocked_in_job.title))
+		say("[capitalize(clocked_in_job.title)] has no free slots available, unable to clock in!")
 		return FALSE
 
-	clocked_in_job.current_positions++
 
 	SSid_access.apply_trim_to_card(inserted_id, id_component.stored_trim.type, TRUE)
 	inserted_id.assignment = id_component.stored_assignment

--- a/modular_nova/modules/time_clock/code/console_tgui.dm
+++ b/modular_nova/modules/time_clock/code/console_tgui.dm
@@ -99,7 +99,8 @@
 	switch(action)
 		if("clock_in_or_out")
 			if(off_duty_check())
-				clock_in()
+				if(!(clock_in()))
+					return
 				log_admin("[key_name(usr)] clocked in as \an [inserted_id.assignment].")
 
 				var/datum/mind/user_mind = usr.mind


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Clocking out opens up your job, so someone else can join and fill in.
The code suggests that this is already supposed to be a thing, but it either broke or never worked.
Makes sure that you can only clock back in if there's still an available slot.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Sometimes you're just done with your job, and you just want to relax. Right now, clocking out is a half-baked solution, because it doesn't mechanically change anything for your department. They'll forever be down a worker  unless the hop opens a new slot, _and_ someone decides to join a job that seems to already be very well staffed.
Not to mention head of staff roles which are just locked in purgatory when someone clocks out.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>

![image](https://github.com/NovaSector/NovaSector/assets/25628932/38bb02a1-d669-4159-b3d1-b0d97b8c14c8)


<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Clocking out will now open up your job slot for new players to take. Should the role become filled in your absence, you will not be able to clock back in until someone clocks out or cryos.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
