### PR TITLE
fixes persocom auto-launching messenger.

### DIFF
--- a/modular_nova/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
+++ b/modular_nova/modules/synths/code/bodyparts/internal_computer/internal_computer.dm
@@ -18,6 +18,9 @@
 	if(!istype(loc, /obj/item/organ/internal/brain/synth))
 		return INITIALIZE_HINT_QDEL
 
+/obj/item/modular_computer/pda/synth/check_power_override()
+	return TRUE
+
 /datum/action/item_action/synth/open_internal_computer
 	name = "Open persocom emulation"
 	desc = "Accesses your built-in virtual machine."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Turns out, it was an easy fix. We have a proc that governs power consumption for our PDAs
https://github.com/NovaSector/NovaSector/blob/72c24ebe10a285c71ae6fa935f7a899473dc6213/code/modules/modular_computers/computers/item/computer_power.dm#L6

Most of the time it will terminate itself after this check. PDAs consume power passively or depending on opened programs. 
https://github.com/NovaSector/NovaSector/blob/72c24ebe10a285c71ae6fa935f7a899473dc6213/code/modules/modular_computers/computers/item/computer_power.dm#L12

But persocom uses 0 power if you didn't launched any programs. It goes further and reaches this check
https://github.com/NovaSector/NovaSector/blob/72c24ebe10a285c71ae6fa935f7a899473dc6213/code/modules/modular_computers/computers/item/computer_power.dm#L21
which should relaunch any `PROGRAM_RUNS_WITHOUT_POWER` program you have. And it is our messenger, the only powerless program out here.

This PR blocks any demand on power for persocom because you can actually deplete its internal battery.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Closes #2959
Closes #1696
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

https://imgur.com/6n0WZkc

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed synths persocom. Rejoice, synthlizards! (and ipcs too but i dont believe in your existence)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
