### PR TITLE
Removes the NRI belt from the BMU

### DIFF
--- a/modular_nova/master_files/code/modules/cargo/markets/market_items/clothing.dm
+++ b/modular_nova/master_files/code/modules/cargo/markets/market_items/clothing.dm
@@ -35,15 +35,6 @@
 	stock_max = 3
 	availability_prob = 85
 
-/datum/market_item/clothing/military_belt
-	name = "Old Military Belt"
-	desc = "A dusty belt which used to fit a military that's no longer active, reviews state their old MREs are sometimes found within these belts."
-	item = /obj/item/storage/belt/military/nri/plus_mre
-	price_min = CARGO_CRATE_VALUE * 0.5
-	price_max = CARGO_CRATE_VALUE
-	stock_max = 3
-	availability_prob = 75
-
 /datum/market_item/clothing/syndie_mask
 	name = "Syndicate Mask"
 	desc = "A mask seen often on the adversaries of Nanotrasen, and so - they are mass produced and not hard to get your hands on."


### PR DESCRIPTION

## About The Pull Request

Tin.

## How This Contributes To The Nova Sector Roleplay Experience

The MRE inside is used for storage powergaming, since its a small sized box. It also has a big credit chip; both of these were an oversight. So I'm just removing it.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  😇
</details>

## Changelog


:cl:
del: Removes the NRI belt from the BMU
/:cl:
