### PR TITLE
Damp Rag Walance Maneuver

### DIFF
--- a/code/modules/reagents/reagent_containers/misc.dm
+++ b/code/modules/reagents/reagent_containers/misc.dm
@@ -131,7 +131,7 @@
 
 /obj/item/reagent_containers/cup/rag/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/cleaner, 3 SECONDS, pre_clean_callback=CALLBACK(src, PROC_REF(should_clean)))
+	AddComponent(/datum/component/cleaner, 3 SECONDS, cleaning_strength = CLEAN_WASH, pre_clean_callback=CALLBACK(src, PROC_REF(should_clean))) //NOVA EDIT CHANGE - Walance, they now don't eliminate fingerprints or fibers. ORIGINAL: AddComponent(/datum/component/cleaner, 3 SECONDS, pre_clean_callback=CALLBACK(src, PROC_REF(should_clean)))
 
 /obj/item/reagent_containers/cup/rag/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is smothering [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!"))


### PR DESCRIPTION
## About The Pull Request
Damp rags no longer eliminate fingerprints or fibers.

## How This Contributes To The Nova Sector Roleplay Experience
Forensics gameplay is super feast or famine right now; either people give you a shot, or they rag down everything in existence and you can't get shit except maybe 'there were black gloves involved'. This is inconvenient for obvious reasons, and part of the reason why playing Detective can really actually genuinely suck; this is a PR I've been thinking about for a bit, but due to discussions I cannot tell you about, I think this would be a good time to finally go ahead and do the damn thing.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
![image](https://github.com/NovaSector/NovaSector/assets/12636964/b20c00e3-c0b5-47aa-9b97-7ebbb440eccc)
</details>

## Changelog
:cl:
balance: Damp rags no longer wipe away fingerprints or fibers.
/:cl: