### PR TITLE
Entombed + paraplegic quirk interaction & minor QoL update

### DIFF
--- a/modular_nova/master_files/code/modules/entombed_quirk/code/entombed.dm
+++ b/modular_nova/master_files/code/modules/entombed_quirk/code/entombed.dm
@@ -195,7 +195,7 @@
 	savefile_key = "entombed_mod_name"
 	savefile_identifier = PREFERENCE_CHARACTER
 	can_randomize = FALSE
-	maximum_value_length = 48
+	maximum_value_length = 64
 
 /datum/preference/text/entombed_mod_name/is_accessible(datum/preferences/preferences)
 	if (!..())

--- a/modular_nova/master_files/code/modules/entombed_quirk/code/entombed.dm
+++ b/modular_nova/master_files/code/modules/entombed_quirk/code/entombed.dm
@@ -114,6 +114,7 @@
 /datum/quirk/equipping/entombed/post_add()
 	. = ..()
 	// quickly deploy it on roundstart. we can't do this in add_unique because that gets called in the preview screen, which overwrites people's loadout stuff in suit/shoes/gloves slot. very unfun for them
+	install_quirk_interaction_features() // have to do this here to ensure all traumas and the like from quirks are applied to our mob
 	modsuit.quick_activation()
 
 /datum/quirk/equipping/entombed/remove()
@@ -133,6 +134,15 @@
 	else if (isplasmaman(human_holder))
 		var/obj/item/mod/module/plasma_stabilizer/entombed/plasma_stab = new
 		modsuit.install(plasma_stab, human_holder)
+
+/datum/quirk/equipping/entombed/proc/install_quirk_interaction_features()
+	// if entombed needs to interact with certain other quirks, add it here
+	if (!modsuit)
+		return
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	if (human_holder.get_quirk(/datum/quirk/paraplegic))
+		var/obj/item/mod/module/anomaly_locked/antigrav/entombed/ambulator = new
+		modsuit.install(ambulator, human_holder)
 
 /datum/quirk_constant_data/entombed
 	associated_typepath = /datum/quirk/equipping/entombed

--- a/modular_nova/master_files/code/modules/entombed_quirk/code/entombed_mod.dm
+++ b/modular_nova/master_files/code/modules/entombed_quirk/code/entombed_mod.dm
@@ -46,6 +46,16 @@
 	idle_power_cost = 0
 	removable = FALSE
 
+/obj/item/mod/module/anomaly_locked/antigrav/entombed
+	name = "assistive anti-gravity ambulator"
+	desc = "An obligatory addition from the NanoTrasen science division as part of the Space Disabilities Act, this augmentation allows your suit to project a limited anti-gravity field to aid in your ambulation around the station for both general use and emergencies. It is powered by a tiny sliver of a gravitational anomaly core, inextricably linked to the power systems that keep you alive. Warning: not rated for EMP protection."
+	complexity = 1
+	allow_flags = MODULE_ALLOW_INACTIVE // the suit is never off, so this just allows this to be used w/o being parts-deployed for cosmetic reasons
+	removable = FALSE
+	active_power_cost = 0 // torsion does not generate power in antigrav, so this is effectively -0.4 * DEFAULT_CHARGE_DRAIN
+	prebuilt = TRUE
+	core_removable = FALSE
+
 /obj/item/mod/control/pre_equipped/entombed
 	theme = /datum/mod_theme/entombed
 	applied_cell = /obj/item/stock_parts/cell/high


### PR DESCRIPTION

## About The Pull Request

Characters with Paraplegic that also take the Entombed quirk will now spawn with a heavily-restricted anti-gravity MOD module, allowing them to ambulate similarly to a grav harness at roundstart.

This module is much more efficient than the standard MOD anti-gravity module with the caveat that an entombed suit's torsion module does not regenerate energy while under zero gravity effect. It cannot be removed, have its innate gravitational anomaly core extracted or sold and uses 1 complexity.  I tested higher drain values on this and nearly all of them involved visiting chargers every 5-10 minutes, which isn't that fun.

The entombed suit is already very low on complexity, so these two factors (no torsion energy regeneration & even less complexity to use) seem a reasonable balance.

Additionally, maximum length of a customized entombed MODsuit name is now 64 instead of 48 characters.

## How This Contributes To The Nova Sector Roleplay Experience

Entombed+paraplegic chars *cannot* use the grav harness without holding it hand, and the default MOD antigravity module uses an exorbitant amount of power that quickly depletes most suit types during extended use. Entombed is deliberately designed to be a prolonged factor during a 3 hr round, so this change actively allows people who want to play off the entombed suit being a life support solution do so with paraplegic characters and not feel like they're missing out.

In addition, this new anti-grav module subtype works without the suit being fully deployed. Very important for that "life support unit" drip when you may not want to walk around in a full hardsuit.

Balancejaks are cordially reminded that even minor EMP effects can randomly shut off or disable MODsuits and their modules.

The name length increase will also let people be more imaginative with their MODsuit names. I'm thinking about doubling it to 128 so that people can put brands and stuff in if they want to, but we'll see how this goes first.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
 
![UAqSkmI4dJ](https://github.com/NovaSector/NovaSector/assets/966289/4f86332c-5be8-4820-9061-95078206c99c)

</details>

## Changelog

:cl: yooriss
qol: Paraplegic characters who also have the Entombed quirk now start with an altered anti-gravity MOD module that allows them to emulate the effects of a gravity harness at roundstart. In addition, entombed MODsuits can have longer custom names (up to 64 chars from 48).
/:cl: