### PR TITLE
removes the xeno-egg bundle from opfor

### DIFF
--- a/modular_nova/modules/opposing_force/code/equipment/biology.dm
+++ b/modular_nova/modules/opposing_force/code/equipment/biology.dm
@@ -76,9 +76,3 @@
 	description = "An organ implant kit filled with illegally obtained xenomorph organs."
 	admin_note = "Gives the ability to place resin structures, spit acid and melt station structures."
 	item_type = /obj/item/storage/organbox/strange
-
-/datum/opposing_force_equipment/organs/xeno_eggsac
-	name = "Xeno-organ plus eggsac Implant Kit"
-	description = "An organ implant kit filled with illegally obtained xenomorph organs. Includes an eggsac which is capable of birthing the prime species itself."
-	admin_note = "Gives every xeno organ, including the one that CAN spawn real xenomorphs."
-	item_type = /obj/item/storage/organbox/strange/eggsac


### PR DESCRIPTION


## About The Pull Request

Removes the xeno-egg bundle from availability, as it's very likely never going to be approved.


## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  it's just a list removal
</details>

## Changelog



:cl:
del: Removed the 'Xeno Egg' bundle from opfor, as xeno-opfors wouldn't be approved

/:cl:
