### PR TITLE
Adds more spawn location to moldies

### DIFF
--- a/modular_nova/modules/mold/code/mold_controller.dm
+++ b/modular_nova/modules/mold/code/mold_controller.dm
@@ -87,10 +87,10 @@
 
 /datum/mold_controller/proc/spawn_expansion()
 	var/list/turfs = list()
-	var/hatcheries_to_spawn = 3
-	var/bulbs_to_spawn = rand(3, 5)
+	var/hatcheries_to_spawn = 2
+	var/bulbs_to_spawn = 2
 	var/conditioners_to_spawn = 2
-	var/spread_radius = 5
+	var/spread_radius = 2
 	var/our_turf = get_turf(our_core)
 	turfs[our_turf] = TRUE
 	for(var/i in 1 to spread_radius)

--- a/modular_nova/modules/mold/code/mold_event.dm
+++ b/modular_nova/modules/mold/code/mold_event.dm
@@ -39,7 +39,38 @@
 
 	var/obj/structure/mold/resin/test/test_resin = new()
 
-	var/list/possible_spawn_areas = typecacheof(typesof(/area/station/maintenance, /area/station/security/prison, /area/station/construction))
+	var/list/possible_spawn_areas = typecacheof(typesof(
+		/area/station/maintenance/aft/greater,
+		/area/station/maintenance/central/greater,
+		/area/station/maintenance/starboard/greater,
+		/area/station/maintenance/port/greater,
+		/area/station/maintenance/disposal,
+		/area/station/maintenance/wrestle,
+		/area/station/maintenance/library,
+		/area/station/maintenance/night_club,
+		/area/station/maintenance/aux_eva,
+		/area/station/maintenance/department/science/xenobiology,
+		/area/station/security/prison,
+		/area/station/engineering/atmos/hfr_room,
+		/area/station/engineering/gravity_generator,
+		/area/station/science/xenobiology,
+		/area/station/science/ordnance/testlab,
+		/area/station/medical/chemistry,
+		/area/station/medical/aslyum,
+		/area/station/medical/abandoned,
+		/area/station/command/gateway,
+		/area/station/cargo/drone_bay,
+		/area/shuttle/supply,
+		/area/station/commons/toilet,
+		/area/station/commons/fitness,
+		/area/station/commons/vacant_room/office,
+		/area/station/common/wrestling/arena,
+		/area/station/service/chapel,
+		/area/station/service/abandoned_gambling_den,
+		/area/station/maintenance/tram/left,
+		/area/station/maintenance/tram/mid,
+		/area/station/maintenance/tram/right,
+		))
 
 	for(var/area/checked_area as anything in GLOB.areas)
 		if(!is_station_level(checked_area.z))

--- a/modular_nova/modules/mold/code/mold_structures.dm
+++ b/modular_nova/modules/mold/code/mold_structures.dm
@@ -192,6 +192,7 @@
 				if(WEST)
 					pixel_x = -32
 			icon_state = "blob_wall"
+			can_atmos_pass = ATMOS_PASS_NO
 			plane = GAME_PLANE
 			layer = LOW_SIGIL_LAYER
 
@@ -312,7 +313,7 @@
 	smoothing_groups = SMOOTH_GROUP_ALIEN_RESIN
 	canSmoothWith = SMOOTH_GROUP_ALIEN_RESIN
 	max_integrity = 200
-	can_atmos_pass = ATMOS_PASS_DENSITY
+	can_atmos_pass = ATMOS_PASS_NO
 
 /obj/structure/mold/wall/Destroy()
 	if(mold_controller)


### PR DESCRIPTION
## About The Pull Request

Atomizes a part of https://github.com/NovaSector/NovaSector/pull/1970.

## How This Contributes To The Nova Sector Roleplay Experience

Regardless of what the mold does, or what kind of mobs it spawns, I'm sure everyone would enjoy more variety in its spawn spots; so I'm separating this part of my previous moldies PR.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
 
Some void raptor spawn locations, a map infamous for only having 2 spawn spots; one of which is always bugged in maintenance.

![dreamseeker_nSYEkpRmRy](https://github.com/NovaSector/NovaSector/assets/77534246/46220d90-cc40-4386-bac2-e0d8cba069dd)
![dreamseeker_JiOtQph0J0](https://github.com/NovaSector/NovaSector/assets/77534246/62a4f6db-3780-47ba-8b5a-cbfb02b96654)
![dreamseeker_0gqNd4dRHZ](https://github.com/NovaSector/NovaSector/assets/77534246/04e74b73-19b3-45fb-8c35-b47a41c685a9)


</details>

## Changelog

:cl:
balance: Moldies can now spawn in many more locations
fix: Fixes a bug where mold tiles allow atmos to bleed through walls
/:cl:

