### PR TITLE
Always spawn freighter crew space ruin

### DIFF
--- a/modular_nova/modules/mapping/code/space.dm
+++ b/modular_nova/modules/mapping/code/space.dm
@@ -132,6 +132,7 @@
 	suffix = "cargodiselost.dmm"
 	name = "Space-Ruin Cargodise Lost"
 	description = "A small crew of freight-haulers are marooned in space after pirates knock out their engines. They must survive off of the cargo on board their ship and fend off the pirate boarders on their ship."
+	always_place = TRUE
 
 /datum/map_template/ruin/space/nova/infestedntship
 	id = "scrapheap"


### PR DESCRIPTION

## About The Pull Request

There's a bunch of dudes lately who're really making the most of the freighter crew ghost role, hampered by the fact that the ruin is weighted the exact same as every other ruin, which means it has a *maximum* spawn chance of 10%, and often much, much lower.

This PR changes it to always spawn, like Tarkon.

## How This Contributes To The Nova Sector Roleplay Experience

Gives people who want to play freighter crews the opportunity to do so much more regularly instead of crossing their fingers and praying every single round.

## Proof of Testing

Shouldn't need it - very straightforward change.

## Changelog

:cl: yooriss
qol: The freighter crew ghost role will now appear on every new round, instead of at a low chance.
/:cl:
