### PR TITLE
trims down akula language description

### DIFF
--- a/modular_nova/modules/customization/modules/language/te_velu_akko.dm
+++ b/modular_nova/modules/customization/modules/language/te_velu_akko.dm
@@ -1,14 +1,9 @@
 /datum/language/akulan
     name = "Te Velu Akko"
-    desc = "Translating to 'The Song of The King,' this language was singlehandedly invented and promulgated by the third King of Agurkrral, Akko the Uniter. \
-        Records show that the King had personally created it so that those with little education, including aliens, could integrate easier with Azulean society. \
-        To this end, the language is known for its rapid pace of learning, the written portion being readily mastered within two weeks, a tongue characterized by hard consonants followed by soft vowel strings. \
-        An underwater component exists, fleshed out and codified by deepwater reformists in the later portions of Akko the Uniter's life; featuring great emphasis on close physical proximity, variations of pitch, high-frequency sounds, and clicking. \
-        Alien tourists frequently either seek temporary genemods, or specialized organisms that dwell in the throat to be able to speak this portion., \n\n\
-        Differences exist in dialect between the Old Principalities and New Principalities; \
-        The Old sounds far slower and smoother, words flowing into each other in a very melodic way; befitting of the language's name. \
-        The New is much faster, more harsh, and more aggressive in an attempt to be more efficient; however, rapidly adopting new loanwords from alien tongues. \
-        A common greeting no matter where one is in Agurkrral is to essentially bump noses, allowing the other Azulean to feel the speaker's bioelectric field."
+    desc = "Translating to 'The Song of the King', this language was custom-made in Agurkrral to allow those with little education, including aliens, to better integrate into Azulean society. \
+			It's easy to learn as a result and is characterised by hard consonants followed by soft vowel strings. \
+			An underwater element exists, featuring great emphasis on close physical proximity, variations in pitch, high-frequency sounds, and clicking. \
+			This part may require genemods for non-Azulean speakers."
 
 
     key = "Z"


### PR DESCRIPTION
Trims down the length of the description to reduce the amount of scrolling you have to do to see the other stuff. Makes the menu a bit easier to use.

:cl:
del: Shortened the Akulan language description in the language selection menu.
/:cl: