### PR TITLE
artifact boulders can sometimes drop xenoarch rocks

### DIFF
--- a/modular_nova/master_files/code/modules/mining/boulder_processing/boulder_types.dm
+++ b/modular_nova/master_files/code/modules/mining/boulder_processing/boulder_types.dm
@@ -1,0 +1,4 @@
+/obj/item/boulder/artifact/Initialize(mapload)
+	if(prob(50))
+		artifact_type = /obj/item/xenoarch/strange_rock
+	. = ..()


### PR DESCRIPTION
## About The Pull Request
artifact boulders have a 50% chance to turn into xenoarch rocks and not strange relics

## How This Contributes To The Nova Sector Roleplay Experience
ties xenoarch into boulders

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
![image](https://github.com/NovaSector/NovaSector/assets/31829017/f4e71ae0-30f4-48cf-b82f-c59a6478c63f)
  
</details>

## Changelog

:cl:
add: Xenoarch strange rocks can now show up in artifact boulders.
/:cl: