### PR TITLE
[SEMI-MODULAR] Fixes taur legs appearing as "right/left leg" in attacks/wounds/everything

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -290,6 +290,11 @@
 			zone_hit_chance += 10
 		targeting = get_random_valid_zone(targeting, zone_hit_chance)
 	var/targeting_human_readable = parse_zone(targeting)
+	// NOVA EDIT ADDITION -- Taur bodies have unique zone names
+	var/obj/item/bodypart/part = get_bodypart(targeting)
+	if (part?.use_plaintext_zone_when_attacked)
+		targeting_human_readable = part.plaintext_zone
+	// NOVA EDIT END
 
 	send_item_attack_message(attacking_item, user, targeting_human_readable, targeting)
 

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -275,7 +275,7 @@
 
 			if(mode == SCANNER_VERBOSE)
 				for(var/obj/item/bodypart/limb as anything in damaged)
-					if(limb.bodytype & BODYTYPE_ROBOTIC || limb.bodytype & BODYTYPE_TAUR) // NOVA EDIT ADDITION - Taur limbs show their full name - ORIGINAL: if(limb.bodytype & BODYTYPE_ROBOTIC)
+					if(limb.bodytype & BODYTYPE_ROBOTIC)
 						dmgreport += "<tr><td><font color='#cc3333'>[capitalize(limb.name)]:</font></td>"
 					else
 						dmgreport += "<tr><td><font color='#cc3333'>[capitalize(limb.plaintext_zone)]:</font></td>"

--- a/modular_nova/modules/customization/modules/surgery/bodyparts/_bodyparts.dm
+++ b/modular_nova/modules/customization/modules/surgery/bodyparts/_bodyparts.dm
@@ -6,6 +6,8 @@
 	/// The bodypart's currently applied style's name. Only necessary for bodyparts that come in multiple
 	/// variants, like prosthetics and cyborg bodyparts.
 	var/current_style = null
+	/// If true, our plaintext_zone will be used instead of our def_zone when we send attacked by messages.
+	var/use_plaintext_zone_when_attacked = FALSE
 
 /obj/item/bodypart/generate_icon_key()
 	RETURN_TYPE(/list)

--- a/modular_nova/modules/customization/modules/surgery/organs/taur_body.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/taur_body.dm
@@ -80,9 +80,13 @@
 		new_right_leg = new /obj/item/bodypart/leg/right/robot/synth/taur()
 
 	if (left_leg_name)
-		new_left_leg.name = left_leg_name + " (Left)"
+		new_left_leg.name = left_leg_name + " (Left leg)"
+		new_left_leg.plaintext_zone = lowertext(new_left_leg.name) // weird otherwise
+		new_left_leg.use_plaintext_zone_when_attacked = TRUE
 	if (right_leg_name)
-		new_right_leg.name = right_leg_name + " (Right)"
+		new_right_leg.name = right_leg_name + " (Right leg)"
+		new_right_leg.plaintext_zone = lowertext(new_right_leg.name)
+		new_right_leg.use_plaintext_zone_when_attacked = TRUE
 
 	new_left_leg.bodyshape |= external_bodyshapes
 	new_left_leg.replace_limb(reciever, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. Does this by overriding plaintext_zone and using a small core edit to force attacks to use plaintext zone.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

finally. my snakes no longer have legs

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Taur legs' names are now respected in all aspects of the game
spellcheck: Taur legs suffix now specifies they are legs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
