### PR TITLE
Removes the permit check for secbots being default

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -53,8 +53,7 @@
 	var/last_found
 
 	///Flags SecBOTs use on what to check on targets when arresting, and whether they should announce it to security/handcuff their target
-	var/security_mode_flags = SECBOT_DECLARE_ARRESTS | SECBOT_CHECK_RECORDS | SECBOT_HANDCUFF_TARGET | SECBOT_CHECK_WEAPONS // NOVA EDIT CHANGE - Original: var/security_mode_flags = SECBOT_DECLARE_ARRESTS | SECBOT_CHECK_RECORDS | SECBOT_HANDCUFF_TARGET
-//	Selections: SECBOT_DECLARE_ARRESTS | SECBOT_CHECK_IDS | SECBOT_CHECK_WEAPONS | SECBOT_CHECK_RECORDS | SECBOT_HANDCUFF_TARGET
+	var/security_mode_flags = SECBOT_DECLARE_ARRESTS | SECBOT_CHECK_RECORDS | SECBOT_HANDCUFF_TARGET
 
 	///On arrest, charges the violator this much. If they don't have that much in their account, they will get beaten instead
 	var/fair_market_price_arrest = 25

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -54,6 +54,7 @@
 
 	///Flags SecBOTs use on what to check on targets when arresting, and whether they should announce it to security/handcuff their target
 	var/security_mode_flags = SECBOT_DECLARE_ARRESTS | SECBOT_CHECK_RECORDS | SECBOT_HANDCUFF_TARGET
+//	Selections: SECBOT_DECLARE_ARRESTS | SECBOT_CHECK_IDS | SECBOT_CHECK_WEAPONS | SECBOT_CHECK_RECORDS | SECBOT_HANDCUFF_TARGET
 
 	///On arrest, charges the violator this much. If they don't have that much in their account, they will get beaten instead
 	var/fair_market_price_arrest = 25


### PR DESCRIPTION
## About The Pull Request

Beepsky doesnt understand what permits are for and in turn think anything with certain flags are just weapons, until a more elegant solution is presented we're just going to undo the modular edit. I like the idea of it don't get me wrong, but it's too broad of a stroke and catches too many innocent items in the way which leads to people just breaking sexbots on sight because they're trying to do their job.

Botanist buff: You can now use your job tools without beepsky trying to beepsky you.

## How This Contributes To The Nova Sector Roleplay Experience

I and many people are kind of tired of getting baton'd by beepsky for having general job tools. Floral ray from botany for example or even a skateboard. 

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

Kinda hard to prove this but since it's a modular edit removal i'll just show the compile.
  
![image](https://github.com/NovaSector/NovaSector/assets/22140677/9e8ad7b8-8684-4a80-a715-3018d334e6b0)

</details>

## Changelog
:cl:
balance: Undoes the permit flah for Beepsky, normal job tools shouldnt make them angry anymore.
/:cl:
