### PR TITLE
Replaces the flashbang with an energy bola to help new security players not get smacked by sec policy

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -384,7 +384,7 @@
 /obj/item/storage/belt/security/full/PopulateContents()
 	new /obj/item/reagent_containers/spray/pepper(src)
 	new /obj/item/restraints/handcuffs(src)
-	new /obj/item/grenade/flashbang(src)
+	new /obj/item/restraints/legcuffs/bola/energy(src) // NOVA EDIT - ADDITION (bola replaces flashbang due to sec policy)
 	new /obj/item/assembly/flash/handheld(src)
 	new /obj/item/melee/baton/security/loaded(src)
 	update_appearance()


### PR DESCRIPTION

## About The Pull Request

Officers are issued their belts at round start, when the alert is green. Thus, one would naturally assume that this means they can use anything on their belt on green. Having a tool locked for only blue alert be handed to players on green may create some misconceptions for new players and serve as a sort of 'rule trap' leading to new sec players getting smacked over policy that. This change seeks to fix that issue. The starter belts now start with a green-appropriate energy bola instead of a flashbang. Flashbangs remain available in the sec vendor for 10 credits and in boxes the armory/hos locker. 

![image](https://github.com/NovaSector/NovaSector/assets/50682821/a9942d9a-bd7c-47fc-9691-c761b5db5c2f)


## How This Contributes To The Nova Sector Roleplay Experience

Gameplay should reflect policy. Making policy changes without necessary gameplay changes leads to players getting notes over misunderstandings and increased load on the moderation team over incidents that could be easily avoided. 

## Proof of Testing

CI isn't real and it can't hurt me. 

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/NovaSector/NovaSector/assets/50682821/5564517d-53c8-4486-9b71-4b66933c18a1)
  

</details>

## Changelog

:cl:
fix: Security belts no longer spawn with items not allowed on green by security policy - the flashbang has been replaced with an energy bola. 
/:cl:

