### PR TITLE
Adds Raptor Ranch to Icebox that NTC vore'd, Icecats and Ashies get a little one

### DIFF
--- a/_maps/RandomRuins/IceRuins/nova/icemoon_underground_icewalker_lower.dmm
+++ b/_maps/RandomRuins/IceRuins/nova/icemoon_underground_icewalker_lower.dmm
@@ -7,6 +7,10 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
+"ap" = (
+/obj/structure/ore_container/food_trough/raptor_trough,
+/turf/open/misc/hay/icemoon,
+/area/ruin/unpowered/primitive_catgirl_den)
 "au" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -258,9 +262,16 @@
 	},
 /turf/open/floor/wood/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
+"gi" = (
+/obj/structure/wall_torch/spawns_lit/directional/south,
+/turf/open/misc/hay/icemoon,
+/area/ruin/unpowered/primitive_catgirl_den)
 "gt" = (
 /obj/structure/rack/wooden,
 /obj/item/shovel,
+/obj/item/raptor_dex{
+	pixel_y = 7
+	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "gD" = (
@@ -277,6 +288,10 @@
 "gU" = (
 /obj/structure/chair/sofa/bamboo/right,
 /turf/open/misc/dirt/icemoon,
+/area/ruin/unpowered/primitive_catgirl_den)
+"gW" = (
+/obj/structure/ladder/wood,
+/turf/open/misc/hay/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "gY" = (
 /obj/structure/table/wood,
@@ -395,7 +410,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 4
 	},
-/turf/open/misc/dirt/icemoon,
+/turf/open/misc/hay/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "jN" = (
 /obj/structure/railing/wooden_fencing{
@@ -703,7 +718,7 @@
 /obj/structure/railing/wooden_fencing{
 	dir = 4
 	},
-/turf/open/misc/dirt/icemoon,
+/turf/open/misc/hay/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "qf" = (
 /obj/item/stack/sheet/copporcitite{
@@ -728,6 +743,10 @@
 	dir = 6
 	},
 /turf/open/misc/dirt/icemoon,
+/area/ruin/unpowered/primitive_catgirl_den)
+"qh" = (
+/obj/structure/wall_torch/spawns_lit/directional/north,
+/turf/open/misc/hay/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "qi" = (
 /obj/effect/turf_decal/weather/dirt,
@@ -1246,7 +1265,7 @@
 /obj/structure/railing/wooden_fencing/gate{
 	dir = 4
 	},
-/turf/open/misc/dirt/icemoon,
+/turf/open/misc/hay/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "DH" = (
 /obj/structure/railing/wooden_fencing,
@@ -1273,6 +1292,10 @@
 	pixel_x = 11
 	},
 /turf/open/misc/dirt/icemoon,
+/area/ruin/unpowered/primitive_catgirl_den)
+"Eh" = (
+/obj/effect/spawner/random/lavaland_mob/raptor,
+/turf/open/misc/hay/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "EA" = (
 /obj/structure/rack/wooden,
@@ -1457,7 +1480,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 4
 	},
-/turf/open/misc/dirt/icemoon,
+/turf/open/misc/hay/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "JK" = (
 /obj/structure/rack/wooden,
@@ -1797,6 +1820,9 @@
 	dir = 8
 	},
 /turf/open/misc/dirt/icemoon,
+/area/ruin/unpowered/primitive_catgirl_den)
+"Sc" = (
+/turf/open/misc/hay/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "Sf" = (
 /obj/structure/rack/wooden,
@@ -2232,13 +2258,13 @@ pa
 yF
 oJ
 yF
-OI
-ZJ
-ZJ
+qh
+Sc
+ap
 yF
-ZJ
-ZJ
-RC
+ap
+Sc
+gi
 yF
 oJ
 yF
@@ -2274,13 +2300,13 @@ GN
 yF
 yF
 pa
-Rp
-ZJ
-ZJ
+gW
+Eh
+Sc
 pa
-ZJ
-ZJ
-ZJ
+Sc
+Sc
+Sc
 pa
 pa
 yF

--- a/_maps/nova/automapper/automapper_config.toml
+++ b/_maps/nova/automapper/automapper_config.toml
@@ -221,6 +221,14 @@ required_map = "IceBoxStation.dmm"
 coordinates = [202, 16, 2]
 trait_name = "Station"
 
+# Icebox Raptor Ranch
+[templates.icebox_ranch]
+map_files = ["icebox_ranch.dmm"]
+directory = "_maps/nova/automapper/templates/icebox/"
+required_map = "IceBoxStation.dmm"
+coordinates = [57, 82, 2]
+trait_name = "Station"
+
 # TRAMSTATION MAP EDITS
 # Tramstation Arrivals
 [templates.tramstation_arrivals]

--- a/_maps/nova/automapper/templates/icebox/icebox_ranch.dmm
+++ b/_maps/nova/automapper/templates/icebox/icebox_ranch.dmm
@@ -1,0 +1,379 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"d" = (
+/obj/structure/table/wood,
+/obj/item/soap/deluxe{
+	pixel_y = 11
+	},
+/obj/item/soap/deluxe{
+	pixel_y = 6
+	},
+/obj/item/soap/deluxe,
+/turf/open/misc/hay/icemoon,
+/area/icemoon/surface)
+"f" = (
+/obj/structure/railing/wooden_fence{
+	dir = 1
+	},
+/turf/open/misc/hay/icemoon,
+/area/icemoon/surface)
+"h" = (
+/obj/structure/railing/wooden_fence{
+	dir = 4
+	},
+/turf/open/misc/hay/icemoon,
+/area/icemoon/surface)
+"j" = (
+/obj/item/flashlight/lantern/on,
+/turf/open/misc/hay/icemoon,
+/area/icemoon/surface)
+"l" = (
+/obj/structure/railing/wooden_fence{
+	dir = 5
+	},
+/turf/open/misc/hay/icemoon,
+/area/icemoon/surface)
+"o" = (
+/obj/structure/railing/wooden_fence{
+	dir = 10
+	},
+/obj/item/flashlight/lantern/on,
+/turf/open/misc/hay/icemoon,
+/area/icemoon/surface)
+"q" = (
+/obj/structure/railing/wooden_fence{
+	dir = 10
+	},
+/turf/open/misc/hay/icemoon,
+/area/icemoon/surface)
+"s" = (
+/obj/structure/railing/wooden_fence{
+	dir = 4
+	},
+/obj/structure/ore_container/food_trough/raptor_trough,
+/turf/open/misc/hay/icemoon,
+/area/icemoon/surface)
+"w" = (
+/obj/structure/railing/wooden_fence{
+	dir = 1
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"x" = (
+/obj/structure/railing/wooden_fence{
+	dir = 9
+	},
+/turf/open/misc/hay/icemoon,
+/area/icemoon/surface)
+"z" = (
+/obj/item/flashlight/lantern/on,
+/obj/structure/table/wood,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface)
+"A" = (
+/obj/structure/railing/wooden_fence{
+	dir = 8
+	},
+/turf/open/misc/hay/icemoon,
+/area/icemoon/surface)
+"B" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lantern/on,
+/turf/open/misc/hay/icemoon,
+/area/icemoon/surface)
+"E" = (
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface)
+"H" = (
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface)
+"I" = (
+/obj/structure/railing/wooden_fence{
+	dir = 8
+	},
+/obj/structure/ore_container/food_trough/raptor_trough,
+/turf/open/misc/hay/icemoon,
+/area/icemoon/surface)
+"J" = (
+/obj/structure/flora/grass/green/style_random,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface)
+"K" = (
+/obj/effect/spawner/random/lavaland_mob/raptor,
+/turf/open/misc/hay/icemoon,
+/area/icemoon/surface)
+"M" = (
+/obj/structure/railing/wooden_fence{
+	dir = 6
+	},
+/turf/open/misc/hay/icemoon,
+/area/icemoon/surface)
+"R" = (
+/obj/structure/railing/wooden_fence,
+/turf/open/misc/hay/icemoon,
+/area/icemoon/surface)
+"S" = (
+/turf/open/openspace/icemoon/keep_below,
+/area/icemoon/underground/explored)
+"T" = (
+/obj/structure/lattice,
+/turf/open/openspace/icemoon/keep_below,
+/area/icemoon/underground/explored)
+"U" = (
+/turf/open/misc/hay/icemoon,
+/area/icemoon/surface)
+"W" = (
+/obj/structure/flora/grass/green/style_random,
+/obj/structure/railing/wooden_fence,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface)
+"X" = (
+/obj/structure/railing/wooden_fence,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface)
+"Y" = (
+/obj/structure/railing/wooden_fence{
+	dir = 6
+	},
+/obj/item/flashlight/lantern/on,
+/turf/open/misc/hay/icemoon,
+/area/icemoon/surface)
+"Z" = (
+/obj/structure/table/wood,
+/obj/item/raptor_dex{
+	pixel_y = 13
+	},
+/obj/item/raptor_dex{
+	pixel_y = 7
+	},
+/obj/item/raptor_dex,
+/turf/open/misc/hay/icemoon,
+/area/icemoon/surface)
+
+(1,1,1) = {"
+S
+T
+S
+S
+S
+S
+w
+a
+a
+a
+a
+a
+a
+"}
+(2,1,1) = {"
+T
+x
+A
+A
+A
+o
+E
+E
+x
+A
+A
+q
+a
+"}
+(3,1,1) = {"
+S
+f
+U
+U
+U
+U
+E
+H
+U
+U
+K
+R
+a
+"}
+(4,1,1) = {"
+S
+f
+U
+U
+K
+U
+H
+H
+j
+U
+U
+R
+a
+"}
+(5,1,1) = {"
+S
+l
+h
+h
+s
+M
+H
+H
+l
+s
+h
+M
+a
+"}
+(6,1,1) = {"
+S
+f
+U
+U
+U
+U
+E
+H
+H
+H
+H
+X
+a
+"}
+(7,1,1) = {"
+S
+f
+U
+U
+U
+U
+E
+H
+E
+H
+H
+X
+a
+"}
+(8,1,1) = {"
+S
+f
+B
+d
+Z
+B
+H
+H
+H
+E
+z
+X
+a
+"}
+(9,1,1) = {"
+S
+f
+U
+U
+U
+U
+E
+H
+H
+H
+H
+X
+a
+"}
+(10,1,1) = {"
+T
+f
+U
+U
+U
+U
+H
+H
+H
+H
+H
+W
+a
+"}
+(11,1,1) = {"
+S
+x
+A
+A
+I
+q
+H
+E
+x
+I
+A
+q
+a
+"}
+(12,1,1) = {"
+S
+f
+U
+U
+U
+U
+E
+H
+j
+U
+U
+R
+a
+"}
+(13,1,1) = {"
+S
+f
+U
+K
+U
+U
+H
+J
+U
+U
+U
+R
+a
+"}
+(14,1,1) = {"
+T
+l
+h
+h
+h
+Y
+E
+E
+l
+h
+h
+M
+a
+"}
+(15,1,1) = {"
+S
+T
+S
+S
+S
+w
+a
+a
+a
+a
+a
+a
+a
+"}

--- a/_maps/nova/automapper/templates/mining/lavaland_ashwalker_fortress.dmm
+++ b/_maps/nova/automapper/templates/mining/lavaland_ashwalker_fortress.dmm
@@ -67,6 +67,9 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
+"aQ" = (
+/turf/open/floor/grass/lavaland,
+/area/ruin/unpowered/ash_walkers)
 "aS" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -124,6 +127,13 @@
 /obj/structure/wall_torch/spawns_lit/directional/west,
 /obj/structure/stone_tile/block/burnt,
 /obj/effect/mapping_helpers/no_lava,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"by" = (
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/railing/wooden_fencing{
+	dir = 8
+	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "bI" = (
@@ -461,6 +471,11 @@
 /obj/structure/wall_torch/spawns_lit/directional/south,
 /turf/open/floor/stone/lavaland,
 /area/ruin/unpowered/ash_walkers)
+"fN" = (
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/ore_vein/stone,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
 "fU" = (
 /obj/structure/wall_torch/spawns_lit/directional/east,
 /obj/structure/rack/wooden,
@@ -519,6 +534,13 @@
 	dir = 2
 	},
 /obj/effect/mapping_helpers/no_lava,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"gT" = (
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/railing/wooden_fencing/gate{
+	dir = 1
+	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "gX" = (
@@ -596,6 +618,10 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
+"hV" = (
+/obj/structure/ore_vein/iron,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
 "ik" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -609,20 +635,11 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "iv" = (
-/obj/structure/closet/crate/wooden/storage_barrel,
-/obj/item/flashlight/flare/torch,
-/obj/item/flashlight/flare/torch,
-/obj/item/flashlight/flare/torch,
-/obj/item/flashlight/flare/torch,
-/obj/item/flashlight/flare/torch,
-/obj/item/flashlight/flare/torch,
-/obj/item/flashlight/flare/torch,
-/obj/item/flashlight/flare/torch,
-/obj/item/stack/sheet/mineral/bamboo{
-	amount = 20
-	},
 /obj/effect/mapping_helpers/no_lava,
-/turf/open/misc/asteroid/basalt/lava_land_surface,
+/obj/structure/railing/wooden_fencing{
+	dir = 1
+	},
+/turf/open/floor/grass/lavaland,
 /area/ruin/unpowered/ash_walkers)
 "iK" = (
 /obj/structure/stone_tile/block/burnt{
@@ -644,6 +661,11 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"iZ" = (
+/obj/structure/wall_torch/spawns_lit/directional/south,
+/obj/effect/mapping_helpers/no_lava,
+/turf/open/floor/grass/lavaland,
 /area/ruin/unpowered/ash_walkers)
 "je" = (
 /obj/machinery/smartfridge/wooden/produce_bin,
@@ -1204,6 +1226,12 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
+"rp" = (
+/obj/structure/railing/wooden_fencing{
+	dir = 1
+	},
+/turf/open/floor/grass/lavaland,
+/area/ruin/unpowered/ash_walkers)
 "rt" = (
 /obj/structure/chair/pew/left{
 	dir = 2
@@ -1519,6 +1547,11 @@
 /obj/item/reagent_containers/cup/watering_can/wood,
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"vm" = (
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/ore_container/food_trough/raptor_trough,
+/turf/open/floor/grass/lavaland,
 /area/ruin/unpowered/ash_walkers)
 "vu" = (
 /obj/effect/mapping_helpers/no_lava,
@@ -1944,6 +1977,11 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
+"As" = (
+/obj/effect/mapping_helpers/no_lava,
+/obj/effect/spawner/random/lavaland_mob/raptor,
+/turf/open/floor/grass/lavaland,
+/area/ruin/unpowered/ash_walkers)
 "Au" = (
 /obj/structure/geyser,
 /obj/effect/mapping_helpers/no_lava,
@@ -2115,6 +2153,23 @@
 "Dq" = (
 /obj/structure/stone_tile/surrounding/burnt,
 /obj/effect/mapping_helpers/no_lava,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"Du" = (
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/closet/crate{
+	desc = "A metal box, stolen from the ruins of old colony.";
+	name = "old cargo crate"
+	},
+/obj/item/clothing/head/utility/hardhat/white,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/shoes/jackboots/colonial,
+/obj/item/storage/box/tiziran_cans,
+/obj/item/toy/plush/lizard_plushie,
+/obj/item/storage/crayons,
+/obj/item/toy/crayon/spraycan,
+/obj/item/hand_labeler,
+/obj/item/raptor_dex,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "DD" = (
@@ -2354,6 +2409,10 @@
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"HP" = (
+/obj/effect/mapping_helpers/no_lava,
+/turf/open/floor/grass/lavaland,
 /area/ruin/unpowered/ash_walkers)
 "HT" = (
 /obj/structure/closet/crate/wooden/storage_barrel,
@@ -2838,13 +2897,16 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"PJ" = (
-/obj/effect/mapping_helpers/no_lava,
-/turf/closed/wall/mineral/wood/nonmetal,
-/area/ruin/unpowered/ash_walkers)
 "PS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/mineral/stone,
+/area/ruin/unpowered/ash_walkers)
+"PT" = (
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/railing/wooden_fencing{
+	dir = 8
+	},
+/turf/open/floor/grass/lavaland,
 /area/ruin/unpowered/ash_walkers)
 "PW" = (
 /obj/structure/table/wood,
@@ -3021,6 +3083,22 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/no_lava,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"So" = (
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/closet/crate/wooden/storage_barrel,
+/obj/item/flashlight/flare/torch,
+/obj/item/flashlight/flare/torch,
+/obj/item/flashlight/flare/torch,
+/obj/item/flashlight/flare/torch,
+/obj/item/flashlight/flare/torch,
+/obj/item/flashlight/flare/torch,
+/obj/item/flashlight/flare/torch,
+/obj/item/flashlight/flare/torch,
+/obj/item/stack/sheet/mineral/bamboo{
+	amount = 20
+	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "St" = (
@@ -3275,22 +3353,6 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/lava/smooth/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"UE" = (
-/obj/structure/closet/crate{
-	desc = "A metal box, stolen from the ruins of old colony.";
-	name = "old cargo crate"
-	},
-/obj/item/clothing/head/utility/hardhat/white,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/shoes/jackboots/colonial,
-/obj/item/storage/box/tiziran_cans,
-/obj/item/toy/plush/lizard_plushie,
-/obj/item/storage/crayons,
-/obj/item/toy/crayon/spraycan,
-/obj/item/hand_labeler,
-/obj/effect/mapping_helpers/no_lava,
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "UL" = (
 /obj/structure/millstone,
 /obj/effect/mapping_helpers/no_lava,
@@ -3301,6 +3363,13 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/no_lava,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"UP" = (
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/railing/wooden_fencing{
+	dir = 1
+	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "UT" = (
@@ -3343,6 +3412,16 @@
 	pixel_y = -3
 	},
 /obj/effect/mapping_helpers/no_lava,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/ash_walkers)
+"VH" = (
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/railing/wooden_fencing{
+	dir = 8
+	},
+/obj/structure/railing/wooden_fencing{
+	dir = 1
+	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "VN" = (
@@ -5231,8 +5310,9 @@ Xr
 Xr
 zf
 LQ
-Zo
+fN
 JC
+So
 CV
 CV
 CV
@@ -5241,8 +5321,7 @@ CV
 CV
 CV
 CV
-CV
-CV
+Du
 um
 XC
 Ho
@@ -5268,16 +5347,16 @@ nr
 CV
 JC
 JC
-sQ
+WK
 CV
-CV
-CV
-CV
-CV
-CV
-CV
-CV
-CV
+VH
+by
+by
+by
+by
+by
+PT
+PT
 um
 Ho
 Ho
@@ -5303,16 +5382,16 @@ Wl
 pK
 JC
 JC
-sQ
+WK
+CV
+UP
 CV
 CV
 CV
-CV
-CV
-CV
-CV
-CV
-pK
+HP
+HP
+HP
+iZ
 JC
 Ho
 Ho
@@ -5338,16 +5417,16 @@ fH
 xE
 JC
 JC
-sQ
+WK
 CV
+gT
 CV
-CV
-CV
-CV
-CV
-CV
-CV
-CV
+HP
+HP
+HP
+HP
+HP
+HP
 JC
 JC
 Ho
@@ -5373,16 +5452,16 @@ Ot
 JC
 JC
 JC
-sQ
-PJ
+WK
+CV
 iv
-CV
-CV
-CV
-UE
-CV
-CV
-CV
+HP
+HP
+HP
+HP
+As
+HP
+HP
 JC
 JC
 Ho
@@ -5409,14 +5488,14 @@ JC
 li
 JC
 JC
-sQ
-sQ
-sQ
-sQ
-sQ
-sQ
-sQ
-CV
+hV
+rp
+aQ
+aQ
+aQ
+aQ
+aQ
+vm
 JC
 JC
 Ho


### PR DESCRIPTION

## About The Pull Request

the NTC ate the stock Ranch so this just adds one a bit lower

## How This Contributes To The Nova Sector Roleplay Experience

Birbs. But also cats and lizards get a tiny ranch to start off with plus one singular raptordex - until it's reskinned

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
  
![image](https://github.com/NovaSector/NovaSector/assets/22140677/4d9ebb09-e10f-42f3-a8c1-e2664388f312)

  
![image](https://github.com/NovaSector/NovaSector/assets/22140677/b0153cf0-98fa-4a4c-ad10-a6acca842791)

  
</details>

## Changelog
:cl:
add: Added new mechanics or gameplay changes
add: Ranch to Icebox, Icecats and Ashwalkers
/:cl:
