### PR TITLE
Fixes peg limbs not being attachable to people with the Cybernetic Limb Mounts quirk

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -367,8 +367,9 @@
 	if(ishuman(victim))
 		var/mob/living/carbon/human/human_victim = victim
 		if(HAS_TRAIT(victim, TRAIT_LIMBATTACHMENT) || HAS_TRAIT(src, TRAIT_EASY_ATTACH) || HAS_TRAIT(victim, TRAIT_ROBOTIC_LIMBATTACHMENT)) // NOVA EDIT CHANGE - ORIGINAL: if(HAS_TRAIT(victim, TRAIT_LIMBATTACHMENT) || HAS_TRAIT(src, TRAIT_EASY_ATTACH))
-			// NOVA EDIT ADDITION START - robot_limb_detach_quirk
-			if (HAS_TRAIT(victim, TRAIT_ROBOTIC_LIMBATTACHMENT) && !(bodytype & BODYTYPE_ROBOTIC)) //if we're trying to attach something that's not robotic, end out
+			// NOVA EDIT ADDITION START - robot_limb_detach_quirk - but first let peg limbs through, and also let androids through
+			if (!(HAS_TRAIT(src, TRAIT_EASY_ATTACH)) && !HAS_TRAIT(victim, TRAIT_LIMBATTACHMENT) && HAS_TRAIT(victim, TRAIT_ROBOTIC_LIMBATTACHMENT) && !(bodytype & BODYTYPE_ROBOTIC)) //if we're trying to attach something that's not robotic, end out - but ONLY if we have this quirk
+				to_chat(user, span_warning("[human_victim]'s body rejects [src]! It can only accept robotic limbs."))
 				return
 			// NOVA EDIT ADDITION END
 			if(!human_victim.get_bodypart(body_zone))


### PR DESCRIPTION
## About The Pull Request

Tin. Peg limbs should be attachable with this quirk but they're not. Also adds feedback so it is clear why the limb is not able to be attached (if it's not robotic or peg).

## How This Contributes To The Nova Sector Roleplay Experience

Fixes a bug/oversight

## Proof of Testing

<details>
<summary>Yarr it works</summary>


![dreamseeker_g4YoTD7qMk](https://github.com/NovaSector/NovaSector/assets/13398309/575fc30a-89f8-4ebc-a712-c2a099f30c74)

![dreamseeker_Yv45IJlf2Q](https://github.com/NovaSector/NovaSector/assets/13398309/84796826-6aaf-4474-8930-8949f4e59538)

</details>

## Changelog


:cl:
fix: fixed an issue where peg limbs were not attachable to mobs with the "cybernetic limb mounts" quirk
/:cl: