### PR TITLE
Fixes hearthkin bath salts.

### DIFF
--- a/modular_nova/modules/primitive_catgirls/code/smelling_salts.dm
+++ b/modular_nova/modules/primitive_catgirls/code/smelling_salts.dm
@@ -60,6 +60,7 @@
 
 	carbon_target.adjustOxyLoss(amount = 60, updating_health = TRUE)
 	playsound(src, 'modular_nova/modules/emotes/sound/emotes/female/female_sniff.ogg', 50, FALSE)
+	carbon_target.set_heartattack(FALSE)
 
 	if(defib_result == DEFIB_POSSIBLE)
 		carbon_target.grab_ghost()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The hearthkin's bath salts were giving hearthkin heart attacks upon revival, rendering them entirely useless in actually reviving someone. And because the hearthkin have no way to defribillate, they would end up stuck with a permanent mood debuff even if they somehow managed to live through it (Choking 24/7 Is Cool).

This fixes it.

## How This Contributes To The Nova Sector Roleplay Experience

Not everyone knows how to make strange reagent to revive Sven Rush-Gibtonite after they walk into said gibtonite with their green raptor.

## Proof of Testing

## Changelog

:cl: MortoSasye
fix: Hearthkin no longer suffer eternal heart attacks via salts, or have the choking moodlet if they survive through it. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
