### PR TITLE
[MODULAR] Bumps up the Medical Doctor job slots by 1 since Virologist is going extinct.

### DIFF
--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -53,7 +53,7 @@ Engineering Guard=2,2
 
 # Medical
 
-Medical Doctor=5,3
+Medical Doctor=6,4
 Paramedic=3,2
 Chemist=2,2
 Geneticist=2,2


### PR DESCRIPTION
## About The Pull Request

Bumps up the Medical Doctor job slots by 1 since Virologist is going extinct.

## How This Contributes To The Nova Sector Roleplay Experience

Skyrat/Nova regularly runs 150+ player rounds; losing a job slot to a job removal will cause issues not intended by the Virologist removal PR #2062, as such we'll bump the slots on Medical Doctors by 1 to accommodate.

## Proof of Testing

This is a configuration file change, a number was increased.

## Changelog
:cl:
balance: Bumps up the Medical Doctor job slots by 1 since Virologist is going extinct.
/:cl: