### PR TITLE
Fixes laugh emote not playing prefs-selected audio

### DIFF
--- a/modular_nova/modules/emotes/code/laugh_emotes.dm
+++ b/modular_nova/modules/emotes/code/laugh_emotes.dm
@@ -4,12 +4,11 @@
 // This sucks and is not how we should be allowing pais to use these emotes
 // for humans use selected_laugh, otherwise default to the species-specific laughs.
 /datum/emote/living/laugh/get_sound(mob/living/user)
-	var/selected_laugh
 	var/mob/living/carbon/human/human_user = user
 	if(!istype(human_user)) // pais
 		return
 
-	if(isnull(selected_laugh)) //For things that don't have a selected laugh(npcs)
+	if(isnull(human_user.selected_laugh)) //For things that don't have a selected laugh(npcs)
 		return ..()
 
 	if(human_user.gender == MALE || !LAZYLEN(human_user.selected_laugh.female_laughsounds))


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. This fixes https://github.com/NovaSector/NovaSector/issues/2842

## How This Contributes To The Nova Sector Roleplay Experience

Restores the laughter.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/13398309/5d799d3f-3b8c-4ded-ad04-deb9e2ebcd3c)

</details>

## Changelog

:cl:
fix: fixes laugh emote not playing prefs-selected audio.
/:cl: