### PR TITLE
Fixes crew monitor

### DIFF
--- a/tgui/packages/tgui/interfaces/CrewConsoleSkyrat.jsx
+++ b/tgui/packages/tgui/interfaces/CrewConsoleSkyrat.jsx
@@ -88,7 +88,7 @@ export const CrewConsoleSkyrat = () => {
 
 const CrewTable = (props) => {
   const { act, data } = useBackend();
-  const sensors = sortBy((s) => s.ijob)(data.sensors ?? []);
+  const sensors = sortBy(data.sensors ?? [], (s) => s.ijob);
   return (
     <Table cellpadding="3">
       <Table.Row>

--- a/tgui/packages/tgui/interfaces/CrewConsoleSkyratBlueshield.jsx
+++ b/tgui/packages/tgui/interfaces/CrewConsoleSkyratBlueshield.jsx
@@ -83,7 +83,7 @@ export const CrewConsoleSkyratBlueshield = () => {
 
 const CrewTable = (props) => {
   const { act, data } = useBackend();
-  const sensors = sortBy((s) => s.ijob)(data.sensors ?? []);
+  const sensors = sortBy(data.sensors ?? [], (s) => s.ijob);
   return (
     <Table cellpadding="3">
       <Table.Row>


### PR DESCRIPTION
## About The Pull Request

Fixes the medical crew monitor

## How This Contributes To The Nova Sector Roleplay Experience

It's useful for medical to know when people are dead

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl: LT3
fix: Medical crew monitor works again
/:cl: