### PR TITLE
Fix apc arcing limit

### DIFF
--- a/modular_nova/modules/apc_arcing/apc.dm
+++ b/modular_nova/modules/apc_arcing/apc.dm
@@ -15,9 +15,9 @@
 
 /obj/machinery/power/apc/late_process(seconds_per_tick)
 	. = ..()
-	var/excess = surplus()
 	if(!cell || shorted)
 		return
+	var/excess = energy_to_power(surplus())
 	if(((excess < APC_ARC_LOWERLIMIT) && !force_arcing) || arc_shielded)
 		return
 	var/shock_chance = 5
@@ -32,7 +32,7 @@
 		#define MAKE_SPARKS 2
 		// cut the power for 2-4 seconds
 		#define CAUSE_BROWNOUT 3
-		
+
 		var/effect = pick(list(
 			SHOCK_SOMEONE,
 			MAKE_SPARKS,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds a missing `energy_to_power` call in apc processing that was making arcing happen too early, ups the effective limit from 2MW excess to 4MW excess
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
![image](https://github.com/NovaSector/NovaSector/assets/25628932/51465b1f-aab0-4d4b-8ac1-3d731c0c5bc5)

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: apc arcing doesn't happen until the intended 4MW limit (previously 2MW due to a conversion issue)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
