### PR TITLE
[MODULAR] Adds Virologist to the MD job titles list since Virologist the job has gone extinct

### DIFF
--- a/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -232,6 +232,7 @@
 		"Physician",
 		"Surgeon",
 		"Medical Student",
+		"Virologist",
 	)
 
 /datum/job/engineering_guard //see orderly


### PR DESCRIPTION
## About The Pull Request

Adds Virologist to the MD job titles list since Virologist the job has gone extinct

## How This Contributes To The Nova Sector Roleplay Experience

When #2062 gets merged, Virology will still exist on the maps and so will the tools, and Skyrat/Nova likes their job titles for departmental subjobs(see: Scientist), so why not add Virologist back as a job title? Accomplishes much the same behavior.

## Proof of Testing

I added a string to a list, will compile this locally in a sec

## Changelog
:cl:
add: Adds Virologist to the MD job titles list since Virologist the job has gone extinct
/:cl:
