### PR TITLE
[NoGBP]Cafe's hotdog vendor can now hotdog less lethally than before.

### DIFF
--- a/_maps/map_files/generic/CentCom_nova_z2.dmm
+++ b/_maps/map_files/generic/CentCom_nova_z2.dmm
@@ -6138,7 +6138,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/vending/hotdog/museum,
+/obj/machinery/vending/hotdog/museum{
+	onstation = 0
+	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
 	},


### PR DESCRIPTION

## About The Pull Request

It's a snowflake code vendor that doesnt auto-assign offstation, so all i've done is toggle the offstation flag for it.

## How This Contributes To The Nova Sector Roleplay Experience

Murderous hotdog vending machines will no longer try to crush your face in the cafe, there's only one things we allow to do that.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: Cafe's Hotdog vendor will no longer try to crush you
/:cl:
