### PR TITLE
[Blueshift] Removes the Power Stations

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -5140,14 +5140,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engineering/engine_aft_port)
-"bbm" = (
-/obj/effect/spawner/random/trash/mess,
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/fore)
 "bbn" = (
 /obj/structure/filingcabinet/security,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -16167,6 +16159,7 @@
 /area/station/common/locker_room_shower)
 "dcL" = (
 /obj/effect/spawner/random/structure/steam_vent,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "dcR" = (
@@ -28121,17 +28114,6 @@
 /obj/structure/sign/departments/restroom/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper)
-"fpW" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/lobby)
 "fpY" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Engineering Maintenance"
@@ -37245,14 +37227,13 @@
 /turf/open/floor/carpet,
 /area/station/service/bar/atrium)
 "hgl" = (
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/structure/sign/poster/contraband/free_drone/directional/south,
-/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "hgo" = (
@@ -37718,7 +37699,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
@@ -66876,6 +66856,7 @@
 /area/station/security/checkpoint)
 "mPS" = (
 /obj/structure/barricade/wooden,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "mPX" = (
@@ -69531,11 +69512,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/transit_tube)
 "nsz" = (
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "nsA" = (
 /obj/structure/chair/office{
@@ -91405,7 +91385,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "rxA" = (
@@ -92288,7 +92267,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "rGo" = (
@@ -117319,7 +117297,6 @@
 /obj/structure/grille,
 /obj/structure/barricade/wooden,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "wrz" = (
@@ -122288,14 +122265,13 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/qm)
 "xpx" = (
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
-	},
 /obj/effect/spawner/random/trash/moisture_trap,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "xpA" = (
@@ -123675,7 +123651,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
@@ -164142,7 +164117,7 @@ rzg
 dDD
 uiv
 iSr
-fpW
+iSr
 hkt
 rxy
 xDq
@@ -165639,11 +165614,11 @@ aqk
 dVy
 qlI
 tVI
-tVI
-tVI
+fqP
+fqP
 dcL
-tVI
-tVI
+fqP
+fqP
 pdU
 hAd
 nYM
@@ -165900,7 +165875,7 @@ mPS
 uyp
 mrV
 ugS
-tVI
+fqP
 pdU
 hAd
 nWm
@@ -166154,8 +166129,8 @@ ivW
 jZl
 rSw
 mZc
-nsz
-bbm
+jYW
+jGU
 mrV
 pvk
 oOr
@@ -166414,7 +166389,7 @@ lSU
 hSi
 hgl
 dVy
-jAj
+nsz
 pdU
 btP
 cWP

--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -877,10 +877,15 @@
 /turf/open/floor/iron,
 /area/station/maintenance/aux_eva)
 "ajh" = (
-/obj/structure/trash_pile,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "ajl" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/table/reinforced,
@@ -1117,6 +1122,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "ali" = (
@@ -2671,6 +2677,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "aBG" = (
@@ -2936,6 +2943,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -4787,10 +4795,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "aXM" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/frame,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "aXP" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
@@ -5131,15 +5141,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/engineering/engine_aft_port)
 "bbm" = (
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
-	},
+/obj/effect/spawner/random/trash/mess,
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/upper)
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/fore)
 "bbn" = (
 /obj/structure/filingcabinet/security,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -6304,6 +6312,7 @@
 /turf/open/floor/plating,
 /area/station/security/execution/transfer)
 "bnj" = (
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 6
 	},
@@ -7884,6 +7893,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -9521,6 +9531,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bRE" = (
@@ -9699,6 +9710,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "bTE" = (
@@ -12222,6 +12234,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -12542,6 +12555,7 @@
 	name = "Medbay Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "cuT" = (
@@ -13824,11 +13838,12 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "cFK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper)
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/medical)
 "cFN" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
@@ -16061,6 +16076,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "dbE" = (
@@ -17571,6 +17587,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -19122,11 +19139,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper)
 "dGZ" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/service)
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/bar)
 "dHb" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -19495,13 +19511,9 @@
 /turf/open/floor/iron/smooth,
 /area/station/cargo/miningdock)
 "dJW" = (
-/obj/item/stack/sheet/cardboard,
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
-	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/turf/open/floor/iron/smooth_large,
+/area/station/cargo/storage)
 "dJY" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -20301,6 +20313,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "dTa" = (
@@ -20647,10 +20660,10 @@
 /turf/open/floor/grass,
 /area/station/hallway/secondary/entry)
 "dWg" = (
+/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/fore)
 "dWt" = (
@@ -21746,6 +21759,7 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/dorms/room7)
 "eib" = (
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "eid" = (
@@ -22627,15 +22641,11 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "erj" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/disposal)
 "erk" = (
 /obj/item/shard,
 /turf/open/floor/plating,
@@ -22743,12 +22753,12 @@
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "esx" = (
-/obj/structure/railing{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/frame,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
+/area/station/cargo/storage)
 "esy" = (
 /obj/effect/turf_decal/vg_decals/numbers/zero,
 /turf/open/floor/iron/shuttle/arrivals/airless,
@@ -23775,6 +23785,10 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
+"eBj" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/service)
 "eBm" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/spawner/random/structure/steam_vent,
@@ -25162,6 +25176,7 @@
 	name = "Robotics Lab Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "eNG" = (
@@ -26276,6 +26291,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "eYE" = (
@@ -26442,6 +26458,7 @@
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -27444,6 +27461,7 @@
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "fiI" = (
@@ -28104,8 +28122,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper)
 "fpW" = (
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/fore)
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/lobby)
 "fpY" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Engineering Maintenance"
@@ -28131,6 +28157,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet/black,
 /area/station/service/barber)
 "fqi" = (
@@ -28933,9 +28960,9 @@
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/starboard/fore)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "fyK" = (
 /obj/structure/railing/corner/end/flip,
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -29246,6 +29273,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "fCB" = (
@@ -29441,6 +29469,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "fFo" = (
@@ -31469,6 +31498,7 @@
 /obj/machinery/light/small/broken/directional/east,
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "fZK" = (
@@ -32158,6 +32188,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "ggF" = (
@@ -32573,6 +32604,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "glt" = (
@@ -35505,9 +35537,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "gOx" = (
+/obj/structure/frame,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/plating,
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/aft/upper)
 "gOy" = (
 /obj/structure/lattice/catwalk,
@@ -37219,6 +37252,7 @@
 	dir = 5
 	},
 /obj/structure/sign/poster/contraband/free_drone/directional/south,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "hgo" = (
@@ -38040,6 +38074,7 @@
 "hnW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "hnX" = (
@@ -40054,6 +40089,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "hJr" = (
@@ -40869,6 +40905,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "hQi" = (
@@ -43922,6 +43959,7 @@
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "ivX" = (
@@ -43942,13 +43980,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "iwe" = (
-/obj/effect/spawner/random/trash/mess,
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/upper)
+/turf/open/floor/carpet/blue,
+/area/station/medical/break_room)
 "iwl" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/door/airlock/security/old{
@@ -45101,6 +45137,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "iHw" = (
@@ -47139,6 +47176,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "jda" = (
@@ -48680,15 +48718,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "jsd" = (
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/turf/open/floor/iron,
+/area/station/hallway/primary/upper)
 "jsj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -48792,12 +48826,12 @@
 /turf/open/floor/eighties/red,
 /area/station/common/arcade)
 "jte" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/light/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/area/station/hallway/primary/port)
 "jtm" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -50373,10 +50407,13 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/port)
 "jJb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/stack/sheet/cardboard,
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/area/station/maintenance/port/fore)
 "jJf" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/assistant,
@@ -51754,6 +51791,7 @@
 /area/station/hallway/primary/upper)
 "jVo" = (
 /obj/effect/spawner/random/trash/mess,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "jVp" = (
@@ -52045,11 +52083,15 @@
 /turf/open/floor/wood,
 /area/station/command/captain_dining)
 "jXN" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/hangover,
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
 /obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "jXO" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8;
@@ -52238,6 +52280,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engineering/engine_aft_port)
+"jZl" = (
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
+/mob/living/basic/mothroach,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/fore)
 "jZm" = (
 /obj/structure/table/wood/poker,
 /obj/item/storage/dice,
@@ -53623,6 +53673,7 @@
 /obj/effect/spawner/random/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "kmg" = (
@@ -54725,6 +54776,7 @@
 "kww" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "kwB" = (
@@ -57621,12 +57673,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "lbu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/turf/open/floor/iron/white,
+/area/station/medical/break_room)
 "lbz" = (
 /obj/structure/chair/pew/right{
 	dir = 8
@@ -58887,15 +58936,11 @@
 /turf/open/floor/iron/grimy,
 /area/station/command/meeting_room/council)
 "lni" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/purple{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/structure/cable,
-/turf/open/floor/glass/reinforced,
-/area/station/science)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "lnk" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
@@ -58927,12 +58972,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "lnJ" = (
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/upper)
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/fore)
 "lnM" = (
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
@@ -59107,11 +59149,12 @@
 	},
 /area/station/holodeck/rec_center)
 "lpC" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
 	},
-/turf/open/floor/iron/white,
-/area/station/science)
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/starboard/fore)
 "lpD" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -59861,6 +59904,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/upper)
+"lyz" = (
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "lyK" = (
 /obj/structure/lattice/catwalk,
 /turf/open/openspace/airless,
@@ -61669,11 +61722,9 @@
 	},
 /area/station/hallway/primary/port)
 "lQt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
-	},
-/turf/open/floor/iron/smooth,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "lQz" = (
 /obj/structure/table/reinforced,
@@ -61755,6 +61806,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "lRj" = (
@@ -62500,8 +62552,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
 "lYe" = (
+/obj/item/cigbutt,
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/crew_quarters/bar)
+/area/station/maintenance/aft/upper)
 "lYg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -62784,10 +62841,10 @@
 /turf/open/floor/iron,
 /area/station/science/explab)
 "map" = (
-/obj/effect/spawner/random/trash/graffiti,
+/obj/effect/turf_decal/tile/purple/half,
 /obj/structure/cable,
-/turf/closed/wall,
-/area/station/maintenance/port/fore)
+/turf/open/floor/iron,
+/area/station/hallway/primary/upper)
 "maq" = (
 /obj/machinery/newscaster/directional/north,
 /obj/structure/disposalpipe/segment{
@@ -63525,6 +63582,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science)
 "mid" = (
@@ -65376,6 +65434,7 @@
 	name = "Medbay Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/upper)
 "mCr" = (
@@ -65927,6 +65986,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "mHp" = (
@@ -67102,16 +67162,12 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
 "mSG" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/cargo/lobby)
+/area/station/hallway/primary/central/fore)
 "mSI" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68778,6 +68834,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/coroner,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "njV" = (
@@ -69474,11 +69531,12 @@
 /turf/open/floor/plating,
 /area/station/engineering/transit_tube)
 "nsz" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/hangover,
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/maintenance/starboard/fore)
 "nsA" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -70218,6 +70276,7 @@
 /area/station/service/chapel)
 "nzH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "nzJ" = (
@@ -71033,10 +71092,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "nHC" = (
-/obj/structure/frame,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/item/stack/cable_coil/five,
-/turf/open/floor/iron/dark,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "nHR" = (
 /obj/structure/cable,
@@ -71349,6 +71407,7 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "nKD" = (
@@ -73951,11 +74010,16 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/visit)
 "ojp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
 /obj/structure/cable,
-/turf/open/floor/carpet/blue,
-/area/station/medical/break_room)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "ojs" = (
 /obj/structure/table/wood,
 /obj/item/modular_computer/laptop/preset/civilian,
@@ -75135,12 +75199,11 @@
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "ouh" = (
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
-	},
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/medical)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/service)
 "oun" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/light/directional/north,
@@ -75408,6 +75471,7 @@
 /obj/effect/turf_decal/tile/green/tram{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "owP" = (
@@ -75901,6 +75965,7 @@
 "oBE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "oBI" = (
@@ -76190,6 +76255,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "oEw" = (
@@ -77156,10 +77222,10 @@
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "oNH" = (
-/obj/effect/turf_decal/tile/purple/half,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "oNI" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
@@ -77208,6 +77274,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "oOt" = (
@@ -77777,13 +77844,8 @@
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
 "oUt" = (
-/obj/item/cigbutt,
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/upper)
+/turf/open/floor/iron/dark,
+/area/station/maintenance/starboard/fore)
 "oUy" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
@@ -79650,12 +79712,13 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/nt_rep)
 "pon" = (
-/obj/effect/turf_decal/siding/purple/end{
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
 	},
+/obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
-/turf/open/floor/glass/reinforced,
-/area/station/science)
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "pov" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
@@ -79824,6 +79887,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "pre" = (
@@ -80045,11 +80109,11 @@
 /turf/open/floor/grass,
 /area/station/hallway/primary/central)
 "ptu" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/disposal)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "ptx" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
@@ -80208,6 +80272,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "pvl" = (
@@ -80567,6 +80632,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "pxL" = (
@@ -81642,6 +81708,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "pJO" = (
@@ -82621,6 +82688,7 @@
 "pSS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "pSY" = (
@@ -83825,10 +83893,10 @@
 	},
 /area/station/hallway/primary/port)
 "qem" = (
-/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/random/trash/graffiti,
 /obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/service/bar/atrium)
+/turf/closed/wall,
+/area/station/maintenance/port/fore)
 "qet" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -86188,8 +86256,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "qzO" = (
-/turf/open/floor/iron/dark,
-/area/station/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "qzQ" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/rack,
@@ -90633,6 +90704,7 @@
 /area/station/engineering/supermatter/room)
 "rqU" = (
 /obj/structure/closet/emcloset,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "rre" = (
@@ -91884,14 +91956,12 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance/office)
 "rDy" = (
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/fore)
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/bar/atrium)
 "rDK" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -92218,6 +92288,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "rGo" = (
@@ -92914,6 +92985,7 @@
 "rOe" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/trash/mess,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "rOj" = (
@@ -93293,6 +93365,7 @@
 	},
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/sign/poster/contraband/icebox_moment/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "rSz" = (
@@ -95719,6 +95792,7 @@
 /obj/item/cigbutt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "srA" = (
@@ -96049,11 +96123,13 @@
 /turf/open/floor/eighties/red,
 /area/station/common/arcade)
 "suP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Medbay Maintenance"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/area/station/maintenance/department/medical/central)
 "suV" = (
 /obj/machinery/power/shuttle_engine/heater{
 	dir = 8
@@ -98094,6 +98170,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "sNJ" = (
@@ -98240,6 +98317,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "sPk" = (
@@ -98587,8 +98665,11 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/dorms/room1)
 "sSZ" = (
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/fore)
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/hangover,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/bar/atrium)
 "sTg" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/vending/wardrobe/sec_wardrobe,
@@ -100142,6 +100223,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -101155,9 +101237,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "tso" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/break_room)
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "tsr" = (
 /obj/structure/table,
 /obj/item/reagent_containers/condiment/peppermill{
@@ -103654,6 +103737,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "tPK" = (
@@ -107483,6 +107567,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "uAG" = (
@@ -107667,13 +107752,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "uCg" = (
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
-	},
-/obj/machinery/door/airlock/maintenance,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/aft/upper)
+/turf/open/floor/wood,
+/area/station/service/bar/atrium)
 "uCj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -107870,6 +107952,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "uEh" = (
@@ -108248,6 +108331,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science)
 "uHL" = (
@@ -109585,6 +109669,7 @@
 /area/station/maintenance/aft/upper)
 "uVs" = (
 /mob/living/basic/sloth/paperwork,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/storage)
 "uVu" = (
@@ -109909,7 +109994,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/upper)
 "uYI" = (
-/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
 "uYL" = (
@@ -111211,6 +111295,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "vms" = (
@@ -111419,6 +111504,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "voB" = (
@@ -112904,6 +112990,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "vBn" = (
@@ -115152,6 +115239,7 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "vXV" = (
@@ -117231,6 +117319,7 @@
 /obj/structure/grille,
 /obj/structure/barricade/wooden,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "wrz" = (
@@ -118576,6 +118665,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science)
 "wDr" = (
@@ -119152,6 +119242,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"wJl" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/hangover,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "wJr" = (
 /obj/item/stack/sheet/cardboard,
 /obj/structure/cable,
@@ -119811,6 +119907,7 @@
 	dir = 6
 	},
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "wQu" = (
@@ -119872,6 +119969,7 @@
 	name = "Medbay Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "wQN" = (
@@ -120565,6 +120663,7 @@
 "wYz" = (
 /obj/effect/spawner/random/structure/steam_vent,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "wYH" = (
@@ -121354,13 +121453,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "xgI" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Medbay Maintenance"
+/obj/effect/spawner/random/trash/mess,
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical/central)
+/area/station/maintenance/aft/upper)
 "xgN" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
@@ -122196,6 +122295,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "xpA" = (
@@ -122276,6 +122376,7 @@
 "xqh" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "xqj" = (
@@ -122666,6 +122767,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/storage)
 "xtV" = (
@@ -125807,6 +125909,7 @@
 "yal" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "yap" = (
@@ -126622,9 +126725,12 @@
 /turf/closed/wall,
 /area/station/maintenance/solars/starboard/fore)
 "yha" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/service)
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/starboard/fore)
 "yhf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -149042,8 +149148,8 @@ gKk
 tNz
 dfX
 uCl
+lnJ
 uYI
-fpW
 hqR
 rKn
 laf
@@ -150846,12 +150952,12 @@ euE
 aOx
 tcI
 ctM
-map
+qem
 rYT
 rYT
 rYT
 rYT
-dJW
+jJb
 pOh
 ctM
 dCQ
@@ -150875,13 +150981,13 @@ jQG
 bOX
 iLN
 uez
-kxO
-kxO
-kxO
-kxO
-kxO
-oXX
-kxO
+ieG
+ieG
+ieG
+ieG
+ieG
+jte
+ieG
 bnj
 aGL
 mRa
@@ -151626,7 +151732,7 @@ kqa
 iPq
 ctM
 rYT
-dJW
+jJb
 rYT
 rYT
 aQk
@@ -157034,12 +157140,12 @@ www
 fKc
 tyH
 tyH
-lbu
+mSG
 tyH
 mvl
-lbu
+mSG
 gaA
-lbu
+mSG
 csj
 uiE
 ceg
@@ -157288,7 +157394,7 @@ rCE
 sjH
 tOv
 weu
-aXM
+tso
 gfr
 krU
 uKc
@@ -159599,9 +159705,9 @@ jVv
 eBp
 bjt
 cnv
-nsz
-aXM
-aXM
+wJl
+tso
+tso
 qrd
 rWO
 mei
@@ -161197,8 +161303,8 @@ lme
 wGE
 rpj
 wEf
-jXN
-qem
+sSZ
+uCg
 aVg
 aVg
 fRV
@@ -161712,7 +161818,7 @@ wGE
 kYW
 utK
 pgb
-jte
+rDy
 lZY
 fSC
 xsG
@@ -162692,7 +162798,7 @@ dVy
 mrV
 jCc
 dVy
-jsd
+lyz
 ykA
 mHE
 gsj
@@ -162949,7 +163055,7 @@ udI
 udI
 cAL
 dVy
-jsd
+lyz
 gBM
 mHE
 gzI
@@ -163204,7 +163310,7 @@ dVy
 mrV
 dVy
 dVy
-jJb
+lQt
 ugS
 oNI
 hbn
@@ -163714,14 +163820,14 @@ qNF
 fBz
 wJa
 uMJ
-qzO
+oUt
 kgl
 bSB
 mrV
-jJb
+lQt
 fwA
 rpO
-jsd
+lyz
 dVy
 bJg
 nYU
@@ -163970,7 +164076,7 @@ qwc
 ltK
 fBz
 mne
-qzO
+oUt
 uMJ
 bxx
 bzC
@@ -164036,7 +164142,7 @@ rzg
 dDD
 uiv
 iSr
-mSG
+fpW
 hkt
 rxy
 xDq
@@ -165037,10 +165143,10 @@ wQt
 xqh
 xqh
 fZJ
-rTB
-rTB
+dGZ
+dGZ
 rOe
-rTB
+dGZ
 wYz
 ePt
 qdF
@@ -165558,7 +165664,7 @@ mAf
 cmQ
 wnW
 rTB
-rTB
+dGZ
 kHF
 xti
 uen
@@ -165815,7 +165921,7 @@ wGZ
 cmQ
 ofM
 rmI
-lYe
+gIS
 sPe
 xjF
 kdg
@@ -166043,13 +166149,13 @@ ctf
 hdS
 fRA
 xPk
-rDy
+xPk
 ivW
-aaN
+jZl
 rSw
-sSZ
-jYW
-jGU
+mZc
+nsz
+bbm
 mrV
 pvk
 oOr
@@ -166308,7 +166414,7 @@ lSU
 hSi
 hgl
 dVy
-suP
+jAj
 pdU
 btP
 cWP
@@ -166330,7 +166436,7 @@ tmY
 iYD
 hRq
 eFn
-gsY
+esx
 oTl
 sAs
 ipg
@@ -166576,7 +166682,7 @@ adt
 tzv
 wOl
 lRh
-lYe
+gIS
 oEv
 npQ
 cuq
@@ -166588,11 +166694,11 @@ pGr
 pGr
 jNf
 xtT
-oTl
-oTl
-oTl
+dJW
+dJW
+dJW
 uVs
-oTl
+dJW
 aSo
 pkD
 llc
@@ -168110,7 +168216,7 @@ lln
 pdU
 aJU
 mFT
-yha
+eBj
 sWA
 aHz
 iLD
@@ -168367,7 +168473,7 @@ jbo
 pdU
 dLl
 mFT
-yha
+eBj
 sWA
 sWA
 sWA
@@ -168624,9 +168730,9 @@ sfw
 pdU
 ceG
 mFT
-dGZ
+ouh
 dsK
-ptu
+erj
 jUp
 jUp
 jUp
@@ -169654,7 +169760,7 @@ dVy
 omU
 hNC
 yeF
-lQt
+dWg
 wTm
 pxb
 pxb
@@ -170165,10 +170271,10 @@ jrX
 eVK
 fqP
 dVy
-fyF
-fyF
+yha
+yha
 mJv
-lQt
+dWg
 wTm
 pxb
 pxb
@@ -170679,7 +170785,7 @@ vii
 mZc
 qte
 dVy
-dWg
+lpC
 qZJ
 fqP
 dFp
@@ -170939,7 +171045,7 @@ dVy
 phz
 tbl
 uHb
-esx
+aXM
 aVy
 pxb
 pxb
@@ -215181,10 +215287,10 @@ bdx
 pEL
 mKQ
 myB
-bdx
+ptu
 iHv
 glr
-uCf
+qzO
 tBF
 piL
 piL
@@ -215967,7 +216073,7 @@ tfJ
 lbA
 emg
 uBS
-nHC
+gOx
 lbA
 qho
 aDV
@@ -216224,7 +216330,7 @@ tfJ
 rNe
 uCf
 kHP
-gOx
+nHC
 tcq
 qho
 jLp
@@ -216734,8 +216840,8 @@ bdS
 pzS
 lNg
 rfn
-oUt
-lnJ
+lYe
+fyF
 tcq
 ekG
 pWy
@@ -216992,7 +217098,7 @@ pzS
 pzS
 pzS
 pzS
-iwe
+xgI
 tcq
 lpQ
 nPY
@@ -217249,7 +217355,7 @@ fyi
 sca
 dXM
 pzS
-bbm
+jXN
 tcq
 dvv
 mqY
@@ -217506,7 +217612,7 @@ paJ
 uJA
 aOH
 pzS
-uCg
+pon
 tcq
 tcq
 iBd
@@ -217764,8 +217870,8 @@ mRD
 wQH
 pzS
 ymh
-lnJ
-lnJ
+fyF
+fyF
 pyb
 pyb
 iKw
@@ -223138,7 +223244,7 @@ fHl
 xcT
 xcT
 hCo
-oNH
+map
 tzu
 vxc
 jXT
@@ -223155,7 +223261,7 @@ ciF
 snK
 idP
 ydU
-erj
+ajh
 sXH
 irK
 tbm
@@ -225454,8 +225560,8 @@ rMz
 coD
 pYa
 sVc
-pon
-lni
+uBP
+lSX
 lSX
 lSX
 jos
@@ -225685,7 +225791,7 @@ afh
 eTA
 xTW
 jWi
-cFK
+jsd
 sDG
 xTW
 cwQ
@@ -225711,7 +225817,7 @@ dFm
 mtF
 sea
 uHE
-lpC
+dkw
 dkw
 dge
 qGw
@@ -227250,9 +227356,9 @@ jUh
 xjw
 uLP
 ixf
-ckd
-ogX
-siX
+lni
+ojp
+oNH
 mCm
 skC
 lqk
@@ -231069,7 +231175,7 @@ boB
 bmu
 svy
 svy
-rTL
+suP
 svy
 svy
 svy
@@ -234156,9 +234262,9 @@ qZD
 dtD
 ili
 lXy
-xgI
-tso
-ojp
+suP
+lbu
+iwe
 fpz
 skT
 nHw
@@ -235215,7 +235321,7 @@ bcQ
 hFX
 gQa
 hFX
-ouh
+cFK
 nrV
 xBK
 kPf
@@ -235471,7 +235577,7 @@ bcQ
 bcQ
 piy
 nEh
-ouh
+cFK
 gnt
 vzQ
 sbR
@@ -235733,7 +235839,7 @@ psl
 dKH
 psl
 asK
-ajh
+qRS
 kgc
 psl
 ukR

--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -152,10 +152,12 @@
 /turf/closed/wall/r_wall,
 /area/station/science/explab)
 "acB" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
+/obj/effect/spawner/random/trash/hobo_squat,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "acE" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
@@ -406,11 +408,9 @@
 /area/station/hallway/secondary/service)
 "aeP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "aeQ" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/delivery,
@@ -1775,6 +1775,7 @@
 	name = "Biohazard Containment Door"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science)
 "asc" = (
@@ -2161,10 +2162,10 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "awq" = (
@@ -2678,6 +2679,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aBK" = (
@@ -2824,6 +2826,7 @@
 "aDa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/stairs/medium{
 	dir = 8
 	},
@@ -3526,7 +3529,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/layer1,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -4219,6 +4221,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "aRD" = (
@@ -4522,11 +4525,13 @@
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
 "aVm" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/small/directional/east,
+/obj/machinery/light/small/dim/directional/east,
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
 /turf/open/floor/plating,
-/area/station/service/power_station)
+/area/station/maintenance/starboard/fore)
 "aVo" = (
 /obj/machinery/power/shuttle_engine/propulsion/burst,
 /turf/open/floor/engine/hull/reinforced,
@@ -4782,8 +4787,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "aXM" = (
-/turf/closed/wall,
-/area/station/security/power_station)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "aXP" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
@@ -5124,8 +5131,15 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/engineering/engine_aft_port)
 "bbm" = (
-/turf/closed/wall/r_wall,
-/area/station/security/power_station)
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "bbn" = (
 /obj/structure/filingcabinet/security,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -5907,6 +5921,7 @@
 	id = "brigfront";
 	name = "Brig Blast Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "bjv" = (
@@ -6242,17 +6257,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "bmN" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Power Station";
-	name = "engineering camera";
-	network = list("ss13","ce")
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/power/port_gen/pacman/pre_loaded,
-/turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "bmP" = (
 /obj/machinery/door/airlock/maintenance/glass,
 /obj/structure/cable,
@@ -7439,14 +7446,14 @@
 /turf/open/floor/iron/shuttle/arrivals/airless,
 /area/space/nearstation)
 "bxx" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
 /turf/open/floor/iron/dark,
-/area/station/service/power_station)
+/area/station/maintenance/starboard/fore)
 "bxy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7661,12 +7668,12 @@
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "bzC" = (
-/obj/machinery/computer/monitor{
+/obj/structure/frame/computer{
+	anchored = 1;
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/service/power_station)
+/area/station/maintenance/starboard/fore)
 "bzG" = (
 /obj/machinery/light/no_nightlight/directional/west,
 /obj/structure/sign/poster/random/directional/west,
@@ -8892,6 +8899,7 @@
 /area/station/medical/treatment_center)
 "bMc" = (
 /obj/machinery/light/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "bMd" = (
@@ -9147,13 +9155,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bOO" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/service/power_station)
+/area/station/maintenance/starboard/fore)
 "bOR" = (
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -9581,9 +9585,11 @@
 /area/station/engineering/storage/tech)
 "bSB" = (
 /obj/effect/mapping_helpers/broken_floor,
-/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
 /turf/open/floor/iron/dark,
-/area/station/service/power_station)
+/area/station/maintenance/starboard/fore)
 "bSN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood/parquet,
@@ -10510,6 +10516,7 @@
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/corner{
 	dir = 8
 	},
@@ -10895,6 +10902,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/navigate_destination,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen/diner)
 "cfv" = (
@@ -11225,6 +11233,7 @@
 /area/station/maintenance/department/eva)
 "ciF" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/research)
 "ciM" = (
@@ -11655,16 +11664,12 @@
 	},
 /area/station/commons/fitness/recreation)
 "cnf" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Security Power Station"
-	},
-/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/any/security/hos,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
-/area/station/security/power_station)
+/area/station/maintenance/port/fore)
 "cnk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11690,6 +11695,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "cnw" = (
@@ -11955,6 +11961,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cqa" = (
@@ -12263,6 +12270,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "ctk" = (
@@ -13335,10 +13343,9 @@
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable,
+/obj/structure/frame,
 /turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/area/station/maintenance/port/fore)
 "cCd" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -13540,7 +13547,7 @@
 /obj/structure/table/rolling,
 /obj/item/wrench,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "cDP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -13817,21 +13824,18 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "cFK" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/power_station)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/upper)
 "cFN" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
 /obj/machinery/power/shuttle_engine/heater,
-/turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "cFO" = (
 /obj/structure/cable,
 /obj/machinery/newscaster/directional/east,
@@ -14134,12 +14138,11 @@
 /turf/open/floor/wood,
 /area/station/common/pool)
 "cHP" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/power_station)
+/area/station/maintenance/starboard/fore)
 "cHT" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -16317,6 +16320,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "deB" = (
@@ -16449,16 +16453,8 @@
 /area/station/maintenance/aft/upper)
 "dfX" = (
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/area/station/maintenance/port/fore)
 "dga" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/circuit,
@@ -16784,7 +16780,6 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/psychology)
 "diF" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/lesser)
@@ -17748,6 +17743,8 @@
 	name = "Service Hallway Maintenance Hatch"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "dsM" = (
@@ -17780,6 +17777,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "dsW" = (
@@ -18027,14 +18025,13 @@
 /turf/open/floor/plating,
 /area/station/science/auxlab/firing_range)
 "dvv" = (
-/obj/structure/cable,
-/obj/machinery/computer/monitor,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
+/obj/structure/frame/computer,
 /turf/open/floor/iron/dark,
-/area/station/science/power_station)
+/area/station/maintenance/aft/upper)
 "dvx" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -18758,6 +18755,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/navigate_destination,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "dDH" = (
@@ -18911,7 +18909,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "dFr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
 	dir = 8
@@ -19124,20 +19122,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper)
 "dGZ" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Cargo Power Station"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/machinery/door/firedoor,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/turf/open/floor/iron,
+/area/station/hallway/secondary/service)
 "dHb" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "dHc" = (
@@ -19500,9 +19495,13 @@
 /turf/open/floor/iron/smooth,
 /area/station/cargo/miningdock)
 "dJW" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/item/stack/sheet/cardboard,
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/port/fore)
 "dJY" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -19599,7 +19598,7 @@
 	icon_state = "dirt-flat-1"
 	},
 /turf/closed/wall,
-/area/station/medical/power_station)
+/area/station/maintenance/department/medical)
 "dKI" = (
 /obj/structure/flora/bush/jungle/b/style_2,
 /obj/structure/flora/bush/flowers_pp/style_3,
@@ -20648,11 +20647,12 @@
 /turf/open/floor/grass,
 /area/station/hallway/secondary/entry)
 "dWg" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
 	},
-/turf/open/floor/plating,
-/area/station/service/power_station)
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/starboard/fore)
 "dWt" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
@@ -20751,7 +20751,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/layer1,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -22019,11 +22018,9 @@
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/dark,
-/area/station/science/power_station)
+/area/station/maintenance/aft/upper)
 "ekI" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
@@ -22198,10 +22195,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/upper)
 "emg" = (
-/obj/machinery/light/small/directional/north,
+/obj/machinery/light/small/dim/directional/north,
 /obj/structure/rack,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/iron/dark,
-/area/station/science/power_station)
+/area/station/maintenance/aft/upper)
 "emk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -22628,11 +22627,15 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "erj" = (
-/obj/effect/turf_decal/stripes{
-	dir = 8
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/service/power_station)
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "erk" = (
 /obj/item/shard,
 /turf/open/floor/plating,
@@ -22740,12 +22743,12 @@
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "esx" = (
-/obj/machinery/power/terminal{
+/obj/structure/railing{
 	dir = 8
 	},
-/obj/structure/cable,
+/obj/structure/frame,
 /turf/open/floor/plating,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "esy" = (
 /obj/effect/turf_decal/vg_decals/numbers/zero,
 /turf/open/floor/iron/shuttle/arrivals/airless,
@@ -23525,6 +23528,7 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "eyK" = (
@@ -23793,6 +23797,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "eBq" = (
@@ -24563,9 +24568,11 @@
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "eIA" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -25125,6 +25132,7 @@
 /obj/machinery/duct,
 /mob/living/basic/pet/bumbles,
 /obj/structure/bed/dogbed,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "eNq" = (
@@ -25209,6 +25217,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/research)
 "eOd" = (
@@ -26449,6 +26458,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/navigate_destination,
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/research)
 "faf" = (
@@ -27039,8 +27049,11 @@
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "feZ" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
@@ -28091,9 +28104,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper)
 "fpW" = (
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/area/station/maintenance/port/fore)
 "fpY" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Engineering Maintenance"
@@ -28922,9 +28934,8 @@
 	icon_state = "dirt-flat-1"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "fyK" = (
 /obj/structure/railing/corner/end/flip,
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -30062,7 +30073,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "fMm" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -30758,6 +30768,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
 "fSN" = (
@@ -32845,14 +32856,11 @@
 /area/station/command/heads_quarters/captain/private)
 "gnt" = (
 /obj/structure/noticeboard/directional/east,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/power_station)
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "gnw" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -33916,6 +33924,7 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "gxY" = (
@@ -34298,7 +34307,6 @@
 	icon_state = "dirt-flat-1"
 	},
 /obj/structure/cable,
-/obj/structure/cable/layer1,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -34650,10 +34658,13 @@
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/obj/machinery/power/smes,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "gFG" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/storage/fancy/cigarettes/cigars/cohiba{
@@ -35179,6 +35190,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "gLm" = (
@@ -35221,6 +35233,7 @@
 	name = "Mining Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "gLu" = (
@@ -35255,6 +35268,7 @@
 "gLQ" = (
 /obj/machinery/seed_extractor,
 /obj/machinery/light/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -35338,7 +35352,6 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/detective,
-/obj/structure/cable,
 /obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron,
 /area/station/security/detectives_office)
@@ -35492,10 +35505,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "gOx" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/science/power_station)
+/obj/effect/mapping_helpers/broken_floor,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "gOy" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -35687,13 +35700,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "gPZ" = (
-/turf/closed/wall/r_wall,
-/area/station/cargo/power_station/upper)
-"gQa" = (
-/obj/machinery/power/smes/engineering,
+/obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/medical/power_station)
+/turf/open/floor/iron,
+/area/station/cargo/miningoffice)
+"gQa" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "gQe" = (
 /obj/structure/weightmachine,
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -36718,10 +36732,10 @@
 /turf/open/floor/carpet/purple,
 /area/station/common/night_club)
 "hbn" = (
-/obj/structure/cable/layer1,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "hbo" = (
@@ -36816,7 +36830,6 @@
 /obj/item/reagent_containers/cup/glass/flask/det{
 	pixel_y = 5
 	},
-/obj/structure/cable,
 /obj/item/paper_bin{
 	pixel_x = 11;
 	pixel_y = 3
@@ -37672,6 +37685,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "hku" = (
@@ -37801,6 +37815,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/shaft_miner,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "hlM" = (
@@ -38290,11 +38305,12 @@
 	icon_state = "dirt-flat-1"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "hrb" = (
 /obj/item/weldingtool,
 /obj/item/weldingtool,
@@ -39708,10 +39724,10 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/aslyum)
 "hFX" = (
-/obj/machinery/power/smes,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/medical/power_station)
+/obj/structure/frame,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "hFZ" = (
 /turf/open/floor/iron/white/textured,
 /area/station/common/cryopods)
@@ -40324,6 +40340,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "hMm" = (
@@ -40512,9 +40529,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "hND" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Toxins Maintenance"
@@ -42150,6 +42166,7 @@
 	name = "Biohazard Containment Door"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/research)
 "idV" = (
@@ -42483,9 +42500,8 @@
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/area/station/maintenance/port/fore)
 "igR" = (
 /obj/effect/turf_decal/siding/thinplating/dark/end{
 	dir = 1
@@ -42721,7 +42737,6 @@
 /obj/structure/table/wood,
 /obj/item/folder/red,
 /obj/item/hand_labeler,
-/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
 "ijq" = (
@@ -43927,10 +43942,13 @@
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "iwe" = (
+/obj/effect/spawner/random/trash/mess,
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/service/power_station)
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "iwl" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/door/airlock/security/old{
@@ -44126,12 +44144,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/cult_chapel_maint)
 "ixJ" = (
-/obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/power_station)
+/area/station/maintenance/starboard/fore)
 "ixK" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -44430,14 +44447,11 @@
 	},
 /area/station/cargo/miningdock)
 "iBd" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Science Power Station"
-	},
+/obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/science/rd,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
-/area/station/science/power_station)
+/area/station/maintenance/aft/upper)
 "iBm" = (
 /obj/machinery/vending/wardrobe/curator_wardrobe,
 /obj/effect/turf_decal/bot,
@@ -44719,7 +44733,7 @@
 /obj/effect/spawner/random/trash/mess,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/multilayer/connected,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "iEu" = (
@@ -44995,13 +45009,9 @@
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/medical/power_station)
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "iGA" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -46934,7 +46944,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "jbn" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -47399,21 +47409,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/transit_tube)
 "jgq" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/obj/effect/turf_decal/stripes,
-/obj/machinery/camera/directional/north{
-	c_tag = "Science - Power Station";
-	name = "engineering camera";
-	network = list("ss13","ce")
-	},
 /turf/open/floor/iron/dark,
-/area/station/science/power_station)
+/area/station/maintenance/aft/upper)
 "jgr" = (
 /obj/structure/light_construct/directional/east,
 /turf/open/floor/iron,
@@ -47536,12 +47537,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/lesser)
 "jhT" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/area/station/maintenance/port/fore)
 "jhU" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
@@ -48683,10 +48683,10 @@
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/obj/structure/cable/multilayer/connected,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "jsj" = (
@@ -48792,8 +48792,12 @@
 /turf/open/floor/eighties/red,
 /area/station/common/arcade)
 "jte" = (
-/turf/closed/wall,
-/area/station/service/power_station)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/bar/atrium)
 "jtm" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -48878,17 +48882,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "jub" = (
-/obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/obj/machinery/power/port_gen/pacman/pre_loaded,
-/turf/open/floor/iron/dark,
-/area/station/medical/power_station)
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "jui" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Council of Practical Gags"
@@ -49472,10 +49471,10 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "jAj" = (
-/obj/structure/cable/layer1,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "jAk" = (
@@ -50299,17 +50298,10 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/command/heads_quarters/ce)
 "jId" = (
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
 /obj/structure/rack,
-/obj/machinery/camera/directional/north{
-	c_tag = "Service - Power Station";
-	name = "engineering camera";
-	network = list("ss13","ce")
-	},
+/obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/iron/dark,
-/area/station/service/power_station)
+/area/station/maintenance/starboard/fore)
 "jIf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50381,9 +50373,10 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/port)
 "jJb" = (
-/obj/effect/spawner/random/trash/graffiti,
-/turf/closed/wall,
-/area/station/cargo/power_station/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "jJf" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/assistant,
@@ -51239,11 +51232,8 @@
 	icon_state = "dirt-flat-1"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "jQG" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/firecloset,
@@ -51882,10 +51872,9 @@
 /area/station/command/heads_quarters/qm)
 "jVT" = (
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable,
+/obj/structure/frame,
 /turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/area/station/maintenance/port/fore)
 "jVV" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
@@ -52056,8 +52045,11 @@
 /turf/open/floor/wood,
 /area/station/command/captain_dining)
 "jXN" = (
-/turf/closed/wall,
-/area/station/cargo/power_station/upper)
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/hangover,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/bar/atrium)
 "jXO" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8;
@@ -52071,6 +52063,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science)
 "jXV" = (
@@ -52245,13 +52238,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engineering/engine_aft_port)
-"jZl" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
-	},
-/turf/open/floor/iron,
-/area/station/cargo/power_station/upper)
 "jZm" = (
 /obj/structure/table/wood/poker,
 /obj/item/storage/dice,
@@ -53532,6 +53518,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "klh" = (
@@ -54287,6 +54274,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
 "ksj" = (
@@ -54483,14 +54471,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "kub" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Service Power Station"
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
-/area/station/service/power_station)
+/area/station/maintenance/starboard/fore)
 "kuh" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt{
@@ -54937,12 +54921,12 @@
 /area/station/science/explab)
 "kyb" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/engineering{
-	name = "Cargo Power Station"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "kye" = (
 /obj/effect/turf_decal/stripes{
 	dir = 9
@@ -55190,14 +55174,10 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "kAe" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Security Power Station"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/security/hos,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
-/area/station/security/power_station)
+/area/station/maintenance/port/fore)
 "kAh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
@@ -55240,6 +55220,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "kAy" = (
@@ -55943,13 +55924,12 @@
 	},
 /area/station/security/brig)
 "kHP" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes,
-/turf/open/floor/iron/dark,
-/area/station/science/power_station)
+/obj/effect/mapping_helpers/broken_floor,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "kHV" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/delivery,
@@ -57641,12 +57621,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "lbu" = (
-/obj/effect/spawner/random/trash/mess,
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "lbz" = (
 /obj/structure/chair/pew/right{
 	dir = 8
@@ -58034,6 +58014,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -58225,15 +58206,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
 "lge" = (
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/medical/power_station)
+/area/station/maintenance/department/medical)
 "lgi" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/reagent_dispensers/fueltank,
@@ -58757,6 +58735,7 @@
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "lmd" = (
@@ -58948,8 +58927,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "lnJ" = (
-/turf/closed/wall/rust,
-/area/station/service/power_station)
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "lnM" = (
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
@@ -59145,10 +59128,9 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "lpQ" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/science/power_station)
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "lpR" = (
 /obj/effect/turf_decal/bot_red,
 /obj/machinery/doppler_array,
@@ -59507,14 +59489,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/upper)
 "ltC" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Service Power Station"
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
-/area/station/service/power_station)
+/area/station/maintenance/starboard/fore)
 "ltF" = (
 /obj/structure/filingcabinet,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59571,9 +59549,10 @@
 	icon_state = "dirt-flat-1"
 	},
 /obj/structure/rack,
-/obj/machinery/light/small/directional/west,
+/obj/machinery/light/small/dim/directional/west,
+/obj/item/screwdriver,
 /turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/area/station/maintenance/port/fore)
 "luf" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet/red,
@@ -59818,6 +59797,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen/diner)
 "lxx" = (
@@ -59881,16 +59861,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/upper)
-"lyz" = (
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
-	},
-/obj/structure/cable/layer1,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
 "lyK" = (
 /obj/structure/lattice/catwalk,
 /turf/open/openspace/airless,
@@ -61420,12 +61390,10 @@
 /area/station/maintenance/aft/upper)
 "lNh" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/engineering{
-	name = "Cargo Power Station"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/iron,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "lNi" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -61702,10 +61670,11 @@
 /area/station/hallway/primary/port)
 "lQt" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/science/power_station)
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/starboard/fore)
 "lQz" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
@@ -61761,15 +61730,12 @@
 	},
 /area/station/security/prison/safe)
 "lQN" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
+/obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "lQX" = (
 /obj/structure/sign/warning/vacuum/external/directional/north,
 /obj/structure/closet/cardboard,
@@ -62544,16 +62510,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "lYi" = (
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/medical/power_station)
+/obj/effect/spawner/random/medical/surgery_tool,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "lYj" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -62739,7 +62702,6 @@
 	},
 /obj/item/clothing/mask/cigarette/cigar,
 /obj/item/lighter,
-/obj/structure/cable,
 /obj/machinery/button/door{
 	id = "DetShutters";
 	name = "Privacy Shutters";
@@ -62822,11 +62784,10 @@
 /turf/open/floor/iron,
 /area/station/science/explab)
 "map" = (
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
-	},
+/obj/effect/spawner/random/trash/graffiti,
+/obj/structure/cable,
 /turf/closed/wall,
-/area/station/security/power_station)
+/area/station/maintenance/port/fore)
 "maq" = (
 /obj/machinery/newscaster/directional/north,
 /obj/structure/disposalpipe/segment{
@@ -64018,10 +63979,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "mne" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable,
+/obj/structure/frame,
 /turf/open/floor/plating,
-/area/station/service/power_station)
+/area/station/maintenance/starboard/fore)
 "mng" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/bot,
@@ -64356,13 +64316,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "mqY" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/power_station)
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "mrb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
@@ -65505,6 +65464,7 @@
 /area/station/medical/medbay/lobby)
 "mDn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "mDo" = (
@@ -66194,14 +66154,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "mJx" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science)
 "mJC" = (
@@ -67141,8 +67102,16 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
 "mSG" = (
-/turf/closed/wall/rust,
-/area/station/science/power_station)
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/lobby)
 "mSI" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68078,11 +68047,9 @@
 	icon_state = "dirt-flat-1"
 	},
 /obj/effect/mapping_helpers/broken_floor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/area/station/maintenance/port/fore)
 "ncB" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/structure/disposalpipe/segment{
@@ -68095,7 +68062,7 @@
 	icon_state = "dirt-flat-1"
 	},
 /turf/closed/wall/rust,
-/area/station/medical/power_station)
+/area/station/maintenance/department/medical)
 "ncD" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
@@ -68630,6 +68597,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "nhW" = (
@@ -68702,6 +68670,7 @@
 	dir = 9
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "niI" = (
@@ -68977,6 +68946,7 @@
 /area/station/maintenance/port/central)
 "nmh" = (
 /obj/machinery/biogenerator,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -69350,7 +69320,7 @@
 /obj/machinery/light/broken/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "nqG" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
@@ -69445,14 +69415,13 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "nrV" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/power_station)
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "nrY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 10
@@ -69505,9 +69474,11 @@
 /turf/open/floor/plating,
 /area/station/engineering/transit_tube)
 "nsz" = (
-/obj/machinery/power/port_gen/pacman/pre_loaded,
-/turf/open/floor/plating,
-/area/station/service/power_station)
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/hangover,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "nsA" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -70694,15 +70665,10 @@
 /turf/open/floor/grass,
 /area/station/command/heads_quarters/cmo)
 "nEh" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron/dark,
-/area/station/medical/power_station)
+/area/station/maintenance/department/medical)
 "nEk" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/reagent_containers/cup/bucket,
@@ -71067,8 +71033,11 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "nHC" = (
-/turf/closed/wall,
-/area/station/medical/power_station)
+/obj/structure/frame,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/aft/upper)
 "nHR" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -71609,14 +71578,10 @@
 /turf/open/space/openspace,
 /area/space/nearstation)
 "nNl" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Medical Power Station"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/medical/cmo,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance,
 /turf/open/floor/iron/dark,
-/area/station/medical/power_station)
+/area/station/maintenance/department/medical)
 "nNn" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
@@ -71857,14 +71822,13 @@
 /turf/open/floor/wood,
 /area/station/service/electronic_marketing_den)
 "nPY" = (
-/obj/structure/cable,
-/obj/machinery/light/small/directional/south,
+/obj/machinery/light/small/dim/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/power_station)
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "nQf" = (
 /obj/machinery/airalarm/directional/west,
 /obj/item/radio/intercom/directional/south,
@@ -73547,7 +73511,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/service/power_station)
+/area/station/maintenance/starboard/fore)
 "ogj" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -73987,10 +73951,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/visit)
 "ojp" = (
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/service/power_station)
+/turf/open/floor/carpet/blue,
+/area/station/medical/break_room)
 "ojs" = (
 /obj/structure/table/wood,
 /obj/item/modular_computer/laptop/preset/civilian,
@@ -74410,10 +74375,9 @@
 "omU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/computer/monitor,
+/obj/structure/frame/computer,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "omW" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/cable,
@@ -75171,18 +75135,12 @@
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "ouh" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/dark,
-/area/station/medical/power_station)
+/area/station/maintenance/department/medical)
 "oun" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/light/directional/north,
@@ -75339,7 +75297,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "ovY" = (
@@ -77199,27 +77156,18 @@
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "oNH" = (
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
-	},
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/power/terminal{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/purple/half,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/service/power_station)
+/turf/open/floor/iron,
+/area/station/hallway/primary/upper)
 "oNI" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/obj/structure/cable/layer1,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "oNL" = (
@@ -77593,10 +77541,9 @@
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "oRy" = (
-/obj/machinery/computer/monitor,
-/obj/structure/cable,
+/obj/structure/frame/computer,
 /turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/area/station/maintenance/port/fore)
 "oRP" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -77830,15 +77777,13 @@
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
 "oUt" = (
-/obj/machinery/power/terminal{
-	dir = 4
+/obj/item/cigbutt,
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/service/power_station)
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "oUy" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
@@ -77970,6 +77915,7 @@
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "oVP" = (
@@ -78202,6 +78148,7 @@
 "oYi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "oYm" = (
@@ -78653,17 +78600,17 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "pdD" = (
-/obj/machinery/light/small/directional/south,
+/obj/machinery/light/small/dim/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/obj/structure/cable,
-/obj/machinery/computer/monitor{
+/obj/structure/frame/computer{
+	anchored = 1;
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/medical/power_station)
+/area/station/maintenance/department/medical)
 "pdH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/layer_manifold/brown/visible,
@@ -78967,10 +78914,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "phz" = (
+/obj/structure/cable,
 /turf/open/floor/iron/stairs/old{
 	dir = 4
 	},
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "phD" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
@@ -79121,19 +79069,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "piy" = (
-/obj/machinery/light/small/directional/north,
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
+/obj/machinery/light/small/dim/directional/north,
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
 /turf/open/floor/iron/dark,
-/area/station/medical/power_station)
+/area/station/maintenance/department/medical)
 "piD" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable,
@@ -79863,7 +79804,7 @@
 /obj/structure/barricade/wooden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "pqX" = (
@@ -80104,14 +80045,11 @@
 /turf/open/floor/grass,
 /area/station/hallway/primary/central)
 "ptu" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/cargo/lobby)
+/turf/open/floor/plating,
+/area/station/maintenance/disposal)
 "ptx" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
@@ -80859,8 +80797,9 @@
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "pAm" = (
 /obj/structure/curtain/bounty,
 /obj/effect/turf_decal/siding/wood{
@@ -82070,8 +82009,9 @@
 	icon_state = "dirt-flat-1"
 	},
 /obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "pMi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 6
@@ -82255,6 +82195,7 @@
 	icon_state = "dirt-flat-1"
 	},
 /obj/machinery/door/airlock/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "pOl" = (
@@ -83095,16 +83036,13 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "pWy" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/power_station)
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "pWA" = (
 /obj/structure/table,
 /obj/item/wirecutters/makeshift,
@@ -83716,6 +83654,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "qcE" = (
@@ -83840,6 +83779,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
 "qdC" = (
@@ -83885,8 +83825,10 @@
 	},
 /area/station/hallway/primary/port)
 "qem" = (
-/turf/closed/wall/rust,
-/area/station/medical/power_station)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/bar/atrium)
 "qet" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -83915,8 +83857,8 @@
 	icon_state = "dirt-flat-1"
 	},
 /obj/effect/decal/cleanable/oil/streak,
-/turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "qeS" = (
 /obj/structure/bed/pod,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -85861,12 +85803,9 @@
 /area/station/hallway/primary/central)
 "qwg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/machinery/light/small/dim/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/area/station/maintenance/port/fore)
 "qwm" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
@@ -86249,10 +86188,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "qzO" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/service/power_station)
+/area/station/maintenance/starboard/fore)
 "qzQ" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/rack,
@@ -86737,7 +86674,6 @@
 	name = "Security Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/detective,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/lesser)
 "qDV" = (
@@ -87992,12 +87928,10 @@
 	},
 /area/station/security/office)
 "qRf" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Cargo Power Station"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "qRp" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
@@ -88509,7 +88443,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "qWx" = (
@@ -88898,8 +88832,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "qZJ" = (
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "qZM" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/condiment/saltshaker{
@@ -89344,6 +89279,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
 "rem" = (
@@ -89421,6 +89357,7 @@
 "reB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science)
 "reE" = (
@@ -90413,6 +90350,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "roO" = (
@@ -90468,6 +90406,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
 "rpk" = (
@@ -91117,10 +91056,9 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/aslyum)
 "ruS" = (
-/obj/machinery/power/smes,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/science/power_station)
+/obj/structure/frame,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "ruT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -91395,6 +91333,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "rxA" = (
@@ -91547,6 +91486,7 @@
 /obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "rzv" = (
@@ -92188,6 +92128,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
 "rFN" = (
@@ -92809,6 +92750,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
 "rMr" = (
@@ -92904,16 +92846,12 @@
 	},
 /area/station/medical/medbay/lobby)
 "rNe" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Science Power Station"
-	},
-/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/any/science/rd,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
-/area/station/science/power_station)
+/area/station/maintenance/aft/upper)
 "rNl" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -94709,6 +94647,7 @@
 "sfS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/structure/steam_vent,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "sfX" = (
@@ -94778,13 +94717,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "sgz" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/area/station/maintenance/port/fore)
 "sgD" = (
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 1
@@ -94821,8 +94756,9 @@
 /area/station/security/office)
 "sgZ" = (
 /obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "sha" = (
 /obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
@@ -95169,6 +95105,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "skT" = (
@@ -95487,6 +95424,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/research)
 "soa" = (
@@ -99531,13 +99469,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology/control)
 "tbl" = (
-/obj/machinery/power/smes/engineering,
 /obj/structure/railing{
 	dir = 9
 	},
-/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/frame,
+/obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "tbm" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -99947,9 +99886,9 @@
 /area/station/medical/storage)
 "tez" = (
 /obj/item/kirbyplants/random,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "teE" = (
@@ -101057,6 +100996,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/beacon,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "tpT" = (
@@ -101216,11 +101156,8 @@
 /area/station/medical/medbay/central)
 "tso" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/lesser)
+/turf/open/floor/iron/white,
+/area/station/medical/break_room)
 "tsr" = (
 /obj/structure/table,
 /obj/item/reagent_containers/condiment/peppermill{
@@ -101930,6 +101867,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/side,
 /area/station/science)
 "tzv" = (
@@ -102633,6 +102571,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science)
 "tFj" = (
@@ -103893,6 +103832,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen/diner)
 "tRm" = (
@@ -104483,7 +104423,7 @@
 	},
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "tXu" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
@@ -105599,6 +105539,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "uiy" = (
@@ -107712,14 +107653,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "uBS" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes,
-/turf/open/floor/iron/dark,
-/area/station/science/power_station)
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "uCa" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/pool_maintenance)
@@ -107729,8 +107667,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "uCg" = (
-/turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/obj/effect/decal/cleanable/dirt{
+	icon_state = "dirt-flat-1"
+	},
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/aft/upper)
 "uCj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -107745,15 +107688,9 @@
 	icon_state = "dirt-flat-1"
 	},
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "uCp" = (
 /obj/effect/turf_decal/stripes/box,
 /obj/effect/turf_decal/stripes/red/box,
@@ -108258,13 +108195,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "uHb" = (
-/obj/machinery/power/smes/engineering,
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "uHf" = (
 /obj/machinery/light/small/broken/directional/south,
 /obj/structure/cable,
@@ -109459,10 +109394,6 @@
 	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/item/paper/fluff{
-	default_raw_text = "To the Engineers of BlueShift, we would like to inform you that the power draw at the start of your shift may be something you're not used to while working on stations. BlueShift is equipped with departmental power banks. You should NEVER connect departments into the main power net to avoid issues. These power banks are located in maintenance around their respective departments, and the head of said department may come in at their leisure. If you ever encounter issues, please have your Chief Engineer contact Central Command. Have a secure shift.";
-	name = "Note to Electricians"
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "uTy" = (
@@ -109978,15 +109909,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/upper)
 "uYI" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/area/station/maintenance/port/fore)
 "uYL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -112423,6 +112348,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science)
 "vxf" = (
@@ -112444,6 +112370,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -112883,13 +112810,9 @@
 	dir = 8
 	},
 /obj/structure/rack,
-/obj/machinery/camera/directional/south{
-	c_tag = "Medical - Power Station";
-	name = "engineering camera";
-	network = list("ss13","ce")
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/power_station)
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "vzT" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -113045,6 +112968,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "vCi" = (
@@ -113519,11 +113443,10 @@
 /turf/open/floor/iron,
 /area/station/science/explab)
 "vGZ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/area/station/maintenance/port/fore)
 "vHe" = (
 /obj/structure/table,
 /obj/item/reagent_containers/cup/glass/drinkingglass{
@@ -114915,7 +114838,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "vUA" = (
@@ -115519,6 +115441,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "wbc" = (
@@ -115920,6 +115843,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "wez" = (
@@ -116841,7 +116765,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "wmD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -118739,6 +118663,7 @@
 	name = "Bar Junction";
 	sortType = 19
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
 "wEk" = (
@@ -119172,16 +119097,9 @@
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/service/power_station)
+/obj/machinery/light/small/dim/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "wJd" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/bot,
@@ -119234,10 +119152,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"wJl" = (
-/obj/effect/spawner/random/trash/graffiti,
-/turf/closed/wall,
-/area/station/service/power_station)
 "wJr" = (
 /obj/item/stack/sheet/cardboard,
 /obj/structure/cable,
@@ -119379,6 +119293,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "wLM" = (
@@ -119774,6 +119689,7 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "wPg" = (
@@ -120204,7 +120120,7 @@
 	name = "Shuttle Bay Blast Door"
 	},
 /turf/open/floor/plating,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "wTq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -120449,6 +120365,7 @@
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "wWy" = (
@@ -120683,7 +120600,7 @@
 	},
 /obj/machinery/power/shuttle_engine/propulsion,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "wYQ" = (
 /obj/structure/closet/cardboard,
 /obj/effect/spawner/random/maintenance,
@@ -120964,6 +120881,7 @@
 "xbG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -121436,8 +121354,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "xgI" = (
-/turf/closed/wall,
-/area/station/science/power_station)
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Medbay Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/central)
 "xgN" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
@@ -121831,7 +121754,7 @@
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "xkR" = (
@@ -122233,6 +122156,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "xpr" = (
@@ -123110,13 +123034,11 @@
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/area/station/maintenance/port/fore)
 "xxp" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/library/lower)
@@ -123360,6 +123282,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen/diner)
 "xAA" = (
@@ -123457,16 +123380,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/pool_maintenance)
 "xBK" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Medical Power Station"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/medical/cmo,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance,
 /turf/open/floor/iron/dark,
-/area/station/medical/power_station)
+/area/station/maintenance/department/medical)
 "xBL" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/curtain/cloth/fancy/mechanical{
@@ -123655,6 +123574,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "xDx" = (
@@ -123720,6 +123640,7 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "xEg" = (
@@ -125127,7 +125048,6 @@
 /area/station/maintenance/abandon_office)
 "xTh" = (
 /obj/effect/spawner/random/trash/mess,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -126356,6 +126276,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "ydV" = (
@@ -126435,9 +126356,8 @@
 /area/station/security/prison/mess)
 "yeF" = (
 /obj/item/weldingtool,
-/obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/area/station/maintenance/starboard/fore)
 "yeG" = (
 /obj/structure/closet/secure_closet/blueshield,
 /obj/item/storage/backpack/blueshield,
@@ -126702,12 +126622,9 @@
 /turf/closed/wall,
 /area/station/maintenance/solars/starboard/fore)
 "yha" = (
-/obj/effect/decal/cleanable/dirt{
-	icon_state = "dirt-flat-1"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth,
-/area/station/cargo/power_station/upper)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/service)
 "yhf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -126908,10 +126825,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "yiE" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/iron/dark,
-/area/station/security/power_station)
+/area/station/maintenance/port/fore)
 "yiI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -127213,6 +127130,7 @@
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-flat-1"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 
@@ -148608,12 +148526,12 @@ mjG
 fVV
 mjG
 ojX
-map
-aXM
-aXM
-aXM
-aXM
-aXM
+nqO
+rKn
+rKn
+rKn
+rKn
+rKn
 laf
 laf
 uMr
@@ -148864,11 +148782,11 @@ mjE
 mjE
 mjE
 mjE
-bbm
-aXM
+tNz
+rKn
 ltX
-uCg
-fpW
+kbf
+ufv
 jhT
 kAe
 laf
@@ -149121,14 +149039,14 @@ hce
 sAN
 euE
 gKk
-bbm
+tNz
 dfX
 uCl
 uYI
-uYI
+fpW
 hqR
-aXM
-ttc
+rKn
+laf
 tPT
 rKn
 tcI
@@ -149378,14 +149296,14 @@ euE
 sAN
 euE
 euE
-bbm
+tNz
 jVT
 cBY
 acB
 gFE
 jQD
-aXM
-kbf
+rKn
+rYT
 tPT
 rKn
 wMc
@@ -149635,14 +149553,14 @@ iHC
 mQE
 iHC
 pYt
-bbm
+tNz
 bmN
 nct
 aeP
 sgz
 qwg
-aXM
-kbf
+rKn
+rYT
 rKn
 rKn
 rKn
@@ -149892,7 +149810,7 @@ euE
 sAN
 euE
 iHC
-bbm
+tNz
 oRy
 igP
 xxn
@@ -150149,13 +150067,13 @@ cgu
 sAN
 euE
 iHC
-bbm
-bbm
-bbm
-bbm
-bbm
-bbm
-aXM
+tNz
+tNz
+tNz
+tNz
+tNz
+tNz
+rKn
 ctM
 mWp
 lqH
@@ -150928,14 +150846,14 @@ euE
 aOx
 tcI
 ctM
-vpO
-kbf
-kbf
-kbf
-kbf
-wno
+map
+rYT
+rYT
+rYT
+rYT
+dJW
 pOh
-tcI
+ctM
 dCQ
 cRG
 dFs
@@ -151192,7 +151110,7 @@ rKn
 rKn
 rKn
 rKn
-kbf
+rYT
 dCQ
 hsZ
 hsZ
@@ -151449,7 +151367,7 @@ grf
 vke
 nbK
 rKn
-lbu
+mzK
 dCQ
 dCQ
 dCQ
@@ -151706,11 +151624,11 @@ dIs
 oMQ
 kqa
 iPq
-tcI
-kbf
-wno
-kbf
-kbf
+ctM
+rYT
+dJW
+rYT
+rYT
 aQk
 hHH
 rKn
@@ -156083,7 +156001,7 @@ hGf
 hGf
 hGf
 wQs
-tso
+kNY
 odQ
 sxa
 mxi
@@ -156340,7 +156258,7 @@ lqx
 unA
 hGf
 chS
-tso
+kNY
 bws
 jYr
 mxi
@@ -156597,7 +156515,7 @@ vqv
 pvj
 hGf
 ssK
-tso
+kNY
 vFi
 jhS
 mxi
@@ -156854,7 +156772,7 @@ eQu
 uvf
 hGf
 kXY
-tso
+kNY
 www
 www
 trQ
@@ -157116,12 +157034,12 @@ www
 fKc
 tyH
 tyH
-tyH
+lbu
 tyH
 mvl
-tyH
+lbu
 gaA
-tyH
+lbu
 csj
 uiE
 ceg
@@ -157370,7 +157288,7 @@ rCE
 sjH
 tOv
 weu
-rWO
+aXM
 gfr
 krU
 uKc
@@ -159681,9 +159599,9 @@ jVv
 eBp
 bjt
 cnv
-npr
-rWO
-rWO
+nsz
+aXM
+aXM
 qrd
 rWO
 mei
@@ -161279,8 +161197,8 @@ lme
 wGE
 rpj
 wEf
-fRV
-aVg
+jXN
+qem
 aVg
 aVg
 fRV
@@ -161794,7 +161712,7 @@ wGE
 kYW
 utK
 pgb
-utK
+jte
 lZY
 fSC
 xsG
@@ -163031,7 +162949,7 @@ udI
 udI
 cAL
 dVy
-lyz
+jsd
 gBM
 mHE
 gzI
@@ -163281,12 +163199,12 @@ fBz
 fBz
 fBz
 ltC
-jte
-jte
-lnJ
-jte
-jte
-ygn
+dVy
+dVy
+mrV
+dVy
+dVy
+jJb
 ugS
 oNI
 hbn
@@ -163537,12 +163455,12 @@ nhb
 ukA
 nMV
 fBz
-iwe
+ygn
 ogh
 ixJ
-nsz
-ojp
-jte
+hEu
+kgl
+dVy
 sfS
 mrV
 hOE
@@ -163795,15 +163713,15 @@ bvl
 qNF
 fBz
 wJa
-oNH
-oUt
-dWg
+uMJ
+qzO
+kgl
 bSB
-lnJ
-ygn
+mrV
+jJb
 fwA
 rpO
-lyz
+jsd
 dVy
 bJg
 nYU
@@ -164053,10 +163971,10 @@ ltK
 fBz
 mne
 qzO
-qzO
+uMJ
 bxx
 bzC
-lnJ
+mrV
 xhw
 xhw
 rpJ
@@ -164117,8 +164035,8 @@ uVh
 rzg
 dDD
 uiv
-ptu
 iSr
+mSG
 hkt
 rxy
 xDq
@@ -164309,7 +164227,7 @@ yez
 rbJ
 fBz
 jId
-erj
+tVI
 cHP
 bOO
 aVm
@@ -164565,12 +164483,12 @@ ePN
 nCO
 joM
 fBz
-jte
-wJl
-jte
-lnJ
-jte
-jte
+dVy
+uyp
+dVy
+mrV
+dVy
+dVy
 bJg
 mrV
 hxZ
@@ -166439,7 +166357,7 @@ oVX
 hlC
 mDn
 deA
-hyY
+gPZ
 gLt
 gxT
 pEc
@@ -168192,7 +168110,7 @@ lln
 pdU
 aJU
 mFT
-vpS
+yha
 sWA
 aHz
 iLD
@@ -168449,7 +168367,7 @@ jbo
 pdU
 dLl
 mFT
-vpS
+yha
 sWA
 sWA
 sWA
@@ -168706,9 +168624,9 @@ sfw
 pdU
 ceG
 mFT
-vpS
+dGZ
 dsK
-jUp
+ptu
 jUp
 jUp
 jUp
@@ -168961,12 +168879,12 @@ tpx
 tfe
 rtr
 rtr
-jXN
-dGZ
-jXN
-jXN
+dVy
+dVy
+dVy
+dVy
 kyb
-gPZ
+hrK
 ocA
 ocA
 ocA
@@ -169218,12 +169136,12 @@ xGF
 apR
 rtr
 pHE
-jXN
+dVy
 wmu
 feX
-qZJ
+jbj
 eIs
-gPZ
+hrK
 pxb
 pxb
 pxb
@@ -169479,7 +169397,7 @@ qRf
 jbj
 tXo
 pMh
-sgZ
+fqP
 wTm
 pxb
 pxb
@@ -169732,11 +169650,11 @@ ivC
 xNV
 rtr
 jvx
-jXN
+dVy
 omU
 hNC
 yeF
-pzU
+lQt
 wTm
 pxb
 pxb
@@ -169989,7 +169907,7 @@ dVy
 dVy
 dVy
 wPg
-jXN
+dVy
 nqC
 cFN
 wYO
@@ -170246,11 +170164,11 @@ sYw
 jrX
 eVK
 fqP
-jXN
+dVy
 fyF
-yha
+fyF
 mJv
-pzU
+lQt
 wTm
 pxb
 pxb
@@ -170503,10 +170421,10 @@ jYW
 nnG
 tZU
 qte
-jJb
+uyp
 qeM
 cDN
-feX
+uMJ
 sgZ
 wTm
 pxb
@@ -170760,12 +170678,12 @@ qte
 vii
 mZc
 qte
-jXN
-feX
+dVy
+dWg
 qZJ
-qZJ
+fqP
 dFp
-gPZ
+hrK
 pxb
 pxb
 pxb
@@ -171017,12 +170935,12 @@ aVy
 hrK
 uFA
 dVy
-jXN
+dVy
 phz
 tbl
 uHb
-uHb
-dJW
+esx
+aVy
 pxb
 pxb
 pxb
@@ -171275,11 +171193,11 @@ gVU
 qte
 qte
 lNh
-jZl
-esx
+qte
+tVI
 lQN
-esx
-dJW
+kgl
+aVy
 pxb
 pxb
 pxb
@@ -171531,12 +171449,12 @@ cyg
 hrK
 hrK
 hrK
-gPZ
-gPZ
-gPZ
-dJW
-dJW
-dJW
+hrK
+hrK
+hrK
+aVy
+aVy
+aVy
 pxb
 pxb
 pxb
@@ -215789,11 +215707,11 @@ pzS
 pzS
 pzS
 tfJ
-xgI
-xgI
-xgI
-xgI
-mSG
+tcq
+tcq
+tcq
+tcq
+lbA
 lEo
 lec
 khL
@@ -216046,11 +215964,11 @@ bdS
 fLw
 pzS
 tfJ
-mSG
+lbA
 emg
 uBS
-gOx
-mSG
+nHC
+lbA
 qho
 aDV
 anF
@@ -216304,10 +216222,10 @@ bpT
 pzS
 tfJ
 rNe
-lQt
+uCf
 kHP
 gOx
-xgI
+tcq
 qho
 jLp
 awA
@@ -216560,11 +216478,11 @@ pzS
 pzS
 pzS
 oVN
-xgI
-xgI
+tcq
+tcq
 jgq
 ruS
-xgI
+tcq
 qFl
 aDV
 gwl
@@ -216816,12 +216734,12 @@ bdS
 pzS
 lNg
 rfn
-qbG
-tpk
-xgI
+oUt
+lnJ
+tcq
 ekG
 pWy
-xgI
+tcq
 sXD
 pFq
 thw
@@ -217074,11 +216992,11 @@ pzS
 pzS
 pzS
 pzS
-wnO
-xgI
+iwe
+tcq
 lpQ
 nPY
-xgI
+tcq
 dFP
 pFq
 maI
@@ -217331,11 +217249,11 @@ fyi
 sca
 dXM
 pzS
-uqF
-xgI
+bbm
+tcq
 dvv
 mqY
-mSG
+lbA
 tpk
 ujy
 bqu
@@ -217588,11 +217506,11 @@ paJ
 uJA
 aOH
 pzS
-cDm
-xgI
-xgI
+uCg
+tcq
+tcq
 iBd
-xgI
+tcq
 lbA
 pFq
 vVn
@@ -217846,8 +217764,8 @@ mRD
 wQH
 pzS
 ymh
-tpk
-tpk
+lnJ
+lnJ
 pyb
 pyb
 iKw
@@ -223220,7 +223138,7 @@ fHl
 xcT
 xcT
 hCo
-mtF
+oNH
 tzu
 vxc
 jXT
@@ -223237,7 +223155,7 @@ ciF
 snK
 idP
 ydU
-fRM
+erj
 sXH
 irK
 tbm
@@ -225767,7 +225685,7 @@ afh
 eTA
 xTW
 jWi
-xcn
+cFK
 sDG
 xTW
 cwQ
@@ -234238,9 +234156,9 @@ qZD
 dtD
 ili
 lXy
-rTL
-cKT
-oBP
+xgI
+tso
+ojp
 fpz
 skT
 nHw
@@ -235294,10 +235212,10 @@ lOi
 dxn
 tkQ
 bcQ
-gQa
+hFX
 gQa
 hFX
-cFK
+ouh
 nrV
 xBK
 kPf
@@ -235556,7 +235474,7 @@ nEh
 ouh
 gnt
 vzQ
-nHC
+sbR
 klc
 wYQ
 wZd
@@ -235808,12 +235726,12 @@ qwm
 tSM
 wUw
 psl
-nHC
-qem
+sbR
+psl
 nNl
-qem
+psl
 dKH
-qem
+psl
 asK
 ajh
 kgc
@@ -236067,7 +235985,7 @@ oOX
 tkG
 nfF
 hOT
-vVB
+fOk
 uBi
 pYb
 psl


### PR DESCRIPTION
## About The Pull Request
Title.

## How This Contributes To The Nova Sector Roleplay Experience

I added these about two years ago. Blueshift was 3-Zs and we had arcing APCs. Couped with it being so massive. Blueshift had a *massive* energy draw and load. Today, with many of /tgs/ power refactors, the removal (I don't know if its removed, but I haven't seen it in ages) of arcing APCs, and of the handful of rounds I've came in to watch that were on Blueshift, the power stations seem to be insufficient.

Not to mention, I would commonly see these stations hot wired back to the main grid, which rendered them null.

I feel that their inclusion impacts nothing, and as such, decided to remove them.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/70232195/b99b9c98-de03-4caf-b363-2fcb7fcefe3b)


</details>

## Changelog

:cl: Jolly
add: [Blueshift] Added more powernet redundancy as compensation. 
del: [Blueshift] There department power stations have been removed. Departments are now powered by the main powernet.
del: [Blueshift] Removed the notice paper about the power stations in Engineering.
/:cl:
