### PR TITLE
Fix wooden seed and ration shelves

### DIFF
--- a/_maps/nova/automapper/templates/mining/lavaland_ashwalker_fortress.dmm
+++ b/_maps/nova/automapper/templates/mining/lavaland_ashwalker_fortress.dmm
@@ -1136,7 +1136,7 @@
 /area/ruin/unpowered/ash_walkers)
 "ul" = (
 /obj/structure/stone_tile/surrounding_tile,
-/obj/machinery/smartfridge/wooden/ration_shelf/wooden,
+/obj/machinery/smartfridge/wooden/ration_shelf,
 /turf/open/floor/bamboo/lavaland,
 /area/ruin/unpowered/ash_walkers)
 "um" = (
@@ -2924,7 +2924,7 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "XU" = (
-/obj/machinery/smartfridge/wooden/seed_shelf/wooden,
+/obj/machinery/smartfridge/wooden/seed_shelf,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "Yb" = (

--- a/modular_nova/modules/primitive_structures/code/storage_structures.dm
+++ b/modular_nova/modules/primitive_structures/code/storage_structures.dm
@@ -63,6 +63,7 @@
 
 /obj/machinery/smartfridge/wooden/Initialize(mapload)
 	. = ..()
+	welded_down = FALSE
 	if(type == /obj/machinery/smartfridge/wooden) // don't even let these prototypes exist
 		return INITIALIZE_HINT_QDEL
 

--- a/modular_nova/modules/primitive_structures/code/storage_structures.dm
+++ b/modular_nova/modules/primitive_structures/code/storage_structures.dm
@@ -113,7 +113,7 @@
 	base_build_path = /obj/machinery/smartfridge/wooden/seed_shelf
 	base_icon_state = "seed"
 
-/obj/machinery/smartfridge/wooden/seed_shelf/wooden/accept_check(obj/item/item_to_check)
+/obj/machinery/smartfridge/wooden/seed_shelf/accept_check(obj/item/item_to_check)
 	return istype(item_to_check, /obj/item/seeds)
 
 /obj/machinery/smartfridge/wooden/ration_shelf
@@ -123,7 +123,7 @@
 	base_build_path = /obj/machinery/smartfridge/wooden/ration_shelf
 	base_icon_state = "ration"
 
-/obj/machinery/smartfridge/wooden/ration_shelf/wooden/accept_check(obj/item/item_to_check)
+/obj/machinery/smartfridge/wooden/ration_shelf/accept_check(obj/item/item_to_check)
 	return (IS_EDIBLE(item_to_check) || (istype(item_to_check,/obj/item/reagent_containers/cup/bowl) && length(item_to_check.reagents?.reagent_list)))
 
 /obj/machinery/smartfridge/wooden/produce_display


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes crafted seed and ration shelves not being able to store their expected contents, because of a redundant /wooden in the typepath. Also makes these not start as welded, because they're **wood** and primitive things like ashwalkers shouldn't need to unweld it to move it around
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Proof of Testing
![image](https://github.com/NovaSector/NovaSector/assets/25628932/177e8cbf-9cd3-441d-ae8b-0e59fb9d6805)

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: crafted wooden produce/seed shelves now properly store their intended resourcessa
qol: wooden "smartfridges" now start unwelded (but wrenched)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
