### PR TITLE
Move some scrubbers in the Blackmarket Burst shuttle

### DIFF
--- a/_maps/shuttles/nova/ruin_blackmarket_burst.dmm
+++ b/_maps/shuttles/nova/ruin_blackmarket_burst.dmm
@@ -81,6 +81,9 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/shuttle/cargo,
 /area/shuttle/blackmarket_burst)
 "mP" = (
@@ -114,12 +117,10 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/shuttle/ferry,
 /area/shuttle/blackmarket_burst)
 "pM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/shuttle/cargo,
 /area/shuttle/blackmarket_burst)
 "rE" = (
@@ -170,22 +171,6 @@
 	dir = 1
 	},
 /obj/item/storage/toolbox/mechanical,
-/turf/open/floor/iron/shuttle/cargo,
-/area/shuttle/blackmarket_burst)
-"wE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/shuttle/cargo,
-/area/shuttle/blackmarket_burst)
-"xQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/shuttle/cargo,
 /area/shuttle/blackmarket_burst)
 "yt" = (
@@ -251,8 +236,8 @@
 /turf/open/floor/engine,
 /area/shuttle/blackmarket_burst)
 "EO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/shuttle/ferry,
 /area/shuttle/blackmarket_burst)
 "Fr" = (
@@ -319,7 +304,7 @@
 /turf/template_noop,
 /area/template_noop)
 "NC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/shuttle/ferry,
 /area/shuttle/blackmarket_burst)
 "Ov" = (
@@ -406,9 +391,6 @@
 "VZ" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/shuttle/ferry,
@@ -511,10 +493,10 @@ ZW
 GO
 pM
 RP
-xQ
+Tk
 Gs
 Tk
-wE
+Tk
 Tk
 OB
 zH


### PR DESCRIPTION

## About The Pull Request

Moved some layer 2 scrubbers to no longer be on the same tile as layer 2 pipes

Additionally moved the scrubber/vent in the control room to not be under the chair
## How This Contributes To The Nova Sector Roleplay Experience

All the messages about it in startup were driving me crazy

![image](https://github.com/NovaSector/NovaSector/assets/102194057/d845f2bc-65be-43e5-b5e3-2c353f5975b4)
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/102194057/d0a36fa0-59b0-413c-97b6-18131f4901e0)

</details>

## Changelog
:cl:
fix: moved some scrubbers in the blackmarket shuttle to not be layered on top of same-layer pipes
/:cl:
