### PR TITLE
Minor map fixes - Interlink and Shuttle 8532

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/shuttle8532.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/shuttle8532.dmm
@@ -92,7 +92,6 @@
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "bp" = (
 /obj/structure/lattice/catwalk,
-/obj/effect/decal/cleanable/cobweb,
 /obj/structure/chair/plastic{
 	dir = 4
 	},
@@ -512,11 +511,6 @@
 /area/ruin/space/has_grav/shuttle8532researchbay)
 "jQ" = (
 /turf/closed/indestructible/syndicate,
-/area/ruin/space/has_grav/shuttle8532crewquarters)
-"kp" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/template_noop,
 /area/ruin/space/has_grav/shuttle8532crewquarters)
 "ks" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -1746,7 +1740,6 @@
 /area/ruin/space/has_grav/shuttle8532bridge)
 "JN" = (
 /obj/structure/lattice/catwalk,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/chair/plastic{
 	dir = 8
 	},
@@ -2966,7 +2959,7 @@ cg
 Hs
 oR
 jQ
-kp
+ou
 ou
 ou
 ou

--- a/_maps/map_files/generic/CentCom_nova_z2.dmm
+++ b/_maps/map_files/generic/CentCom_nova_z2.dmm
@@ -7717,7 +7717,7 @@
 /area/centcom/interlink)
 "hjK" = (
 /obj/machinery/light/directional/north,
-/turf/closed/indestructible/riveted,
+/turf/open/floor/iron/dark,
 /area/centcom/interlink)
 "hkQ" = (
 /obj/effect/turf_decal/siding/wood{
@@ -25290,8 +25290,8 @@ aWb
 dkE
 tvw
 tvw
+tvw
 hjK
-aXG
 aXG
 ubn
 sci


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves a light that was inside a wall at Interlink and removes some cobwebs that were causing runtimes from Shuttle 8532

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Wall lights bad. Runtimes bad.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/102194057/ea657341-db9b-4755-bcb4-b2ef3b41ab56)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: removed a light inside the wall on the Interlink
fix: removed some cobwebs in space in shuttle 8532 ruin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
