### PR TITLE
Heretic's blade has blockchance 30%

### DIFF
--- a/modular_nova/master_files/code/modules/antagonists/heretic/items/heretic_blades.dm
+++ b/modular_nova/master_files/code/modules/antagonists/heretic/items/heretic_blades.dm
@@ -1,0 +1,3 @@
+// Heretic' blades has chance to block upcoming punch AND projectile.
+/obj/item/melee/sickly_blade
+	block_chance = 30

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6493,6 +6493,7 @@
 #include "modular_nova\master_files\code\modules\antagonists\changeling\powers\tiny_prick.dm"
 #include "modular_nova\master_files\code\modules\antagonists\cult\cult_items.dm"
 #include "modular_nova\master_files\code\modules\antagonists\ert\ert.dm"
+#include "modular_nova\master_files\code\modules\antagonists\heretic\items\heretic_blades.dm"
 #include "modular_nova\master_files\code\modules\antagonists\heretic\knowledge\general_side.dm"
 #include "modular_nova\master_files\code\modules\antagonists\pirate\pirate_gang.dm"
 #include "modular_nova\master_files\code\modules\antagonists\pirate\pirate_outfits.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Heretic's blade get 30% blockchance (45% if wielding blades in both hands)
## How This Contributes To The Nova Sector Roleplay Experience

Nova Sector is Range-combat oriented build, but TG and it's antags mainly melee-combat oriented, especially heretic. Not all his paths have possibility to short the distance between heretic and his enemy or block projectile when approaching and only 2 paths have possibility to get range-attack skill or gun.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Heretic's blade got 30% block chance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
