### PR TITLE
Pipe Dreams: Disposals is actually usable as an escape again

### DIFF
--- a/modular_nova/modules/hurtsposals/code/pipe.dm
+++ b/modular_nova/modules/hurtsposals/code/pipe.dm
@@ -22,4 +22,4 @@
 			continue
 		if(HAS_TRAIT(living_within, TRAIT_TRASHMAN))
 			continue
-		living_within.adjustBruteLoss(5)
+		living_within.adjustBruteLoss(0.5)


### PR DESCRIPTION
## About The Pull Request

For reasons unknown to man or science (and mostly just to me), traversing the disposals network on Nova will basically kill you unless you're a slime or a hemophage (and even then, it has a decent shot) depending on the map.

Disposals shenanigans is a core SS13 escape experience and depositing criminals straight into one of the most heavily armed departments in the station (Cargo) is both funny and thematic, so I'm putting up a 90% reduction in the total disposal damage dealt in the hopes that we can have it back more readily again.

You still end up a little injured from a disposals journey, but it probably won't kill you anymore.

## How This Contributes To The Nova Sector Roleplay Experience

Encourages more crew-provoked antagonism by allowing people to readily escape bad situations, chute people that are annoying them and foster all the hell-grudges that this kind of behavior inevitably generates. We currently can't chute a clown on the frontier because this will probably kill them.

## Proof of Testing

Basic number tweak!

## Changelog

:cl: yooriss
balance: Damage dealt by travelling through the disposal tubes has been reduced by 90%. You can now (sort of) safely use them as an escape method again without dosing yourself to the eyeballs on anti-brute medicine.
/:cl:
