### PR TITLE
Tweaks a donator item, makes sure it doesn't appear as a random poster anymore

### DIFF
--- a/modular_nova/modules/customization/modules/clothing/~donator/donator_clothing.dm
+++ b/modular_nova/modules/customization/modules/clothing/~donator/donator_clothing.dm
@@ -1329,16 +1329,17 @@
 
 // Donation reward for 1ceres
 /obj/item/poster/korpstech
-	name = "Korps Genetics poster"
+	name = "Empire Enhancements poster"
 	poster_type = /obj/structure/sign/poster/contraband/korpstech
 	icon = 'modular_nova/modules/aesthetics/posters/contraband.dmi'
 	icon_state = "rolled_poster"
 
 /obj/structure/sign/poster/contraband/korpstech
-	name = "Korps Genetics"
-	desc = "This poster bears a huge, pink helix on it, with smaller text underneath it that reads 'The Korps institute, advancing the Genetics field since 2423!'"
+	name = "Empire Enhancements"
+	desc = "This poster bears a huge, pink helix on it, with smaller text underneath it that mentions some alleged genetic advancements from a long time ago."
 	icon = 'modular_nova/modules/aesthetics/posters/contraband.dmi'
 	icon_state = "korpsposter"
+	never_random = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/korpstech, 32)
 


### PR DESCRIPTION
## About The Pull Request
What it says on the tin.

## How This Contributes To The Nova Sector Roleplay Experience
Less player-made lore being accidentally made to look like it's apart of the official lore.

## Proof of Testing
I forgot to take a screenshot, and I don't feel like doing it all over again. It's mainly just that it doesn't show up randomly on station anymore.

## Changelog

:cl: GoldenAlpharex
fix: Fixed a donator item appearing on station when it wasn't supposed to.
/:cl: