### PR TITLE
The End of the Galactic Materials Market: Economy shakeup

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -1,5 +1,5 @@
 /// Number of paychecks jobs start with at the creation of a new bank account for a player (So at shift-start or game join, but not a blank new account.)
-#define STARTING_PAYCHECKS 5
+#define STARTING_PAYCHECKS 10 // NOVA EDIT: increase from 5 to 10
 /// How much mail the Economy SS will create per minute, regardless of firing time.
 #define MAX_MAIL_PER_MINUTE 3
 /// Probability of using letters of envelope sprites on all letters.
@@ -25,7 +25,7 @@
 #define MAX_GRANT_DPT 500
 
 //What should vending machines charge when you buy something in-department.
-#define DEPARTMENT_DISCOUNT 0.2
+#define DEPARTMENT_DISCOUNT 0.5 // NOVA EDIT: increase from 0.2 to 0.5
 
 #define ACCOUNT_CIV "CIV"
 #define ACCOUNT_CIV_NAME "Civil Budget"

--- a/code/modules/cargo/packs/imports.dm
+++ b/code/modules/cargo/packs/imports.dm
@@ -286,6 +286,7 @@
 	contains = list(/obj/item/weaponcrafting/giant_wrench)
 	crate_name = "unknown parts crate"
 
+/* NOVA REMOVAL - economy fixes (stops people printing infinite money via basic arbitrage)
 /datum/supply_pack/imports/materials_market
 	name = "Galactic Materials Market Crate"
 	desc = "A circuit board to build your own materials market for use by certified market traders. Warning: Losses are not covered by insurance."
@@ -299,6 +300,7 @@
 	)
 	crate_name = "materials market crate"
 	crate_type = /obj/structure/closet/crate/cargo
+*/
 
 /datum/supply_pack/imports/floortilecamo
 	name = "Floor-tile Camouflage Uniform"


### PR DESCRIPTION
## About The Pull Request

tldr;

- The GMM crate has been removed from cargo, functionally removing it from the game except for when admins want it there.
- The amount of credits a character joins the round with has doubled from 5 paychecks to 10. You can expect to have 50 minutes of paychecks available to you from the moment you enter the round instead of the usual 25.
- Using departmental vendors grants you a 50% discount instead of a 20%.

We need to be honest with ourselves: the in-game economy sucks.

There's several highly publicized ways to produce an absurd quantity of credits that involve minimal interaction with other players, this is not news to anyone who has played for longer than a few days. One of these methods in particular has proven *absolutely disastrous* for an entire department: the Galactic Materials Market.

The GMM has damaged cargo gameplay more than any other addition in the past five years. With our three hour round outlook, anyone with even a basic understanding of arbitrage (buy low, sell high) and the willingness to forego **all** interaction with the round to stare at the GMM terminal to watch for the 60 second market ticks can produce millions of credits entirely without risk. Quartermasters have pivoted from dodgy logistics officers to silent, statuesque financiers interested only in numbers on a terminal. I have seen vault break-ins ignored because quartermasters are able to produce money faster than someone *draining the bank terminal* can steal it.

No more. This PR removes the GMM terminal from the cargo market, rendering its inclusion in rounds at the sole discretion of the administration. Cargo is once again free to harp at each other over crates, export actual, physical items, and generally grub the station for things to pawn for a profit, as the Space Gods intended.

With that out of the way, we arrive at the next contention point: bounties.

I have made a concerted push over the past few months to try and ensure that the basic chargen loadout options provide a wide gamut of outfits, equipment and tools to tide people over without them feeling compelled to waste time printing things from a departmental autolathe for the Funny Golden Cubes.

Basically nobody enjoys doing bounties. The boffins in devcont have some ideas(tm) about what we can do about bounties in the long term, but this'll require some elbow grease.

To alleviate this, the starting number of paychecks has been doubled from 5 to 10. In practice, this shakes out to roughly two bounties worth of money (for anyone but medical/supply, who have absolutely cracked bounties). You can buy more gear from the get-go and spend more time plotting things to do in round, or interacting with people.

Additionally, departmental vendors now have a whopping 50% discount for people who work in the department, up from 20%. This makes gearing up cheaper and also opens up opportunity for characters to flip gear off to other characters at a slight profit.

## How This Contributes To The Nova Sector Roleplay Experience

The small essay above covers most of the scope, but the summary of it is: with the GMM gone, cargo is free to do fun and dodgy cargo things to earn obscene quantities of money (such as selling bricks of cocaine or contraband gear).

Individual players will have less of a need to do bounties to purchase the lingering non-loadout necessities for their characters, and the departmental vendor discount makes gearing up in new roles cheaper, while also allowing opportunities for player-to-player arbitrage in terms of selling off gear.

## Proof of Testing

Basic number tweaking - CI will let us know if not.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: yooriss
del: The Galactic Materials Market can no longer be purchased from cargo. Admins are able to spawn it in, but it will not generally be accessible in normal rounds anymore.
balance: Characters now start with 10 paychecks in their bank account instead of 5, functionally doubling the credits people enter the round with.
balance: Departmental vendors now offer a 50% discount to employees of their given department, up from 20%.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
