### PR TITLE
Makes Deathmatch Stop Turning Akula Into Bald White Men

### DIFF
--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -17,8 +17,8 @@
 
 	if(!isnull(species_override))
 		user.set_species(species_override)
-	else if (!isnull(user.dna.species.outfit_important_for_life)) //plasmamen get lit on fire and die
-		user.set_species(/datum/species/human)
+	// else if (!isnull(user.dna.species.outfit_important_for_life)) //plasmamen get lit on fire and die
+		// user.set_species(/datum/species/human) /// NOVA EDIT REMOVAL - STOP GENTRIFYING MY AKULA IN DEATHMATCH
 	for(var/datum/action/act as anything in granted_spells)
 		var/datum/action/new_ability = new act(user)
 		if(istype(new_ability, /datum/action/cooldown/spell))


### PR DESCRIPTION

## About The Pull Request

Edits out an addition tg made a while ago that makes any race that has special spawning items (meant to be for plasmamen) be gentrified and spawned as bald white guys.
## How This Contributes To The Nova Sector Roleplay Experience

I think the people should be allowed to play as akula or plasmamen or whatever in deathmatch what does it matter.
## Proof of Testing
![image](https://github.com/NovaSector/NovaSector/assets/82386923/4e55e8f4-ab35-4ab0-b0c7-e5a7a349eea6)

## Changelog
:cl:
fix: Any species that has special spawn items like plasmapeople or akula no longer get gentrified in deathmatch
/:cl:
