### PR TITLE
Make narcolepsy use the same stimulant reagent list as all nighter (woo latte)

### DIFF
--- a/modular_nova/master_files/code/datums/quirks/negative_quirks/narcolepsy.dm
+++ b/modular_nova/master_files/code/datums/quirks/negative_quirks/narcolepsy.dm
@@ -39,7 +39,7 @@
 
 	var/sleep_chance = 0.333 //3
 	var/drowsy = !!owner.has_status_effect(/datum/status_effect/drowsiness)
-	var/caffeinated = owner.reagents.has_reagent(/datum/reagent/consumable/coffee)
+	var/caffeinated = HAS_TRAIT(owner, TRAIT_STIMULATED)
 	if(drowsy)
 		sleep_chance = 1
 	if(caffeinated) //make it real hard to fall asleep on caffeine


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hi! It's me! 
The person who made All Nighter on mainline tg have more stimulants work on it.
Like all the coffee variants, cause out of those it was coded to only work with normal coffee.
And hey wait, Narcolepsy is hardcoded to only coffee...

### I PLANNED FOR THIS.

So when I made that All Nighter change I refactored it to instead check for a trait, `TRAIT_STIMULATED`, and made all of the reagents it worked with apply that trait on metabolize instead. Then made all the other reagents I thought fit the theme apply that.
This change was made with both the ideas of "what if we ever have another similar thing" and "what if we want a non-chem source keeping you up and awake at night" in mind.

While I didn't have _specifically_ this codebase in mind, I noticed Narcolepsy existing, and it feels like the former.
Sooo we change Narcolepsy to check for the trait too, and badabing badaboom, single line change and it just works.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

It's nicer if all the fancy coffee variants work for reducing the Narcolepsy chance too, or other weirder stimulants.
Also, parity with All Nighter.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

In both cases, temporarily set the permanent narcolepsy brain trauma's `on_life(...)` proc to message admins about the current state of the caffeinated var. Then, drank coffee, latte, and water. The first two applying the tag, the final one not.
<details>
<summary>Test with coffee</summary>


![image](https://github.com/NovaSector/NovaSector/assets/42909981/a1af2420-7552-4687-8aea-33e06a51ea61)
  
</details>

<details>
<summary>Test with latte</summary>

![image](https://github.com/NovaSector/NovaSector/assets/42909981/55c32f52-35fe-452d-bb15-89aa62c4c150)
  
</details>

<details>
<summary>Test with water</summary>

![image](https://github.com/NovaSector/NovaSector/assets/42909981/176b8c75-8ec1-4ca8-828a-5197d27b1be3)
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Narcolepsy now has parity with All Nighter regarding drinks that offset the effects. Most importantly, the coffee variants actually reduces your sleepy chances just like coffee.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
