### PR TITLE
Hearthkin learn to fall on their feet again.

### DIFF
--- a/modular_nova/modules/primitive_catgirls/code/species.dm
+++ b/modular_nova/modules/primitive_catgirls/code/species.dm
@@ -28,6 +28,7 @@
 	bodytemp_cold_damage_limit = 213 // Man up bro its not even that cold out here
 
 	inherent_traits = list(
+		TRAIT_CATLIKE_GRACE,
 		TRAIT_VIRUSIMMUNE,
 		TRAIT_RESISTCOLD,
 		TRAIT_USES_SKINTONES,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hearthkin had been falling on their faces because they forgot how to stand on their own feet. They have now remembered how to properly fall with grace though.

Adds TRAIT_CATLIKE_GRACE to their inherent traits.

## How This Contributes To The Nova Sector Roleplay Experience

Less concussions from falling.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>![image](https://github.com/NovaSector/NovaSector/assets/38175176/c0682603-a7a6-44af-b088-193d059c4893)
</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: MortoSasye
fix: Hearthkin remembered how to fall on their own two feet.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
