### PR TITLE
Fix clock out timer deleting trim singletons

### DIFF
--- a/modular_nova/modules/time_clock/code/off_duty_component.dm
+++ b/modular_nova/modules/time_clock/code/off_duty_component.dm
@@ -27,10 +27,6 @@
 
 /datum/component/off_duty_timer/Destroy(force)
 	UnregisterSignal(parent, COMSIG_ATOM_ATTACKBY)
-	if(stored_trim)
-		qdel(stored_trim)
-		stored_trim = null
-
 	return ..()
 
 ///Sets the on_cooldown variable to false, making it so that the ID can clock back in.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When the clockout timer is destroyed, it called qdel on the stored trim. This isn't owned by the component, and is the same datum globally used to set up job trims. So after waiting 5 minutes for it to hard delete, clocking in makes it impossible to new players joining to get a working ID, since ID setup will runtime on the missing datum.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->


<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  ![image](https://github.com/NovaSector/NovaSector/assets/25628932/bcb6d9f8-066b-4d3a-931b-85c563b028b7)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: clocking in no longer bricks ID creation for that job type
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
