### PR TITLE
Gives the CE a RCF in their locker.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -22,6 +22,7 @@
 	new /obj/item/construction/plumbing/engineering(src) //NOVA EDIT ADDITION
 	new /obj/item/circuitboard/machine/rodstopper(src) //NOVA EDIT ADDITION
 	new /obj/item/card/id/departmental_budget/eng(src) //NOVA EDIT ADDITION
+	new /obj/item/flatpacked_machine(src) //NOVA EDIT ADDITION
 
 /obj/structure/closet/secure_closet/engineering_chief/populate_contents_immediate()
 	. = ..()


### PR DESCRIPTION


## About The Pull Request
It's a machine that's generally helpful for early-mid round engineering, that is usually segued behind 'only cargo can get it for you,' this just plops it into the CE's locker so it can be useful during the early round.

## How This Contributes To The Nova Sector Roleplay Experience
Gives engineering the funky ""new"" machine to play with off the bat, as long as there's a CE, and helps distant it from being 'only available from cargo.'


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: gives the CE a RCF in their locker at the start of the round, removing the need to get it from the colony starter crate.
/:cl:

