### PR TITLE
buffs the expeditionary corps surplus crate

### DIFF
--- a/modular_nova/modules/cargo/code/packs.dm
+++ b/modular_nova/modules/cargo/code/packs.dm
@@ -333,39 +333,6 @@
 	)
 	crate_name = "candle crate"
 
-/datum/supply_pack/imports/vanguard_surplus
-	name = "Vanguard Expeditionary Corps Surplus"
-	desc = "Contains an assortment of surplus equipment from the now-defunct Vanguard Expeditionary Corps."
-	cost = CARGO_CRATE_VALUE * 20
-	// note: weights are entirely arbitrary. also arbitrarily sorted by weight
-	contains = list(
-		// clothes incl. storage
-		/obj/item/clothing/under/rank/expeditionary_corps = 4,
-		/obj/item/storage/belt/military/expeditionary_corps = 4,
-		/obj/item/storage/backpack/duffelbag/expeditionary_corps = 3,
-		/obj/item/clothing/gloves/color/black/expeditionary_corps = 3,
-		/obj/item/clothing/shoes/combat/expeditionary_corps = 3,
-		// misc goodies?
-		/obj/item/storage/box/expeditionary_survival = 3,
-		/obj/item/melee/tomahawk = 3,
-		/obj/item/knife/combat/marksman = 3,
-		/obj/item/storage/medkit/expeditionary = 2,
-		// armor
-		/obj/item/clothing/head/helmet/expeditionary_corps = 2,
-		/obj/item/clothing/suit/armor/vest/expeditionary_corps = 2,
-		// maybe not junk
-		/obj/item/pointman_broken = 1, // diy project for a 75 blockchance shield that you can beat people to death with
-		/obj/item/clothing/gloves/chief_engineer/expeditionary_corps = 1, // congratulations you won (it's basically combat gloves but not quite)
-		/obj/item/modular_computer/pda/expeditionary_corps = 1, // except for when you didn't (scammed)
-	)
-	/// How many of the contains to put in the crate
-	var/num_contained = 10
-
-/datum/supply_pack/imports/vanguard_surplus/fill(obj/structure/closet/crate/filled_crate)
-	for(var/i in 1 to num_contained)
-		var/item = pick_weight(contains)
-		new item(filled_crate)
-
 /datum/supply_pack/misc/gravity_harness
 	name = "Gravity Suspension Harness"
 	desc = "A back-mounted suspensor harness powered by cells, designed by Deep Spacer tribes to either nullify or amplify gravity. \

--- a/modular_nova/modules/cargo/code/packs.dm
+++ b/modular_nova/modules/cargo/code/packs.dm
@@ -333,30 +333,37 @@
 	)
 	crate_name = "candle crate"
 
-/datum/supply_pack/misc/vanguard_surplus
-	name = "Expeditionary Corps Surplus"
+/datum/supply_pack/imports/vanguard_surplus
+	name = "Vanguard Expeditionary Corps Surplus"
 	desc = "Contains an assortment of surplus equipment from the now-defunct Vanguard Expeditionary Corps."
-	cost = CARGO_CRATE_VALUE * 19
+	cost = CARGO_CRATE_VALUE * 20
+	// note: weights are entirely arbitrary. also arbitrarily sorted by weight
 	contains = list(
-		/obj/item/storage/box/expeditionary_survival,
-		/obj/item/melee/tomahawk,
-		/obj/item/storage/backpack/duffelbag/expeditionary_corps,
-		/obj/item/clothing/gloves/color/black/expeditionary_corps,
-		/obj/item/clothing/head/helmet/expeditionary_corps,
-		/obj/item/clothing/suit/armor/vest/expeditionary_corps,
-		/obj/item/storage/belt/military/expeditionary_corps,
-		/obj/item/clothing/under/rank/expeditionary_corps,
-		/obj/item/clothing/shoes/combat/expeditionary_corps,
-		/obj/item/modular_computer/pda/expeditionary_corps,
-		/obj/item/knife/combat/marksman,
+		// clothes incl. storage
+		/obj/item/clothing/under/rank/expeditionary_corps = 4,
+		/obj/item/storage/belt/military/expeditionary_corps = 4,
+		/obj/item/storage/backpack/duffelbag/expeditionary_corps = 3,
+		/obj/item/clothing/gloves/color/black/expeditionary_corps = 3,
+		/obj/item/clothing/shoes/combat/expeditionary_corps = 3,
+		// misc goodies?
+		/obj/item/storage/box/expeditionary_survival = 3,
+		/obj/item/melee/tomahawk = 3,
+		/obj/item/knife/combat/marksman = 3,
+		/obj/item/storage/medkit/expeditionary = 2,
+		// armor
+		/obj/item/clothing/head/helmet/expeditionary_corps = 2,
+		/obj/item/clothing/suit/armor/vest/expeditionary_corps = 2,
+		// maybe not junk
+		/obj/item/pointman_broken = 1, // diy project for a 75 blockchance shield that you can beat people to death with
+		/obj/item/clothing/gloves/chief_engineer/expeditionary_corps = 1, // congratulations you won (it's basically combat gloves but not quite)
+		/obj/item/modular_computer/pda/expeditionary_corps = 1, // except for when you didn't (scammed)
 	)
 	/// How many of the contains to put in the crate
-	var/num_contained = 3
+	var/num_contained = 10
 
-/datum/supply_pack/misc/vanguard_surplus/fill(obj/structure/closet/crate/filled_crate)
-	var/list/contain_copy = contains.Copy()
+/datum/supply_pack/imports/vanguard_surplus/fill(obj/structure/closet/crate/filled_crate)
 	for(var/i in 1 to num_contained)
-		var/item = pick_n_take(contain_copy)
+		var/item = pick_weight(contains)
 		new item(filled_crate)
 
 /datum/supply_pack/misc/gravity_harness

--- a/modular_nova/modules/exp_corps/code/clothing.dm
+++ b/modular_nova/modules/exp_corps/code/clothing.dm
@@ -16,7 +16,7 @@
 
 /obj/item/storage/belt/military/expeditionary_corps
 	name = "expeditionary corps chest rig"
-	desc = "A set of tactical webbing worn by expeditionary corps."
+	desc = "A set of tactical webbing worn by the now-defunct Vanguard Expeditionary Corps."
 	icon_state = "webbing_exp_corps"
 	worn_icon_state = "webbing_exp_corps"
 	icon = 'modular_nova/master_files/icons/obj/clothing/belts.dmi'
@@ -92,6 +92,8 @@
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF
+	uses_advanced_reskins = FALSE
+	unique_reskin = NONE
 
 /obj/item/clothing/gloves/chief_engineer/expeditionary_corps
 	name = "expeditionary corps insulated gloves"
@@ -99,12 +101,9 @@
 	icon = 'modular_nova/master_files/icons/obj/clothing/gloves.dmi'
 	worn_icon = 'modular_nova/master_files/icons/mob/clothing/hands.dmi'
 	worn_icon_state = "exp_corps"
-	cold_protection = HANDS
-	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
-	heat_protection = HANDS
-	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF
 	armor_type = /datum/armor/chief_engineer_expeditionary_corps
+	clothing_traits = list(TRAIT_FAST_CUFFING) // parity with other black-gloves-likes
 
 /datum/armor/chief_engineer_expeditionary_corps
 	fire = 80
@@ -148,7 +147,7 @@
 
 /obj/item/clothing/suit/armor/vest/expeditionary_corps
 	name = "expeditionary corps armor vest"
-	desc = "An armored vest that provides okay protection against most types of damage."
+	desc = "An armored vest that provides okay protection against most types of damage. Somehow also covers the arms."
 	icon = 'modular_nova/master_files/icons/obj/clothing/suits/armor.dmi'
 	worn_icon = 'modular_nova/master_files/icons/mob/clothing/suits/armor.dmi'
 	icon_state = "exp_corps"
@@ -167,7 +166,8 @@
 		/obj/item/reagent_containers,
 		/obj/item/restraints/handcuffs,
 		/obj/item/tank/internals/emergency_oxygen,
-		/obj/item/tank/internals/plasmaman
+		/obj/item/tank/internals/plasmaman,
+		/obj/item/storage/belt/holster,
 		)
 
 

--- a/modular_nova/modules/exp_corps/code/clothing.dm
+++ b/modular_nova/modules/exp_corps/code/clothing.dm
@@ -147,7 +147,7 @@
 
 /obj/item/clothing/suit/armor/vest/expeditionary_corps
 	name = "expeditionary corps armor vest"
-	desc = "An armored vest that provides okay protection against most types of damage. Somehow also covers the arms."
+	desc = "An armored vest that provides okay protection against most types of damage. Includes concealable sleeves for your arms."
 	icon = 'modular_nova/master_files/icons/obj/clothing/suits/armor.dmi'
 	worn_icon = 'modular_nova/master_files/icons/mob/clothing/suits/armor.dmi'
 	icon_state = "exp_corps"

--- a/modular_nova/modules/exp_corps/code/gear.dm
+++ b/modular_nova/modules/exp_corps/code/gear.dm
@@ -1,6 +1,6 @@
 //Gateway Medkit, no more combat defibs!
 /obj/item/storage/medkit/expeditionary
-	name = "combat medical kit"
+	name = "expeditionary medical kit"
 	desc = "Now with 100% less bullshit."
 	icon_state = "medkit_tactical"
 	damagetype_healed = "all"
@@ -27,6 +27,7 @@
 	new /obj/item/stack/medical/suture/medicated(src)
 	new /obj/item/stack/medical/mesh/advanced(src)
 	new /obj/item/stack/medical/mesh/advanced(src)
+	new /obj/item/clothing/glasses/hud/health(src)
 
 //Field Medic's weapon, no more tomahawk!
 /obj/item/circular_saw/field_medic
@@ -56,7 +57,7 @@
 	throwforce = 5
 	throw_speed = 1
 	throw_range = 1
-	block_chance = 30
+	block_chance = 15
 	w_class = WEIGHT_CLASS_BULKY
 	attack_verb_continuous = list("slams", "bashes")
 	attack_verb_simple = list("slam", "bash")
@@ -66,19 +67,24 @@
 
 /obj/item/shield/riot/pointman/Initialize(mapload)
 	. = ..()
-	RegisterSignals(src, list(COMSIG_TWOHANDED_WIELD, COMSIG_TWOHANDED_UNWIELD), PROC_REF(shield_wield))
-	AddComponent(/datum/component/two_handed, force_unwielded=10, force_wielded=20)
+	AddComponent(/datum/component/two_handed, \
+	force_unwielded=10, force_wielded=20, \
+	wield_callback = CALLBACK(src, PROC_REF(shield_wield)), \
+	unwield_callback = CALLBACK(src, PROC_REF(shield_unwield)), \
+	)
+
 
 /// handles buffing the shield's defensive ability and nerfing user mobility
 /obj/item/shield/riot/pointman/proc/shield_wield()
-	if(HAS_TRAIT(src, TRAIT_WIELDED))
-		item_flags |= SLOWS_WHILE_IN_HAND
-		block_chance *= 2.5 // 30 * 2.5 = 75
-		slowdown = 0.3
-	else
-		item_flags &= ~SLOWS_WHILE_IN_HAND
-		block_chance /= 2.5
-		slowdown = 0
+	item_flags |= SLOWS_WHILE_IN_HAND
+	block_chance *= 5 // 15 * 5 = 75
+	slowdown = 0.6
+
+/// nerfs the shield's defensive ability, buffs user mobility
+/obj/item/shield/riot/pointman/proc/shield_unwield()
+	item_flags &= ~SLOWS_WHILE_IN_HAND
+	block_chance /= 5
+	slowdown = 0
 
 /obj/item/pointman_broken
 	name = "broken pointman shield"
@@ -96,7 +102,7 @@
 	)
 
 //broken shield fixing
-/datum/crafting_recipe/pointman
+/datum/crafting_recipe/pointman_repair
 	name = "pointman shield (repaired)"
 	result = /obj/item/shield/riot/pointman
 	reqs = list(/obj/item/pointman_broken = 1,

--- a/modular_nova/modules/exp_corps/code/tomahawk.dm
+++ b/modular_nova/modules/exp_corps/code/tomahawk.dm
@@ -1,6 +1,6 @@
 /obj/item/melee/tomahawk
 	name = "expeditionary tomahawk"
-	desc = "A somewhat dulled axe blade upon a short fibremetal handle."
+	desc = "A decently sharp axe blade upon a short fibremetal handle. "
 	icon = 'modular_nova/modules/exp_corps/icons/tomahawk.dmi'
 	icon_state = "tomahawk"
 	inhand_icon_state = "tomahawk"
@@ -14,6 +14,7 @@
 	throw_speed = 4
 	throw_range = 8
 	embedding = list("pain_mult" = 6, "embed_chance" = 60, "fall_chance" = 10)
+	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT*7.5)
 	attack_verb_continuous = list("chops", "tears", "lacerates", "cuts")
 	attack_verb_simple = list("chop", "tear", "lacerate", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -21,4 +22,7 @@
 
 /obj/item/melee/tomahawk/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/butchering, 70, 100)
+	AddComponent(/datum/component/butchering, \
+	speed = 7 SECONDS, \
+	effectiveness = 100, \
+	)

--- a/modular_nova/modules/modular_items/code/bags.dm
+++ b/modular_nova/modules/modular_items/code/bags.dm
@@ -156,3 +156,14 @@
 		/obj/item/reagent_containers/hypospray/medipen/ekit = 2,
 	)
 	generate_items_inside(items_inside, src)
+
+/obj/item/storage/pouch/medical/firstaid/advanced/Initialize(mapload)
+	. = ..()
+	desc += " Repackaged with improved medical supplies."
+	var/static/items_inside = list(
+		/obj/item/stack/medical/suture/medicated = 2,
+		/obj/item/stack/medical/mesh/advanced = 1,
+		/obj/item/stack/medical/gauze/twelve = 1,
+		/obj/item/reagent_containers/hypospray/medipen/ekit = 1,
+	)
+	generate_items_inside(items_inside, src)

--- a/modular_nova/modules/modular_weapons/code/cargo_crates/surplus_crates.dm
+++ b/modular_nova/modules/modular_weapons/code/cargo_crates/surplus_crates.dm
@@ -18,9 +18,31 @@
 /datum/supply_pack/imports/russian
 	special = TRUE
 
-/datum/supply_pack/imports/cin_surplus
+/// placeholder type that uses paxil's crate budgeting system
+/datum/supply_pack/imports/budgeted
+	/// lower bound of random crate budget
+	var/item_budget_min = CRATE_BUDGET_MINIMUM
+	/// upper bound of random crate budget
+	var/item_budget_max = CRATE_BUDGET_MAXIMUM
+	/// maximum number of contents
+	var/max_contents = 20
+
+/datum/supply_pack/imports/budgeted/fill(obj/structure/closet/crate/we_are_filling_this_crate)
+	var/item_budget = rand(item_budget_min, item_budget_max)
+	for(var/iterator in 1 to max_contents) // 20 items max, but we have a budget too
+		var/new_thing = pick_weight(contains)
+		// We don't want to go too far over budget
+		if(item_budget <= 0)
+			return
+		new new_thing(we_are_filling_this_crate)
+		// Basically inverts the weight before subtracting it from the budget
+		item_budget -= ((CRATE_ITEM_WEIGHT_MAX + 1) - contains[new_thing])
+
+/// contains stuff from the CIN
+/datum/supply_pack/imports/budgeted/cin_surplus
 	name = "CIN Surplus Equipment Crate"
-	desc = "A collection of surplus equipment sourced from the Coalition of Independent Nations' military stockpiles. Likely to contain old and outdated equipment, as is the nature of surplus."
+	desc = "A collection of surplus equipment sourced from the Coalition of Independent Nations' military stockpiles. \
+	Likely to contain old and outdated equipment, as is the nature of surplus."
 	contraband = TRUE
 	cost = CARGO_CRATE_VALUE * 20
 	contains = list(
@@ -71,16 +93,46 @@
 		/obj/item/storage/toolbox/maint_kit = ITEM_WEIGHT_MISC_BUT_RARER,
 	)
 
-/datum/supply_pack/imports/cin_surplus/fill(obj/structure/closet/crate/we_are_filling_this_crate)
-	var/item_budget = rand(CRATE_BUDGET_MINIMUM, CRATE_BUDGET_MAXIMUM)
-	for(var/iterator in 1 to 20) // 20 items max, but we have a budget too
-		var/new_thing = pick_weight(contains)
-		// We don't want to go too far over budget
-		if(item_budget <= 0)
-			return
-		new new_thing(we_are_filling_this_crate)
-		// Basically inverts the weight before subtracting it from the budget
-		item_budget -= ((CRATE_ITEM_WEIGHT_MAX + 1) - contains[new_thing])
+/// contains stuff from the vanguard expeditionary corps
+/datum/supply_pack/imports/budgeted/vanguard_surplus
+	name = "Vanguard Expeditionary Corps Surplus"
+	desc = "Contains an assortment of surplus equipment from the now-defunct Vanguard Expeditionary Corps. May or may not just be things they stole from other stations."
+	cost = CARGO_CRATE_VALUE * 20
+	// note: weights are entirely arbitrary. also arbitrarily sorted by weight
+	contains = list(
+		// clothes incl. storage
+		/obj/item/clothing/under/rank/expeditionary_corps = ITEM_WEIGHT_CLOTHING,
+		/obj/item/storage/belt/military/expeditionary_corps = ITEM_WEIGHT_CLOTHING,
+		/obj/item/storage/backpack/duffelbag/expeditionary_corps = ITEM_WEIGHT_CLOTHING,
+		/obj/item/clothing/gloves/color/black/expeditionary_corps = ITEM_WEIGHT_CLOTHING,
+		/obj/item/clothing/shoes/combat/expeditionary_corps = ITEM_WEIGHT_CLOTHING,
+		/obj/item/clothing/gloves/latex/nitrile/expeditionary_corps = ITEM_WEIGHT_CLOTHING,
+		// armor
+		/obj/item/clothing/head/helmet/expeditionary_corps = ITEM_WEIGHT_CLOTHING,
+		/obj/item/clothing/suit/armor/vest/expeditionary_corps = ITEM_WEIGHT_CLOTHING,
+		// misc goodies?
+		/obj/item/storage/box/expeditionary_survival = ITEM_WEIGHT_MISC,
+		/obj/item/melee/tomahawk = ITEM_WEIGHT_MISC_BUT_RARER,
+		// the stuff they probably just stole from the station before going
+		/obj/item/storage/medkit = ITEM_WEIGHT_MISC_BUT_RARER,
+		/obj/item/trench_tool = ITEM_WEIGHT_MISC,
+		/obj/item/binoculars = ITEM_WEIGHT_MISC,
+		/obj/item/storage/box/nri_flares = ITEM_WEIGHT_MISC,
+		/obj/item/storage/pouch/medical/firstaid/loaded = ITEM_WEIGHT_MISC_BUT_RARER,
+		/obj/item/storage/pouch/medical/firstaid/advanced = ITEM_WEIGHT_MISC_BUT_RARER,
+		// maybe not junk
+		/obj/item/knife/combat/marksman = ITEM_WEIGHT_MISC_BUT_RARER,
+		/obj/item/storage/medkit/expeditionary/surplus = ITEM_WEIGHT_MISC_BUT_RARER,
+		/obj/item/pointman_broken = ITEM_WEIGHT_GUN_RARE, // diy project for a shield that you can wield for 75 blockchance + beat people to death with
+		/obj/item/clothing/gloves/chief_engineer/expeditionary_corps = ITEM_WEIGHT_MISC_BUT_RARER, // congratulations you won (it's basically combat gloves but not quite)
+		/obj/item/modular_computer/pda/expeditionary_corps = ITEM_WEIGHT_MISC_BUT_RARER, // except for when you didn't (scammed)
+	)
+	// lowered values because of smaller loot pool
+	item_budget_min = CRATE_BUDGET_MINIMUM - 15
+	item_budget_max = CRATE_BUDGET_MAXIMUM - 20
+	max_contents = 10
+	crate_name = "vanguard surplus crate"
+	crate_type = /obj/structure/closet/crate/cargo
 
 #undef ITEM_WEIGHT_CLOTHING
 #undef ITEM_WEIGHT_ARMOR


### PR DESCRIPTION
## About The Pull Request
- recategorizes the expeditionary surplus crate as imports, making it show up next to other import crates e.g. CIN crate
- reworks the exp. surplus crate to work off a similar weighted budget system as the CIN surplus crate
- arbitrarily shakes up the inventory list. throws in some weird stuff. reweights some absolute junk
    - added stuff like medkits, medkits but with the botany sutures/mesh, first aid pouches, gloves variants
- pointman shield: blockchance dropped to 15 in offhand, can be wielded for 75 blockchance, can be slapcraft-repaired, 10 force unwielded, 20 force wielded

## How This Contributes To The Nova Sector Roleplay Experience
if the CIN crate can get some funny gear I think this goofy little box can get some too


## Proof of Testing
![image](https://github.com/NovaSector/NovaSector/assets/31829017/a212a6bc-f7ca-4546-ac7e-79c8a5d0b6d9)

## Changelog

:cl:
balance: The Vanguard Expeditionary Corps surplus crate now works off a weighted budget system, like the CIN surplus crate.
balance: Some more valuable equipment can now be rolled for from the Vanguard surplus crate, like better gloves and medkits with improved medical supplies.
/:cl: