### PR TITLE
Freerunning is no longer needed to flip

### DIFF
--- a/modular_nova/modules/emotes/code/emotes.dm
+++ b/modular_nova/modules/emotes/code/emotes.dm
@@ -77,11 +77,13 @@
 				carbon_user.next_smell = world.time + SMELL_COOLDOWN
 			current_turf.pollution.smell_act(user)
 
+/* NOVA REMOVAL BEGIN - flipping freedom
 /datum/emote/flip/can_run_emote(mob/user, status_check, intentional)
 	if(intentional && (!HAS_TRAIT(user, TRAIT_FREERUNNING) && !HAS_TRAIT(user, TRAIT_STYLISH)) && !isobserver(user))
 		user.balloon_alert(user, "not nimble enough!")
 		return FALSE
 	return ..()
+*/
 
 /datum/emote/living/peep
 	key = "peep"


### PR DESCRIPTION
## About The Pull Request

Unbound by celestial tethers, the crew of Space Station 13 now finds themselves able to flip, even if they don't have the Freerunning trait.

## How This Contributes To The Nova Sector Roleplay Experience

Someone raised in #main-talk that it kind of sucks to have to take a mechanical advantage quirk to do something their character might ordinarily be able to do, so, here we are.

## Proof of Testing

CI, you know the drill.

## Changelog

:cl: yooriss
balance: The Freerunning quirk is no longer required to *flip.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
