### PR TITLE
Food vendors drop their appropriate parts when deconstructed

### DIFF
--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -664,7 +664,7 @@
 		/obj/machinery/vending/access/command = "Command Outfitting Station", //NOVA EDIT ADDITION
 		/obj/machinery/vending/barbervend = "Fab-O-Vend", //NOVA EDIT ADDITION
 		/obj/machinery/vending/dorms = "LustWish",	//NOVA EDIT CHANGE - ERP UPDATE - ORIGINAL: /obj/machinery/vending/dorms = "KinkVend"
-		/obj/machinery/vending/imported = "NT Sustenance Supplier", //NOVA EDIT ADDITION
+		/obj/machinery/vending/imported/nt = "NT Sustenance Supplier", //NOVA EDIT ADDITION
 		/obj/machinery/vending/imported/mothic = "Nomad Fleet Ration Chit Exchange", //NOVA EDIT ADDITION
 		/obj/machinery/vending/imported/tiziran = "Tiziran Imported Delicacies", //NOVA EDIT ADDITION
 		/obj/machinery/vending/imported/yangyu = "Fudobenda", //NOVA EDIT ADDITION

--- a/modular_nova/modules/imported_vendors/code/vendors.dm
+++ b/modular_nova/modules/imported_vendors/code/vendors.dm
@@ -1,6 +1,6 @@
 /obj/effect/spawner/random/vending/snackvend
 	loot = list(
-		/obj/machinery/vending/imported,
+		/obj/machinery/vending/imported/nt,
 		/obj/machinery/vending/imported/yangyu,
 		/obj/machinery/vending/imported/mothic,
 		/obj/machinery/vending/imported/tiziran,
@@ -9,7 +9,7 @@
 
 /obj/effect/spawner/random/vending/colavend //These can serve both snacks AND drinks so its kinda both of them?
 	loot = list(
-		/obj/machinery/vending/imported,
+		/obj/machinery/vending/imported/nt,
 		/obj/machinery/vending/imported/yangyu,
 		/obj/machinery/vending/imported/mothic,
 		/obj/machinery/vending/imported/tiziran,
@@ -18,15 +18,21 @@
 
 /datum/supply_pack/vending/imported/fill(obj/structure/closet/crate/target_crate)
 	. = ..()
-	for(var/obj/vendor_refill as anything in typesof(/obj/item/vending_refill/snack/imported))
+	for(var/obj/vendor_refill as anything in typesof(/obj/item/vending_refill/snack/imported) - /obj/item/vending_refill/snack/imported)
 		new vendor_refill(target_crate)
 
 /obj/machinery/vending/imported
+	icon = 'modular_nova/modules/imported_vendors/icons/imported_vendors.dmi'
+	panel_type = "panel15"
+	default_price = PAYCHECK_CREW * 0.5
+	extra_price = PAYCHECK_COMMAND
+	payment_department = NO_FREEBIES
+
+
+/obj/machinery/vending/imported/nt
 	name = "NT Sustenance Supplier"
 	desc = "A vending machine serving up only the finest of human college student food."
-	icon = 'modular_nova/modules/imported_vendors/icons/imported_vendors.dmi'
 	icon_state = "nt_food"
-	panel_type = "panel15"
 	light_mask = "nt_food-light-mask"
 	light_color = LIGHT_COLOR_LIGHT_CYAN
 	product_slogans = "Caution, contents may be selling hot!;Look at these low prices!;Hungry? Me too- Wait, no, you didn't hear that!"
@@ -60,12 +66,9 @@
 		),
 	)
 
-	refill_canister = /obj/item/vending_refill/snack/imported
-	default_price = PAYCHECK_CREW * 0.5
-	extra_price = PAYCHECK_COMMAND
-	payment_department = NO_FREEBIES
+	refill_canister = /obj/item/vending_refill/snack/imported/nt
 
-/obj/item/vending_refill/snack/imported
+/obj/item/vending_refill/snack/imported/nt
 	machine_name = "NT Sustenance Supplier"
 
 /obj/machinery/vending/imported/yangyu


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Food vendors currently all drop NT Sustenance boards/canisters when deconstructed, making it impossible to reconstruct them. The vendor canister also contains the "correct" ingredients despite being the wrong type, so cannot be used to restock EITHER vendor type. Fixes all that weirdness by making the NT vendor not be the parent type.

(The issue is from an istype check on the circuit selection process; having a selectable vendor that also passed the istype for other selectable vendors)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing


<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

  https://github.com/NovaSector/NovaSector/assets/25628932/4d136bfe-efcf-470d-9595-59866b4771f1


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: food vendors now drop the correct circuit and resupply canister
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
