### PR TITLE
Fixes a gigantism exploit

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -208,8 +208,8 @@
 	// NOVA EDIT ADDITION BEGIN
 	if(owner.dna.features["body_size"] > 1)
 		to_chat(owner, "You feel relief as your bones cease their growth spurt.")
-		if(!HAS_TRAIT_FROM(owner, TRAIT_GIANT, GENETIC_MUTATION)) // Don't shrink if we didn't grow in the first place.
-			return
+	if(!HAS_TRAIT_FROM(owner, TRAIT_GIANT, GENETIC_MUTATION)) // Don't shrink if we didn't grow in the first place.
+		return
 	// NOVA EDIT ADDITION END
 	REMOVE_TRAIT(owner, TRAIT_GIANT, GENETIC_MUTATION)
 	owner.update_transform(0.8)

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -192,12 +192,12 @@
 /datum/mutation/human/gigantism/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
 		return
-	// NOVA EDIT BEGIN
+	// NOVA EDIT ADDITION BEGIN
 	if(owner.dna.features["body_size"] > 1)
 		to_chat(owner, "You feel your body expanding even further, but it feels like your bones are expanding too much!")
 		owner.adjustBruteLoss(25) // take some DAMAGE
 		return
-	// NOVA EDIT END
+	// NOVA EDIT ADDITION END
 	ADD_TRAIT(owner, TRAIT_GIANT, GENETIC_MUTATION)
 	owner.update_transform(1.25)
 	owner.visible_message(span_danger("[owner] suddenly grows!"), span_notice("Everything around you seems to shrink.."))
@@ -205,12 +205,15 @@
 /datum/mutation/human/gigantism/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
-	// NOVA EDIT BEGIN
+	// NOVA EDIT ADDITION BEGIN
 	if(owner.dna.features["body_size"] > 1)
 		to_chat(owner, "You feel relief as your bones cease their growth spurt.")
-		REMOVE_TRAIT(owner, TRAIT_GIANT, GENETIC_MUTATION)
-		return
-	// NOVA EDIT END
+		if(!HAS_TRAIT_FROM(owner, TRAIT_GIANT, GENETIC_MUTATION)) // Don't shrink if we didn't grow in the first place.
+			return
+	// NOVA EDIT ADDITION END
+	REMOVE_TRAIT(owner, TRAIT_GIANT, GENETIC_MUTATION)
+	owner.update_transform(0.8)
+	owner.visible_message(span_danger("[owner] suddenly shrinks!"), span_notice("Everything around you seems to grow.."))
 
 //Clumsiness has a very large amount of small drawbacks depending on item.
 /datum/mutation/human/clumsy


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/3192

The transform increase wasn't being reversed in `on_losing()` under certain conditions, resulting in a potential exploit where you could just keep increasing in size that way indefinitely.

## How This Contributes To The Nova Sector Roleplay Experience

Fixes a bug/exploit.

## Proof of Testing

<details>
<summary>It works</summary>

![dreamseeker_yhNQyrWZSE](https://github.com/NovaSector/NovaSector/assets/13398309/fb38fbfc-2d4e-45e2-a230-f0e6e6a13987)

![image](https://github.com/NovaSector/NovaSector/assets/13398309/efc7614b-c9d6-487c-b3d6-ade06c6a72f5)

</details>

## Changelog

:cl:
fix: fixes gigantism mutation not reducing a mob's size upon losing when it should be doing so.
/:cl: