### PR TITLE
Unapologetic Jetpack Implant Nerf

### DIFF
--- a/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_chest.dm
@@ -207,7 +207,7 @@
 		return
 
 	on = TRUE
-	owner.add_movespeed_modifier(/datum/movespeed_modifier/jetpack/cybernetic)
+	owner.add_movespeed_modifier(/datum/movespeed_modifier/jetpack) //NOVA EDIT CHANGE -- Walance, since anyone can get it. ORIGINAL: owner.add_movespeed_modifier(/datum/movespeed_modifier/jetpack/cybernetic)
 	if(!silent)
 		to_chat(owner, span_notice("You turn your thrusters set on."))
 	update_appearance()


### PR DESCRIPTION
## About The Pull Request
Since we have this thing in Robotics now, it's seen a lot of less-than-pleasant synergy with our increasing amount of anti-gravity technology (which, I'm glad it's there, but wew it doesn't mesh well with this!)
This makes it have the same speed as a normal jetpack, which is pretty cracked just not outright broken.

## How This Contributes To The Nova Sector Roleplay Experience
This level of practically free speed indoors is crazy, man. The combat jetpack speed was only ever meant to be something that you have to at least pay air for, or have a MODsuit for, or use a slot for; not something that's relatively easy-access *and* can be stacked with a normal jetpack and whatever other speed boosts. This is going to be vital with our increasingly easy access to indoor anti-grav.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
It's a one-line broh. 
</details>

## Changelog
:cl:
balance: Thruster implants are now normal speed, instead of ludicrous speed.
/:cl:
