### PR TITLE
[99% MODULAR] Refactors species.eye_icon to head.eye_icon

### DIFF
--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -142,7 +142,8 @@
 	if(isnull(eye_icon_state))
 		return list()
 
-	var/eye_icon = parent.dna?.species.eyes_icon || 'icons/mob/human/human_face.dmi' // NOVA EDIT ADDITION
+	var/obj/item/bodypart/head/my_head = parent.get_bodypart(BODY_ZONE_HEAD) // NOVA EDIT CHANGE: moved up from below
+	var/eye_icon = my_head?.eyes_icon || 'icons/mob/human/human_face.dmi' // NOVA EDIT ADDITION
 
 	var/mutable_appearance/eye_left = mutable_appearance(eye_icon, "[eye_icon_state]_l", -eyes_layer) // NOVA EDIT CHANGE - Customization - ORIGINAL: var/mutable_appearance/eye_left = mutable_appearance('icons/mob/human/human_face.dmi', "[eye_icon_state]_l", -BODY_LAYER)
 	var/mutable_appearance/eye_right = mutable_appearance(eye_icon, "[eye_icon_state]_r", -eyes_layer) // NOVA EDIT CHANGE - Customization - ORIGINAL: var/mutable_appearance/eye_right = mutable_appearance('icons/mob/human/human_face.dmi', "[eye_icon_state]_r", -BODY_LAYER)
@@ -152,7 +153,7 @@
 	if(overlay_ignore_lighting && !(obscured & ITEM_SLOT_EYES))
 		overlays += emissive_appearance(eye_left.icon, eye_left.icon_state, parent, -eyes_layer, alpha = eye_left.alpha) // NOVA EDIT CHANGE - ORIGINAL: overlays += emissive_appearance(eye_left.icon, eye_left.icon_state, parent, -BODY_LAYER, alpha = eye_left.alpha)
 		overlays += emissive_appearance(eye_right.icon, eye_right.icon_state, parent, -eyes_layer, alpha = eye_right.alpha) // NOVA EDIT CHANGE - ORIGINAL: overlays += emissive_appearance(eye_left.icon, eye_left.icon_state, parent, -BODY_LAYER, alpha = eye_left.alpha)
-	var/obj/item/bodypart/head/my_head = parent.get_bodypart(BODY_ZONE_HEAD)
+	//var/obj/item/bodypart/head/my_head = parent.get_bodypart(BODY_ZONE_HEAD) // NOVA EDIT CHANGE: moved up a couple lines
 	if(my_head)
 		if(my_head.head_flags & HEAD_EYECOLOR)
 			eye_right.color = eye_color_right

--- a/modular_nova/master_files/code/modules/mob/living/carbon/human/species_type/snail.dm
+++ b/modular_nova/master_files/code/modules/mob/living/carbon/human/species_type/snail.dm
@@ -1,12 +1,9 @@
 #define SHELL_TRANSPARENCY_ALPHA 90
 
 /datum/species/snail
-	eyes_icon = 'modular_nova/modules/organs/icons/snail_eyes.dmi' //This is to consolidate our icons and prevent future calamity.
 	mutantliver = /obj/item/organ/internal/liver/snail //This is just a better liver to deal with toxins, it's a thematic thing.
 	mutantheart = /obj/item/organ/internal/heart/snail //This gives them the shell buff where they take less damage from behind, and their heart's more durable.
 	exotic_blood = null
-
-	eyes_icon = 'modular_nova/modules/organs/icons/snail_eyes.dmi'
 
 /datum/species/snail/on_species_gain(mob/living/carbon/new_snailperson, datum/species/old_species, pref_load)
 	. = ..()

--- a/modular_nova/modules/better_vox/code/vox_bodyparts.dm
+++ b/modular_nova/modules/better_vox/code/vox_bodyparts.dm
@@ -8,6 +8,7 @@
 	is_dimorphic = FALSE
 	should_draw_greyscale = FALSE
 	limb_id = SPECIES_VOX_PRIMALIS
+	eyes_icon = 'modular_nova/modules/better_vox/icons/bodyparts/vox_eyes.dmi'
 
 /obj/item/bodypart/chest/mutant/vox_primalis
 	icon_static = 'modular_nova/modules/better_vox/icons/bodyparts/vox_bodyparts.dmi'

--- a/modular_nova/modules/better_vox/code/vox_species.dm
+++ b/modular_nova/modules/better_vox/code/vox_species.dm
@@ -1,7 +1,6 @@
 /datum/species/vox_primalis
 	name = "Vox Primalis"
 	id = SPECIES_VOX_PRIMALIS
-	eyes_icon = 'modular_nova/modules/better_vox/icons/bodyparts/vox_eyes.dmi'
 	can_augment = FALSE
 	body_size_restricted = TRUE
 	digitigrade_customization = DIGITIGRADE_NEVER // We have our own unique sprites!

--- a/modular_nova/modules/bodyparts/code/akula_bodyparts.dm
+++ b/modular_nova/modules/bodyparts/code/akula_bodyparts.dm
@@ -3,6 +3,7 @@
 	icon_greyscale = BODYPART_ICON_AKULA
 	limb_id = SPECIES_AKULA
 	bodyshape = parent_type::bodyshape | BODYSHAPE_SNOUTED
+	eyes_icon = 'modular_nova/modules/organs/icons/akula_eyes.dmi'
 
 /obj/item/bodypart/chest/mutant/akula
 	icon_greyscale = BODYPART_ICON_AKULA

--- a/modular_nova/modules/bodyparts/code/insect_bodyparts.dm
+++ b/modular_nova/modules/bodyparts/code/insect_bodyparts.dm
@@ -2,6 +2,7 @@
 /obj/item/bodypart/head/mutant/insect
 	icon_greyscale = BODYPART_ICON_INSECT
 	limb_id = SPECIES_INSECT
+	eyes_icon = 'modular_nova/modules/organs/icons/insect_eyes.dmi'
 
 /obj/item/bodypart/chest/mutant/insect
 	icon_greyscale = BODYPART_ICON_INSECT

--- a/modular_nova/modules/bodyparts/code/parts.dm
+++ b/modular_nova/modules/bodyparts/code/parts.dm
@@ -5,3 +5,7 @@
 /obj/item/bodypart/chest/Destroy(force)
 	QDEL_NULL(worn_accessory_offset)
 	return ..()
+
+/obj/item/bodypart/head
+	///Override of the eyes icon file, used for Vox and maybe more in the future - The future is now, with Teshari using it too
+	var/eyes_icon

--- a/modular_nova/modules/bodyparts/code/skrell_bodyparts.dm
+++ b/modular_nova/modules/bodyparts/code/skrell_bodyparts.dm
@@ -8,6 +8,7 @@
 	brute_modifier = SKRELL_BRUTE_MODIFIER
 	burn_modifier = SKRELL_BURN_MODIFIER
 	head_flags = HEAD_LIPS|HEAD_EYESPRITES|HEAD_EYECOLOR|HEAD_EYEHOLES|HEAD_DEBRAIN
+	eyes_icon = 'modular_nova/modules/organs/icons/skrell_eyes.dmi'
 
 /obj/item/bodypart/chest/mutant/skrell
 	icon_greyscale = BODYPART_ICON_SKRELL

--- a/modular_nova/modules/bodyparts/code/snail_bodyparts.dm
+++ b/modular_nova/modules/bodyparts/code/snail_bodyparts.dm
@@ -3,6 +3,7 @@
 /obj/item/bodypart/head/snail
 	icon_greyscale = BODYPART_ICON_SNAIL
 	head_flags = HEAD_HAIR|HEAD_FACIAL_HAIR|HEAD_EYESPRITES|HEAD_EYECOLOR|HEAD_DEBRAIN
+	eyes_icon = 'modular_nova/modules/organs/icons/snail_eyes.dmi'
 
 /obj/item/bodypart/chest/snail
 	icon_greyscale = BODYPART_ICON_SNAIL

--- a/modular_nova/modules/bodyparts/code/teshari_bodyparts.dm
+++ b/modular_nova/modules/bodyparts/code/teshari_bodyparts.dm
@@ -11,6 +11,7 @@
 	brute_modifier = TESHARI_BRUTE_MODIFIER
 	burn_modifier = TESHARI_BURN_MODIFIER
 	head_flags = HEAD_EYESPRITES|HEAD_EYECOLOR|HEAD_EYEHOLES|HEAD_DEBRAIN
+	eyes_icon = 'modular_nova/modules/organs/icons/teshari_eyes.dmi'
 
 /obj/item/bodypart/head/mutant/teshari/Initialize(mapload)
 	worn_ears_offset = new(

--- a/modular_nova/modules/bodyparts/code/vox_bodyparts.dm
+++ b/modular_nova/modules/bodyparts/code/vox_bodyparts.dm
@@ -3,6 +3,7 @@
 	icon_greyscale = BODYPART_ICON_VOX
 	bodyshape = parent_type::bodyshape | BODYSHAPE_SNOUTED | BODYSHAPE_CUSTOM
 	limb_id = SPECIES_VOX
+	eyes_icon = 'modular_nova/modules/organs/icons/vox_eyes.dmi'
 
 /obj/item/bodypart/chest/mutant/vox
 	icon_greyscale = BODYPART_ICON_VOX

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species.dm
@@ -9,8 +9,6 @@ GLOBAL_LIST_EMPTY(customizable_races)
 	var/no_gender_shaping
 	///A list of actual body markings on the owner of the species. Associative lists with keys named by limbs defines, pointing to a list with names and colors for the marking to be rendered. This is also stored in the DNA
 	var/list/list/body_markings = list()
-	///Override of the eyes icon file, used for Vox and maybe more in the future - The future is now, with Teshari using it too
-	var/eyes_icon
 	///How are we treated regarding processing reagents, by default we process them as if we're organic
 	var/reagent_flags = PROCESS_ORGANIC
 	///Whether a species can use augmentations in preferences

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/akula.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/akula.dm
@@ -17,7 +17,6 @@
 		OFFSET_HEAD = list(0, 2),
 		OFFSET_HAIR = list(0, 1),
 	)
-	eyes_icon = 'modular_nova/modules/organs/icons/akula_eyes.dmi'
 	mutanteyes = /obj/item/organ/internal/eyes/akula
 	mutanttongue = /obj/item/organ/internal/tongue/akula
 	inherent_traits = list(

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/insect.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/insect.dm
@@ -21,7 +21,6 @@
 		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/mutant/insect,
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/mutant/insect,
 	)
-	eyes_icon = 'modular_nova/modules/organs/icons/insect_eyes.dmi'
 
 /datum/species/insect/get_default_mutant_bodyparts()
 	return list(

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/skrell.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/skrell.dm
@@ -17,7 +17,6 @@
 	mutanttongue = /obj/item/organ/internal/tongue/skrell
 	payday_modifier = 1.0
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-	eyes_icon = 'modular_nova/modules/organs/icons/skrell_eyes.dmi'
 	mutantbrain = /obj/item/organ/internal/brain/skrell
 	mutanteyes = /obj/item/organ/internal/eyes/skrell
 	mutantlungs = /obj/item/organ/internal/lungs/skrell

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/vox.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/vox.dm
@@ -2,7 +2,6 @@
 	// Bird-like humanoids
 	name = "Vox"
 	id = SPECIES_VOX
-	eyes_icon = 'modular_nova/modules/organs/icons/vox_eyes.dmi'
 	can_augment = FALSE
 	inherent_traits = list(
 		TRAIT_ADVANCEDTOOLUSER,

--- a/modular_nova/modules/mutants/code/mutant_species.dm
+++ b/modular_nova/modules/mutants/code/mutant_species.dm
@@ -4,7 +4,6 @@
 	name = "High-Functioning mutant"
 	id = SPECIES_MUTANT
 	meat = /obj/item/food/meat/slab/human/mutant/zombie
-	eyes_icon = 'modular_nova/modules/mutants/icons/mutant_eyes.dmi'
 	inherent_traits = list(
 		TRAIT_NOBLOOD,
 		TRAIT_NODISMEMBER,

--- a/modular_nova/modules/mutants/code/mutant_zombie_bodyparts.dm
+++ b/modular_nova/modules/mutants/code/mutant_zombie_bodyparts.dm
@@ -8,6 +8,7 @@
 	limb_id = SPECIES_MUTANT
 	species_color = "#ffffff"
 	head_flags = HEAD_HAIR|HEAD_LIPS|HEAD_DEBRAIN
+	eyes_icon = 'modular_nova/modules/mutants/icons/mutant_eyes.dmi'
 
 /obj/item/bodypart/chest/mutant_zombie
 	icon_greyscale = 'modular_nova/modules/mutants/icons/mutant_parts_greyscale.dmi'

--- a/modular_nova/modules/teshari/code/_teshari.dm
+++ b/modular_nova/modules/teshari/code/_teshari.dm
@@ -6,7 +6,6 @@
 	name = "Teshari"
 	id = SPECIES_TESHARI
 	no_gender_shaping = TRUE // Female uniform shaping breaks Teshari worn sprites, so this is disabled. This will not affect anything else in regards to gender however.
-	eyes_icon = 'modular_nova/modules/organs/icons/teshari_eyes.dmi'
 	inherent_traits = list(
 		TRAIT_ADVANCEDTOOLUSER,
 		TRAIT_CAN_STRIP,


### PR DESCRIPTION
## About The Pull Request

Refactors species with custom eye icons to store the icon type on /bodypart/head - this keeps eye sprites consistent no matter the parent species, so if you slap some poor teshari's lopped off head on a monkey in a rush to stabilize them they won't magically sprout human or monkey eyes.

## How This Contributes To The Nova Sector Roleplay Experience

This is more or less just behind the scenes stuff for now, though it should result in some minor immersion improvements when medical has to fix up gibbing/decapitation victims.  Also serves as a baseline for #1587 & other similar PRs to be refactored into entirely just augs+ options instead of yet another new species.

## Proof of Testing

Gaze upon this abomination against god and man at your own risk.
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/NovaSector/NovaSector/assets/2958111/4bd0f6f3-444b-4027-ae6c-4cbef76d2fdc)
</details>

## Changelog

:cl:
refactor: refactored eye sprites to be head-type dependant
/:cl:
