### PR TITLE
Disallow IPC/synth base organs from medical bounties

### DIFF
--- a/code/modules/cargo/bounties/medical.dm
+++ b/code/modules/cargo/bounties/medical.dm
@@ -4,6 +4,7 @@
 	reward = CARGO_CRATE_VALUE * 5
 	wanted_types = list(
 		/obj/item/organ/internal/heart = TRUE,
+		/obj/item/organ/internal/heart/synth = FALSE,
 		/obj/item/organ/internal/heart/cybernetic = FALSE,
 		/obj/item/organ/internal/heart/cybernetic/tier2 = TRUE,
 		/obj/item/organ/internal/heart/cybernetic/tier3 = TRUE,
@@ -16,6 +17,7 @@
 	required_count = 3
 	wanted_types = list(
 		/obj/item/organ/internal/lungs = TRUE,
+		/obj/item/organ/internal/lungs/synth = FALSE,
 		/obj/item/organ/internal/lungs/cybernetic = FALSE,
 		/obj/item/organ/internal/lungs/cybernetic/tier2 = TRUE,
 		/obj/item/organ/internal/lungs/cybernetic/tier3 = TRUE,
@@ -34,6 +36,7 @@
 	required_count = 3
 	wanted_types = list(
 		/obj/item/organ/internal/ears = TRUE,
+		/obj/item/organ/internal/ears/synth = FALSE,
 		/obj/item/organ/internal/ears/cybernetic = FALSE,
 		/obj/item/organ/internal/ears/cybernetic/upgraded = TRUE,
 		/obj/item/organ/internal/ears/cybernetic/whisper = TRUE,
@@ -47,6 +50,7 @@
 	required_count = 3
 	wanted_types = list(
 		/obj/item/organ/internal/liver = TRUE,
+		/obj/item/organ/internal/liver/synth = FALSE,
 		/obj/item/organ/internal/liver/cybernetic = FALSE,
 		/obj/item/organ/internal/liver/cybernetic/tier2 = TRUE,
 		/obj/item/organ/internal/liver/cybernetic/tier3 = TRUE,
@@ -59,6 +63,7 @@
 	required_count = 3
 	wanted_types = list(
 		/obj/item/organ/internal/eyes = TRUE,
+		/obj/item/organ/internal/eyes/synth = FALSE,
 		/obj/item/organ/internal/eyes/robotic = FALSE,
 	)
 
@@ -67,7 +72,10 @@
 	description = "A recent attack by Mime extremists has left staff at Station 23 speechless. Ship some spare tongues."
 	reward = CARGO_CRATE_VALUE * 10
 	required_count = 3
-	wanted_types = list(/obj/item/organ/internal/tongue = TRUE)
+	wanted_types = list(
+		/obj/item/organ/internal/tongue = TRUE,
+		/obj/item/organ/internal/tongue/synth = FALSE,
+	)
 
 /datum/bounty/item/medical/lizard_tail
 	name = "Lizard Tail"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It was very obviously never intended for medical to be able to print our custom base IPC organs more or less from roundstart and use them to cash in on some of the higher-value bounties currently available. This PR fixes that upon request from someone in devcont.

However, I am cognizant of the fact that all this PR really does is delay the bounty tide burden from roundstart to whenever science & mining cough up enough prerequisites for t2 cybernetic organs, then the floodgates open again.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Makes paramedics and other medical department staff have to wait a little bit before they can spam the high value bounties. Maybe it'll give early game doctors & morticians something to do in terms of dissecting humonkeys for bounty organs or something.

## Proof of Testing

It compiles.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: yooriss
fix: Medical bounties no longer accept the base IPC organs that could be printed from medical's techfab pretty much at round start. Sorry, paramedics - you'll have to wait a bit for science to research t2 cybernetic organs before the money fountain opens again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
