### PR TITLE
Adds the sombrero to the loadout and autodrobe

### DIFF
--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_heads.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_heads.dm
@@ -373,6 +373,9 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 	name = "Ushanka"
 	item_path = /obj/item/clothing/head/costume/ushanka
 
+/datum/loadout_item/head/sombrero
+	name = "Sombrero"
+	item_path = /obj/item/clothing/head/costume/sombrero
 
 /datum/loadout_item/head/wrussian
 	name = "Black Papakha"

--- a/modular_nova/modules/modular_vending/code/autodrobe.dm
+++ b/modular_nova/modules/modular_vending/code/autodrobe.dm
@@ -9,6 +9,7 @@
 				/obj/item/clothing/head/costume/kabuto = 5,
 				/obj/item/clothing/suit/costume/samurai = 5,
 				/obj/item/clothing/suit/dutchjacketsr = 5,
+				/obj/item/clothing/head/costume/sombrero = 5,
 			),
 		),
 		list(


### PR DESCRIPTION

## About The Pull Request

This hat wasn't attainable at all except if the map was blueshift, then 1 (one) spawned in a locker room.

## How This Contributes To The Nova Sector Roleplay Experience

I was asked nicely in Discord to make this available.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/77534246/7912c3b5-e789-47a7-b3cd-9521202593d3)


![image](https://github.com/NovaSector/NovaSector/assets/77534246/6a7caa4c-54c8-4ef4-922d-217132cf92bb)

</details>

## Changelog
:cl:
add: You can now buy a sombrero from the autodrobe, or maybe you already have one from the loadout list
/:cl:
