### PR TITLE
Fixes some runtimes that can happen from the examine menu still being opened and displaying a mob that's been deleted

### DIFF
--- a/modular_nova/master_files/code/modules/mob/living/examine_tgui.dm
+++ b/modular_nova/master_files/code/modules/mob/living/examine_tgui.dm
@@ -9,6 +9,10 @@
 	return GLOB.always_state
 
 
+/datum/examine_panel/ui_status(mob/user, datum/ui_state/state)
+	return QDELETED(holder) ? UI_CLOSE : ..()
+
+
 /datum/examine_panel/ui_close(mob/user)
 	user.client.clear_map(examine_panel_screen.assigned_map)
 
@@ -46,6 +50,9 @@
 
 /datum/examine_panel/ui_data(mob/user)
 	var/list/data = list()
+
+	if(QDELETED(holder))
+		return data
 
 	var/datum/preferences/preferences = holder.client?.prefs
 


### PR DESCRIPTION
## About The Pull Request
It was causing a runtime, because it remained opened, so now it closes when the holder is deleted. It's no longer going to runtime anymore.

## How This Contributes To The Nova Sector Roleplay Experience
Less runtimes == more better.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

This is where my test character was, and where the UI was. As you can see, both are gone, now that the mob has been deleted.  
![image](https://github.com/NovaSector/NovaSector/assets/58045821/6b8fa46e-a1c6-4a8c-800e-7fbf5d782407)

</details>

## Changelog

:cl: GoldenAlpharex
fix: The examine menu will now close when the mob it's attached to gets deleted, avoiding runtimes.
/:cl: