### PR TITLE
Lets roundstart slimes have hair colors again

### DIFF
--- a/modular_nova/master_files/code/modules/client/preferences/mutant_parts.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/mutant_parts.dm
@@ -15,7 +15,7 @@
 		return FALSE
 	return ..()
 
-/datum/preference/toggle/allow_mismatched_parts/deserialize(input, datum/preferences/preferences)
+/datum/preference/toggle/allow_mismatched_parts/deserialize(input)
 	if(CONFIG_GET(flag/disable_mismatched_parts))
 		return FALSE
 	return ..()
@@ -30,12 +30,6 @@
 	return // applied in apply_supplementary_body_changes()
 
 /datum/preference/toggle/allow_mismatched_hair_color/is_accessible(datum/preferences/preferences)
-	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	if(!ispath(species, /datum/species/jelly)) // only slimes can see this pref
-		return FALSE
-	return ..()
-
-/datum/preference/toggle/allow_mismatched_hair_color/deserialize(input, datum/preferences/preferences)
 	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
 	if(!ispath(species, /datum/species/jelly)) // only slimes can see this pref
 		return FALSE

--- a/modular_nova/master_files/code/modules/mob/living/human/species.dm
+++ b/modular_nova/master_files/code/modules/mob/living/human/species.dm
@@ -34,8 +34,6 @@
 
 
 /datum/species/proc/apply_supplementary_body_changes(mob/living/carbon/human/target, datum/preferences/preferences, visuals_only = FALSE)
-	if(preferences.read_preference(/datum/preference/toggle/allow_mismatched_hair_color))
-		target.dna.species.hair_color_mode = null
 	return
 
 /datum/species/create_pref_traits_perks()

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -56,6 +56,10 @@
 
 	return perk_descriptions
 
+/datum/species/jelly/roundstartslime/apply_supplementary_body_changes(mob/living/carbon/human/target, datum/preferences/preferences, visuals_only = FALSE)
+	if(preferences.read_preference(/datum/preference/toggle/allow_mismatched_hair_color))
+		target.dna.species.hair_color_mode = null
+
 /**
  * Alter Form is the ability of slimes to edit many of their character attributes at will
  * This covers most thing about their character, from body size or colour, to adding new wings, tails, ears, etc, to changing the presence of their genitalia


### PR DESCRIPTION
## About The Pull Request

Tin. 

Fixes https://github.com/NovaSector/NovaSector/issues/2378

Edit: added new pref as well, for people who actually might _want_ to be locked into the mutantpart hair color.
It can be found at the top of prefs 'Allow mismatched hair color'

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![AELo1sDbzt](https://github.com/NovaSector/NovaSector/assets/13398309/e9399b9f-6c08-402a-b8f8-6da616057e0f)

![zJoTRdL2Zn](https://github.com/NovaSector/NovaSector/assets/13398309/1c0bc16e-2e60-4a3d-a474-a71ef936674c)

![dreamseeker_6NqlRqJ0XV](https://github.com/NovaSector/NovaSector/assets/13398309/d0371fc0-736f-49cc-b3fd-da3eff728f82)

</details>

## Changelog

:cl:
fix: roundstart slimes can change their hair color once again and are no longer locked to their mutant color
qol: for roundstart slimes who actually want to be locked to mutant color there is a new pref for them, 'allow mismatched hair color', and can be found near the top of the prefs menu (only viewable by slimes, and toggled on by default).
/:cl:
