### PR TITLE
Time clock poster mapping

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -90465,10 +90465,10 @@
 /turf/open/floor/carpet/green,
 /area/station/service/abandoned_gambling_den)
 "roc" = (
-/obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/computer/cryopod/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/station/common/cryopods)
 "rof" = (
@@ -118063,7 +118063,7 @@
 /area/station/science/xenobiology)
 "wxt" = (
 /obj/structure/cable,
-/obj/machinery/computer/cryopod/directional/north,
+/obj/structure/sign/poster/timeclock_psa/directional/north,
 /turf/open/floor/iron/white/textured,
 /area/station/common/cryopods)
 "wxu" = (

--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -27699,6 +27699,9 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/structure/sign/poster/timeclock_psa/directional/west{
+	pixel_y = 4
+	},
 /turf/open/floor/iron/dark/corner{
 	dir = 8
 	},
@@ -27800,7 +27803,7 @@
 /obj/effect/turf_decal/box,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/light/cold/directional/north,
-/obj/machinery/airalarm/directional/north,
+/obj/structure/sign/poster/timeclock_psa/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/common/cryopods)
 "ier" = (
@@ -29108,7 +29111,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/newscaster/directional/south,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark/small,
 /area/station/common/cryopods)
 "ixC" = (

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -1261,6 +1261,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/sign/poster/timeclock_psa/directional/south{
+	pixel_y = -28
+	},
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/central)
 "asr" = (
@@ -65292,7 +65295,6 @@
 	},
 /obj/machinery/light/warm/directional/north,
 /obj/machinery/disposal/bin,
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/effect/turf_decal/box,
 /obj/structure/disposalpipe/trunk{
 	dir = 4

--- a/_maps/nova/automapper/templates/birdshot/birdshot_cryo.dmm
+++ b/_maps/nova/automapper/templates/birdshot/birdshot_cryo.dmm
@@ -53,13 +53,13 @@
 /turf/open/floor/iron/small,
 /area/station/common/cryopods)
 "s" = (
-/obj/structure/sign/poster/official/random/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 1
 	},
+/obj/structure/sign/poster/timeclock_psa/directional/north,
 /turf/open/floor/iron/small,
 /area/station/common/cryopods)
 "v" = (

--- a/_maps/nova/automapper/templates/deltastation/deltastation_cryo.dmm
+++ b/_maps/nova/automapper/templates/deltastation/deltastation_cryo.dmm
@@ -29,6 +29,12 @@
 /obj/machinery/camera/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
+"l" = (
+/obj/structure/sign/poster/timeclock_psa{
+	pixel_y = 4
+	},
+/turf/closed/wall,
+/area/station/commons/fitness/recreation)
 "v" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -72,7 +78,7 @@
 /area/station/commons/fitness/recreation)
 
 (1,1,1) = {"
-a
+l
 I
 G
 I

--- a/_maps/nova/automapper/templates/icebox/icebox_cryo.dmm
+++ b/_maps/nova/automapper/templates/icebox/icebox_cryo.dmm
@@ -114,6 +114,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/north,
+/obj/structure/sign/poster/timeclock_psa/directional/north,
 /turf/open/floor/iron,
 /area/station/common/cryopods)
 "M" = (

--- a/_maps/nova/automapper/templates/metastation/metastation_cryo.dmm
+++ b/_maps/nova/automapper/templates/metastation/metastation_cryo.dmm
@@ -4,7 +4,6 @@
 /area/template_noop)
 "e" = (
 /obj/machinery/computer/cryopod/directional/west,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -42,16 +41,17 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/common/cryopods)
 "v" = (
 /obj/machinery/cryopod,
 /obj/effect/turf_decal/siding/white,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /obj/machinery/camera/directional/north{
 	c_tag = "Cryogenics Pods"
 	},
+/obj/structure/sign/poster/timeclock_psa/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/common/cryopods)
 "x" = (

--- a/_maps/nova/automapper/templates/northstar/northstar_cryo.dmm
+++ b/_maps/nova/automapper/templates/northstar/northstar_cryo.dmm
@@ -455,6 +455,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/thinplating_new/light/end,
+/obj/structure/sign/poster/timeclock_psa/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/common/cryopods)
 "IB" = (
@@ -540,6 +541,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/south,
+/obj/structure/sign/poster/timeclock_psa/directional/south,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor3/aft)
 "QZ" = (

--- a/_maps/nova/automapper/templates/tramstation/tramstation_cryo.dmm
+++ b/_maps/nova/automapper/templates/tramstation/tramstation_cryo.dmm
@@ -30,6 +30,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/sign/poster/timeclock_psa/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms/laundry)
 "f" = (
@@ -47,6 +48,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms/laundry)
+"h" = (
+/obj/structure/sign/poster/timeclock_psa{
+	pixel_y = 4
+	},
+/turf/closed/wall,
+/area/station/common/cryopods)
 "j" = (
 /obj/structure/window/spawner/directional/south,
 /obj/structure/flora/bush/flowers_br/style_random,
@@ -276,7 +283,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "Q" = (
@@ -361,7 +367,7 @@ D
 D
 D
 D
-D
+h
 P
 "}
 (2,1,1) = {"

--- a/_maps/nova/automapper/templates/wawastation/wawastation_commons.dmm
+++ b/_maps/nova/automapper/templates/wawastation/wawastation_commons.dmm
@@ -88,7 +88,7 @@
 /area/station/service/library)
 "dG" = (
 /obj/effect/turf_decal/siding,
-/obj/structure/sign/timeclock_psa/directional/west{
+/obj/structure/sign/poster/timeclock_psa/directional/west{
 	pixel_y = 4
 	},
 /turf/open/floor/iron/white,

--- a/_maps/nova/automapper/templates/wawastation/wawastation_lockers.dmm
+++ b/_maps/nova/automapper/templates/wawastation/wawastation_lockers.dmm
@@ -156,7 +156,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/timeclock_psa/directional/west{
+/obj/structure/sign/poster/timeclock_psa/directional/west{
 	pixel_y = 4
 	},
 /turf/open/floor/iron,

--- a/modular_nova/modules/time_clock/code/sign.dm
+++ b/modular_nova/modules/time_clock/code/sign.dm
@@ -1,8 +1,8 @@
-/obj/structure/sign/timeclock_psa
+/obj/structure/sign/poster/timeclock_psa
 	name = "HoP Moth - Time Clock"
 	desc = "This informational sign uses HoP Moth™ reminding the viewer to do their part in the station's Enterprise Resource Planning efforts, clocking out before periods of prolonged absence or leisure time."
 	icon = 'modular_nova/modules/time_clock/icons/sign.dmi'
 	icon_state = "moff-clockout"
 	anchored = TRUE
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/timeclock_psa, 32)
+MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/timeclock_psa, 32)


### PR DESCRIPTION
## About The Pull Request

Puts the time clock informational poster on the rest of the automapper templates/maps.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/NovaSector/NovaSector/assets/83487515/2bd41f82-d810-4788-9c40-84ba54ea4743)
  
</details>

## Changelog

:cl: LT3
image: Added time clock informational poster to all maps
/:cl: