### PR TITLE
Fixes sanusfentynal recipe spawning in space ruins

### DIFF
--- a/modular_nova/modules/HMS_Changes/sansufentanyl.dm
+++ b/modular_nova/modules/HMS_Changes/sansufentanyl.dm
@@ -93,7 +93,7 @@
 /obj/item/folder/syndicate/red/secretformula
 	icon_state = "folder_sred"
 
-/obj/item/folder/syndicate/red/Initialize(mapload)
+/obj/item/folder/syndicate/red/secretformula/Initialize(mapload)
 	. = ..()
 	new /obj/item/paper/secretrecipe/secretformula(src)
 	update_appearance()


### PR DESCRIPTION
## About The Pull Request

i accidentally made the recipe spawn in the regular red syndi folder rather than the variant i made just for interdyne as i intended

## How This Contributes To The Nova Sector Roleplay Experience

fixes a quick bug, it wasnt ever intended to be in space ruins

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![dreamseeker_Ar7ysTE5mv](https://github.com/NovaSector/NovaSector/assets/2568378/da687b6f-14d8-4443-a3ea-23609fe02582)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Interdyne has noticed that the syndicate has stolen their secret recipe for sanusfentynal, through extensive legal battles they have reclaimed their stolen recipe. (AKA it no longer spawns in space ruins)
/:cl:

