### PR TITLE
undoes the 'weak against armor' nerf for shotguns

### DIFF
--- a/modular_nova/modules/shotgunrebalance/code/shotgun.dm
+++ b/modular_nova/modules/shotgunrebalance/code/shotgun.dm
@@ -97,7 +97,6 @@
 /obj/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
 	damage = 6
-	weak_against_armour = TRUE
 
 /obj/item/ammo_casing/shotgun/rubbershot
 	name = "rubber shot"
@@ -109,7 +108,6 @@
 	harmful = FALSE
 
 /obj/projectile/bullet/pellet/shotgun_rubbershot
-	weak_against_armour = TRUE
 	stamina = 10
 
 /obj/item/ammo_casing/shotgun/magnum


### PR DESCRIPTION


## About The Pull Request

despite being on the low-end of damage, buckshot (and it's variations) and rubbershot were inexplicably weak against armor, this undoes that 

## How This Contributes To The Nova Sector Roleplay Experience

shotguns are the go-to baseline "does a fair amount situation regardless" and it's a bit out of place for them to be double-bad against armor, and namely against sec

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog.

:cl:
balance: buckshot, rubbershot, and their equivalents no longer do muchless damage against people with the relevant armors.
/:cl:

