### PR TITLE
Tweaks to the Interlink disposal access/room

### DIFF
--- a/_maps/map_files/generic/CentCom_nova_z2.dmm
+++ b/_maps/map_files/generic/CentCom_nova_z2.dmm
@@ -15042,6 +15042,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/freezer,
 /area/centcom/interlink)
+"sYV" = (
+/obj/machinery/door/poddoor/ert,
+/turf/closed/indestructible/riveted,
+/area/centcom/interlink)
 "sYY" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
@@ -36042,7 +36046,7 @@ aaa
 aaa
 aaa
 aaa
-asv
+sYV
 xkb
 tvw
 aaa


### PR DESCRIPTION
## About The Pull Request

Fixes #2074 (the disposal room's conveyor belt not being linked to the conveyor switch) while also adjusting a few things in the Interlink disposal room along the way, and replacing a few of the trash bins with disposal units.

## How This Contributes To The Nova Sector Roleplay Experience

It gives the disposal room flavor. Instead of it being a dull and dark room, it now looks like an actual disposal room that has a purpose, even if illustratively so.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/NovaSector/NovaSector/assets/64568243/28f6219c-5e22-445e-947b-5bd9f02aa3c9)

and diffbot
</details>

## Changelog
:cl: Chelxox
fix: The Interlink disposal room's conveyor belt now works.
qol: The Interlink disposal room has been expanded a little bit.
qol: A few of the trash bins in the Interlink have been replaced for disposal units.
/:cl:
