### PR TITLE
Entombed quirk bug fixes & QoL improvements

### DIFF
--- a/modular_nova/master_files/code/modules/entombed_quirk/code/entombed.dm
+++ b/modular_nova/master_files/code/modules/entombed_quirk/code/entombed.dm
@@ -25,9 +25,10 @@
 /datum/quirk/equipping/entombed/process(seconds_per_tick)
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	if (!modsuit || life_support_failed)
-		// we've got no modsuit or life support. take damage ow
-		human_holder.adjustToxLoss(ENTOMBED_TICK_DAMAGE * seconds_per_tick, updating_health = TRUE, forced = TRUE)
-		human_holder.set_jitter_if_lower(10 SECONDS)
+		if (!HAS_TRAIT(human_holder, TRAIT_STASIS))
+			// we've got no modsuit or life support and we're not on stasis. take damage ow
+			human_holder.adjustToxLoss(ENTOMBED_TICK_DAMAGE * seconds_per_tick, updating_health = TRUE, forced = TRUE)
+			human_holder.set_jitter_if_lower(10 SECONDS)
 
 	if (!modsuit.active)
 		if (!life_support_timer)

--- a/modular_nova/master_files/code/modules/entombed_quirk/code/entombed_alt_actions.dm
+++ b/modular_nova/master_files/code/modules/entombed_quirk/code/entombed_alt_actions.dm
@@ -1,0 +1,28 @@
+// This code handles the strip menu minutae for re-enabling someone's deactivated entombed suit.
+
+/datum/strippable_item/mob_item_slot/back/get_alternate_actions(atom/source, mob/user)
+	. = ..()
+	var/obj/item/mod/control/pre_equipped/entombed/entombed_suit = get_item(source)
+	if (!istype(entombed_suit))
+		return null
+
+	if (!entombed_suit.active)
+		return list("entombed_emergency_reactivate")
+
+/datum/strippable_item/mob_item_slot/back/perform_alternate_action(atom/source, mob/user, action_key)
+	. = ..()
+	var/obj/item/mod/control/pre_equipped/entombed/entombed_suit = get_item(source)
+	if (!istype(entombed_suit))
+		return null
+
+	switch (action_key)
+		if ("entombed_emergency_reactivate")
+			if (!entombed_suit.active)
+				user.visible_message(span_info("[user] begins initiating emergency reactivation procedures on [entombed_suit]..."))
+				if (do_after(user, 3 SECONDS, entombed_suit.wearer))
+					// deploy all our parts so activation actually works
+					for (var/obj/item/part as anything in entombed_suit.mod_parts)
+						entombed_suit.deploy(user, part)
+					entombed_suit.toggle_activate(user, TRUE)
+			else
+				user.balloon_alert(usr, "their suit is already online!")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6538,6 +6538,7 @@
 #include "modular_nova\master_files\code\modules\clothing\under\jobs\civilian\clown_mime.dm"
 #include "modular_nova\master_files\code\modules\clothing\under\jobs\civilian\suits.dm"
 #include "modular_nova\master_files\code\modules\entombed_quirk\code\entombed.dm"
+#include "modular_nova\master_files\code\modules\entombed_quirk\code\entombed_alt_actions.dm"
 #include "modular_nova\master_files\code\modules\entombed_quirk\code\entombed_mod.dm"
 #include "modular_nova\master_files\code\modules\events\_event.dm"
 #include "modular_nova\master_files\code\modules\experisci\experiment.dm"

--- a/tgui/packages/tgui/interfaces/StripMenu.tsx
+++ b/tgui/packages/tgui/interfaces/StripMenu.tsx
@@ -77,6 +77,11 @@ const ALTERNATE_ACTIONS: Record<string, AlternateAction> = {
     icon: 'microchip',
     text: 'Adjust sensors',
   },
+  //NOVA ADDITION BEGIN - entombed quirk suit reactivation
+  entombed_emergency_reactivate: {
+    icon: 'power-off',
+    text: 'Emergency MODsuit reactivation',
+  }, // NOVA ADDITION END
 };
 
 const SLOTS: Record<


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Couple of basic changes upon requests & user feedback throughout play for the Entombed quirk. Unfortunately, one of them is semi-modular.

- Stasis effects (beds, bags, etc) now halt the life support failure damage ticks. If you lose your suit somehow, this is the only way you'll be able to remain in the round outside of carrying a 1u ammoniated mercury IV drip with you.
- You can now manually power on another player's entombed suit via the strip menu, but only if it is off. It will attempt to deploy all the parts it can to facilitate this. If they're out of charge, throw them into a cyborg charger first.
- Entombed MODsuit pieces will now make a herculean effort to remain permanently attached to the suit in both soft-DNR and normal modes. MODsuits should honestly do this in general, but this quirk is pushing them far, far beyond the limits of their original design.
    - In the event that the suit object itself ends up deleted somehow, any discarded entombed MOD pieces will gracefully self-delete so as to avoid having less NODROP clutter around for people to trap themselves with. 
- Entombed MODsuit units lose their NODROP flag if they are for some inexplicable reason, actually dropped. First responders can pick up entombed suits safely without needing admins to remove the flag/delete the item.

## How This Contributes To The Nova Sector Roleplay Experience

Facilitates *much* easier revival of Entombed patients, provides a realistic way for them to survive outside of a suit if theirs becomes inaccessible somehow, and tries to make entombed suits more codedly resilient to unusual dismemberment shenanigans to lessen the quantity of NODROP items left around the game world. Easier for everyone!

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![](https://puu.sh/K6V7G/5e34cb9d33.png)

![](https://puu.sh/K6V7R/d53968f9ab.png)
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: yooriss
fix: Entombed MODsuits now handle dismemberment much better, hopefully resulting in less cases of discarded MOD clothing with the NODROP flag lying around. It is also  safe for first responders to pick up and transport Entombed MODs without them fusing to their hand and becoming undroppable.
qol: Stasis beds (and other sources of the effect) now halt the life support failure damage for Entombed characters. Side note: it is also possible to mitigate the toxin damage this causes with slow IV drips of anti-tox chemicals.
qol: It is now possible to turn on an Entombed character's MODsuit via the strip menu after a short delay if it is off and they are otherwise unconscious/unable/unwilling. You cannot turn it off, however, as this would kill them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
