### PR TITLE
Fixes flap emote not making any sound

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -128,8 +128,6 @@
 	hands_use_check = TRUE
 	var/wing_time = 20
 
-//NOVA EDIT REMOVAL BEGIN - EMOTES - Not working due to modified mutant code, TODO: Fix this
-/*
 /datum/emote/living/flap/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
 	if(. && ishuman(user))
@@ -149,8 +147,6 @@
 		// play moth flutter noise if moth wing
 		if(istype(wings, /obj/item/organ/external/wings/moth))
 			playsound(H, 'sound/voice/moth/moth_flutter.ogg', 50, TRUE)
-*/
-//NOVA EDIT REMOVAL END
 
 /datum/emote/living/flap/aflap
 	key = "aflap"


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/134

## How This Contributes To The Nova Sector Roleplay Experience

That's it really.

## Changelog

:cl:
fix: using the flap emote with moth wings now makes a sound like it's supposed to
/:cl: