### PR TITLE
Split off death degradation recovery while alive and decay while alive

### DIFF
--- a/modular_nova/master_files/code/modules/client/preferences/quirks/death_consequences.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/quirks/death_consequences.dm
@@ -29,11 +29,20 @@
 /datum/preference/numeric/death_consequences/living_degradation_recovery_per_second
 	savefile_key = "dc_living_degradation_recovery_per_second"
 
-	minimum = -100 // if you want, you can just die slowly
+	minimum = 0
 	maximum = 1000
 
 /datum/preference/numeric/death_consequences/living_degradation_recovery_per_second/create_default_value()
 	return DEATH_CONSEQUENCES_DEFAULT_LIVING_DEGRADATION_RECOVERY
+
+/datum/preference/numeric/death_consequences/living_degradation_per_second
+	savefile_key = "dc_living_degradation_per_second"
+
+	minimum = 0
+	maximum = 1000
+
+/datum/preference/numeric/death_consequences/living_degradation_per_second/create_default_value()
+	return 0
 
 /datum/preference/numeric/death_consequences/dead_degradation_per_second
 	savefile_key = "dc_dead_degradation_per_second"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/death_degradation.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/death_degradation.tsx
@@ -17,7 +17,14 @@ export const dc_living_degradation_recovery_per_second: Feature<number> = {
   name: 'B_Recovery per second while alive',
   component: FeatureNumberInput,
   description:
-    'While alive, your degradation will be reduced by this much per second. If negative, this will cause you to slowly die.',
+    'While alive, your degradation will be reduced by this much per second.',
+};
+
+export const dc_living_degradation_per_second: Feature<number> = {
+  name: 'B_Degradation per second while alive',
+  component: FeatureNumberInput,
+  description:
+    'While alive, your degradation will be increased by this much per second.',
 };
 
 export const dc_dead_degradation_per_second: Feature<number> = {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So Death Degradation let you choose to slowly die by... setting the recovery while alive to a negative value.
While this is cool and whatever, it's uh. A bit jank.
And most importantly? It doesn't let us do anything cool with having both.

So in this pr we split off the decay while alive bit into a separate preference, letting you set both at once.
We also change up the health analyzer info, making it actually account for decay while alive being possible unlike the previous version, and if both preferences are set showing the default result and separately showing the values it's compounded out of.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Before these two were the same setting, and thus you could choose to either slowly recover or slowly die.
By splitting these off, you could additionally choose to slowly die by default while letting buckling/resting/sleeping mults overpower your base level of dying!
This lets you play a character that needs to sometimes sit down or take breaks or they will actually just straight up fucking die, or say run it like a hardcore All Nighter quirk.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots</summary>

Only recovery:
![image](https://github.com/NovaSector/NovaSector/assets/42909981/17e9f93a-81fc-45c1-8ef7-5fed328235ed)
Only decay:
![image](https://github.com/NovaSector/NovaSector/assets/42909981/4f7b35de-69c7-465f-b424-104fea660480)
Both recovery and decay
![image](https://github.com/NovaSector/NovaSector/assets/42909981/84ce69f2-ee7a-404b-b778-6381051dcc5c)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Split off settings for Death Degradation's degradation decay and recovery while alive. You could now set both at once, letting you die by default while letting buckle/rest/sleeping overpower the dying.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
