### PR TITLE
Neuters synthetic electrical damage 

### DIFF
--- a/modular_nova/modules/synths/code/species/synthetic.dm
+++ b/modular_nova/modules/synths/code/species/synthetic.dm
@@ -45,7 +45,7 @@
 	digitigrade_customization = DIGITIGRADE_OPTIONAL
 	coldmod = 1.2
 	heatmod = 2 // TWO TIMES DAMAGE FROM BEING TOO HOT?! WHAT?! No wonder lava is literal instant death for us.
-	siemens_coeff = 1.4 // Not more because some shocks will outright crit you, which is very unfun
+	siemens_coeff = 1 // Puts you in deep crit and near death but not outright dead
 	/// The innate action that synths get, if they've got a screen selected on species being set.
 	var/datum/action/innate/monitor_change/screen
 	/// This is the screen that is given to the user after they get revived. On death, their screen is temporarily set to BSOD before it turns off, hence the need for this var.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This hard tweaks down the Synthetic electrical bonus damage, the power rework introduced new ways to zap zap via wires and it hit synths extremely hard. This brings it in default line with all other species we have in play so synths dont immediately take 370-400 burn damage the moment they touch a grill they didnt see in maintenance.

It may be better to look into our own damage cap now that TG has a set-in-stone multiplier at play to better reflect our health pool, but i'm across the world atm and it's a lil outta scope. This just eases the pain of maint running deaths.

## How This Contributes To The Nova Sector Roleplay Experience

insta-kills aren't fun, even less fun with maps that have premade grills on electrical wires

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
From left to right

Synth Roundstart New | Human Roundstart  - Synth old  Max Wattage | Synth New old Max Wattage

![image](https://github.com/NovaSector/NovaSector/assets/22140677/4b55835c-070b-464e-939e-1ba434f4f060)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Turns down the added shock multiplier for synths
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
