### PR TITLE
[s] Fixes a serious issue WRT The Interlink.

### DIFF
--- a/_maps/map_files/generic/CentCom_nova_z2.dmm
+++ b/_maps/map_files/generic/CentCom_nova_z2.dmm
@@ -9078,7 +9078,8 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/window/indestructible{
 	id = "arriv_hall";
-	name = "Windowed Interlink Access Shutters"
+	name = "Windowed Interlink Access Shutters";
+	move_resist = 3001
 	},
 /turf/open/floor/plating,
 /area/centcom/interlink)
@@ -11846,7 +11847,8 @@
 "onb" = (
 /obj/machinery/door/poddoor/shutters/indestructible{
 	id = "arriv_hall";
-	name = "Interlink Access Shutters"
+	name = "Interlink Access Shutters";
+	move_resist = 3001
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
@@ -12841,7 +12843,8 @@
 /obj/effect/turf_decal/trimline/dark_green/corner,
 /obj/machinery/door/poddoor/shutters/indestructible{
 	id = "arr_hall_lookout";
-	name = "Interlink Access Shutters"
+	name = "Interlink Access Shutters";
+	move_resist = 3001
 	},
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /obj/effect/mapping_helpers/airlock/access/any/cent_com/rep_or_captain,
@@ -13160,7 +13163,8 @@
 	},
 /obj/machinery/door/poddoor/shutters/indestructible{
 	id = "arriv_hall";
-	name = "Interlink Access Shutters"
+	name = "Interlink Access Shutters";
+	move_resist = 3001
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
@@ -17729,7 +17733,8 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/indestructible{
 	id = "arr_hall_lookout";
-	name = "Interlink Access Shutters"
+	name = "Interlink Access Shutters";
+	move_resist = 3001
 	},
 /turf/open/floor/plating,
 /area/centcom/interlink)

--- a/_maps/map_files/generic/CentCom_nova_z2.dmm
+++ b/_maps/map_files/generic/CentCom_nova_z2.dmm
@@ -4957,10 +4957,10 @@
 /turf/open/floor/grass,
 /area/centcom/interlink)
 "bWy" = (
-/obj/machinery/button/door/directional/east{
+/obj/machinery/button/door/indestructible/no_telekinesis/directional/east{
+	pixel_y = -8;
 	id = "arr_hall_lookout";
 	name = "Lookout Shutters Control";
-	pixel_y = -8;
 	req_access = list("command")
 	},
 /turf/open/floor/iron/dark,
@@ -8949,25 +8949,20 @@
 	pixel_x = 7;
 	pixel_y = 5
 	},
-/obj/item/paper/fluff/junkmail_redpill/true,
-/obj/item/paper/fluff/junkmail_redpill{
-	pixel_x = 1;
-	pixel_y = 8
-	},
 /obj/item/paper/fluff/jobs/prisoner/letter,
 /obj/item/paper/fluff/jobs/security/court_judgement{
 	pixel_x = -5;
 	pixel_y = 1
 	},
 /obj/machinery/light/cold/directional/east,
-/obj/machinery/button/door/directional/east{
-	id = "arriv_hall";
-	name = "Arrivals Access Shutter Control";
-	pixel_y = 8;
-	req_access = list("security")
-	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/button/door/indestructible/no_telekinesis/directional/east{
+	pixel_y = 8;
+	id = "arriv_hall";
+	name = "Arrivals Access Shutter Control";
+	req_access = list("security")
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
 "joj" = (
@@ -17803,13 +17798,13 @@
 	req_access = list("security")
 	},
 /obj/machinery/light/cold/directional/west,
-/obj/machinery/button/door/directional/west{
-	id = "arriv_hall";
-	name = "Arrivals Access Shutter Control";
-	pixel_y = 8;
-	req_access = list("security")
-	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/button/door/indestructible/no_telekinesis/directional/west{
+	pixel_y = 8;
+	req_access = list("security");
+	id = "arriv_hall";
+	name = "Arrivals Access Shutter Control"
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
 "xVV" = (

--- a/modular_nova/modules/mapping/code/buttons.dm
+++ b/modular_nova/modules/mapping/code/buttons.dm
@@ -1,0 +1,5 @@
+/// Used in the Interlink to prevent breakouts.
+/obj/machinery/button/door/indestructible/no_telekinesis/attack_tk(mob/user)
+	return
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/button/door/indestructible/no_telekinesis, 24)

--- a/modular_nova/modules/mapping/code/fence.dm
+++ b/modular_nova/modules/mapping/code/fence.dm
@@ -5,4 +5,6 @@
 	name = "reinforced fence"
 	desc = "The latest in Nanotrasen development: A reinforced metal fence. This'll keep those pesky assistants out!"
 	cuttable = FALSE
-	invulnerable = TRUE
+	invulnerable = TRUE // This only prevents cutting through with wirecutters; everything below handles the rest.
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	move_resist = INFINITY

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7565,6 +7565,7 @@
 #include "modular_nova\modules\mapping\code\airless.dm"
 #include "modular_nova\modules\mapping\code\asteroid_moon.dm"
 #include "modular_nova\modules\mapping\code\automatic_respawner.dm"
+#include "modular_nova\modules\mapping\code\buttons.dm"
 #include "modular_nova\modules\mapping\code\color.dm"
 #include "modular_nova\modules\mapping\code\doors.dm"
 #include "modular_nova\modules\mapping\code\dungeon.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I was testing #2306 and noticed the nuke codes were being consistently randomly generated at roundstart. I was confused; because that *shouldn't* be the case; `junkmail_redpill/true` is supposed to be an incredibly rare spawn with a purpose behind notifying admins, rather than be a consistent roundstart fixture. Turns out someone had mapped it into the Interlink; so I spun up a PR to get rid of it and tried to figure out if there was a plan of attack when including it or if it was just meant to be harmless. What I found out was it was *very* possible to break into and not just get the first two digits of the nuke code (especially if you know which of the papers is the real one); but to break into the Emergency Shuttle and preemptively grief it before it even hits the station.
I've closed up every method of attack without sacrificing functionality here.

I opted to remove both `junkmail_redmill` papers; because if it *is* going to roll - ideally it'd be within bounds for the round.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
As funny as it is that anyone with a security ID and telekinesis can, at any time, decide to try and crack the remaining digits of the nuke code; or strip the entire emergency shuttle of everything down to air - it probably should be fixed.

This removes something Nova's staff would otherwise have to now look out for.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

Telepathy-Proof Buttons
![image](https://github.com/NovaSector/NovaSector/assets/50649185/f1cc5f6b-890d-464d-bae7-8e62c1655207)

Not even Megafauna can physically push the fences now (and they're no longer destructible - also applies to the shutters leading into this area)
![image](https://github.com/NovaSector/NovaSector/assets/50649185/26b47daa-cda7-44f8-9221-6132f24f9bc1)

  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: The nuke codes will no longer be consistently randomly generated roundstart, though it's still possible.
fix: It's no longer possible to break into the emergency shuttle before it reaches the station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
