### PR TITLE
makes the wall medstation actually print robo-foam-spray

### DIFF
--- a/modular_nova/modules/deforest_medical_items/code/medstation_designs/medical.dm
+++ b/modular_nova/modules/deforest_medical_items/code/medstation_designs/medical.dm
@@ -91,7 +91,7 @@
 	id = "organic_repair_foam"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass = 100)
-	build_path = /obj/item/stack/sticky_tape/surgical
+	build_path = /obj/item/stack/medical/wound_recovery/robofoam
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_DEFOREST_MEDICAL,


### PR DESCRIPTION


## About The Pull Request
I Don't Think That's Supposed To Be Tape

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The wall med station now properly dispenses the robo-spray-foam
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
