### PR TITLE
Removes the possibility to grief with the Anomalous Crystal

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -147,7 +147,7 @@
 	return ..()
 
 /obj/structure/closet/crate/necropolis/colossus/PopulateContents()
-	var/list/choices = subtypesof(/obj/machinery/anomalous_crystal)
+	var/list/choices = subtypesof(/obj/machinery/anomalous_crystal) - /obj/machinery/anomalous_crystal/theme_warp // NOVA EDIT - Less griefing - ORIGINAL: var/list/choices = subtypesof(/obj/machinery/anomalous_crystal)
 	var/random_crystal = pick(choices)
 	new random_crystal(src)
 	new /obj/item/organ/internal/vocal_cords/colossus(src)

--- a/modular_nova/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
+++ b/modular_nova/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
@@ -134,7 +134,7 @@
 				return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 			current_research -= 150
-			var/list/choices = subtypesof(/obj/machinery/anomalous_crystal)
+			var/list/choices = subtypesof(/obj/machinery/anomalous_crystal) - /obj/machinery/anomalous_crystal/theme_warp
 			var/random_crystal = pick(choices)
 			new random_crystal(src_turf)
 


### PR DESCRIPTION
## About The Pull Request
It was bad, so it's getting removed.

## How This Contributes To The Nova Sector Roleplay Experience
A one-click-to-grief item was never a good idea, I still don't understand who thought this genuinely was a good idea, upstream, but I've grown tired of it, so it's going away.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/58045821/fe0f8e4e-658b-48a1-b575-e52ccd6d6473)

</details>

## Changelog

:cl: GoldenAlpharex
fix: You can no longer easily grief people using the anomalous crystal to change the theme of entire areas.
/:cl: