### PR TITLE
Fixes latejoiners not having their general/medical/security records and alt-title prefs show up in the ingame records

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -274,7 +274,7 @@
 		SSquirks.AssignQuirks(humanc, humanc.client)
 
 	if(humanc) // Quirks may change manifest datapoints, so inject only after assigning quirks
-		GLOB.manifest.inject(humanc)
+		GLOB.manifest.inject(humanc, humanc.client) // NOVA EDIT - RP Records - ORIGINAL: GLOB.manifest.inject(humanc)
 
 	var/area/station/arrivals = GLOB.areas_by_type[/area/station/hallway/secondary/entry]
 	if(humanc && arrivals && !arrivals.power_environ) //arrivals depowered


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So a friend of mine was being confused about why nova has general/medical/security records preferences, while they don't actually show up ingame.
Given I've previously fixed manifest bugs on tg, I asked them the typical question:
**"Did you latejoin?"**

Lo and behold, they did, and that's the issue.
Nova made manifest injections take an additional parameter, the client, and takes the prefs from that for both alt job titles and all flavours of records prefs.
However, it doesn't use this parameter for latejoiners...

Heyyyy wait a second. This is _my_ fault-
Kind of, not really.

Apparently a bug I fixed on mainline tg caused _this_ bug, as I moved the injection point further down, but y'all never actually re-added the client parameter.
Anyhow that fixes it.

Iunno what y'all do to keep track of base edits, but the other manifest injection point change added the same
` // NOVA EDIT - RP Records - ORIGINAL: [original_code]`
type of line to it, so I did the same here.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Sucks if your written out all fancy schmancy records never actually show up ingame.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Latejoin Manifest Screenshots</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/42909981/45d7f72f-7cbb-41f1-822c-db42fd5826f0)
![image](https://github.com/NovaSector/NovaSector/assets/42909981/ae2858bd-2787-4fc2-9668-623123d77bb8)
![image](https://github.com/NovaSector/NovaSector/assets/42909981/bd576c36-27a0-48ff-adff-a9ae9873b5d5)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Latejoiners' alt titles, general/medical/security records, backgrounds, and exploitable information are actually saved to the manifest data. This means your general/medical/security records actually show up in the records console again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
