### PR TITLE
[MODULAR] double-weapon rebalance

### DIFF
--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/ammo/pistol.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/ammo/pistol.dm
@@ -18,7 +18,7 @@
 
 /obj/projectile/bullet/c27_54cesarzowa
 	name = ".27-54 Cesarzowa piercing bullet"
-	damage = 15
+	damage = 18
 	armour_penetration = 30
 	wound_bonus = -30
 	bare_wound_bonus = -10
@@ -36,7 +36,7 @@
 
 	caliber = CALIBER_CESARZOWA
 	ammo_type = /obj/item/ammo_casing/c27_54cesarzowa
-	max_ammo = 18
+	max_ammo = 28
 
 // .27-54 Cesarzowa rubber
 // Small caliber pistol round meant to be fired out of something that shoots real quick like, this one is less lethal

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/magazines.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/magazines.dm
@@ -29,7 +29,7 @@
 
 	ammo_type = /obj/item/ammo_casing/c27_54cesarzowa
 	caliber = CALIBER_CESARZOWA
-	max_ammo = 18
+	max_ammo = 28
 
 /obj/item/ammo_box/magazine/miecz/spawns_empty
 	start_empty = TRUE

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/submachinegun.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/submachinegun.dm
@@ -18,7 +18,7 @@
 
 	bolt_type = BOLT_TYPE_STANDARD
 
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	weapon_weight = WEAPON_MEDIUM
 	slot_flags = ITEM_SLOT_BELT
 

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/submachinegun.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/submachinegun.dm
@@ -51,7 +51,7 @@
 /obj/item/gun/ballistic/automatic/miecz/examine_more(mob/user)
 	. = ..()
 
-	. += "The Meicz is one of the newest weapons to come out of CIN member state hands and \
+	. += "The Miecz is one of the newest weapons to come out of CIN member state hands and \
 		into the wild, typically the frontier. It was built alongside the round it fires, the \
 		.27-54 Cesarzawa pistol round. Based on the proven Lanca design, it seeks to bring that \
 		same reliable weapon design into the factor of a submachinegun. While it is significantly \

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/trappiste_fabriek/pistol.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/trappiste_fabriek/pistol.dm
@@ -47,6 +47,10 @@
 /obj/item/gun/ballistic/automatic/pistol/sol/no_mag
 	spawnwithmagazine = FALSE
 
+/obj/item/gun/ballistic/automatic/pistol/sol/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/automatic_fire, 0.3 SECONDS)
+
 // Sol pistol evil gun
 
 /obj/item/gun/ballistic/automatic/pistol/sol/evil


### PR DESCRIPTION


## About The Pull Request

Changes two things, one moreso then the other:
- The wespe is now full auto, completing the holy trinity of the sol pistol caliber guns: Semi (revolver), Full auto (gl- wespe), burst (sindano)
- the miecz now does slightly more damage 15 --> 18, holds ten more shots per magazine, and is no long bulky sized for a supposedly compact gun.

## How This Contributes To The Nova Sector Roleplay Experience
Evens out the playing field for the miecz making it no longer objectively the worst pick, even against armored targets, while making the wespe at-least slightly different from the sindano on singleshot.

both of these are still worse then just rocking a battlerifle.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The miecz now holds ten more shots per magazine, and does 18 instead of 15 damage.
balance:  The wespe is now full-auto, meaning solfed finally found the switches for them.
spellcheck: fixed the miecz being misspelled (meicz) in it's expanded flavortext.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
