### PR TITLE
Xenobiology will no longer require the cytology experiment (instead it's a discount)

### DIFF
--- a/modular_nova/master_files/code/modules/research/techweb/all_nodes.dm
+++ b/modular_nova/master_files/code/modules/research/techweb/all_nodes.dm
@@ -148,6 +148,12 @@
 	)
 	return ..()
 
+/datum/techweb_node/xenobiology/New()
+	// QOL - Makes cytology experiment a discount rather than required experiment
+	required_experiments -= list(/datum/experiment/scanning/random/cytology)
+	discount_experiments += list(/datum/experiment/scanning/random/cytology)
+	return ..()
+
 /datum/techweb_node/cyber/cyber_organs/New()
 	design_ids += list(
 		"cybernetic_tongue",

--- a/modular_nova/master_files/code/modules/research/techweb/all_nodes.dm
+++ b/modular_nova/master_files/code/modules/research/techweb/all_nodes.dm
@@ -154,6 +154,12 @@
 	discount_experiments += list(/datum/experiment/scanning/random/cytology)
 	return ..()
 
+/datum/techweb_node/selection/New()
+	// QOL - Makes wild harvest experiment a discount rather than required experiment
+	required_experiments -= list(/datum/experiment/scanning/random/plants/wild)
+	discount_experiments += list(/datum/experiment/scanning/random/plants/wild)
+	return ..()
+
 /datum/techweb_node/cyber/cyber_organs/New()
 	design_ids += list(
 		"cybernetic_tongue",


### PR DESCRIPTION
## About The Pull Request

This PR just switches the cytology and wild harvest experiments from being a requirement, to giving a discount.

## How This Contributes To The Nova Sector Roleplay Experience

Makes the SAD a lot easier to unlock, no longer being locked behind the cytology experiment.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![TWg11IiqSN](https://github.com/NovaSector/NovaSector/assets/13398309/ff69e17b-2e00-4c7e-8095-42918da14a6f)


</details>

## Changelog

:cl:
qol: xenobiology research node no longer requires the cytology experiment; instead it gives a discount
qol: artificial selection research node no longer requires the wild harvest experiment; instead it gives a discount
/:cl