### PR TITLE
Re-Add Cargo Technician and Shaft Miner title

### DIFF
--- a/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -112,6 +112,7 @@
 
 /datum/job/cargo_technician
 	alt_titles = list(
+		"Cargo Technician",
 		"Warehouse Technician",
 		"Commodities Trader",
 		"Deck Worker",
@@ -388,6 +389,7 @@
 
 /datum/job/shaft_miner
 	alt_titles = list(
+		"Shaft Miner",
 		"Union Miner",
 		"Excavator",
 		"Drill Technician",


### PR DESCRIPTION

## About The Pull Request

This is for re-adding the titles for Cargo Technician and Shaft Miner. I will note that it would be nice to have the original titles back since our lore isn't really consolidated enough to make Union Miner and Warehouse Technician take the place of the original titles. I'll also add that because this is only an alt title change originally, new people come in with the Shaft Miner and Cargo Tech title anyway and changing it means they can't really change back without a new character file. This shouldn't change that much, and it'll keep the other titles for those that would like to use them.
## How This Contributes To The Nova Sector Roleplay Experience

General roleplay.
## Proof of Testing

I checked to make sure it works. It's simple code, and it didn't really mess up, and it is already modular.
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
qol: Re-Add original Cargo Technician and Shaft Miner title. 
/:cl:
