### PR TITLE
Give maintenance drones the duffel bag instead of a new backpack

### DIFF
--- a/modular_nova/modules/drone_adjustments/drone.dm
+++ b/modular_nova/modules/drone_adjustments/drone.dm
@@ -21,14 +21,12 @@
 	//So that drones can do things without worrying about stuff
 	shy = FALSE
 	//So drones aren't forced to carry around a nodrop toolbox essentially
-	default_storage = /obj/item/storage/backpack/drone_bag
+	//and so drones don't have to choose between a multitool and an upgraded welder
+	default_storage = /obj/item/storage/backpack/dufflebag/drone
 
 /mob/living/basic/drone/Initialize(mapload)
 	. = ..()
 	name = "[initial(name)] [rand(0,9)]-[rand(100,999)]" //So that we can identify drones from each other
-
-/obj/item/storage/backpack/drone_bag
-	name = "drone backpack"
 
 /obj/item/storage/backpack/drone_bag/PopulateContents()
 	. = ..()

--- a/modular_nova/modules/drone_adjustments/drone.dm
+++ b/modular_nova/modules/drone_adjustments/drone.dm
@@ -22,7 +22,7 @@
 	shy = FALSE
 	//So drones aren't forced to carry around a nodrop toolbox essentially
 	//and so drones don't have to choose between a multitool and an upgraded welder
-	default_storage = /obj/item/storage/backpack/dufflebag/drone
+	default_storage = /obj/item/storage/backpack/duffelbag/drone
 
 /mob/living/basic/drone/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The maintenance drone duffel bag already existed and WAS the default before they got the weird undroppable toolbox. This gives them that back
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
It was very difficult to help repair, let alone improve, the station with the limitation on storage in a backpack. The duffel bag being slightly larger will let you store just enough more to make your time worthwhile and improve your ability to repair, maintain and improve!
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>![image](https://github.com/NovaSector/NovaSector/assets/9438930/5f1a9aa2-8152-4fa4-874e-87b42a64c55a)</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Maintenance drones now have a duffel bag instead of a backpack.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
