### PR TITLE
Stops admin item deletion sparks from setting everything on fire

### DIFF
--- a/code/modules/admin/view_variables/admin_delete.dm
+++ b/code/modules/admin/view_variables/admin_delete.dm
@@ -25,10 +25,7 @@
 			qdel(D)
 			if(!QDELETED(D))
 				vv_update_display(D, "deleted", "")
-		// NOVA EDIT addition start -- optional bluespace sparks on delete
-		if(T && prefs.read_preference(/datum/preference/toggle/admin/delete_sparks))
-			playsound(T, 'sound/magic/Repulse.ogg', 100, 1)
-			var/datum/effect_system/spark_spread/quantum/sparks = new
-			sparks.set_up(10, 1, T)
-			sparks.attach(T)
-			sparks.start()
+		// NOVA EDIT ADDITION START -- optional bluespace sparks on delete
+		if(prefs.read_preference(/datum/preference/toggle/admin/delete_sparks))
+			do_admin_sparks(10, TRUE, T) // non-interactive sparks
+		// NOVA EDIT ADDITION END

--- a/code/modules/buildmode/submodes/advanced.dm
+++ b/code/modules/buildmode/submodes/advanced.dm
@@ -58,12 +58,8 @@
 	else if(right_click)
 		if(isobj(object))
 			log_admin("Build Mode: [key_name(c)] deleted [object] at [AREACOORD(object)]")
-			// NOVA EDIT -- BS delete sparks. Original was just qdel(object)
-			var/turf/T = get_turf(object)
+			// NOVA EDIT ADDITION START -- optional bluespace sparks on delete
+			if(c.prefs.read_preference(/datum/preference/toggle/admin/delete_sparks))
+				do_admin_sparks(10, TRUE, object) // non-interactive sparks
+			// NOVA EDIT ADDITION END
 			qdel(object)
-			if(T && c.prefs.read_preference(/datum/preference/toggle/admin/delete_sparks))
-				playsound(T, 'sound/magic/Repulse.ogg', 100, 1)
-				var/datum/effect_system/spark_spread/quantum/sparks = new
-				sparks.set_up(10, 1, T)
-				sparks.attach(T)
-				sparks.start()

--- a/code/modules/buildmode/submodes/basic.dm
+++ b/code/modules/buildmode/submodes/basic.dm
@@ -37,15 +37,11 @@
 			var/turf/T = object
 			T.ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 		else if(isobj(object))
-			// NOVA EDIT -- BS delete sparks. Original was just qdel(object)
-			var/turf/T = get_turf(object)
+			// NOVA EDIT ADDITION START -- optional bluespace sparks on delete
+			if(c.prefs.read_preference(/datum/preference/toggle/admin/delete_sparks))
+				do_admin_sparks(10, TRUE, object) // non-interactive sparks
+			// NOVA EDIT ADDITION END
 			qdel(object)
-			if(T && c.prefs.read_preference(/datum/preference/toggle/admin/delete_sparks))
-				playsound(T, 'sound/magic/Repulse.ogg', 100, 1)
-				var/datum/effect_system/spark_spread/quantum/sparks = new
-				sparks.set_up(10, 1, T)
-				sparks.attach(T)
-				sparks.start()
 		return
 	else if(istype(object,/turf) && alt_click && left_click)
 		log_admin("Build Mode: [key_name(c)] built an airlock at [AREACOORD(object)]")

--- a/code/modules/buildmode/submodes/delete.dm
+++ b/code/modules/buildmode/submodes/delete.dm
@@ -15,15 +15,11 @@
 			var/turf/T = object
 			T.ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 		else if(isatom(object))
-			// NOVA EDIT -- BS delete sparks. Original was just qdel(object)
-			var/turf/T = get_turf(object)
+			// NOVA EDIT ADDITION START -- optional bluespace sparks on delete
+			if(c.prefs.read_preference(/datum/preference/toggle/admin/delete_sparks))
+				do_admin_sparks(10, TRUE, object) // non-interactive sparks
+			// NOVA EDIT ADDITION END
 			qdel(object)
-			if(T && c.prefs.read_preference(/datum/preference/toggle/admin/delete_sparks))
-				playsound(T, 'sound/magic/Repulse.ogg', 100, 1)
-				var/datum/effect_system/spark_spread/quantum/sparks = new
-				sparks.set_up(10, 1, T)
-				sparks.attach(T)
-				sparks.start()
 
 	if(LAZYACCESS(modifiers, RIGHT_CLICK))
 		if(check_rights(R_DEBUG|R_SERVER)) //Prevents buildmoded non-admins from breaking everything.

--- a/modular_nova/master_files/code/game/objects/effects/effect_system/effect_sparks.dm
+++ b/modular_nova/master_files/code/game/objects/effects/effect_system/effect_sparks.dm
@@ -16,7 +16,7 @@ GLOBAL_DATUM(admin_sparks_system, /datum/effect_system/spark_spread/admin_sparks
 	return
 
 /// Creates non-interactive rainbow sparks at the given source location
-proc/do_admin_sparks(number, cardinals_only, datum/source)
+/proc/do_admin_sparks(number, cardinals_only, datum/source)
 	var/location = isturf(source) ? source : get_turf(source)
 	if(isnull(location))
 		return

--- a/modular_nova/master_files/code/game/objects/effects/effect_system/effect_sparks.dm
+++ b/modular_nova/master_files/code/game/objects/effects/effect_system/effect_sparks.dm
@@ -1,6 +1,7 @@
 /// We want there to be only one of these because this way we cap the amount that are able to run concurrently to 20. (so mass-deletions don't create massive lag)
 GLOBAL_DATUM(admin_sparks_system, /datum/effect_system/spark_spread/admin_sparks)
 
+/// The singleton spark system, don't make more of these please!
 /datum/effect_system/spark_spread/admin_sparks
 	effect_type = /obj/effect/particle_effect/sparks/quantum/inert
 
@@ -15,7 +16,7 @@ GLOBAL_DATUM(admin_sparks_system, /datum/effect_system/spark_spread/admin_sparks
 	return
 
 /// Creates non-interactive rainbow sparks at the given source location
-proc/do_admin_sparks(number, cardinals_only, datum/source, client/admin)
+proc/do_admin_sparks(number, cardinals_only, datum/source)
 	var/location = isturf(source) ? source : get_turf(source)
 	if(isnull(location))
 		return

--- a/modular_nova/master_files/code/game/objects/effects/effect_system/effect_sparks.dm
+++ b/modular_nova/master_files/code/game/objects/effects/effect_system/effect_sparks.dm
@@ -1,0 +1,32 @@
+/// We want there to be only one of these because this way we cap the amount that are able to run concurrently to 20. (so mass-deletions don't create massive lag)
+GLOBAL_DATUM(admin_sparks_system, /datum/effect_system/spark_spread/admin_sparks)
+
+/datum/effect_system/spark_spread/admin_sparks
+	effect_type = /obj/effect/particle_effect/sparks/quantum/inert
+
+/// This spark effect should not start fires or affect turfs/atoms in any way
+/obj/effect/particle_effect/sparks/quantum/inert
+
+/obj/effect/particle_effect/sparks/quantum/inert/LateInitialize()
+	. = ..()
+	UnregisterSignal(src, list(COMSIG_MOVABLE_CROSS, COMSIG_MOVABLE_CROSS_OVER))
+	
+/obj/effect/particle_effect/sparks/quantum/inert/affect_location(turf/location, just_initialized = FALSE)
+	return
+
+/// Creates non-interactive rainbow sparks at the given source location
+proc/do_admin_sparks(number, cardinals_only, datum/source, client/admin)
+	var/location = isturf(source) ? source : get_turf(source)
+	if(isnull(location))
+		return
+
+	playsound(location, 'sound/magic/Repulse.ogg', 100, 1)
+
+	// only created when needed
+	if(isnull(GLOB.admin_sparks_system)) 
+		GLOB.admin_sparks_system = new
+	
+	var/datum/effect_system/spark_spread/admin_sparks/admin_sparks = GLOB.admin_sparks_system
+	admin_sparks.set_up(number, cardinals_only, location)
+	admin_sparks.attach(location)
+	admin_sparks.start()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6443,6 +6443,7 @@
 #include "modular_nova\master_files\code\game\objects\effects\decals\cleanable\misc.dm"
 #include "modular_nova\master_files\code\game\objects\effects\decals\turfdecals\markings.dm"
 #include "modular_nova\master_files\code\game\objects\effects\decals\turfdecals\tilecoloring.dm"
+#include "modular_nova\master_files\code\game\objects\effects\effect_system\effect_sparks.dm"
 #include "modular_nova\master_files\code\game\objects\items\AI_modules.dm"
 #include "modular_nova\master_files\code\game\objects\items\cards_ids.dm"
 #include "modular_nova\master_files\code\game\objects\items\dualsaber.dm"


### PR DESCRIPTION
## About The Pull Request

Also cleans up and refactors the code to be a bit neater, and removes the possibility of having more than 20 of these particle effects running at a time. Should people be spamming it this should no longer be able to create lag.

## How This Contributes To The Nova Sector Roleplay Experience

Less accidental arson while in build mode for people who play with this enabled.

## Proof of Testing

<details>
<summary>Working as before</summary>
  
![dreamseeker_VyHOKno933](https://github.com/NovaSector/NovaSector/assets/13398309/03147417-a64d-4dc4-bcdb-c635ed708adf)

![dreamseeker_4qM2bEqwy5](https://github.com/NovaSector/NovaSector/assets/13398309/de1d7500-5716-435a-b785-891a139bd42e)

</details>

## Changelog

:cl:
fix: the optional admin rainbow sparks (from item deletion) will no longer set things on fire
/:cl:

