### PR TITLE
[MODULAR] Quiver crafting change, also adds torch crafting

### DIFF
--- a/modular_nova/modules/tribal_extended/code/recipes.dm
+++ b/modular_nova/modules/tribal_extended/code/recipes.dm
@@ -94,7 +94,7 @@
 	result = /obj/item/storage/bag/quiver
 	reqs = list(
 		/obj/item/stack/sheet/leather = 2,
-		/obj/item/stack/sheet/sinew = 4,
+		/obj/item/weaponcrafting/silkstring = 4,
 	)
 	time = 8 SECONDS
 	category = CAT_WEAPON_AMMO
@@ -108,3 +108,14 @@
 	)
 	time = 20 SECONDS
 	category = CAT_WEAPON_RANGED
+
+
+/datum/crafting_recipe/torch
+	name = "Torch"
+	result = /obj/item/flashlight/flare/torch
+	reqs = list(
+		/obj/item/stack/sheet/mineral/wood = 1,
+		/obj/item/stack/sheet/mineral/coal = 1,
+	)
+	time = 4 SECONDS
+	category = CAT_MISC


### PR DESCRIPTION


## About The Pull Request
Quivers needing legion-sinew made them even less appealing then just filling up a crusader belt, so this makes them slightly easier to make (essentially just leather+cloth)

Also adds a crafting recipe for torches, because they didn't have one before
## How This Contributes To The Nova Sector Roleplay Experience
Drip + Questionably letting people use torch lighting more often

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
will do
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: You can now craft torches, to uhhh light stuff.
qol: made it more practical to craft quivers by using string, keeping it inline with belt-primal-options.
/:cl:
