### PR TITLE
Adds the cowboy belt holster to recipes.

### DIFF
--- a/modular_nova/master_files/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/modular_nova/master_files/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -121,8 +121,7 @@ GLOBAL_LIST_INIT(nova_leather_belt_recipes, list(
 	new/datum/stack_recipe("medical bandolier", /obj/item/storage/belt/medbandolier, 5, category = CAT_CONTAINERS),
 	new/datum/stack_recipe("gear harness", /obj/item/clothing/under/misc/nova/gear_harness, 6, category = CAT_CLOTHING),
 	new/datum/stack_recipe("ammo pouch", /obj/item/storage/pouch/ammo, 4, category = CAT_CONTAINERS),
-	new/datum/stack_recipe("Cowboy Belt (Thigh Holster)", /obj/item/storage/belt/holster/cowboy, 3, crafting_flags = NONE, category = CAT_CONTAINERS), \
-
+	new/datum/stack_recipe("Cowboy Belt (Thigh Holster)", /obj/item/storage/belt/holster/cowboy, 3, crafting_flags = NONE, category = CAT_CONTAINERS),
 ))
 
 /obj/item/stack/sheet/leather/get_main_recipes()


### PR DESCRIPTION

## About The Pull Request
title has all you need   : D
## How This Contributes To The Nova Sector Roleplay Experience
Item used to only exist in loadout, why is it not obtainable any other way?
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/109750345/38715526-47a4-475a-8ed3-50f6530be49d)
this doesnt even need a video but here u go
https://cdn.discordapp.com/attachments/575068385625374740/1253097140360843374/2024-06-20_00-18-32.mp4?ex=66749d27&is=66734ba7&hm=631af5a254f0b30d1ee36b47d9aa2e040e40d018a5e820458a63496942d6b77c&
</details>

## Changelog
:cl: Mitsukiyo
qol: Added the cowboy belt holster to leather sheet recipes
/:cl:
