### PR TITLE
Nerfs the required synth blunt T3 wound's burn wound to be T1

### DIFF
--- a/modular_nova/modules/medical/code/wounds/synth/blunt/robotic_blunt.dm
+++ b/modular_nova/modules/medical/code/wounds/synth/blunt/robotic_blunt.dm
@@ -166,7 +166,7 @@
 	RETURN_TYPE(/datum/wound/burn/robotic/overheat)
 	for (var/datum/wound/found_wound as anything in limb.wounds)
 		var/datum/wound_pregen_data/pregen_data = found_wound.get_pregen_data()
-		if (pregen_data.wound_series == WOUND_SERIES_METAL_BURN_OVERHEAT && found_wound.severity >= WOUND_SEVERITY_SEVERE) // meh solution but whateva
+		if (pregen_data.wound_series == WOUND_SERIES_METAL_BURN_OVERHEAT && found_wound.severity >= WOUND_SEVERITY_MODERATE) // meh solution but whateva
 			return found_wound
 	return null
 

--- a/modular_nova/modules/medical/code/wounds/synth/blunt/robotic_blunt_T3.dm
+++ b/modular_nova/modules/medical/code/wounds/synth/blunt/robotic_blunt_T3.dm
@@ -216,7 +216,7 @@
 	if (!welder.use_tool(target = victim, user = user, delay = 7 SECONDS * delay_mult, volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
 		return TRUE
 
-	var/wound_path = /datum/wound/burn/robotic/overheat/severe
+	var/wound_path = /datum/wound/burn/robotic/overheat/moderate
 	if (user != victim && user.combat_mode)
 		wound_path = /datum/wound/burn/robotic/overheat/critical // it really isnt that bad, overheat wounds are a bit funky
 		user.visible_message(span_danger("[user] heats [victim]'s [limb.plaintext_zone] aggressively, overheating it far beyond the necessary point!"), \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

To meld metal, you need a T2 wound. This changes it to T1.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

T2 burns tend to overheat dead synths. This was not intended, I just wanted to use burn wounds in the treatment. This fixes this, as T1 is not enough to overheat dead synths.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Synth blunt T3 now requires a T1 burn wound to mold
balance: Synth blunt T3 heating step now gives a T1 burn wound
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
