### PR TITLE
Fix chronological age resetting by fixing old savefile updating always running

### DIFF
--- a/modular_nova/master_files/code/modules/client/preferences_savefile.dm
+++ b/modular_nova/master_files/code/modules/client/preferences_savefile.dm
@@ -100,8 +100,9 @@
 
 	food_preferences = SANITIZE_LIST(save_data["food_preferences"])
 
-	if(needs_update >= 0)
-		update_character_nova(needs_update, save_data) // needs_update == savefile_version if we need an update (positive integer)
+	var/needs_nova_update = savefile_needs_update_nova(save_data)
+	if(needs_nova_update >= 0)
+		update_character_nova(needs_nova_update, save_data) // needs_update == savefile_version if we need an update (positive integer)
 
 
 /// Brings a savefile up to date with modular preferences. Called if savefile_needs_update_nova() returned a value higher than 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So, I was told chronological age was broken and would reset each time you selected a different character.
Looking into it, I narrowed it down to two possible things, either:
1. It's failing to read, and thus defaulting to physical age.
2. Or it's erroneously trying to update the savefile, and thus setting it to physical age.

From some basic testing, it seemed to be the latter, as no matter what `needs_update` would be 1 and it would run the character updating code:
https://github.com/NovaSector/NovaSector/blob/d6e5aa6d2e5ea1e735d832a4e89b5b823b477e5a/modular_nova/master_files/code/modules/client/preferences_savefile.dm#L103-L104
Which would then reset it to default, as it's treated as a pre-chronological-age savefile:
https://github.com/NovaSector/NovaSector/blob/d6e5aa6d2e5ea1e735d832a4e89b5b823b477e5a/modular_nova/master_files/code/modules/client/preferences_savefile.dm#L258-L260

There _is_ code for determining whether it needs to be updated:
https://github.com/NovaSector/NovaSector/blob/d6e5aa6d2e5ea1e735d832a4e89b5b823b477e5a/modular_nova/master_files/code/modules/client/preferences_savefile.dm#L19-L29
But it's never actually called, anywhere in the codebase:
![image](https://github.com/NovaSector/NovaSector/assets/42909981/68eecdef-7542-435f-b512-4ccbeb170ca1)
Even though the code in question says it does!
https://github.com/NovaSector/NovaSector/blob/d6e5aa6d2e5ea1e735d832a4e89b5b823b477e5a/modular_nova/master_files/code/modules/client/preferences_savefile.dm#L107-L108

Sooooooooooooooooooooooooooooooo making it actually call that proc and use its return value fixes the issue.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Fixes #2444.
Should actually avoid attempting to update savefiles that don't need updating, which feels like it'll matter with the tg loadout port also using this system.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Random new character</summary>
Using two random debug characters with random other settings turned on/off:
1. First setting the chronological age:

![image](https://github.com/NovaSector/NovaSector/assets/42909981/152f6c16-8292-4514-9eeb-b2a6f8526ff5)

2. Then swapping to the second debug character:

![image](https://github.com/NovaSector/NovaSector/assets/42909981/bf8cb4fc-9e8c-4e2c-8f87-110062f37e61)

3. Finally swapping back, and chronological age is still there:

![image](https://github.com/NovaSector/NovaSector/assets/42909981/fd267e73-ef64-4ff7-9c27-401aba7551fa)

4. For good measure, swapping back to the second character, still as normal:

![image](https://github.com/NovaSector/NovaSector/assets/42909981/dea165c2-276d-40ee-99de-8d2e65434fd9)

</details>

<details>
<summary>Real imported prefs, unedited</summary>
Using two full characters, made on the actual servers, prefs exported and put in the localhost player saves:
1. Normal imported character:

![image](https://github.com/NovaSector/NovaSector/assets/42909981/06aae77e-047c-4843-b44b-5f41e3e436fd)

2. Change chronological age:

![image](https://github.com/NovaSector/NovaSector/assets/42909981/21c62a7d-a49b-47e9-9fb5-142662af28af)

3. Swap to second character:

![image](https://github.com/NovaSector/NovaSector/assets/42909981/2cb422ce-dadf-4a63-9098-9e127f228b6c)

4. Swap back to edited character, and chronological age is still there:

![image](https://github.com/NovaSector/NovaSector/assets/42909981/2b5b3f2f-56c6-4f5d-ba2f-74564baaf496)

5. Swap to second character again for good measure, and all is normal:

![image](https://github.com/NovaSector/NovaSector/assets/42909981/0f9515d2-28a6-417f-a159-1211a571c62b)

</details>

<details>
<summary>Real imported prefs, age edited, modular version edited</summary>
Using the same two characters from the previous batch, including the age edits made, but with an additional edit to the modular version in the savefile:

![image](https://github.com/NovaSector/NovaSector/assets/42909981/aef05d25-d5b8-4cfb-8ae4-3a68b11ebb0d)

1. Open version edited character, see chronological age is reset as intended:

![image](https://github.com/NovaSector/NovaSector/assets/42909981/30e97e97-7f57-4ff2-bf17-206187c33a07)

2. Repeat same song and dance, chronological age saves and persists between swaps:

![image](https://github.com/NovaSector/NovaSector/assets/42909981/587350a3-c6e0-49c2-bf75-d125bf7a4c75)

3. Check file, see modular version has been updated:

![image](https://github.com/NovaSector/NovaSector/assets/42909981/4f86dfae-1fab-4082-8ddf-bf9bf2091c4a)

4. Check file for ages, see those are saved properly too:

![image](https://github.com/NovaSector/NovaSector/assets/42909981/e6c2cbb7-5907-4257-8187-899bcdf2de60)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes chronological age resetting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
