### PR TITLE
Rebalances the premium synth medkit, as well as increasing the plasmide in the pens/decreasing plasmide metabolizatio nrate

### DIFF
--- a/modular_nova/modules/deforest_medical_items/code/injectors.dm
+++ b/modular_nova/modules/deforest_medical_items/code/injectors.dm
@@ -216,7 +216,7 @@
 	icon_state = "robor"
 	list_reagents = list(
 		/datum/reagent/medicine/system_cleaner = 15,
-		/datum/reagent/dinitrogen_plasmide = 5,
+		/datum/reagent/dinitrogen_plasmide = 30,
 	)
 
 // Medpen for robots that fixes brain damage but slows them down for a bit

--- a/modular_nova/modules/deforest_medical_items/code/storage_items_robotics.dm
+++ b/modular_nova/modules/deforest_medical_items/code/storage_items_robotics.dm
@@ -65,12 +65,13 @@
 	var/static/items_inside = list(
 		/obj/item/stack/medical/gauze/twelve = 1,
 		/obj/item/stack/cable_coil/thirty = 1,
-		/obj/item/reagent_containers/pill/robotic_patch/synth_repair = 4,
+		/obj/item/reagent_containers/pill/robotic_patch/synth_repair = 3,
 		/obj/item/stack/medical/wound_recovery/robofoam = 1,
-		/obj/item/stack/medical/wound_recovery/robofoam_super = 1,
 		/obj/item/reagent_containers/hypospray/medipen/deforest/robot_system_cleaner = 1,
 		/obj/item/reagent_containers/hypospray/medipen/deforest/robot_liquid_solder = 1,
 		/obj/item/reagent_containers/hypospray/medipen/deforest/coagulants = 1,
+		/obj/item/reagent_containers/spray/dinitrogen_plasmide = 1,
+		/obj/item/reagent_containers/spray/hercuri/chilled = 1,
 		/obj/item/healthanalyzer/simple = 1,
 	)
 	generate_items_inside(items_inside,src)

--- a/modular_nova/modules/deforest_medical_items/code/synth_healing.dm
+++ b/modular_nova/modules/deforest_medical_items/code/synth_healing.dm
@@ -99,6 +99,6 @@
 	icon_state = "synth_patch"
 	list_reagents = list(
 		/datum/reagent/medicine/nanite_slurry = 10,
-		/datum/reagent/dinitrogen_plasmide = 5,
+		/datum/reagent/dinitrogen_plasmide = 30,
 		/datum/reagent/medicine/coagulant/fabricated = 10,
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

I recently revisited the PR and noticed two things. One: It gives robos a roundstart premium wound removal tool (dumb as hell, med doesnt get this), and Two: It removes the ability for robos to spawn with plasmide and hercuri.

I have fixed this by removing the wound tool and one patch (for space), so I can fit in a plasmide and chilled hercuri spray.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Robos should be able to get off the shuttle and immediately start treating someone with burn wounds effectively, WITHOUT having to resort to the spray. Also, screw the spray. Seriously. At minimum, you should have to order these, robos shouldnt always get a "GET RID OF ONE WOUND FREE" tool.

The other foam spray is also on thin ice by my standards, but at least it doesnt let you trivialize every wound.

Also, the plasmide in the pens did basically nothing. Deforest pens should usually have at least some downside - at least now they slow for an appreciable period of time.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/59709059/da3e7abe-ea06-4b17-8270-72854fa0d8d4)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Synth premium medkits no longer have a premium spray (and now have 3 repair patches), instead having a plaside and hercuri spray.
balance: Synth pens now have far more plasmide
balance: Plasmide now metabolizes slower
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
