### PR TITLE
Manage Player Ranks button fix

### DIFF
--- a/modular_nova/modules/admin/code/player_ranks.dm
+++ b/modular_nova/modules/admin/code/player_ranks.dm
@@ -2,7 +2,6 @@
 #define NOVA_PLAYER_RANKS list("Donator", "Mentor", "Veteran")
 
 ADMIN_VERB(manage_player_ranks, R_PERMISSIONS, "Manage Player Ranks", "Manage who has the special player ranks while the server is running.", ADMIN_CATEGORY_MAIN)
-/client/proc/manage_player_ranks()
 	usr.client?.holder.manage_player_ranks()
 
 /// Proc for admins to change people's "player" ranks (donator, mentor, veteran, etc.)

--- a/modular_nova/modules/lorecaster/code/story_manager.dm
+++ b/modular_nova/modules/lorecaster/code/story_manager.dm
@@ -1,5 +1,4 @@
 ADMIN_VERB(lorecaster_story_manager, R_ADMIN, "Lorecaster Stories", "Open the Lorecaster Story Manager.", ADMIN_CATEGORY_EVENTS)
-/client/proc/lorecaster_story_manager()
 	var/datum/story_manager_interface/ui = new(usr)
 	ui.ui_interact(usr)
 


### PR DESCRIPTION
## About The Pull Request

Fixes: #2681 

Looks like the manage player ranks thing might not have been fully moved over to tg's new way of handling admin verbs as of https://github.com/NovaSector/NovaSector/pull/1950/files 

Edit: Lorecaster stories as well. 

## How This Contributes To The Nova Sector Roleplay Experience

Buttons should do the thing they are intended to.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/102194057/c5b6c3b5-8bb7-48a3-9600-3603d489a422)
![image](https://github.com/NovaSector/NovaSector/assets/102194057/ecda8e6c-a092-4101-9d2c-3fa67657727c)

</details>

## Changelog
:cl:
fix: manage player ranks & lorecaster stories buttons work again
/:cl:
