### PR TITLE
Fix Death Degradation not being configurable for ckeys with symbols in them

### DIFF
--- a/modular_nova/modules/death_consequences_perk/death_consequences_trauma.dm
+++ b/modular_nova/modules/death_consequences_perk/death_consequences_trauma.dm
@@ -505,7 +505,7 @@
 	if (isnull(source))
 		return // sanity
 
-	var/ckey = LOWER_TEXT(owner.mind?.key)
+	var/ckey = ckey(owner.mind?.key)
 	if (isnull(ckey) || ckey != source.ckey)
 		return // sanity
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So Death Degradation `update_variables(...)` would check if the ckey for the owner mind matches the ckey for the given client, returning early if not.
However, because this uses `LOWER_TEXT(...)` for the owner mind ckey, this fails flat out for anyone with symbols in their ckey, as this doesn't actually strip the symbols.

Using the dm-standard `ckey(...)` fixes this.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Tends to be good when a quirk isn't locked behind the characters in your ckey.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/42909981/e6b340c3-b3f9-435c-8bda-b3730d06678c)
See, it's a proof of testing because I have an underscore in my ckey, and these are non-standard settings.

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed players with symbols in their ckey being unable to configure the Death Degration quirk.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
