### PR TITLE
remove stamcrit from death degradation

### DIFF
--- a/modular_nova/modules/death_consequences_perk/death_consequences_trauma.dm
+++ b/modular_nova/modules/death_consequences_perk/death_consequences_trauma.dm
@@ -338,7 +338,6 @@
 	if (owner_staminaloss > (minimum_stamina_damage + 1))
 		return
 	else if ((owner_staminaloss >= (minimum_stamina_damage - 1)) && (owner_staminaloss <= (minimum_stamina_damage + 1)))
-		owner.apply_status_effect(/datum/status_effect/incapacitating/stamcrit)
 		return
 
 	var/final_adjustment = (minimum_stamina_damage - owner_staminaloss)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Previously, this part of the code would set a timer value that stops stamina from decaying while it's up.
During a recent change, this timer value and the associated code got removed, so this got removed too!

...And instead, for some reason, the part used by Death Degradation got replaced with a stamcrit application.

This caused you to essentially endlessly cycle through stamcrits, as it puts you at your minimum stamina damage, you go into stamcrit because of being at your minimum stamina damage, it does nothing while you're in stamcrit, you get up once it's over and lose your staminaloss, and you _immediately_ flop back down again as the cycle repeat.

I feel like it's honestly better to just not have that. It seems to work just fine without it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Fixes #3182.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots</summary>

![image](https://github.com/NovaSector/NovaSector/assets/42909981/87dad41f-a6b7-49a7-931a-1f9a3aca4bb0)
Hey look I'm not permanently horizontal-

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed Death Degradation sending you into an endless stamcrit loop.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
