### PR TITLE
Removes the martyr ("Die a glorious death!") escape objective from the pool of escape objectives

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -590,7 +590,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 		var/static/list/escape_objectives = list(
 			/datum/objective/escape,
 			/datum/objective/survive,
-			/datum/objective/martyr,
+			///datum/objective/martyr, // NOVA EDIT REMOVAL
 			/datum/objective/exile,
 		)
 		for (var/datum/objective/check_objective in objectives)


### PR DESCRIPTION
## About The Pull Request

This just takes the martyr escape objective out from the possible options that get rolled for antags. Was a request, apparently we are not supposed to have this one come up.

## Changelog

:cl:
del: removed the martyr escape objective from the antag escape objective pool (aka "Die a glorious death!")
/:cl: