### PR TITLE
[NO GBP] standard medkits actually come with things in the expeditionary gacha

### DIFF
--- a/modular_nova/modules/modular_weapons/code/cargo_crates/surplus_crates.dm
+++ b/modular_nova/modules/modular_weapons/code/cargo_crates/surplus_crates.dm
@@ -112,7 +112,7 @@
 		/obj/item/storage/box/expeditionary_survival = ITEM_WEIGHT_MISC,
 		/obj/item/melee/tomahawk = ITEM_WEIGHT_MISC_BUT_RARER,
 		// the stuff they probably just stole from the station before going
-		/obj/item/storage/medkit = ITEM_WEIGHT_MISC_BUT_RARER,
+		/obj/item/storage/medkit/regular = ITEM_WEIGHT_MISC_BUT_RARER,
 		/obj/item/trench_tool = ITEM_WEIGHT_MISC,
 		/obj/item/binoculars = ITEM_WEIGHT_MISC,
 		/obj/item/storage/box/nri_flares = ITEM_WEIGHT_MISC,


### PR DESCRIPTION
## About The Pull Request
i forgot there was a /regular subtype that actually comes with items, my bad

## How This Contributes To The Nova Sector Roleplay Experience
thing in box you buy with big money should have thing

## Changelog
:cl:
fix: The medkit-ransacking charlatan in the Vanguard Expeditionary surplus warehouses has been field-executed by comically large mallet. Regular medkits in the expeditionary surplus crates should now come with actual items.
/:cl:
