### PR TITLE
Fix electrocution damage

### DIFF
--- a/modular_nova/master_files/code/modules/power/powernet.dm
+++ b/modular_nova/master_files/code/modules/power/powernet.dm
@@ -1,6 +1,0 @@
-/datum/powernet/get_electrocute_damage()
-	if(avail >= 1000)
-		var/damage = clamp(20 + round(avail/25000), 20, 195) + rand(-5,5)
-		return damage * HUMAN_HEALTH_MODIFIER
-	else
-		return 0

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6643,7 +6643,6 @@
 #include "modular_nova\master_files\code\modules\paperwork\paperplane.dm"
 #include "modular_nova\master_files\code\modules\paperwork\stamps.dm"
 #include "modular_nova\master_files\code\modules\power\cable.dm"
-#include "modular_nova\master_files\code\modules\power\powernet.dm"
 #include "modular_nova\master_files\code\modules\power\lighting\light_mapping_helpers.dm"
 #include "modular_nova\master_files\code\modules\power\singularity\containment_field.dm"
 #include "modular_nova\master_files\code\modules\power\tesla\coil.dm"


### PR DESCRIPTION
## About The Pull Request

Removes a modular override for electrocution damage that should have been removed when the other power change PRs came through.

With the changes to realistic powernet availability this was turning people into dead pieces of burnt toast rather often.

## How This Contributes To The Nova Sector Roleplay Experience

People stop taking up to 300-400 damage from a single cable cut or grille smash

## Changelog

:cl: LT3
fix: Getting electrocuted should no longer be a guaranteed death sentence
/:cl: