### PR TITLE
[SEMI-MODULAR] A few taur fixes + constrict legs fix

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1107,7 +1107,7 @@
 	if(is_husked)
 		override_color = "#888888"
 	// We need to check that the owner exists(could be a placed bodypart) and that it's not a chainsawhand and that they're a human with usable DNA.
-	if(!(bodypart_flags & BODYPART_PSEUDOPART))
+	if(!(bodypart_flags & BODYPART_PSEUDOPART) && (!(bodyshape & BODYSHAPE_TAUR))) // taur legs never ever render
 		for(var/key in markings) // Cycle through all of our currently selected markings.
 			var/datum/body_marking/body_marking = GLOB.body_markings[key]
 			if (!body_marking) // Edge case prevention.

--- a/modular_nova/modules/bodyparts/code/taur_bodyparts.dm
+++ b/modular_nova/modules/bodyparts/code/taur_bodyparts.dm
@@ -1,16 +1,18 @@
+/obj/item/bodypart/leg/generate_icon_key()
+	RETURN_TYPE(/list)
+
+	if (bodyshape & BODYSHAPE_TAUR)
+		// We don't want more than one icon for all of the taur legs, because they're going to be invisible.
+		return list("taur")
+
+	return ..()
+
 /obj/item/bodypart/leg/right/taur
 	icon_greyscale = BODYPART_ICON_TAUR
 	limb_id = LIMBS_TAUR
 	bodypart_flags = BODYPART_UNREMOVABLE
 	can_be_surgically_removed = FALSE
 	bodyshape = parent_type::bodyshape | BODYSHAPE_TAUR
-
-
-/obj/item/bodypart/leg/right/taur/generate_icon_key()
-	RETURN_TYPE(/list)
-	// We don't want more than one icon for all of the taur legs, because they're going to be invisible.
-	return list("taur")
-
 
 /obj/item/bodypart/leg/left/taur
 	icon_greyscale = BODYPART_ICON_TAUR
@@ -19,16 +21,18 @@
 	can_be_surgically_removed = FALSE
 	bodyshape = parent_type::bodyshape | BODYSHAPE_TAUR
 
-
-/obj/item/bodypart/leg/left/taur/generate_icon_key()
-	RETURN_TYPE(/list)
-	// We don't want more than one icon for all of the taur legs, because they're going to be invisible.
-	return list("taur")
-
 /obj/item/bodypart/leg/right/robot/synth/taur
+	icon_greyscale = BODYPART_ICON_TAUR
+	limb_id = LIMBS_TAUR
+	bodypart_flags = BODYPART_UNREMOVABLE
+	can_be_surgically_removed = FALSE
 	bodyshape = parent_type::bodyshape | BODYSHAPE_TAUR
 	damage_examines = list(BRUTE = ROBOTIC_BRUTE_EXAMINE_TEXT, BURN = ROBOTIC_BURN_EXAMINE_TEXT)
 
 /obj/item/bodypart/leg/left/robot/synth/taur
+	icon_greyscale = BODYPART_ICON_TAUR
+	limb_id = LIMBS_TAUR
+	bodypart_flags = BODYPART_UNREMOVABLE
+	can_be_surgically_removed = FALSE
 	bodyshape = parent_type::bodyshape | BODYSHAPE_TAUR
 	damage_examines = list(BRUTE = ROBOTIC_BRUTE_EXAMINE_TEXT, BURN = ROBOTIC_BURN_EXAMINE_TEXT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes https://github.com/NovaSector/NovaSector/issues/2422

Prevents taur legs from rendering markings, as well as a few code improvements and symmetry between all taur legs.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Bugs bad, symmetry good.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Synth taur legs now have all attributes of a organic taur leg except the fact theyre robotic
fix: Markings no longer render on taur legs
code: Various improvements to taur leg code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
