### PR TITLE
Ports an EMP Effect on the Crew Monitor

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -237,7 +237,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			continue
 
 		// Check if their uniform is in a compatible mode.
-		if((uniform.has_sensor <= NO_SENSORS) || !uniform.sensor_mode)
+		if((uniform.has_sensor == NO_SENSORS) || !uniform.sensor_mode) //Nova Edit: Original (uniform.has_sensor <= NO_SENSORS)
 			stack_trace("Human without active suit sensors is in suit_sensors_list: [tracked_human] ([tracked_human.type]) ([uniform.type])")
 			continue
 
@@ -258,6 +258,21 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			var/trim_assignment = id_card.get_trim_assignment()
 			if (jobs[trim_assignment] != null)
 				entry["ijob"] = jobs[trim_assignment]
+
+		// NOVA EDIT ADDITION: EMP SENSORS
+		if(uniform.has_sensor == BROKEN_SENSORS)
+			entry["is_robot"] = rand(0,1)
+			entry["life_status"] = rand(0,1)
+			entry["area"] = prob(80) ? pick_list (ION_FILE, "ionarea") : pick("BEEPING", "CRYING", "NAPPING", "IN THE VOID")
+			entry["oxydam"] = rand(0,1000)
+			entry["toxdam"] = rand(0,1000)
+			entry["burndam"] =rand(0,1000)
+			entry["brutedam"] = rand(0,1000)
+			entry["health"] = -50
+			entry["can_track"] = tracked_living_mob.can_track()
+			results[++results.len] = entry
+			continue
+		// NOVA EDIT END
 
 		// NOVA EDIT BEGIN: Checking for robotic race
 		if (issynthetic(tracked_human))

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -132,6 +132,7 @@
 		has_sensor = HAS_SENSORS
 	update_appearance()
 
+/* NOVA CHANGE: See modular_nova\master_files\code\modules\clothing\under\_under.dm for EMP Act
 /obj/item/clothing/under/emp_act(severity)
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
@@ -155,6 +156,7 @@
 		var/mob/living/carbon/human/ooman = loc
 		if(ooman.w_uniform == src)
 			ooman.update_suit_sensors()
+*/
 
 /obj/item/clothing/under/visual_equipped(mob/user, slot)
 	. = ..()

--- a/modular_nova/master_files/code/modules/clothing/under/_under.dm
+++ b/modular_nova/master_files/code/modules/clothing/under/_under.dm
@@ -1,3 +1,37 @@
 /obj/item/clothing/under
 	/// Does this object get cropped when worn by a taur on their suit or uniform slot?
 	var/gets_cropped_on_taurs = TRUE
+
+/mob/living/carbon/human/update_sensor_list()
+	var/obj/item/clothing/under/U = w_uniform
+	if(istype(U) && U.has_sensor != NO_SENSORS && U.sensor_mode)
+		GLOB.suit_sensors_list |= src
+	else
+		GLOB.suit_sensors_list -= src
+
+/obj/item/clothing/under/emp_act(severity)
+
+	. = ..()
+
+	if(. & EMP_PROTECT_SELF)
+		return
+
+	if(has_sensor == NO_SENSORS || has_sensor == BROKEN_SENSORS)
+		return
+
+	if(severity <= EMP_HEAVY) //Believe it or not, EMP_HEAVY < EMP_LIGHT
+		has_sensor = BROKEN_SENSORS
+		sensor_mode = SENSOR_LIVING
+		if(ismob(loc))
+			var/mob/M = loc
+			to_chat(M,span_danger("The sensors on [src] short out!"))
+	else
+		sensor_mode = clamp(sensor_mode + pick(-1,1), SENSOR_OFF, SENSOR_COORDS)
+		if(ismob(loc))
+			var/mob/M = loc
+			to_chat(M,span_warning("The sensors on [src] change rapidly!"))
+
+	if(ishuman(loc))
+		var/mob/living/carbon/human/H = loc
+		if(H.w_uniform == src)
+			H.update_suit_sensors()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Someone showed me https://github.com/Bubberstation/Bubberstation/pull/801 and I thought that's pretty neat, and makes sense your sensors would start sending bad data back instead of just going off.

## How This Contributes To The Nova Sector Roleplay Experience

It helps raise alarm that someone got EMP'd and may be stuck somewhere for a while because of it, at the same time it doesnt ruin an antags EMP as the location gets completely scrambled. If your suit's malfunctioning, let it send bad and unreliable data back.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
  
![image](https://github.com/NovaSector/NovaSector/assets/22140677/f943094f-3364-46e9-b6c0-a2a5205e0040)

![image](https://github.com/NovaSector/NovaSector/assets/22140677/dc47c625-196c-43f3-80ee-5744aac2e4d2)

  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: EMP's on suit sensors now show flavor on the crew console
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
