### PR TITLE
Fix port tarkon and DS-2 camera tag issues

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
@@ -7954,7 +7954,7 @@
 	},
 /obj/machinery/vending/cigarette/syndicate,
 /obj/machinery/camera/xray/directional/east{
-	c_tag = "DS-2 Botany";
+	c_tag = "DS-2 Library";
 	network = list("ds2")
 	},
 /turf/open/floor/wood/parquet,

--- a/_maps/RandomRuins/SpaceRuins/nova/port_tarkon.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/port_tarkon.dmm
@@ -134,7 +134,7 @@
 /obj/structure/cable,
 /obj/structure/alien/resin/wall,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/camera/tarkon/directional/west,
+/obj/machinery/camera/autoname/tarkon/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/porthall)
 "aY" = (
@@ -331,12 +331,12 @@
 /obj/item/storage/backpack/security/redsec,
 /obj/item/clothing/head/utility/welding/hat,
 /obj/item/clothing/head/utility/welding/hat,
-/obj/machinery/camera/tarkon/directional/east,
+/obj/machinery/camera/autoname/tarkon/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon)
 "cq" = (
 /obj/machinery/recharge_station,
-/obj/machinery/camera/tarkon/directional/south,
+/obj/machinery/camera/autoname/tarkon/directional/south,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/port_tarkon/centerhall)
 "ct" = (
@@ -449,7 +449,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/camera/tarkon/directional/south,
+/obj/machinery/camera/autoname/tarkon/directional/south,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "dd" = (
@@ -503,7 +503,7 @@
 /obj/effect/turf_decal/tile/brown/anticorner{
 	dir = 4
 	},
-/obj/machinery/camera/tarkon/directional/east,
+/obj/machinery/camera/autoname/tarkon/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/storage)
 "dv" = (
@@ -591,7 +591,7 @@
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 8
 	},
-/obj/machinery/camera/tarkon/directional/west,
+/obj/machinery/camera/autoname/tarkon/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/toolstorage)
 "dV" = (
@@ -619,7 +619,7 @@
 /area/ruin/space/has_grav/port_tarkon/centerhall)
 "ex" = (
 /obj/effect/turf_decal/tile/brown/anticorner,
-/obj/machinery/camera/tarkon/directional/east,
+/obj/machinery/camera/autoname/tarkon/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/storage)
 "ey" = (
@@ -720,7 +720,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/port_tarkon/centerhall)
 "fd" = (
-/obj/machinery/camera/tarkon/directional/east,
+/obj/machinery/camera/autoname/tarkon/directional/east,
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/port_tarkon/dorms)
 "fe" = (
@@ -847,7 +847,7 @@
 /obj/effect/turf_decal/tile/red/real_red/half{
 	dir = 1
 	},
-/obj/machinery/camera/tarkon/directional/north,
+/obj/machinery/camera/autoname/tarkon/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/starboardhall)
 "gb" = (
@@ -908,7 +908,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner{
 	dir = 4
 	},
-/obj/machinery/camera/tarkon/directional/north,
+/obj/machinery/camera/autoname/tarkon/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/toolstorage)
 "gE" = (
@@ -946,7 +946,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/camera/tarkon/directional/east,
+/obj/machinery/camera/autoname/tarkon/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/afthall)
 "gR" = (
@@ -997,7 +997,7 @@
 /obj/structure/rack,
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
-/obj/machinery/camera/tarkon/directional/north,
+/obj/machinery/camera/autoname/tarkon/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/power1)
 "hc" = (
@@ -1012,7 +1012,7 @@
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 1
 	},
-/obj/machinery/camera/tarkon/directional/west,
+/obj/machinery/camera/autoname/tarkon/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/trauma)
 "hh" = (
@@ -1345,7 +1345,7 @@
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 1
 	},
-/obj/machinery/camera/tarkon/directional/north,
+/obj/machinery/camera/autoname/tarkon/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/mining)
 "jL" = (
@@ -1369,7 +1369,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/garden)
 "jT" = (
-/obj/machinery/camera/tarkon/directional/north,
+/obj/machinery/camera/autoname/tarkon/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "jV" = (
@@ -1394,7 +1394,7 @@
 "jZ" = (
 /obj/effect/turf_decal/sand,
 /obj/machinery/light/small/directional/east,
-/obj/machinery/camera/tarkon/directional/north,
+/obj/machinery/camera/autoname/tarkon/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/mining)
 "kc" = (
@@ -1660,7 +1660,7 @@
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 1
 	},
-/obj/machinery/camera/tarkon/directional/north,
+/obj/machinery/camera/autoname/tarkon/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/centerhall)
 "lM" = (
@@ -1714,10 +1714,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/mining)
-"mb" = (
-/obj/machinery/camera/tarkon/directional/west,
-/turf/closed/wall,
-/area/ruin/space/has_grav/port_tarkon/power1)
 "mc" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/turf_decal/tile/brown,
@@ -1956,7 +1952,7 @@
 /obj/structure/closet/radiation,
 /obj/item/clothing/head/utility/radiation,
 /obj/item/clothing/suit/utility/radiation,
-/obj/machinery/camera/tarkon/directional/south,
+/obj/machinery/camera/autoname/tarkon/directional/south,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/atmos)
 "nr" = (
@@ -1967,7 +1963,7 @@
 /obj/item/storage/part_replacer/cargo,
 /obj/structure/noticeboard/directional/east,
 /obj/item/paper/fluff/ruins/tarkon/scisafe,
-/obj/machinery/camera/tarkon/directional/east,
+/obj/machinery/camera/autoname/tarkon/directional/east,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "ns" = (
@@ -2119,7 +2115,7 @@
 /area/ruin/space/has_grav/port_tarkon/starboardhall)
 "oA" = (
 /obj/effect/turf_decal/tile/neutral/half,
-/obj/machinery/camera/tarkon/directional/south,
+/obj/machinery/camera/autoname/tarkon/directional/south,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/centerhall)
 "oE" = (
@@ -2179,7 +2175,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/camera/tarkon/directional/west,
+/obj/machinery/camera/autoname/tarkon/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/porthall)
 "oQ" = (
@@ -2191,7 +2187,7 @@
 /area/ruin/space/has_grav/port_tarkon/garden)
 "oU" = (
 /obj/effect/turf_decal/tile/purple/half,
-/obj/machinery/camera/tarkon/directional/south,
+/obj/machinery/camera/autoname/tarkon/directional/south,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "oV" = (
@@ -2235,7 +2231,7 @@
 /obj/machinery/computer/rdconsole{
 	dir = 4
 	},
-/obj/machinery/camera/tarkon/directional/west,
+/obj/machinery/camera/autoname/tarkon/directional/west,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "pf" = (
@@ -2320,7 +2316,7 @@
 /area/ruin/space/has_grav/port_tarkon/secoff)
 "pt" = (
 /obj/structure/cable,
-/obj/machinery/camera/tarkon/directional/south,
+/obj/machinery/camera/autoname/tarkon/directional/south,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/port_tarkon/observ)
 "py" = (
@@ -2398,7 +2394,7 @@
 /obj/item/storage/backpack/satchel/explorer,
 /obj/item/clothing/head/utility/welding/hat,
 /obj/item/clothing/head/utility/welding/hat,
-/obj/machinery/camera/tarkon/directional/west,
+/obj/machinery/camera/autoname/tarkon/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon)
 "pP" = (
@@ -2486,7 +2482,7 @@
 /obj/machinery/cryopod{
 	dir = 8
 	},
-/obj/machinery/camera/tarkon/directional/east,
+/obj/machinery/camera/autoname/tarkon/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon)
 "qr" = (
@@ -2543,7 +2539,7 @@
 /obj/item/reagent_containers/condiment/flour,
 /obj/item/reagent_containers/condiment/sugar,
 /obj/item/reagent_containers/condiment/sugar,
-/obj/machinery/camera/tarkon/directional/east,
+/obj/machinery/camera/autoname/tarkon/directional/east,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/port_tarkon/kitchen)
 "qG" = (
@@ -2574,7 +2570,7 @@
 /obj/machinery/cryopod{
 	dir = 4
 	},
-/obj/machinery/camera/tarkon/directional/west,
+/obj/machinery/camera/autoname/tarkon/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon)
 "qP" = (
@@ -2666,7 +2662,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/camera/tarkon/directional/east,
+/obj/machinery/camera/autoname/tarkon/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/centerhall)
 "rp" = (
@@ -2923,7 +2919,7 @@
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 8
 	},
-/obj/machinery/camera/tarkon/directional/west,
+/obj/machinery/camera/autoname/tarkon/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/afthall)
 "tg" = (
@@ -3034,7 +3030,7 @@
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "ud" = (
 /obj/effect/turf_decal/tile/brown/anticorner,
-/obj/machinery/camera/tarkon/directional/east,
+/obj/machinery/camera/autoname/tarkon/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/starboardhall)
 "ug" = (
@@ -3063,7 +3059,7 @@
 /obj/item/storage/medkit/regular,
 /obj/item/storage/medkit/regular,
 /obj/machinery/firealarm/directional/south,
-/obj/machinery/camera/tarkon/directional/south,
+/obj/machinery/camera/autoname/tarkon/directional/south,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/trauma)
 "uu" = (
@@ -3145,7 +3141,7 @@
 /obj/effect/turf_decal/tile/red/real_red/anticorner{
 	dir = 1
 	},
-/obj/machinery/camera/tarkon/directional/north,
+/obj/machinery/camera/autoname/tarkon/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/secoff)
 "vb" = (
@@ -3167,7 +3163,7 @@
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 8
 	},
-/obj/machinery/camera/tarkon/directional/west,
+/obj/machinery/camera/autoname/tarkon/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/centerhall)
 "vl" = (
@@ -3346,7 +3342,7 @@
 /area/ruin/space/has_grav/port_tarkon/storage)
 "wq" = (
 /obj/machinery/processor,
-/obj/machinery/camera/tarkon/directional/west,
+/obj/machinery/camera/autoname/tarkon/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/port_tarkon/kitchen)
 "wr" = (
@@ -3444,7 +3440,7 @@
 /obj/machinery/computer/atmos_control/tarkon/carbon_tank{
 	dir = 8
 	},
-/obj/machinery/camera/tarkon/directional/east,
+/obj/machinery/camera/autoname/tarkon/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/atmos)
 "xc" = (
@@ -3579,7 +3575,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 1
 	},
-/obj/machinery/camera/tarkon/directional/east,
+/obj/machinery/camera/autoname/tarkon/directional/east,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/atmos)
 "xT" = (
@@ -3757,7 +3753,7 @@
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/port_tarkon/comms)
 "zh" = (
-/obj/machinery/camera/tarkon/directional/north,
+/obj/machinery/camera/autoname/tarkon/directional/north,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/port_tarkon/afthall)
 "zk" = (
@@ -3896,7 +3892,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/starboardhall)
 "Aa" = (
-/obj/machinery/camera/tarkon/directional/west,
+/obj/machinery/camera/autoname/tarkon/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "Ab" = (
@@ -3935,7 +3931,7 @@
 /obj/item/circuitboard/machine/protolathe/tarkon,
 /obj/item/circuitboard/computer/tarkon_driver,
 /obj/item/circuitboard/machine/rdserver/tarkon,
-/obj/machinery/camera/tarkon/directional/east,
+/obj/machinery/camera/autoname/tarkon/directional/east,
 /obj/item/circuitboard/computer/tarkon_cam,
 /obj/item/circuitboard/computer/xenobiology/tarkon,
 /turf/open/floor/iron/dark,
@@ -4098,7 +4094,9 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/camera/tarkon_xenob,
+/obj/machinery/camera/tarkon_xenob{
+	c_tag = "P-T Xenobiology"
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "BI" = (
@@ -4171,7 +4169,7 @@
 /obj/machinery/cryo_cell{
 	dir = 8
 	},
-/obj/machinery/camera/tarkon/directional/east,
+/obj/machinery/camera/autoname/tarkon/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/trauma)
 "Ch" = (
@@ -4410,7 +4408,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/tank_compressor,
-/obj/machinery/camera/tarkon/directional/west,
+/obj/machinery/camera/autoname/tarkon/directional/west,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "DL" = (
@@ -4433,7 +4431,7 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/camera/tarkon/directional/north,
+/obj/machinery/camera/autoname/tarkon/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/power1)
 "DN" = (
@@ -4481,7 +4479,7 @@
 /obj/effect/turf_decal/tile/brown/anticorner{
 	dir = 1
 	},
-/obj/machinery/camera/tarkon/directional/west,
+/obj/machinery/camera/autoname/tarkon/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/storage)
 "Eb" = (
@@ -4784,7 +4782,7 @@
 	dir = 8
 	},
 /obj/item/construction/rcd/tarkon,
-/obj/machinery/camera/tarkon/directional/south,
+/obj/machinery/camera/autoname/tarkon/directional/south,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/atmos)
 "GN" = (
@@ -5087,7 +5085,7 @@
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "IF" = (
 /obj/structure/bed/maint,
-/obj/machinery/camera/tarkon/directional/west,
+/obj/machinery/camera/autoname/tarkon/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/secoff)
 "IJ" = (
@@ -5257,7 +5255,7 @@
 	dir = 1
 	},
 /obj/machinery/recharger,
-/obj/machinery/camera/tarkon/directional/west,
+/obj/machinery/camera/autoname/tarkon/directional/west,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/comms)
 "JP" = (
@@ -5526,7 +5524,7 @@
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/port_tarkon/garden)
 "Ln" = (
-/obj/machinery/camera/tarkon/directional/east,
+/obj/machinery/camera/autoname/tarkon/directional/east,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/port_tarkon/observ)
 "Ls" = (
@@ -5894,7 +5892,7 @@
 "NI" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/brown/anticorner,
-/obj/machinery/camera/tarkon/directional/east,
+/obj/machinery/camera/autoname/tarkon/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/storage)
 "NO" = (
@@ -5907,7 +5905,7 @@
 "NS" = (
 /obj/structure/cable,
 /obj/machinery/power/smes/tarkon_backup,
-/obj/machinery/camera/tarkon/directional/west,
+/obj/machinery/camera/autoname/tarkon/directional/west,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/port_tarkon/power1)
 "NT" = (
@@ -5994,7 +5992,7 @@
 	start_showpiece_type = /obj/item/gun/energy/recharge/resonant_system;
 	req_access = list("tarkon")
 	},
-/obj/machinery/camera/tarkon/directional/north,
+/obj/machinery/camera/autoname/tarkon/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/mining)
 "Om" = (
@@ -6165,7 +6163,7 @@
 /obj/structure/disposalpipe/broken{
 	dir = 8
 	},
-/obj/machinery/camera/tarkon/directional/south,
+/obj/machinery/camera/autoname/tarkon/directional/south,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/port_tarkon/observ)
 "Po" = (
@@ -6258,7 +6256,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner{
 	dir = 4
 	},
-/obj/machinery/camera/tarkon/directional/north,
+/obj/machinery/camera/autoname/tarkon/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/atmos)
 "PW" = (
@@ -6307,7 +6305,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
-/obj/machinery/camera/tarkon/directional/west,
+/obj/machinery/camera/autoname/tarkon/directional/west,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/port_tarkon/storage)
 "Qq" = (
@@ -6535,7 +6533,7 @@
 /area/ruin/space/has_grav/port_tarkon/forehall)
 "Se" = (
 /obj/structure/bed/maint,
-/obj/machinery/camera/tarkon/directional/east,
+/obj/machinery/camera/autoname/tarkon/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/secoff)
 "Sg" = (
@@ -6900,7 +6898,7 @@
 /obj/effect/turf_decal/tile/red/real_red/anticorner{
 	dir = 4
 	},
-/obj/machinery/camera/tarkon/directional/north,
+/obj/machinery/camera/autoname/tarkon/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/secoff)
 "Uo" = (
@@ -7144,7 +7142,7 @@
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 4
 	},
-/obj/machinery/camera/tarkon/directional/east,
+/obj/machinery/camera/autoname/tarkon/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/mining)
 "Wd" = (
@@ -7275,7 +7273,7 @@
 /obj/machinery/firealarm/directional/south{
 	pixel_y = -31
 	},
-/obj/machinery/camera/tarkon/directional/south,
+/obj/machinery/camera/autoname/tarkon/directional/south,
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/port_tarkon/garden)
 "Xf" = (
@@ -7367,7 +7365,7 @@
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
-/obj/machinery/camera/tarkon/directional/east,
+/obj/machinery/camera/autoname/tarkon/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/porthall)
 "XO" = (
@@ -7497,7 +7495,7 @@
 /obj/item/raw_anomaly_core/random,
 /obj/item/raw_anomaly_core/random,
 /obj/item/raw_anomaly_core/random,
-/obj/machinery/camera/tarkon/directional/north,
+/obj/machinery/camera/autoname/tarkon/directional/north,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "YT" = (
@@ -7529,7 +7527,7 @@
 /obj/machinery/computer/atmos_control/tarkon/nitrogen_tank{
 	dir = 4
 	},
-/obj/machinery/camera/tarkon/directional/west,
+/obj/machinery/camera/autoname/tarkon/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/atmos)
 "YZ" = (
@@ -7550,7 +7548,7 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/camera/tarkon/directional/east,
+/obj/machinery/camera/autoname/tarkon/directional/east,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/comms)
 "Zh" = (
@@ -7561,7 +7559,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/tarkon/directional/south,
+/obj/machinery/camera/autoname/tarkon/directional/south,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/porthall)
 "Zs" = (
@@ -10113,7 +10111,7 @@ if
 oV
 ms
 ms
-mb
+ms
 ms
 ms
 bO

--- a/_maps/shuttles/nova/ruin_tarkon_driver.dmm
+++ b/_maps/shuttles/nova/ruin_tarkon_driver.dmm
@@ -69,7 +69,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/camera/tarkon/directional/south,
+/obj/machinery/camera/autoname/tarkon/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "hW" = (
@@ -107,7 +107,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/tarkon/directional/south,
+/obj/machinery/camera/autoname/tarkon/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "ni" = (
@@ -136,12 +136,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/camera/tarkon/directional/south,
+/obj/machinery/camera/autoname/tarkon/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "pi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/tarkon/directional/south,
+/obj/machinery/camera/autoname/tarkon/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "rr" = (
@@ -224,7 +224,7 @@
 /obj/item/tank/internals/emergency_oxygen,
 /obj/machinery/door/window/brigdoor/tarkon/right/directional/west,
 /obj/machinery/light/directional/south,
-/obj/machinery/camera/tarkon/directional/south,
+/obj/machinery/camera/autoname/tarkon/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "Cv" = (
@@ -280,7 +280,7 @@
 /obj/item/clothing/mask/breath,
 /obj/machinery/door/window/brigdoor/tarkon/right/directional/east,
 /obj/machinery/light/directional/south,
-/obj/machinery/camera/tarkon/directional/south,
+/obj/machinery/camera/autoname/tarkon/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "Jo" = (
@@ -396,7 +396,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /obj/machinery/light_switch/directional/east,
-/obj/machinery/camera/tarkon/directional/east,
+/obj/machinery/camera/autoname/tarkon/directional/east,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "Ut" = (

--- a/modular_nova/modules/tarkon/code/machines/camera_systems.dm
+++ b/modular_nova/modules/tarkon/code/machines/camera_systems.dm
@@ -29,4 +29,8 @@
 /obj/machinery/camera/tarkon
 	network = list("tarkon")
 
+/obj/machinery/camera/autoname/tarkon
+	network = list("tarkon")
+
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/tarkon, 0)
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/autoname/tarkon, 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I just want to test some camera stuff but every time I run the camera report, camera issues at P-T and DS-2 fill up the whole report. Mostly P-T; its camera subtype does not have autonaming, but there's no c_tags mapped in, so they're all null and all duplicates. This PR changes the cameras on P-T to a subtype of autoname cameras instead. This has the added bonus of having those auto generated c_tags show up in the jump to camera when viewing the tarkon camera console. The tarkon xenobio camera is it's own subtype, so that was just given a c_tag in mapping. Additionally, there was a camera in the wall in P-T that was removed, and a DS-2 camera was retagged from "DS-2 Botany" to "DS-2 Library" to avoid duplicate c_tags

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

This
![image](https://github.com/NovaSector/NovaSector/assets/102194057/705fffb7-f6b7-4fbc-a440-7b21a62a7e58)
Becomes this
![image](https://github.com/NovaSector/NovaSector/assets/102194057/7c8123a6-246c-435e-857a-8bfe4a438266)


<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  Viewing the Jump to Camera option in the P-T advanced camera console
  
![image](https://github.com/NovaSector/NovaSector/assets/102194057/7e679481-3580-4aaa-a609-12cababf7df8)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Thlumyn
fix: fixed duplicated camera tags on P-T and DS-2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
