### PR TITLE
[PORT] Stamcrit Is No Longer Extended By Any Sort Of Stamina Damage

### DIFF
--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -145,8 +145,13 @@
 
 /mob/living/carbon/adjustStaminaLoss(amount, updating_stamina, forced, required_biotype = ALL)
 	. = ..()
+	//NOVA EDIT BEGIN - ADDITION - Stamcrit is no longer extended by any sort of stamina damage
+	if(amount <= 0 || HAS_TRAIT_FROM(src, TRAIT_INCAPACITATED, STAMINA))
+		return
+	stam_regen_start_time = world.time + STAMINA_REGEN_BLOCK_TIME
+	/*NOVA EDIT END- ORIGINAL:
 	if(amount > 0)
-		stam_regen_start_time = world.time + STAMINA_REGEN_BLOCK_TIME
+		stam_regen_start_time = world.time + STAMINA_REGEN_BLOCK_TIME */
 
 /**
  * If an organ exists in the slot requested, and we are capable of taking damage (we don't have [GODMODE] on), call the damage proc on that organ.


### PR DESCRIPTION
## About The Pull Request
A port of https://github.com/tgstation/tgstation/pull/82397.
I'll keep this simple.
Did you know that if you're in stamcrit, **any amount** of stamina damage will prolong it? 

https://github.com/NovaSector/NovaSector/assets/12636964/aba5e14c-df8b-4a0b-aad6-f5c2e330ef8b

If you're in stamcrit, hopefully you aren't as you're reading this, I could keep you in stamcrit literally forever using just a pillow.

That's fucking insane.

This PR makes it so that if you're in stamcrit, further stamina will not count as preventing your regen timer from happening.
Some stats. modified by the fact that my hands are not an instant way to activate a timer. I do not have a speedrun timer, I'm just a woman with a phone.
It takes 9.56 seconds to just baton someone into stamcrit no shoves no punches no nothing just batong. 
It takes 9.03 seconds to baton+shove+punch+etc (which did introduce a dislocated limb).
It takes 2.96 seconds to flash someone into stamcrit.
It takes 2.18 seconds to disabler someone into stamcrit.
It also takes 4.58 seconds to cuff someone.
It takes 10 seconds for the stamcrit to clear up and that is guaranteed, you can rely on this every single time.

## How This Contributes To The Nova Sector Roleplay Experience
To quote OOP,
right now you can keep people forever be it with a pillow, stun baton, punch, etc
this is because receiving stamina damage resets your stamina recovery timer (10s)
the victim can stay this way forever until the assailant gets bored and goes away or if the victim powergames hard enough

with this PR the victim has a window of opportunity to run away or fight back so they cannot be stunlocked forever

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
In the OP.
</details>

## Changelog
:cl:
balance: stamina damage does not reset stamcrit recovery timer
/:cl:
