### PR TITLE
More loadout choices: uniforms, chest rigs, holsters & hairbrushes

### DIFF
--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_belts.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_belts.dm
@@ -71,3 +71,36 @@ GLOBAL_LIST_INIT(loadout_belts, generate_loadout_items(/datum/loadout_item/belts
 /datum/loadout_item/belts/candle_box
 	name = "Candle Box"
 	item_path = /obj/item/storage/fancy/candle_box
+
+// HOLSTERS
+
+/datum/loadout_item/belts/holster_shoulders
+	name = "Shoulder Holster"
+	item_path = /obj/item/storage/belt/holster
+
+/datum/loadout_item/belts/holster_cowboy
+	name = "Cowboy Belt (Thigh Holster)"
+	item_path = /obj/item/storage/belt/holster/cowboy
+
+// RIGS/WEBBING (for military larpers)
+
+/datum/loadout_item/belts/cin_surplus_chestrig
+	name = "CIN Surplus Chest Rig (Standard)"
+	item_path = /obj/item/storage/belt/military/cin_surplus
+
+/datum/loadout_item/belts/cin_surplus_chestrig_desert
+	name = "CIN Surplus Chest Rig (Desert)"
+	item_path = /obj/item/storage/belt/military/cin_surplus/desert
+
+/datum/loadout_item/belts/cin_surplus_chestrig_forest
+	name = "CIN Surplus Chest Rig (Forest)"
+	item_path = /obj/item/storage/belt/military/cin_surplus/forest
+
+/datum/loadout_item/belts/cin_surplus_chestrig_marine
+	name = "CIN Surplus Chest Rig (Marine)"
+	item_path = /obj/item/storage/belt/military/cin_surplus/marine
+
+/datum/loadout_item/belts/expeditionary_chestrig_belt
+	name = "Expeditionary Chest Rig/Webbing Belt"
+	item_path = /obj/item/storage/belt/military/expeditionary_corps
+

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_pocket.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_pocket.dm
@@ -200,6 +200,14 @@ GLOBAL_LIST_INIT(loadout_pocket_items, generate_loadout_items(/datum/loadout_ite
 *	UTILITY
 */
 
+/datum/loadout_item/pocket_items/hairbrush
+	name = "Hairbrush"
+	item_path = /obj/item/hairbrush
+
+/datum/loadout_item/pocket_items/comb
+	name = "Comb"
+	item_path = /obj/item/hairbrush/comb
+
 /datum/loadout_item/pocket_items/moth_mre
 	name = "Mothic Rations Pack"
 	item_path = /obj/item/storage/box/mothic_rations

--- a/modular_nova/modules/loadouts/loadout_items/under/loadout_datum_under.dm
+++ b/modular_nova/modules/loadouts/loadout_items/under/loadout_datum_under.dm
@@ -138,6 +138,10 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 	item_path = /obj/item/clothing/under/colonial/nri_police
 	restricted_roles = list(JOB_SECURITY_OFFICER, JOB_DETECTIVE)
 
+/datum/loadout_item/under/jumpsuit/cin_surplus_uniform
+	name = "CIN Combat Uniform"
+	item_path = /obj/item/clothing/under/syndicate/rus_army/cin_surplus
+
 /datum/loadout_item/under/jumpsuit/disco
 	name = "Superstar Cop Uniform"
 	item_path = /obj/item/clothing/under/rank/security/detective/disco
@@ -568,6 +572,26 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 /datum/loadout_item/under/miscellaneous/blastwave_uniform
 	name = "Blastwave Uniform"
 	item_path = /obj/item/clothing/under/blastwave
+
+/datum/loadout_item/under/miscellaneous/black_bunnysuit
+	name = "Black Bunny Suit"
+	item_path = /obj/item/clothing/under/costume/bunnylewd //contrary to the path, it's actually tame
+
+/datum/loadout_item/under/miscellaneous/white_bunnysuit
+	name = "White Bunny Suit"
+	item_path = /obj/item/clothing/under/costume/bunnylewd/white //also tame
+
+/datum/loadout_item/under/miscellaneous/latex_catsuit
+	name = "Latex Catsuit"
+	item_path = /obj/item/clothing/under/misc/latex_catsuit
+
+/datum/loadout_item/under/miscellaneous/geisha_suit
+	name = "Geisha Suit"
+	item_path = /obj/item/clothing/under/costume/geisha
+
+/datum/loadout_item/under/miscellaneous/jabroni
+	name = "Jabroni Outfit"
+	item_path = /obj/item/clothing/under/costume/jabroni
 
 //HALLOWEEN
 /datum/loadout_item/under/miscellaneous/pj_blood


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds the following items to the loadout selection screen:

Misc. Under: black bunny suit, white bunny suit, latex catsuit, geisha suit, jabroni outfit
Uniform: CIN combat uniform (normally importable from cargo)
Belts: Shoulder holsters (normal holsters you get when making w/ leather), cowboy belt (special thigh holster + belt sprite that works like an ordinary holster, very aesthetic, highly recommend), all CIN surplus chest rigs (normally importable from cargo), expeditionary chest rig (found in expedition surplus crates, also orderable from cargo)
Pocket: hairbrush, comb

The general rule-of-thumb when adding items to the loadout is that they should be already be readily and trivially accessible from the get-go, and I believe all of the above satisfy this criteria. Most of them are either basic 1-step crafts with easily-obtainable items, importable/orderable from cargo, or available in public vendors.

## How This Contributes To The Nova Sector Roleplay Experience

Loadout items are a major customization point for players, especially since they can be easily altered. 90% of the items added above were from requests fielded on #main-talk over about 25 minutes.

## Proof of Testing

Super simple changes. It compiles, if anything breaks, CI will let us know.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: The following items are now available in the loadout menu: bunny suit (black), bunny suit (white), latex catsuit, geisha suit, jabroni outfit, CIN combat uniform, shoulder holsters, cowboy belt, all the CIN surplus chest rigs, expeditionary chest rig, hairbrush, and combs. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
