### PR TITLE
[non-modular] removes ltsrbt from bmu

### DIFF
--- a/code/modules/cargo/markets/market_items/tools.dm
+++ b/code/modules/cargo/markets/market_items/tools.dm
@@ -1,7 +1,8 @@
 /datum/market_item/tool
 	category = "Tools"
 	abstract_path = /datum/market_item/tool
-/*	NOVA REMOVAL - Removes LTSRBT
+
+/*	NOVA EDIT REMOVAL START - Removes LTSRBT
 /datum/market_item/tool/blackmarket_telepad
 	name = "Black Market LTSRBT"
 	desc = "Need a faster and better way of transporting your illegal goods from and to the \
@@ -13,7 +14,8 @@
 	price_min = CARGO_CRATE_VALUE * 2.5
 	price_max = CARGO_CRATE_VALUE * 3.75
 	availability_prob = 100
-	NOVA REMOVAL END */
+	NOVA EDIT REMOVAL END */
+
 /datum/market_item/tool/caravan_wrench
 	name = "Experimental Wrench"
 	desc = "The extra fast and handy wrench you always wanted!"


### PR DESCRIPTION

## About The Pull Request
removes something from the bmu i promised to remove when i made the bmu much more powerful than upstream

## How This Contributes To The Nova Sector Roleplay Experience

removes cargo monopoly on bmu

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  works
</details>

## Changelog
:cl:
balance: the long to short range bluespace transceiver has received the same fate cloning machines have (theyre gone)
/:cl:
