### PR TITLE
[MODULAR] Removes Virologist spawnpoints from Ouroboros, Blueshift, and Void Raptor

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -3378,7 +3378,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/science/xenobiology)
 "aIA" = (
-/obj/effect/landmark/start/virologist,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/duct,
 /turf/open/floor/carpet/green,
@@ -5510,7 +5509,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/effect/landmark/start/virologist,
 /turf/open/floor/iron,
 /area/station/medical/virology/isolation)
 "ben" = (
@@ -46689,7 +46687,6 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/effect/landmark/start/virologist,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -115585,7 +115582,6 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/effect/landmark/start/virologist,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},

--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -33470,11 +33470,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
-"jWd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
-/obj/effect/landmark/start/virologist,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "jWe" = (
 /obj/structure/chair/pew/left,
 /obj/effect/turf_decal/siding/wood{
@@ -48474,7 +48469,6 @@
 /area/station/security/warden)
 "oqc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
-/obj/effect/landmark/start/virologist,
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
@@ -65659,7 +65653,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/virologist,
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
 "tCd" = (
@@ -71136,7 +71129,6 @@
 /turf/open/floor/wood/tile,
 /area/station/service/bar)
 "vje" = (
-/obj/effect/landmark/start/virologist,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -123649,7 +123641,7 @@ kTx
 pIa
 oqc
 ggh
-jWd
+pIa
 pIa
 aXk
 hWq

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -22200,7 +22200,6 @@
 /obj/effect/turf_decal/trimline/dark_green/filled/warning{
 	dir = 8
 	},
-/obj/effect/landmark/start/virologist,
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/smooth_edge{
@@ -37450,7 +37449,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
-/obj/effect/landmark/start/virologist,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -49158,7 +49156,6 @@
 /area/station/commons/lounge)
 "nPC" = (
 /obj/structure/cable,
-/obj/effect/landmark/start/virologist,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -65766,7 +65763,6 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/effect/landmark/start/virologist,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/virology)
 "sqD" = (


### PR DESCRIPTION
## About The Pull Request

Removes Virologist spawnpoints from Ouroboros, Blueshift, and Void Raptor

## How This Contributes To The Nova Sector Roleplay Experience

Virologist the job is going the way of the dodo in #2062 with Medical Doctors inheriting the lab, so this removes the job spawn points for Virologists from Skyrat/Nova's 3 unique maps to ensure the maps compile.

## Proof of Testing

See the map bot's preview

## Changelog

:cl:
del: Removes Virologist spawnpoints from Ouroboros, Blueshift, and Void Raptor
/:cl: