### PR TITLE
Makes Blueshift atmos less insufferable

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -836,7 +836,7 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "aiS" = (
 /obj/machinery/disposal/bin,
@@ -1409,13 +1409,12 @@
 /turf/open/floor/wood,
 /area/station/commons/dorms/room2)
 "aop" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "aox" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /obj/machinery/light/small/broken/directional/east,
@@ -1603,7 +1602,8 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
 /area/station/engineering/atmos/upper)
 "aqj" = (
 /obj/effect/turf_decal/siding/wood,
@@ -4788,12 +4788,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "aXB" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "aXD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -4987,10 +4986,9 @@
 /turf/open/floor/engine/vacuum,
 /area/station/maintenance/disposal/incinerator)
 "aZA" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "aZG" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -6382,7 +6380,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/meter,
 /obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "bnL" = (
 /obj/effect/mapping_helpers/broken_floor,
@@ -12116,7 +12114,7 @@
 	name = "O2 to Airmix"
 	},
 /obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "cqh" = (
 /obj/effect/turf_decal/siding/wood{
@@ -12155,12 +12153,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics)
 "cqE" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "cqG" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/firealarm/directional/west,
@@ -12384,12 +12381,11 @@
 	},
 /area/station/hallway/primary/central)
 "csV" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "csY" = (
 /obj/effect/turf_decal/stripes,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13506,13 +13502,12 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "cBx" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "cBC" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/lethalshot{
@@ -16342,7 +16337,7 @@
 	name = "N2 to pure"
 	},
 /obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "dcJ" = (
 /obj/structure/window/spawner/directional/north,
@@ -18510,7 +18505,7 @@
 	name = "CO2 to Pure"
 	},
 /obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "dyS" = (
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted,
@@ -19863,7 +19858,7 @@
 	name = "O2 to Pure"
 	},
 /obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "dLv" = (
 /obj/structure/bed/dogbed/runtime,
@@ -20787,7 +20782,7 @@
 	name = "N2O to Pure"
 	},
 /obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "dVq" = (
 /obj/structure/chair/office/light{
@@ -20827,7 +20822,7 @@
 	name = "N2 to Airmix"
 	},
 /obj/effect/turf_decal/stripes/end,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "dVN" = (
 /obj/item/kirbyplants/random,
@@ -20986,13 +20981,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
-"dXH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "dXJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21151,9 +21139,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 6
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "dZo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23864,6 +23851,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/workout)
+"eAA" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "eAB" = (
 /obj/structure/sign/departments/holy,
 /turf/closed/wall,
@@ -24378,10 +24369,9 @@
 /turf/open/floor/stone,
 /area/station/common/wrestling/arena)
 "eEX" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "eEY" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -24505,7 +24495,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "eGh" = (
 /obj/structure/cable,
@@ -27399,7 +27389,7 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "fhc" = (
 /obj/structure/cable,
@@ -28365,7 +28355,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "fqF" = (
 /obj/structure/trash_pile,
@@ -29424,12 +29414,11 @@
 /turf/open/floor/carpet,
 /area/station/service/theater)
 "fCh" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 1
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "fCo" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -29966,7 +29955,7 @@
 /obj/effect/turf_decal/stripes{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "fIC" = (
 /obj/structure/chair/sofa/bench/right{
@@ -30953,12 +30942,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "fSo" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 10
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "fSq" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -35821,12 +35809,8 @@
 /turf/open/floor/iron/dark,
 /area/station/common/laser_tag)
 "gPt" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/engine/hull/reinforced,
+/area/space)
 "gPv" = (
 /obj/machinery/door/window/brigdoor/left/directional/east{
 	id = "scicell";
@@ -36093,12 +36077,11 @@
 /turf/open/floor/carpet,
 /area/station/service/library/lounge)
 "gSg" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 6
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "gSi" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/airalarm/directional/east,
@@ -40446,11 +40429,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"hMe" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
 "hMh" = (
 /obj/structure/chair/office,
 /turf/open/floor/iron,
@@ -40754,14 +40732,13 @@
 /turf/open/floor/carpet/blue,
 /area/station/commons/dorms/room3)
 "hOw" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/violet/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "hOx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/lone,
@@ -43495,9 +43472,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/barber)
 "iqf" = (
-/obj/machinery/atmospherics/components/binary/valve/digital/layer4{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 8
 	},
@@ -44626,12 +44600,8 @@
 /turf/open/floor/wood/large,
 /area/station/service/theater/abandoned)
 "iBs" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/closed/wall,
+/area/station/engineering/atmos/upper)
 "iBv" = (
 /obj/item/stack/sheet/cardboard,
 /obj/effect/spawner/random/maintenance,
@@ -45841,12 +45811,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "iOk" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
-	dir = 10
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "iOl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46337,15 +46303,14 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "iUk" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "iUs" = (
 /obj/structure/chair,
 /obj/machinery/status_display/evac/directional/north,
@@ -47274,10 +47239,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics)
 "jco" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "jct" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -49257,9 +49221,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "jvQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49268,13 +49231,12 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "jvV" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/light/directional/south,
+/turf/open/floor/catwalk_floor,
 /area/station/engineering/atmos/upper)
 "jvX" = (
 /obj/effect/decal/cleanable/dirt{
@@ -53345,9 +53307,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "khi" = (
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/engine,
@@ -54359,10 +54320,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper)
 "kqy" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "kqC" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -57348,11 +57308,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/lesser)
 "kWI" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "kWL" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
@@ -57547,8 +57506,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 6
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "kYN" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
@@ -57631,11 +57590,6 @@
 "kZs" = (
 /turf/open/floor/iron/smooth_large,
 /area/station/command/secure_bunker)
-"kZx" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
 "kZA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
@@ -59832,12 +59786,11 @@
 	},
 /area/station/hallway/primary/port)
 "luR" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 5
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "luT" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -60971,12 +60924,11 @@
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "lHd" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 9
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "lHh" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -61133,11 +61085,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/upper)
 "lIR" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "lIS" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -61734,13 +61685,6 @@
 "lOb" = (
 /turf/closed/wall,
 /area/station/maintenance/library/upper)
-"lOf" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "lOh" = (
 /obj/machinery/duct,
 /obj/effect/landmark/start/hangover,
@@ -62272,12 +62216,11 @@
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "lTC" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 6
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "lTE" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -63325,7 +63268,7 @@
 /obj/machinery/light/small/directional/north,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor,
 /area/station/engineering/atmos/upper)
 "mdH" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -66655,7 +66598,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "mMd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68194,15 +68137,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer2{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible/layer4{
-	dir = 8
-	},
 /obj/machinery/meter/layer4,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nbI" = (
@@ -68530,9 +68471,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "nfj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrous_output,
 /turf/open/floor/engine/n2o,
@@ -68679,7 +68619,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor,
 /area/station/engineering/atmos)
 "ngG" = (
 /obj/machinery/door/airlock/grunge{
@@ -69368,9 +69308,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "noh" = (
 /obj/machinery/rnd/experimentor,
 /obj/effect/turf_decal/stripes/end{
@@ -69909,8 +69848,9 @@
 /turf/open/floor/iron/stairs/old,
 /area/station/service/barber)
 "nuU" = (
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "nuZ" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
@@ -71354,8 +71294,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "nIV" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood,
@@ -72073,13 +72013,12 @@
 	},
 /area/station/engineering/atmos/hfr_room)
 "nQt" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "nQw" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 4;
@@ -75534,12 +75473,11 @@
 /turf/closed/wall,
 /area/station/engineering/break_room)
 "owp" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 6
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "owq" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/stairs/left{
@@ -79019,15 +78957,14 @@
 /turf/open/floor/iron,
 /area/station/science/tele_sci)
 "pfD" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 10
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "pfI" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -79853,12 +79790,11 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "pnL" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "pnM" = (
 /obj/effect/turf_decal/stripes{
 	dir = 5
@@ -82233,15 +82169,14 @@
 	},
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "pLX" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 5
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "pLY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -82407,7 +82342,6 @@
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit)
 "pNw" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 9
@@ -82415,8 +82349,8 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/violet/visible{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "pNA" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -83266,10 +83200,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "pWs" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
+	},
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "pWt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -84477,12 +84412,10 @@
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
 "qhR" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "qhS" = (
 /turf/open/floor/plating,
 /area/station/maintenance/law)
@@ -88038,13 +87971,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/upper)
 "qPO" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/violet/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "qPQ" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/trash/garbage,
@@ -88636,15 +88568,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "qVI" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "qVP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -90152,13 +90083,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/clown_chamber)
 "rjS" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "rjW" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -91994,6 +91924,10 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/dorms/room3)
+"rCu" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "rCv" = (
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /obj/effect/turf_decal/bot/right,
@@ -92352,7 +92286,7 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "rFr" = (
 /turf/open/floor/iron/dark/corner,
@@ -96009,7 +95943,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "ssm" = (
 /obj/structure/flora/grass/jungle,
@@ -97139,11 +97073,10 @@
 /turf/open/floor/wood,
 /area/station/maintenance/rus_gambling)
 "sCF" = (
-/obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/atmospheric_technician,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor,
 /area/station/engineering/atmos/upper)
 "sCJ" = (
 /obj/structure/table/reinforced,
@@ -97754,6 +97687,15 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"sIT" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "sJb" = (
 /obj/machinery/door/airlock/silver{
 	name = "Locker Room"
@@ -98363,12 +98305,12 @@
 /turf/open/floor/carpet/purple,
 /area/station/common/night_club/back_stage)
 "sNY" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 9
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "sOh" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -98622,13 +98564,12 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "sQH" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "sQI" = (
 /obj/structure/girder,
 /obj/structure/grille/broken,
@@ -99539,9 +99480,13 @@
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "sZd" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Factory"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/stairs/old,
 /area/station/engineering/atmos/upper)
 "sZm" = (
@@ -99904,12 +99849,11 @@
 /turf/open/floor/iron/dark/textured_edge,
 /area/station/security/prison/garden)
 "tch" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "tci" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -101802,10 +101746,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "twj" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent/layer4,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/cable,
+/obj/machinery/power/floodlight{
+	anchored = 1
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "two" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -101949,10 +101895,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "txl" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "txp" = (
 /obj/machinery/conveyor{
 	dir = 10;
@@ -102033,7 +101978,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "tyl" = (
 /obj/effect/turf_decal/delivery,
@@ -102836,10 +102781,9 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library/printer)
 "tES" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "tEU" = (
 /obj/structure/window/spawner/directional/east,
 /turf/open/floor/iron/white,
@@ -102932,12 +102876,8 @@
 /turf/open/floor/carpet,
 /area/station/security/courtroom)
 "tGf" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer4{
-	dir = 9
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "tGg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -105575,11 +105515,12 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/upper)
 "ugd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "ugk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -105893,12 +105834,11 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
 "ujw" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 5
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "ujx" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes{
@@ -106663,12 +106603,11 @@
 /turf/closed/wall,
 /area/station/maintenance/gamer_lair)
 "upT" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 10
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "upU" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes{
@@ -109470,7 +109409,7 @@
 	name = "plasma mixer"
 	},
 /obj/effect/turf_decal/stripes/end,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "uSe" = (
 /obj/structure/cable,
@@ -110661,12 +110600,11 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
 "veC" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "veM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -112982,9 +112920,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 9
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "vze" = (
 /obj/machinery/door/airlock/external{
 	name = "Atmospherics External Airlock";
@@ -113870,8 +113807,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 10
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "vHZ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -114089,7 +114026,7 @@
 /area/station/maintenance/starboard/fore)
 "vJU" = (
 /obj/effect/turf_decal/stripes/end,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "vJY" = (
 /obj/structure/bed/pod{
@@ -114625,10 +114562,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "vOJ" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "vOS" = (
 /obj/structure/rack,
 /obj/item/tank/internals/anesthetic,
@@ -117453,13 +117390,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "wqo" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "wqq" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -117649,12 +117585,12 @@
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "wst" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "wsu" = (
 /obj/machinery/door/airlock/wood,
 /obj/effect/turf_decal/siding/wood,
@@ -120892,15 +120828,14 @@
 /turf/open/floor/wood,
 /area/station/security/detectives_office/private_investigators_office)
 "wYy" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "wYz" = (
 /obj/effect/spawner/random/structure/steam_vent,
 /obj/structure/disposalpipe/segment,
@@ -123978,9 +123913,8 @@
 /area/station/maintenance/starboard/fore)
 "xEd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/foam,
+/area/station/engineering/atmos/upper)
 "xEe" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Engineering Maintenance"
@@ -126463,15 +126397,11 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "ycW" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/chair{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/machinery/light/directional/south,
+/turf/open/floor/catwalk_floor,
 /area/station/engineering/atmos/upper)
 "yda" = (
 /obj/effect/turf_decal/siding/wood{
@@ -161573,11 +161503,11 @@ kYI
 cBx
 pNw
 bnG
-rjS
+ugd
 lHd
-nuU
+tGf
 sBt
-qhR
+aXD
 aXD
 aXD
 sBt
@@ -161826,21 +161756,21 @@ iWN
 qAu
 kFQ
 tHY
-wst
+nIO
 sBt
 hWB
 mui
 wMy
 sBt
-xJH
-twj
+tGf
+tGf
 tGf
 dZc
 kqy
 kqy
 rjS
 wqo
-gPt
+sIT
 sBt
 wdb
 sBt
@@ -162089,7 +162019,7 @@ dSi
 kQh
 mRe
 sBt
-nuU
+tGf
 sBt
 sBt
 iEy
@@ -162097,7 +162027,7 @@ sBt
 sBt
 tch
 nfg
-xJH
+tGf
 sBt
 eGk
 sBt
@@ -162346,14 +162276,14 @@ eer
 xbl
 eer
 sBt
-nuU
+tGf
 sBt
 vLj
 qhN
 vLj
 sBt
 tch
-dXH
+nfg
 lTC
 eEX
 pWs
@@ -162603,17 +162533,17 @@ eer
 eer
 eer
 sBt
-nuU
+tGf
 sBt
 nrB
 vLa
 vLj
 sBt
 tch
-dXH
+nfg
 aXB
-nuU
-iBs
+tGf
+tGf
 maA
 wSf
 aPt
@@ -162854,23 +162784,23 @@ iWN
 wHI
 qAu
 tHY
-wst
+nIO
 sBt
 sBt
 sBt
 sBt
 sBt
-xJH
+tGf
 sBt
 vLj
 ryM
 vLj
 sBt
 tch
-dXH
+nfg
 aXB
-nuU
-lOf
+tGf
+tGf
 lTE
 wSf
 aPt
@@ -163113,11 +163043,11 @@ qAu
 tHY
 vHY
 ujw
-nrT
-nrT
-nrT
-xJH
-nuU
+tGf
+tGf
+tGf
+tGf
+tGf
 sBt
 sBt
 fnE
@@ -163368,13 +163298,13 @@ qXp
 wHI
 ybS
 tHY
-xJH
+tGf
 pfD
-ugd
 lIR
 lIR
 lIR
-ugd
+lIR
+lIR
 lIR
 kWI
 hOw
@@ -163625,21 +163555,21 @@ yey
 wHI
 qAu
 tHY
-nuU
+tGf
 tch
 sBt
 sBt
 sBt
 sBt
-xJH
+iOk
 owp
-kZx
+aZA
 aop
-kZx
-kZx
+aZA
+xEd
 xEd
 vza
-nrT
+tGf
 iUk
 ycW
 cgU
@@ -163882,23 +163812,23 @@ wHI
 wHI
 qAu
 tHY
-nuU
+tGf
 khh
 sBt
 gJP
 jss
 sBt
-xJH
+iOk
 cqE
-xJH
+iOk
 pnL
-xJH
+rCu
 sBt
 sBt
 sBt
 sBt
 iUk
-nuU
+tGf
 dTf
 wSf
 aPt
@@ -164139,7 +164069,7 @@ wHI
 fZh
 pqq
 tHY
-xJH
+tGf
 tyk
 swy
 jal
@@ -164147,7 +164077,7 @@ nfj
 ehn
 dVm
 tES
-xJH
+iOk
 aiP
 dVD
 xdG
@@ -164155,7 +164085,7 @@ pWL
 egM
 sBt
 nog
-nuU
+tGf
 pfq
 wSf
 vLv
@@ -164396,17 +164326,17 @@ wHI
 pbt
 qAu
 liN
-nuU
+tGf
 khh
 sBt
 bJT
 jss
 sBt
-xJH
+iOk
 cqE
-xJH
+iOk
 pnL
-xJH
+iOk
 mui
 cLk
 bLI
@@ -164653,13 +164583,13 @@ wHI
 vMj
 qAu
 liN
-nuU
+tGf
 tch
 sBt
 sBt
 sBt
 sBt
-xJH
+iOk
 fCh
 aZA
 nQt
@@ -164910,17 +164840,17 @@ iYE
 qAu
 qAu
 liN
-nuU
+tGf
 khh
 sBt
 xBF
 uZR
 sBt
-xJH
+iOk
 cqE
-nuU
+iOk
 pnL
-xJH
+iOk
 sBt
 sBt
 sBt
@@ -165167,7 +165097,7 @@ wHI
 qAu
 qAu
 tHY
-xJH
+tGf
 ssj
 swy
 psE
@@ -165175,13 +165105,13 @@ iBp
 ehn
 rFk
 uRT
-nuU
+twj
 pnL
-nuU
-xJH
-nuU
-nuU
-xJH
+iOk
+tGf
+tGf
+tGf
+tGf
 wYy
 maA
 sdV
@@ -165424,17 +165354,17 @@ wHI
 qAu
 qAu
 liN
-nuU
+tGf
 khh
 sBt
 eNx
 uZR
 sBt
-xJH
+iOk
 cqE
 nuU
 pnL
-xJH
+iOk
 sBt
 sBt
 sBt
@@ -165681,13 +165611,13 @@ wHI
 apw
 qAu
 liN
-nuU
+tGf
 tch
 sBt
 sBt
 sBt
 sBt
-xJH
+iOk
 cqE
 nuU
 veC
@@ -165938,23 +165868,23 @@ wHI
 ptW
 qAu
 liN
-nuU
+tGf
 khh
 sBt
 dtC
 dyA
 sBt
-xJH
+iOk
 cqE
 nuU
-nrT
-xJH
+iOk
+iOk
 mui
 nXN
 xfT
 swy
 mMc
-nuU
+tGf
 cgU
 mdG
 vLv
@@ -166195,7 +166125,7 @@ wHI
 cmy
 cEv
 tHY
-xJH
+tGf
 fqD
 swy
 oDV
@@ -166203,7 +166133,7 @@ dCk
 ehn
 dyP
 csV
-aZA
+qhR
 aZA
 dLt
 qdO
@@ -166211,7 +166141,7 @@ tCY
 vGy
 sBt
 jvL
-nuU
+tGf
 cgU
 aqf
 vLv
@@ -166452,25 +166382,25 @@ wHI
 iDd
 qAu
 tHY
-nuU
+tGf
 khh
 sBt
 bjM
 dyA
 sBt
-xJH
-nrT
-xJH
-nrT
-xJH
+iOk
+iOk
+nuU
+iOk
+iOk
 sBt
 sBt
 sBt
 sBt
 wYy
-xJH
-xJH
-nrT
+tGf
+eAA
+nuU
 vLv
 vLv
 vLv
@@ -166709,27 +166639,27 @@ wHI
 wTR
 qAu
 tHY
-nuU
+tGf
 tch
 sBt
 sBt
 sBt
 sBt
-xJH
-nrT
-xJH
-nrT
+tGf
+tGf
 nuU
+tGf
+tGf
 gSg
 jco
 jco
 jco
 qVI
+tGf
+tGf
 nuU
-nuU
-nuU
-nuU
-nuU
+tGf
+tGf
 fth
 fYp
 euL
@@ -166973,10 +166903,10 @@ jco
 jco
 jco
 jco
-vOJ
 jco
 vOJ
-jco
+vOJ
+vOJ
 sNY
 nuU
 nuU
@@ -166985,8 +166915,8 @@ wst
 nuU
 nuU
 nuU
-nuU
-nuU
+tGf
+tGf
 fth
 hGY
 xPp
@@ -167225,24 +167155,24 @@ qAu
 pUW
 liN
 liN
-nuU
-xJH
-nuU
-nuU
-nuU
-xJH
-nuU
-xJH
-nuU
-nuU
-nuU
-nuU
-nuU
-iOk
-hMe
-hMe
-hMe
-hMe
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+vHY
+txl
+txl
+txl
+txl
 txl
 haM
 fRn
@@ -167482,25 +167412,25 @@ qAu
 qAu
 qAu
 liN
-nuU
-ojX
-ojX
-ojX
-nuU
-xJH
-nuU
-xJH
-nuU
-nuU
-nuU
-nuU
-nuU
-xJH
-nuU
-nuU
-nuU
-nuU
-nrT
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
 vwS
 pqj
 mJK
@@ -167739,25 +167669,25 @@ iYE
 wHI
 vMj
 tHY
-nuU
-nuU
-nuU
-xJH
-nuU
-xJH
-xJH
-xJH
-nuU
-nuU
-nuU
-nuU
-nuU
-xJH
-xJH
-xJH
-xJH
-xJH
-nrT
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
 vwS
 oKJ
 wZF
@@ -168000,21 +167930,21 @@ liN
 liN
 liN
 tHY
-nuU
-xJH
-nuU
-xJH
-nuU
-nuU
-nuU
-nuU
-nuU
-xJH
-nrT
-nrT
-nrT
-xJH
-nuU
+iBs
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
 fth
 vwS
 oFH
@@ -168257,21 +168187,21 @@ qAu
 qAu
 yjO
 tHY
-nuU
-xJH
-nuU
-xJH
-nuU
-nuU
-nuU
-nuU
-nuU
-xJH
+iBs
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
+tGf
 fgR
 fIA
 vJU
-xJH
-nuU
+tGf
+tGf
 aCz
 wGe
 vOZ
@@ -232256,16 +232186,16 @@ qfl
 jFL
 oyb
 eQK
-ulx
-ulx
-czg
-ulx
-ulx
-ulx
-czg
-ulx
-ulx
-ulx
+nvJ
+nvJ
+nvJ
+nvJ
+nvJ
+nvJ
+nvJ
+nvJ
+nvJ
+nvJ
 iYY
 mWQ
 iYY
@@ -232522,7 +232452,7 @@ dtl
 dtl
 dtl
 dEi
-czg
+nvJ
 nvJ
 mWQ
 nvJ
@@ -232761,11 +232691,11 @@ hkN
 oZd
 rTH
 sus
-ulx
-ulx
-ulx
-ulx
-ulx
+gPt
+gPt
+gPt
+gPt
+gPt
 lLn
 cLr
 eQK
@@ -232779,7 +232709,7 @@ iZl
 wfG
 iZl
 gHy
-ulx
+soz
 cpE
 ilE
 cpE
@@ -233018,11 +232948,11 @@ ukK
 ukK
 fJT
 sus
-ulx
-ulx
-ulx
-ulx
-ulx
+gPt
+gPt
+gPt
+gPt
+gPt
 lLn
 jgT
 hdL
@@ -233036,7 +232966,7 @@ iZl
 dwJ
 iZl
 gHy
-ulx
+jmM
 jmM
 qiR
 weU
@@ -233275,11 +233205,11 @@ ukK
 ukK
 iki
 sus
-ulx
-ulx
-ulx
-ulx
-ulx
+gPt
+gPt
+gPt
+gPt
+gPt
 lLn
 lLn
 lLn
@@ -233293,7 +233223,7 @@ iZl
 wfG
 iZl
 gHy
-ulx
+soz
 cpE
 hNU
 cpE
@@ -233550,7 +233480,7 @@ lBe
 lBe
 lBe
 jKz
-czg
+nvJ
 nvJ
 mWQ
 nvJ
@@ -233794,20 +233724,20 @@ xam
 kzr
 wcw
 gcg
-czg
-ulx
-czg
-ulx
-ulx
-ulx
-czg
-ulx
-ulx
-ulx
-czg
-ulx
-ulx
-ulx
+nvJ
+nvJ
+nvJ
+nvJ
+nvJ
+nvJ
+nvJ
+nvJ
+nvJ
+nvJ
+nvJ
+nvJ
+nvJ
+nvJ
 kta
 mWQ
 kta

--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -1413,6 +1413,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/atmos/upper)
 "aox" = (
@@ -1602,8 +1603,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "aqj" = (
 /obj/effect/turf_decal/siding/wood,
@@ -4791,7 +4791,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
-/turf/open/floor/plating/foam,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
 /area/station/engineering/atmos/upper)
 "aXD" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -6380,7 +6382,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/meter,
 /obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/station/engineering/atmos/upper)
 "bnL" = (
 /obj/effect/mapping_helpers/broken_floor,
@@ -13001,6 +13003,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"cxg" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Airlock";
+	space_dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "cxr" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgedoors";
@@ -13502,12 +13515,13 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "cBx" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2,
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "cBC" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/lethalshot{
@@ -15954,6 +15968,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"cYB" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "cYF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20981,6 +21000,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
+"dXH" = (
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "dXJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21139,8 +21162,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 6
 	},
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "dZo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23851,10 +23875,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/workout)
-"eAA" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
 "eAB" = (
 /obj/structure/sign/departments/holy,
 /turf/closed/wall,
@@ -24370,7 +24390,10 @@
 /area/station/common/wrestling/arena)
 "eEX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/open/floor/plating/foam,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/light/small/directional/west,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
 /area/station/engineering/atmos/upper)
 "eEY" = (
 /obj/structure/railing/corner{
@@ -24495,7 +24518,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/station/engineering/atmos/upper)
 "eGh" = (
 /obj/structure/cable,
@@ -24519,6 +24542,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "eGr" = (
@@ -27389,7 +27413,7 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/station/engineering/atmos/upper)
 "fhc" = (
 /obj/structure/cable,
@@ -28355,7 +28379,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/station/engineering/atmos/upper)
 "fqF" = (
 /obj/structure/trash_pile,
@@ -28459,6 +28483,10 @@
 "frp" = (
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"frz" = (
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/upper)
 "frA" = (
 /obj/structure/table_frame/wood,
 /obj/effect/decal/cleanable/dirt{
@@ -28746,6 +28774,15 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"fva" = (
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "fvc" = (
 /obj/machinery/light/directional/east,
 /obj/structure/sign/warning/radiation/directional/east,
@@ -29955,7 +29992,7 @@
 /obj/effect/turf_decal/stripes{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/station/engineering/atmos/upper)
 "fIC" = (
 /obj/structure/chair/sofa/bench/right{
@@ -30942,10 +30979,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "fSo" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 10
+	dir = 4
 	},
-/turf/open/floor/plating/foam,
+/turf/open/floor/catwalk_floor,
 /area/station/engineering/atmos/upper)
 "fSq" = (
 /obj/effect/turf_decal/siding/wood{
@@ -31434,6 +31473,17 @@
 	},
 /turf/open/floor/plating/airless,
 /area/station/maintenance/port/upper)
+"fXF" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Airlock";
+	space_dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "fXN" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -33383,6 +33433,12 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
+"gqH" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/binary/valve,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "gqL" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
@@ -35809,8 +35865,12 @@
 /turf/open/floor/iron/dark,
 /area/station/common/laser_tag)
 "gPt" = (
-/turf/open/floor/engine/hull/reinforced,
-/area/space)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "gPv" = (
 /obj/machinery/door/window/brigdoor/left/directional/east{
 	id = "scicell";
@@ -36077,10 +36137,11 @@
 /turf/open/floor/carpet,
 /area/station/service/library/lounge)
 "gSg" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 6
 	},
-/turf/open/floor/plating/foam,
+/turf/closed/wall/r_wall,
 /area/station/engineering/atmos/upper)
 "gSi" = (
 /obj/structure/disposalpipe/segment,
@@ -36754,6 +36815,10 @@
 "gZm" = (
 /turf/open/floor/wood,
 /area/station/service/library)
+"gZo" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "gZu" = (
 /obj/machinery/computer/atmos_control/ordnancemix{
 	dir = 8
@@ -40429,6 +40494,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"hMe" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "hMh" = (
 /obj/structure/chair/office,
 /turf/open/floor/iron,
@@ -43472,6 +43542,9 @@
 /turf/open/floor/iron/dark,
 /area/station/service/barber)
 "iqf" = (
+/obj/machinery/atmospherics/components/binary/valve/digital/layer4{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 8
 	},
@@ -44431,6 +44504,11 @@
 /obj/structure/railing,
 /turf/open/floor/iron/dark/side,
 /area/station/ai_monitored/command/storage/eva)
+"izH" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/upper)
 "izM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -44599,9 +44677,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/theater/abandoned)
-"iBs" = (
-/turf/closed/wall,
-/area/station/engineering/atmos/upper)
 "iBv" = (
 /obj/item/stack/sheet/cardboard,
 /obj/effect/spawner/random/maintenance,
@@ -45811,8 +45886,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "iOk" = (
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/atmos/upper)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "iOl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46303,14 +46382,15 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "iUk" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "iUs" = (
 /obj/structure/chair,
 /obj/machinery/status_display/evac/directional/north,
@@ -47239,9 +47319,10 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics)
 "jco" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "jct" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -49221,8 +49302,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/atmos/upper)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "jvQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49231,12 +49313,13 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "jvV" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "jvX" = (
 /obj/effect/decal/cleanable/dirt{
@@ -53307,8 +53390,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/atmos/upper)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "khi" = (
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/engine,
@@ -54320,9 +54404,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper)
 "kqy" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "kqC" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -57506,8 +57591,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 6
 	},
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "kYN" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
@@ -57590,6 +57675,10 @@
 "kZs" = (
 /turf/open/floor/iron/smooth_large,
 /area/station/command/secure_bunker)
+"kZx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/upper)
 "kZA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
@@ -59785,12 +59874,6 @@
 	dir = 6
 	},
 /area/station/hallway/primary/port)
-"luR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 5
-	},
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
 "luT" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -60924,11 +61007,12 @@
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "lHd" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 9
 	},
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "lHh" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -61085,10 +61169,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/upper)
 "lIR" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2,
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "lIS" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -61685,6 +61770,13 @@
 "lOb" = (
 /turf/closed/wall,
 /area/station/maintenance/library/upper)
+"lOf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 9
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "lOh" = (
 /obj/machinery/duct,
 /obj/effect/landmark/start/hangover,
@@ -62219,7 +62311,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 6
 	},
-/turf/open/floor/plating/foam,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
 /area/station/engineering/atmos/upper)
 "lTE" = (
 /obj/structure/grille,
@@ -63268,7 +63361,7 @@
 /obj/machinery/light/small/directional/north,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "mdH" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -63909,6 +64002,13 @@
 /obj/structure/flora/bush/jungle/a/style_3,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/service)
+"mkN" = (
+/obj/structure/cable,
+/obj/machinery/power/floodlight{
+	anchored = 1
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "mkR" = (
 /obj/machinery/holopad,
 /obj/effect/decal/cleanable/dirt{
@@ -66598,7 +66698,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/station/engineering/atmos/upper)
 "mMd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68137,13 +68237,15 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer2{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible/layer4{
+	dir = 8
+	},
 /obj/machinery/meter/layer4,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nbI" = (
@@ -68471,7 +68573,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/turf/open/floor/plating/foam,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "nfj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrous_output,
@@ -68619,7 +68722,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "ngG" = (
 /obj/machinery/door/airlock/grunge{
@@ -69308,8 +69411,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/atmos/upper)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "noh" = (
 /obj/machinery/rnd/experimentor,
 /obj/effect/turf_decal/stripes/end{
@@ -69848,9 +69952,8 @@
 /turf/open/floor/iron/stairs/old,
 /area/station/service/barber)
 "nuU" = (
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "nuZ" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
@@ -71294,8 +71397,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "nIV" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood,
@@ -78957,14 +79060,15 @@
 /turf/open/floor/iron,
 /area/station/science/tele_sci)
 "pfD" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 10
 	},
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "pfI" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -79112,6 +79216,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"phF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "phG" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/newscaster/directional/north,
@@ -82169,14 +82286,14 @@
 	},
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "pLX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 5
 	},
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "pLY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -82342,6 +82459,7 @@
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit)
 "pNw" = (
+/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 9
@@ -82349,8 +82467,8 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/violet/visible{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "pNA" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -83200,10 +83318,12 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "pWs" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 9
 	},
-/turf/open/floor/plating/foam,
+/turf/open/floor/catwalk_floor,
 /area/station/engineering/atmos/upper)
 "pWt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -83263,6 +83383,9 @@
 	dir = 1
 	},
 /area/station/security/prison/upper)
+"pWI" = (
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "pWK" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -83862,6 +83985,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"qcL" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos/upper)
 "qcP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -84412,10 +84539,12 @@
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
 "qhR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/atmos/upper)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "qhS" = (
 /turf/open/floor/plating,
 /area/station/maintenance/law)
@@ -87971,11 +88100,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/upper)
 "qPO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/violet/visible/layer2,
-/turf/open/floor/plating/foam,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor,
 /area/station/engineering/atmos/upper)
 "qPQ" = (
 /obj/structure/table/wood,
@@ -88568,14 +88700,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "qVI" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "qVP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -90083,12 +90216,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/clown_chamber)
 "rjS" = (
+/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "rjW" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -91924,10 +92058,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/dorms/room3)
-"rCu" = (
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/atmos/upper)
 "rCv" = (
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /obj/effect/turf_decal/bot/right,
@@ -95943,7 +96073,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/station/engineering/atmos/upper)
 "ssm" = (
 /obj/structure/flora/grass/jungle,
@@ -97073,10 +97203,11 @@
 /turf/open/floor/wood,
 /area/station/maintenance/rus_gambling)
 "sCF" = (
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/atmospheric_technician,
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "sCJ" = (
 /obj/structure/table/reinforced,
@@ -97687,15 +97818,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"sIT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
 "sJb" = (
 /obj/machinery/door/airlock/silver{
 	name = "Locker Room"
@@ -98305,12 +98427,12 @@
 /turf/open/floor/carpet/purple,
 /area/station/common/night_club/back_stage)
 "sNY" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 9
 	},
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "sOh" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -98568,7 +98690,10 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2,
-/turf/open/floor/plating/foam,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor,
 /area/station/engineering/atmos/upper)
 "sQI" = (
 /obj/structure/girder,
@@ -98993,6 +99118,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "sVt" = (
@@ -99480,13 +99606,9 @@
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "sZd" = (
+/obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Factory"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/stairs/old,
 /area/station/engineering/atmos/upper)
 "sZm" = (
@@ -99849,11 +99971,12 @@
 /turf/open/floor/iron/dark/textured_edge,
 /area/station/security/prison/garden)
 "tch" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "tci" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -101746,12 +101869,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "twj" = (
-/obj/structure/cable,
-/obj/machinery/power/floodlight{
-	anchored = 1
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/atmos/upper)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer4,
+/turf/open/space/basic,
+/area/space/nearstation)
 "two" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -101895,9 +102016,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "txl" = (
+/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2,
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "txp" = (
 /obj/machinery/conveyor{
 	dir = 10;
@@ -101978,7 +102100,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/station/engineering/atmos/upper)
 "tyl" = (
 /obj/effect/turf_decal/delivery,
@@ -102876,8 +102998,12 @@
 /turf/open/floor/carpet,
 /area/station/security/courtroom)
 "tGf" = (
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible/layer4{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "tGg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -104833,6 +104959,7 @@
 /area/station/ai_monitored/command/storage/eva/upper)
 "tZB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -105515,12 +105642,11 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/upper)
 "ugd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/atmos/upper)
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ugk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -105834,11 +105960,12 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
 "ujw" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 5
 	},
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "ujx" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes{
@@ -106603,11 +106730,12 @@
 /turf/closed/wall,
 /area/station/maintenance/gamer_lair)
 "upT" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 10
 	},
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "upU" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes{
@@ -109378,6 +109506,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"uRH" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/upper)
 "uRL" = (
 /obj/structure/table/glass,
 /obj/structure/window/spawner/directional/east,
@@ -112917,10 +113052,11 @@
 	},
 /area/station/security/warden)
 "vza" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 9
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 10
 	},
-/turf/open/floor/plating/foam,
+/turf/open/floor/catwalk_floor,
 /area/station/engineering/atmos/upper)
 "vze" = (
 /obj/machinery/door/airlock/external{
@@ -113807,8 +113943,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 10
 	},
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "vHZ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -114026,7 +114162,7 @@
 /area/station/maintenance/starboard/fore)
 "vJU" = (
 /obj/effect/turf_decal/stripes/end,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/station/engineering/atmos/upper)
 "vJY" = (
 /obj/structure/bed/pod{
@@ -114563,8 +114699,7 @@
 /area/station/medical/medbay/central)
 "vOJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
+/turf/closed/wall/r_wall,
 /area/station/engineering/atmos/upper)
 "vOS" = (
 /obj/structure/rack,
@@ -115885,6 +116020,7 @@
 	dir = 4
 	},
 /obj/machinery/light/small/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "wdc" = (
@@ -117390,12 +117526,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "wqo" = (
+/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
 	dir = 4
 	},
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "wqq" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -117585,12 +117722,12 @@
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "wst" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "wsu" = (
 /obj/machinery/door/airlock/wood,
 /obj/effect/turf_decal/siding/wood,
@@ -120828,14 +120965,15 @@
 /turf/open/floor/wood,
 /area/station/security/detectives_office/private_investigators_office)
 "wYy" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating/foam,
-/area/station/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "wYz" = (
 /obj/effect/spawner/random/structure/steam_vent,
 /obj/structure/disposalpipe/segment,
@@ -123913,7 +124051,8 @@
 /area/station/maintenance/starboard/fore)
 "xEd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/floor/plating/foam,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
 /area/station/engineering/atmos/upper)
 "xEe" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -126397,11 +126536,15 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "ycW" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/chair{
+	dir = 1
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/plating,
 /area/station/engineering/atmos/upper)
 "yda" = (
 /obj/effect/turf_decal/siding/wood{
@@ -161503,11 +161646,11 @@ kYI
 cBx
 pNw
 bnG
-ugd
+rjS
 lHd
-tGf
+nuU
 sBt
-aXD
+qhR
 aXD
 aXD
 sBt
@@ -161756,21 +161899,21 @@ iWN
 qAu
 kFQ
 tHY
-nIO
+wst
 sBt
 hWB
 mui
 wMy
 sBt
-tGf
-tGf
+xJH
+twj
 tGf
 dZc
 kqy
 kqy
 rjS
 wqo
-sIT
+gPt
 sBt
 wdb
 sBt
@@ -162019,7 +162162,7 @@ dSi
 kQh
 mRe
 sBt
-tGf
+nuU
 sBt
 sBt
 iEy
@@ -162027,7 +162170,7 @@ sBt
 sBt
 tch
 nfg
-tGf
+kZx
 sBt
 eGk
 sBt
@@ -162276,7 +162419,7 @@ eer
 xbl
 eer
 sBt
-tGf
+nuU
 sBt
 vLj
 qhN
@@ -162533,7 +162676,7 @@ eer
 eer
 eer
 sBt
-tGf
+nuU
 sBt
 nrB
 vLa
@@ -162542,8 +162685,8 @@ sBt
 tch
 nfg
 aXB
-tGf
-tGf
+nuU
+xJH
 maA
 wSf
 aPt
@@ -162784,13 +162927,13 @@ iWN
 wHI
 qAu
 tHY
-nIO
+wst
 sBt
 sBt
 sBt
 sBt
 sBt
-tGf
+xJH
 sBt
 vLj
 ryM
@@ -162799,8 +162942,8 @@ sBt
 tch
 nfg
 aXB
-tGf
-tGf
+nuU
+nrT
 lTE
 wSf
 aPt
@@ -163043,20 +163186,20 @@ qAu
 tHY
 vHY
 ujw
-tGf
-tGf
-tGf
-tGf
-tGf
+nrT
+nrT
+nrT
+cgU
+cgU
 sBt
 sBt
 fnE
 sBt
 sBt
-tch
+uRH
 nfg
 fSo
-luR
+nuU
 jvV
 cgU
 akL
@@ -163298,21 +163441,21 @@ qXp
 wHI
 ybS
 tHY
-tGf
+xJH
 pfD
+ugd
 lIR
 lIR
-lIR
-lIR
-lIR
-lIR
+izH
+kWI
+kWI
 kWI
 hOw
 kWI
-lIR
+kWI
 sQH
 qPO
-txl
+fva
 pLX
 sCF
 sZd
@@ -163555,22 +163698,22 @@ yey
 wHI
 qAu
 tHY
-tGf
+nuU
 tch
 sBt
 sBt
 sBt
 sBt
-iOk
+qcL
 owp
-aZA
+xEd
 aop
-aZA
 xEd
 xEd
+lOf
 vza
-tGf
-iUk
+gqH
+phF
 ycW
 cgU
 wSf
@@ -163812,23 +163955,23 @@ wHI
 wHI
 qAu
 tHY
-tGf
+nuU
 khh
 sBt
 gJP
 jss
 sBt
-iOk
+pWI
 cqE
-iOk
+dXH
 pnL
-rCu
+gZo
 sBt
 sBt
 sBt
 sBt
 iUk
-tGf
+nuU
 dTf
 wSf
 aPt
@@ -164069,7 +164212,7 @@ wHI
 fZh
 pqq
 tHY
-tGf
+xJH
 tyk
 swy
 jal
@@ -164077,7 +164220,7 @@ nfj
 ehn
 dVm
 tES
-iOk
+dXH
 aiP
 dVD
 xdG
@@ -164085,7 +164228,7 @@ pWL
 egM
 sBt
 nog
-tGf
+nuU
 pfq
 wSf
 vLv
@@ -164326,17 +164469,17 @@ wHI
 pbt
 qAu
 liN
-tGf
+nuU
 khh
 sBt
 bJT
 jss
 sBt
-iOk
+pWI
 cqE
-iOk
+dXH
 pnL
-iOk
+pWI
 mui
 cLk
 bLI
@@ -164583,15 +164726,15 @@ wHI
 vMj
 qAu
 liN
-tGf
+nuU
 tch
 sBt
 sBt
 sBt
 sBt
-iOk
+pWI
 fCh
-aZA
+xEd
 nQt
 dcu
 qdO
@@ -164840,17 +164983,17 @@ iYE
 qAu
 qAu
 liN
-tGf
+nuU
 khh
 sBt
 xBF
 uZR
 sBt
-iOk
+pWI
 cqE
-iOk
+dXH
 pnL
-iOk
+pWI
 sBt
 sBt
 sBt
@@ -165097,7 +165240,7 @@ wHI
 qAu
 qAu
 tHY
-tGf
+xJH
 ssj
 swy
 psE
@@ -165105,13 +165248,13 @@ iBp
 ehn
 rFk
 uRT
-twj
+mkN
 pnL
-iOk
-tGf
-tGf
-tGf
-tGf
+pWI
+kZx
+nuU
+nuU
+xJH
 wYy
 maA
 sdV
@@ -165354,17 +165497,17 @@ wHI
 qAu
 qAu
 liN
-tGf
+nuU
 khh
 sBt
 eNx
 uZR
 sBt
-iOk
+pWI
 cqE
-nuU
+pWI
 pnL
-iOk
+gZo
 sBt
 sBt
 sBt
@@ -165611,15 +165754,15 @@ wHI
 apw
 qAu
 liN
-tGf
+nuU
 tch
 sBt
 sBt
 sBt
 sBt
-iOk
+pWI
 cqE
-nuU
+pWI
 veC
 cqd
 xdG
@@ -165868,23 +166011,23 @@ wHI
 ptW
 qAu
 liN
-tGf
+nuU
 khh
 sBt
 dtC
 dyA
 sBt
-iOk
+qcL
 cqE
-nuU
-iOk
-iOk
+pWI
+pWI
+pWI
 mui
 nXN
 xfT
 swy
 mMc
-tGf
+nuU
 cgU
 mdG
 vLv
@@ -166125,7 +166268,7 @@ wHI
 cmy
 cEv
 tHY
-tGf
+xJH
 fqD
 swy
 oDV
@@ -166133,7 +166276,7 @@ dCk
 ehn
 dyP
 csV
-qhR
+aZA
 aZA
 dLt
 qdO
@@ -166141,7 +166284,7 @@ tCY
 vGy
 sBt
 jvL
-tGf
+nuU
 cgU
 aqf
 vLv
@@ -166382,25 +166525,25 @@ wHI
 iDd
 qAu
 tHY
-tGf
+nuU
 khh
 sBt
 bjM
 dyA
 sBt
-iOk
-iOk
-nuU
-iOk
-iOk
+pWI
+pWI
+pWI
+pWI
+pWI
 sBt
 sBt
 sBt
 sBt
 wYy
-tGf
-eAA
-nuU
+xJH
+xJH
+nrT
 vLv
 vLv
 vLv
@@ -166639,27 +166782,27 @@ wHI
 wTR
 qAu
 tHY
-tGf
+nuU
 tch
 sBt
 sBt
 sBt
 sBt
-tGf
-tGf
-nuU
-tGf
-tGf
+frz
+cgU
+cxg
+cgU
+cgU
 gSg
 jco
 jco
 jco
 qVI
-tGf
-tGf
 nuU
-tGf
-tGf
+nuU
+nuU
+nuU
+nuU
 fth
 fYp
 euL
@@ -166903,10 +167046,10 @@ jco
 jco
 jco
 jco
+vOJ
+cYB
+vOJ
 jco
-vOJ
-vOJ
-vOJ
 sNY
 nuU
 nuU
@@ -166915,8 +167058,8 @@ wst
 nuU
 nuU
 nuU
-tGf
-tGf
+nuU
+nuU
 fth
 hGY
 xPp
@@ -167155,24 +167298,24 @@ qAu
 pUW
 liN
 liN
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-vHY
-txl
-txl
-txl
-txl
+nuU
+xJH
+nuU
+nuU
+nuU
+cgU
+fXF
+cgU
+nuU
+nuU
+nuU
+nuU
+nuU
+iOk
+hMe
+hMe
+hMe
+hMe
 txl
 haM
 fRn
@@ -167412,25 +167555,25 @@ qAu
 qAu
 qAu
 liN
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
+nuU
+ojX
+ojX
+ojX
+nuU
+xJH
+nuU
+xJH
+nuU
+nuU
+nuU
+nuU
+nuU
+xJH
+nuU
+nuU
+nuU
+nuU
+nrT
 vwS
 pqj
 mJK
@@ -167669,25 +167812,25 @@ iYE
 wHI
 vMj
 tHY
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
+nuU
+nuU
+nuU
+xJH
+nuU
+xJH
+xJH
+xJH
+nuU
+nuU
+nuU
+nuU
+nuU
+xJH
+xJH
+xJH
+xJH
+xJH
+nrT
 vwS
 oKJ
 wZF
@@ -167930,21 +168073,21 @@ liN
 liN
 liN
 tHY
-iBs
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
+nuU
+xJH
+nuU
+xJH
+nuU
+nuU
+nuU
+nuU
+nuU
+xJH
+nrT
+nrT
+nrT
+xJH
+nuU
 fth
 vwS
 oFH
@@ -168187,21 +168330,21 @@ qAu
 qAu
 yjO
 tHY
-iBs
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
-tGf
+nuU
+xJH
+nuU
+xJH
+nuU
+nuU
+nuU
+nuU
+nuU
+xJH
 fgR
 fIA
 vJU
-tGf
-tGf
+xJH
+nuU
 aCz
 wGe
 vOZ
@@ -232186,16 +232329,16 @@ qfl
 jFL
 oyb
 eQK
-nvJ
-nvJ
-nvJ
-nvJ
-nvJ
-nvJ
-nvJ
-nvJ
-nvJ
-nvJ
+ulx
+ulx
+czg
+ulx
+ulx
+ulx
+czg
+ulx
+ulx
+ulx
 iYY
 mWQ
 iYY
@@ -232452,7 +232595,7 @@ dtl
 dtl
 dtl
 dEi
-nvJ
+czg
 nvJ
 mWQ
 nvJ
@@ -232691,11 +232834,11 @@ hkN
 oZd
 rTH
 sus
-gPt
-gPt
-gPt
-gPt
-gPt
+ulx
+ulx
+ulx
+ulx
+ulx
 lLn
 cLr
 eQK
@@ -232709,7 +232852,7 @@ iZl
 wfG
 iZl
 gHy
-soz
+ulx
 cpE
 ilE
 cpE
@@ -232948,11 +233091,11 @@ ukK
 ukK
 fJT
 sus
-gPt
-gPt
-gPt
-gPt
-gPt
+ulx
+ulx
+ulx
+ulx
+ulx
 lLn
 jgT
 hdL
@@ -232966,7 +233109,7 @@ iZl
 dwJ
 iZl
 gHy
-jmM
+ulx
 jmM
 qiR
 weU
@@ -233205,11 +233348,11 @@ ukK
 ukK
 iki
 sus
-gPt
-gPt
-gPt
-gPt
-gPt
+ulx
+ulx
+ulx
+ulx
+ulx
 lLn
 lLn
 lLn
@@ -233223,7 +233366,7 @@ iZl
 wfG
 iZl
 gHy
-soz
+ulx
 cpE
 hNU
 cpE
@@ -233480,7 +233623,7 @@ lBe
 lBe
 lBe
 jKz
-nvJ
+czg
 nvJ
 mWQ
 nvJ
@@ -233724,20 +233867,20 @@ xam
 kzr
 wcw
 gcg
-nvJ
-nvJ
-nvJ
-nvJ
-nvJ
-nvJ
-nvJ
-nvJ
-nvJ
-nvJ
-nvJ
-nvJ
-nvJ
-nvJ
+czg
+ulx
+czg
+ulx
+ulx
+ulx
+czg
+ulx
+ulx
+ulx
+czg
+ulx
+ulx
+ulx
 kta
 mWQ
 kta

--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -28483,10 +28483,6 @@
 "frp" = (
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"frz" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/upper)
 "frA" = (
 /obj/structure/table_frame/wood,
 /obj/effect/decal/cleanable/dirt{
@@ -36137,7 +36133,6 @@
 /turf/open/floor/carpet,
 /area/station/service/library/lounge)
 "gSg" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 6
 	},
@@ -166788,7 +166783,7 @@ sBt
 sBt
 sBt
 sBt
-frz
+cgU
 cgU
 cxg
 cgU


### PR DESCRIPTION

## About The Pull Request
unspaces blueshift atmos, everyone I have talked to did not like half of atmos being in space
## How This Contributes To The Nova Sector Roleplay Experience
Makes playing atmos on Blueshift much nicer
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/59183821/c7c31636-d77c-43dd-ae1d-55722ae17d70)
![image](https://github.com/NovaSector/NovaSector/assets/59183821/bd3e8e9e-3130-4c6a-b49f-ffa48ed2d11b)

</details>

## Changelog
:cl:
qol: Blueshift atmos in no longer spaced
/:cl:
