### PR TITLE
[MISSED MIRROR] Fixes another image harddel in station blueprints (and more) (#80780)

### DIFF
--- a/code/datums/components/lock_on_cursor.dm
+++ b/code/datums/components/lock_on_cursor.dm
@@ -97,7 +97,6 @@
 		return
 	for(var/image/overlay as anything in lock_images)
 		owner.client.images -= overlay
-		qdel(overlay)
 	lock_images.Cut()
 
 /// Reset the overlays on all targets

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -203,12 +203,12 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		for(var/A in B.contents)
 			qdel(A)
 		return
-	QDEL_LIST(blueprint_data)
+	LAZYCLEARLIST(blueprint_data)
 	flags_1 &= ~INITIALIZED_1
 	requires_activation = FALSE
 	..()
 
-	if (length(vis_contents))
+	if(length(vis_contents))
 		vis_contents.Cut()
 
 /// WARNING WARNING

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -97,11 +97,13 @@ Proc: RemoveInfectionImages()
 Des: Removes all infected images from the alien.
 ----------------------------------------*/
 /mob/living/carbon/alien/proc/RemoveInfectionImages()
-	if (client)
-		for(var/image/I in client.images)
+	if(client)
+		var/list/image/to_remove
+		for(var/image/client_image as anything in client.images)
 			var/searchfor = "infected"
-			if(findtext(I.icon_state, searchfor, 1, length(searchfor) + 1))
-				qdel(I)
+			if(findtext(client_image.icon_state, searchfor, 1, length(searchfor) + 1))
+				to_remove += client_image
+		client.images -= to_remove
 	return
 
 /mob/living/carbon/alien/canBeHandcuffed()

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -186,7 +186,7 @@
 	if(current_user.client)
 		current_user.client.images -= the_eye.placed_images
 
-	QDEL_LIST(the_eye.placed_images)
+	LAZYCLEARLIST(the_eye.placed_images)
 
 	for(var/image/place_spots as anything in the_eye.placement_images)
 		var/image/newI = image('icons/effects/alphacolors.dmi', the_eye.loc, "blue")
@@ -303,8 +303,8 @@
 /mob/camera/ai_eye/remote/shuttle_docker
 	visible_icon = FALSE
 	use_static = FALSE
-	var/list/placement_images = list()
-	var/list/placed_images = list()
+	var/list/image/placement_images = list()
+	var/list/image/placed_images = list()
 
 /mob/camera/ai_eye/remote/shuttle_docker/Initialize(mapload, obj/machinery/computer/camera_advanced/origin)
 	src.origin = origin


### PR DESCRIPTION
## Original PR: https://github.com/tgstation/tgstation/pull/80780

## About The Pull Request


![image](https://github.com/tgstation/tgstation/assets/13398309/063c58ef-6233-4c91-aaf0-7e9589c0e912)

Tin. Just more uncovering of some of these image harddels. `blueprint_data` is a list of images.

I also went through the code and looked for any more instances of images being qdeleted that I could find.

## Why It's Good For The Game

Hard dels begone

## Changelog

:cl: vinylspiders
fix: fixes an /image harddel in station blueprints code: cleaned up some more /image qdels
/:cl: