### PR TITLE
Unapologetic salt PR! Removes knockdown from the emergency shuttle (on low alert)

### DIFF
--- a/modular_nova/modules/emergency_shuttle/emergency.dm
+++ b/modular_nova/modules/emergency_shuttle/emergency.dm
@@ -1,3 +1,15 @@
 // Removes the knockdown on take-off/landing of the emergency shuttle
 /obj/docking_port/mobile/emergency
 	movement_force = list("KNOCKDOWN"=0,"THROW"=0)
+
+// We still launch with haste on amber or above
+/obj/docking_port/mobile/emergency/on_emergency_launch()
+	. = ..()
+	// Lets not overwrite the emag effect
+	for (var/obj/machinery/computer/emergency_shuttle/shuttle_computer as anything in shuttle_areas[/area/shuttle/escape])
+		if(shuttle_computer.obj_flags & EMAGGED)
+			return
+	// Check the security level
+	var/security_level = SSsecurity_level.current_security_level.number_level
+	if (security_level >= SEC_LEVEL_AMBER)
+		SSshuttle.emergency.movement_force = list("KNOCKDOWN" = 3, "THROW" = 0)

--- a/modular_nova/modules/emergency_shuttle/emergency.dm
+++ b/modular_nova/modules/emergency_shuttle/emergency.dm
@@ -1,0 +1,3 @@
+// Removes the knockdown on take-off/landing of the emergency shuttle
+/obj/docking_port/mobile/emergency
+	movement_force = list("KNOCKDOWN"=0,"THROW"=0)

--- a/modular_nova/modules/emergency_shuttle/emergency.dm
+++ b/modular_nova/modules/emergency_shuttle/emergency.dm
@@ -5,7 +5,7 @@
 // We still launch with haste on amber or above
 /obj/docking_port/mobile/emergency/on_emergency_launch()
 	// Lets not overwrite the emag effect
-	for (var/obj/machinery/computer/emergency_shuttle/shuttle_computer as anything in shuttle_areas[/area/shuttle/escape])
+	for (var/obj/machinery/computer/emergency_shuttle/shuttle_computer as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/computer/emergency_shuttle))
 		if(shuttle_computer.obj_flags & EMAGGED)
 			return ..()
 	// Check the security level

--- a/modular_nova/modules/emergency_shuttle/emergency.dm
+++ b/modular_nova/modules/emergency_shuttle/emergency.dm
@@ -4,12 +4,12 @@
 
 // We still launch with haste on amber or above
 /obj/docking_port/mobile/emergency/on_emergency_launch()
-	. = ..()
 	// Lets not overwrite the emag effect
 	for (var/obj/machinery/computer/emergency_shuttle/shuttle_computer as anything in shuttle_areas[/area/shuttle/escape])
 		if(shuttle_computer.obj_flags & EMAGGED)
-			return
+			return ..()
 	// Check the security level
 	var/security_level = SSsecurity_level.current_security_level.number_level
 	if (security_level >= SEC_LEVEL_AMBER)
 		SSshuttle.emergency.movement_force = list("KNOCKDOWN" = 3, "THROW" = 0)
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7376,6 +7376,7 @@
 #include "modular_nova\modules\echolocation_quirk\code\echolocation.dm"
 #include "modular_nova\modules\echolocation_quirk\code\echolocation_component.dm"
 #include "modular_nova\modules\electric_welder\code\electric_welder.dm"
+#include "modular_nova\modules\emergency_shuttle\emergency.dm"
 #include "modular_nova\modules\emergency_spacesuit\code\emergency_spacesuit.dm"
 #include "modular_nova\modules\emote_panel\code\emote_panel.dm"
 #include "modular_nova\modules\emotes\code\dna_screams.dm"


### PR DESCRIPTION
## About The Pull Request

Modifies a docking_port's variable inside a modules folder.

## How This Contributes To The Nova Sector Roleplay Experience

I think its cool if there's another layer of urgency to the transfer shuttle. Getting knockdown'd is pretty annoying when its just a regular shift swap, so this PR edits it to only apply it when the shuttle leaves with haste on high alert levels!

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

### On green and blue

https://github.com/NovaSector/NovaSector/assets/77534246/f653dc71-8793-4096-afed-d33cc66b48d6

### On amber+

https://github.com/NovaSector/NovaSector/assets/77534246/2f224871-baef-4a18-9613-2cb8a19eabad

### On emag

https://github.com/NovaSector/NovaSector/assets/77534246/62e74a25-89ad-468d-b12c-3258809029f1

</details>

## Changelog

:cl:
qol: The emergency shuttle autopilot has learned to take-off and land graciously, preventing passenger knockdowns on low alert levels
/:cl:

