### PR TITLE
Fixes misuse of on_examine()

### DIFF
--- a/modular_nova/modules/icemoon_additions/code/pet_commands.dm
+++ b/modular_nova/modules/icemoon_additions/code/pet_commands.dm
@@ -8,8 +8,8 @@
 
 /datum/component/obeys_commands/on_examine(mob/living/source, mob/user, list/examine_list)
 	. = ..()
-	. += span_italics("You can alt+click [source.p_them()] when adjacent to see available commands.")
-	. += span_italics("You can also examine [source.p_them()] closely to check on [source.p_their()] wounds. Many companions can be healed with sutures or creams!")
+	examine_list += span_italics("You can alt+click [source.p_them()] when adjacent to see available commands.")
+	examine_list += span_italics("You can also examine [source.p_them()] closely to check on [source.p_their()] wounds. Many companions can be healed with sutures or creams!")
 
 /datum/component/obeys_commands/proc/on_examine_more(mob/living/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request

Fixes the following runtime that was caused by on_examine returning the string instead of adding it to its `examine_list` arg as it is supposed to be.

![image](https://github.com/NovaSector/NovaSector/assets/13398309/5f0ec005-d9d4-4335-8b82-6536754c6863)

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/NovaSector/NovaSector/assets/13398309/1b4b6c07-5d6d-4921-a8fe-ab642068145f)

</details>

## Changelog

:cl:
fix: mobs with the obeys_commands component (e.g cleanbots, tamed mobs, and more) will now show all of the related examine text
/:cl: