### PR TITLE
Ports effigy-se #814 (Leashes)

### DIFF
--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_items/_erp_disabled_item_enforcement.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_items/_erp_disabled_item_enforcement.dm
@@ -227,3 +227,8 @@
 	. = ..()
 	if(CONFIG_GET(flag/disable_lewd_items))
 		return INITIALIZE_HINT_QDEL
+
+/obj/item/clothing/erp_leash/Initialize(mapload)
+	. = ..()
+	if(CONFIG_GET(flag/disable_lewd_items))
+		return INITIALIZE_HINT_QDEL

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_items/leash.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_items/leash.dm
@@ -1,0 +1,87 @@
+/obj/item/clothing/erp_leash
+	name = "leash"
+	desc = "A guiding hand's best friend; in a sleek, semi-elastic package. Can either clip to a collar or be affixed to the neck on it's own."
+	icon = 'modular_nova/modules/modular_items/lewd_items/icons/obj/lewd_clothing/lewd_belts.dmi'
+	worn_icon = 'modular_nova/modules/modular_items/lewd_items/icons/mob/lewd_clothing/lewd_belts.dmi'
+	icon_state = "neckleash_pink"
+	equip_sound = 'sound/items/equip/toolbelt_equip.ogg'
+	drop_sound = 'sound/items/handling/toolbelt_drop.ogg'
+	slot_flags = ITEM_SLOT_BELT
+	/// Who's this attached to?
+	var/mob/living/currently_leashed
+
+	unique_reskin = list(
+		"Pink" = "neckleash_pink",
+		"Teal" = "neckleash_teal"
+	)
+
+	COOLDOWN_DECLARE(tug_cd)
+
+/// HERE BE DRAGONS ///
+
+/// Checks; leashing start
+/obj/item/clothing/erp_leash/attack(mob/living/carbon/human/to_be_leashed, mob/living/user, params)
+	/// Are they already leashed by another leash? If so; don't go further.
+	for(var/datum/component/leash/leash_component in to_be_leashed.GetComponents(/datum/component/leash))
+		if(leash_component.owner != src)
+			to_chat(user, span_danger("There's a leash attached to [to_be_leashed] already!"))
+			return
+	/// Do we have the target already leashed? If so; proceed to remove the leash.
+	if(to_be_leashed == currently_leashed)
+		remove_leash(currently_leashed)
+		return
+	/// Check if we even CAN leash someone / if we already have someone leashed / if someone is leashing themselves. If so; prevent it.
+	if(!istype(to_be_leashed) || currently_leashed != null || user == to_be_leashed)
+		return
+	/// Check their ERP prefs; if they don't allow sextoys: BTFO
+	if(!to_be_leashed.check_erp_prefs(/datum/preference/toggle/erp/sex_toy, user, src))
+		to_chat(user, span_danger("[to_be_leashed] doesn't want you to do that."))
+		return
+	/// Actually start the leashing part here
+	to_be_leashed.visible_message(span_warning("[user] raises the [src] to [to_be_leashed]'s neck!"),\
+				span_userdanger("[user] starts to bring the [src] to your neck!"),\
+				span_hear("You hear a light click as pressure builds in the air around your neck."))
+	if(!do_after(user, 2 SECONDS, to_be_leashed))
+		return
+	currently_leashed = to_be_leashed
+	create_leash(currently_leashed)
+	currently_leashed.balloon_alert(user, "leashed")
+
+/obj/item/clothing/erp_leash/attack_self(mob/user, modifiers)
+	. = ..()
+	if(!COOLDOWN_FINISHED(src, tug_cd))
+		return
+	if(istype(currently_leashed, /mob/living))
+		var/mob/living/yoinked = currently_leashed
+		yoinked.Move(get_step_towards(yoinked,user))
+		yoinked.adjustStaminaLoss(10)
+		yoinked.visible_message(span_warning("[yoinked] is pulled in as [user] tugs the [src]!"),\
+				span_userdanger("[user] suddenly tugs the [src], pulling you closer!"),\
+				span_userdanger("A sudden tug against your neck pulls you ahead!"))
+	COOLDOWN_START(src, tug_cd, 1 SECONDS)
+
+/// Leash Initialization
+/obj/item/clothing/erp_leash/proc/create_leash(mob/ouppy)
+	if(!istype(ouppy))
+		return
+	ouppy.AddComponent(/datum/component/leash, src, 2)
+
+/// Leash Removal
+/obj/item/clothing/erp_leash/proc/remove_leash(mob/free_bird)
+	if(!istype(free_bird))
+		return
+	free_bird.balloon_alert_to_viewers("unhooked")
+	for(var/datum/component/leash/leash_component in free_bird.GetComponents(/datum/component/leash))
+		if(leash_component.owner == src) // We don't want to remove any other possible leash components - not that they'd play nice regardless.
+			qdel(leash_component)
+		currently_leashed = null
+
+/// Dropped it
+/obj/item/clothing/erp_leash/dropped(mob/user, silent)
+	. = ..()
+	remove_leash(currently_leashed)
+
+/// Clean up when destroyed
+/obj/item/clothing/erp_leash/Destroy()
+	remove_leash(currently_leashed)
+	. = ..()

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_machinery/lustwish.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_machinery/lustwish.dm
@@ -101,6 +101,7 @@
 
 				//neck
 				/obj/item/key/collar = 48,
+				/obj/item/clothing/erp_leash = 8,
 				/obj/item/clothing/neck/kink_collar = 8,
 				/obj/item/clothing/neck/human_petcollar = 8,
 				/obj/item/clothing/neck/human_petcollar/choker = 8,

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7803,6 +7803,7 @@
 #include "modular_nova\modules\modular_items\lewd_items\code\lewd_items\feather.dm"
 #include "modular_nova\modules\modular_items\lewd_items\code\lewd_items\fleshlight.dm"
 #include "modular_nova\modules\modular_items\lewd_items\code\lewd_items\kinky_shocker.dm"
+#include "modular_nova\modules\modular_items\lewd_items\code\lewd_items\leash.dm"
 #include "modular_nova\modules\modular_items\lewd_items\code\lewd_items\leather_whip.dm"
 #include "modular_nova\modules\modular_items\lewd_items\code\lewd_items\magic_wand.dm"
 #include "modular_nova\modules\modular_items\lewd_items\code\lewd_items\pinkcuffs.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
https://github.com/effigy-se/effigy-se/pull/814
Hey there. Did you know the fluffy-stg nerds left a perfectly good set of sprites laying around when their project to add more dormitory-related content stalled out around 2021? I did. And I've been stewing on it for *a while*.
This is my take on a "modern" (without the baggage of the rest of the module) implementation; using the conveinently-recently-ish-implemented leash component to do the heavy lifting. It *should* be impossible to abuse due to the range limitation. *Should.* I remain wary of any possible holes that slipped through.

See initial PR for additional development artefacts. There was a beam component to this that was fully functional sans breaking when going down a flight of stairs in Multi-Z, when resting, and with sprite scaling; if that interests any codebase archaeologists to pick up.

Any and all other codebases are free to port this without asking; I'm just making good on what already half-existed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
It technically *shouldn't,* - broadly; at least. In the Interlink; Dorms; or Cafe; all bets are off.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
(Ignore the beam - this was an earlier point in development where I was trying to get it to line up. It does not exist in the final version. It is; however; handy for visualizing that it works; so thus it's here.)
![image](https://github.com/NovaSector/NovaSector/assets/50649185/a192d345-f50a-46c4-b7b6-b0a61d271c20)

In world; in vendor:
![image](https://github.com/NovaSector/NovaSector/assets/50649185/c724f818-cbc3-4c59-b5b0-dfafb9c44c21)

Belt Sprite:
![image](https://github.com/NovaSector/NovaSector/assets/50649185/d41f5296-c937-46a9-8514-47c6ee211384)

Prefs Checking:
![image](https://github.com/NovaSector/NovaSector/assets/50649185/6e13fdf7-691f-4f01-85db-05fcba09e34c)



</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Leashes have been stocked in a very particular vendor in the dormitories.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
