### PR TITLE
Makes necropolis stone tiles prevent immersion

### DIFF
--- a/code/modules/mapfluff/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/necropolis_gate.dm
@@ -262,7 +262,7 @@ GLOBAL_DATUM(necropolis_gate, /obj/structure/necropolis_gate/legion_gate)
 
 	var/static/list/give_turf_traits
 	if(!give_turf_traits)
-		give_turf_traits = string_list(list(TRAIT_LAVA_STOPPED, TRAIT_CHASM_STOPPED))
+		give_turf_traits = string_list(list(TRAIT_LAVA_STOPPED, TRAIT_CHASM_STOPPED, TRAIT_IMMERSE_STOPPED))
 	AddElement(/datum/element/give_turf_traits, give_turf_traits)
 
 /obj/structure/stone_tile/singularity_pull()


### PR DESCRIPTION

## About The Pull Request
Fixes this mess

![324258541-00e2782d-394d-48fc-89ce-4deea914770f](https://github.com/NovaSector/NovaSector/assets/25628932/9c1e353d-70ff-4321-839c-8bac2fd03c01)
## Proof of Testing
![image](https://github.com/NovaSector/NovaSector/assets/25628932/86ac9307-010b-436a-ae11-00bfc4aba916)
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: necropolis stone tiles prevent you from taking a (visual) dunk in lava
/:cl:
