### PR TITLE
Fixes produce bins not displaying their overlays and shelves no longer letting you mouse-drop items onto them to place them where you want

### DIFF
--- a/modular_nova/modules/primitive_structures/code/storage_structures.dm
+++ b/modular_nova/modules/primitive_structures/code/storage_structures.dm
@@ -8,8 +8,14 @@
 
 /obj/structure/rack/wooden/MouseDrop_T(obj/object, mob/user, params)
 	. = ..()
-	if(!.)
+	if ((!isitem(object) || user.get_active_held_item() != object))
 		return
+
+	if(!user.dropItemToGround(object))
+		return
+
+	if(object.loc != src.loc)
+		step(object, get_dir(object, src))
 
 	var/list/modifiers = params2list(params)
 	if(!LAZYACCESS(modifiers, ICON_X) || !LAZYACCESS(modifiers, ICON_Y))
@@ -51,8 +57,8 @@
 	icon = 'modular_nova/modules/primitive_structures/icons/storage.dmi'
 	resistance_flags = FLAMMABLE
 	base_build_path = /obj/machinery/smartfridge/wooden
-	base_icon_state = "producebin"
 	icon_state = "producebin"
+	base_icon_state = "produce" // This is used to decide which overlay to display. Blame upstream.
 	use_power = NO_POWER_USE
 	light_power = 0
 	idle_power_usage = 0
@@ -96,7 +102,7 @@
 	desc = "A wooden hamper, used to hold plant products and try to keep them safe from pests."
 	icon_state = "producebin"
 	base_build_path = /obj/machinery/smartfridge/wooden/produce_bin
-	base_icon_state = "producebin"
+	base_icon_state = "produce" // This is used to decide which overlay to display. Blame upstream.
 
 /obj/machinery/smartfridge/wooden/produce_bin/accept_check(obj/item/item_to_check)
 	var/static/list/accepted_items = list(


### PR DESCRIPTION
## About The Pull Request
What it says on the tin.
In the first case, that bug was introduced by a CI fix that accidentally changed the value of `base_icon_state` when it shouldn't have, as that's now used to determine the overlay on smartfridges. Stupid, I know, blame upstream.
For the second, they just removed the handling for `MouseDrop_T()` on racks upstream, so I had to reproduce what it used to be in order to allow for it to work again here.

## How This Contributes To The Nova Sector Roleplay Experience
Seeing the contents of the produce bin is nice, and being about to mouse-drop items onto shelves as intended is *also* very nice.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/58045821/0ae84fd9-bcbe-4120-86d7-5feb156e0114)

</details>

## Changelog

:cl: GoldenAlpharex
fix: Produce bins now display their contents overlay once more!
fix: Wooden shelves can now be interacted with via mouse-drop once more, allowing pixel-precision when setting down items onto them!
/:cl: