### PR TITLE
Fixes missing fuel tank on lavaland_surface_interdyne_base1.dmm

### DIFF
--- a/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1.dmm
@@ -2386,6 +2386,7 @@
 "ug" = (
 /obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/light/cold/directional/east,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/ruin/interdyne_planetary_base/eng)
 "ui" = (


### PR DESCRIPTION
## About The Pull Request

The recent remap dropped the welding fuel tank from interdyne's engineering storage. This readds it.

## How This Contributes To The Nova Sector Roleplay Experience

Fixes missing equipment

## Proof of Testing


<details>

![image](https://github.com/NovaSector/NovaSector/assets/86855173/fa85e846-4be5-48be-a48c-dfd18f732cd1)
  
</details>

## Changelog

:cl:
fix: Fixed missing fuel tank on interdyne after a previous remap
/:cl:

