### PR TITLE
Tram malfunction frequency reduction [NO GBP]

### DIFF
--- a/modular_nova/modules/ices_events/code/ICES_event_config.dm
+++ b/modular_nova/modules/ices_events/code/ICES_event_config.dm
@@ -558,8 +558,7 @@
  * Only runs on Tramstation, otherwise rolls a different event.
  */
 /datum/round_event_control/tram_malfunction
-	max_occurrences = 2
-	weight = VERY_HIGH_EVENT_FREQ
+	weight = HIGH_EVENT_FREQ
 
 /**
  * Wisdom Cow


### PR DESCRIPTION
## About The Pull Request

Halves the rate of the tram malfunction event, in line with adjustments made at TG.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/83487515/a5c9c830-ec1e-4cc4-984c-27dcee23ce10)

</details>

## Changelog

:cl: LT3
balance: Tram malfunction event frequency reduced by half
/:cl: