### PR TITLE
Fix railing/rack deconstruction

### DIFF
--- a/modular_nova/modules/primitive_structures/code/fencing.dm
+++ b/modular_nova/modules/primitive_structures/code/fencing.dm
@@ -24,12 +24,12 @@
 /obj/structure/railing/wooden_fencing/atom_deconstruct(disassembled)
 	var/obj/plank = new /obj/item/stack/sheet/mineral/wood(drop_location(), 5)
 	transfer_fingerprints_to(plank)
-  
+
 // formerly NO_DECONSTRUCTION
-/obj/structure/railing/wirecutter_act(mob/living/user, obj/item/tool)
+/obj/structure/railing/wooden_fencing/wirecutter_act(mob/living/user, obj/item/tool)
 	return NONE
 
-/obj/structure/railing/crowbar_act(mob/living/user, obj/item/tool)
+/obj/structure/railing/wooden_fencing/crowbar_act(mob/living/user, obj/item/tool)
 	. = ..()
 	to_chat(user, span_warning("You pry apart the railing."))
 	tool.play_tool_sound(src, 100)

--- a/modular_nova/modules/primitive_structures/code/storage_structures.dm
+++ b/modular_nova/modules/primitive_structures/code/storage_structures.dm
@@ -24,7 +24,7 @@
 	dropping.pixel_x = clamp(text2num(LAZYACCESS(modifiers, ICON_X)) - 16, -(world.icon_size / 3), world.icon_size / 3)
 	dropping.pixel_y = text2num(LAZYACCESS(modifiers, ICON_Y)) > 16 ? 10 : -4
 
-/obj/structure/rack/wrench_act_secondary(mob/living/user, obj/item/tool)
+/obj/structure/rack/wooden/wrench_act_secondary(mob/living/user, obj/item/tool)
 	return NONE
 
 /obj/structure/rack/wooden/crowbar_act(mob/living/user, obj/item/tool)


### PR DESCRIPTION

## About The Pull Request
I thought for sure this would've been an upstream issue
Turns out the bug was within us all along
## Proof of Testing
you're going to have to trust me that these were, at some point, actually racks and railings
![image](https://github.com/NovaSector/NovaSector/assets/25628932/204cf813-a6c4-478b-acb2-3b2a472aca69)
## Changelog
:cl:
fix: railings can be deconstructed
fix: racks can be deconstructed
/:cl:
