### PR TITLE
Makes panic bunker bypass functional again

### DIFF
--- a/modular_nova/modules/panicbunker/code/panicbunker.dm
+++ b/modular_nova/modules/panicbunker/code/panicbunker.dm
@@ -1,8 +1,12 @@
 GLOBAL_LIST_EMPTY(bunker_passthrough)
 
-ADMIN_VERB(addbunkerbypass, R_ADMIN, "Add PB Bypass", "Allows a given ckey to connect despite the panic bunker for a given round.", ADMIN_CATEGORY_MAIN, ckeytobypass as text|null)
+ADMIN_VERB(addbunkerbypass, R_ADMIN, "Add PB Bypass", "Allows a given ckey to connect despite the panic bunker for a given round.", ADMIN_CATEGORY_MAIN)
 	if(!CONFIG_GET(flag/sql_enabled))
 		to_chat(usr, span_adminnotice("The Database is not enabled!"))
+		return
+
+	var/ckeytobypass = input(user, "Enter a ckey to add panic bunker bypass for.", "Ckey Input") as text|null
+	if(!ckeytobypass)
 		return
 
 	GLOB.bunker_passthrough |= ckey(ckeytobypass)
@@ -11,9 +15,13 @@ ADMIN_VERB(addbunkerbypass, R_ADMIN, "Add PB Bypass", "Allows a given ckey to co
 	log_admin("[key_name(usr)] has added [ckeytobypass] to the current round's bunker bypass list.")
 	message_admins("[key_name_admin(usr)] has added [ckeytobypass] to the current round's bunker bypass list.")
 
-ADMIN_VERB(revokebunkerbypass, R_ADMIN, "Revoke PB Bypass", "Revoke's a ckey's permission to bypass the panic bunker for a given round.", ADMIN_CATEGORY_MAIN, ckeytobypass as text|null)
+ADMIN_VERB(revokebunkerbypass, R_ADMIN, "Revoke PB Bypass", "Revoke's a ckey's permission to bypass the panic bunker for a given round.", ADMIN_CATEGORY_MAIN)
 	if(!CONFIG_GET(flag/sql_enabled))
 		to_chat(usr, span_adminnotice("The Database is not enabled!"))
+		return
+
+	var/ckeytobypass = input(user, "Enter a ckey to revoke panic bunker bypass for.", "Ckey Input") as text|null
+	if(!ckeytobypass)
 		return
 
 	GLOB.bunker_passthrough -= ckey(ckeytobypass)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/2369

Tin. During the admin verb to datum refactor this must have gotten busted.

## How This Contributes To The Nova Sector Roleplay Experience

Bugfix

## Changelog

:cl:
fix: (admins) 'Add/Revoke PB Bypass' verbs will now prompt for a ckey once again
/:cl:
