### PR TITLE
[Modular] Allows the translator necklaces to be equipped in the suit slot

### DIFF
--- a/modular_nova/modules/modular_items/code/necklace.dm
+++ b/modular_nova/modules/modular_items/code/necklace.dm
@@ -7,6 +7,7 @@
 	icon = 'modular_nova/master_files/icons/obj/clothing/neck.dmi'
 	icon_state = "ashnecklace"
 	worn_icon = 'modular_nova/master_files/icons/mob/clothing/neck.dmi'
+	slot_flags = ITEM_SLOT_NECK | ITEM_SLOT_OCLOTHING
 	w_class = WEIGHT_CLASS_SMALL //allows this to fit inside of pockets.
 	/// The language granted by this necklace
 	var/datum/language/language_granted = /datum/language/ashtongue
@@ -23,7 +24,7 @@
 /obj/item/clothing/neck/necklace/translator/proc/on_necklace_equip(datum/source, mob/living/carbon/human/equipper, slot)
 	SIGNAL_HANDLER
 
-	if(!(slot & ITEM_SLOT_NECK))
+	if(!(slot_flags & slot))
 		return
 
 	if(!istype(equipper))
@@ -51,9 +52,6 @@
 	SIGNAL_HANDLER
 
 	if(!istype(unequipper))
-		return
-
-	if(unequipper.wear_neck != source)
 		return
 
 	unequipper.remove_language(language_granted, source = LANGUAGE_TRANSLATOR)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As above. allows the exo suit slot to be used instead of just the neck slot. (Can also expand the list of slots easily if requested)

## How This Contributes To The Nova Sector Roleplay Experience

More options good, it's an RP focused object so neck only limitations arent quite nessisary and can be quite limiting for characters relying on neckwear for clothing. 

## Proof of Testing

Doesnt seem to brick anything/everything.
You CAN wear multiple if you like now... but removing the first will remove the language and doesn't seem to cause errors.

<details>
<summary>Testing</summary>

Neck
![image](https://github.com/NovaSector/NovaSector/assets/167525706/ca1abe41-446c-433e-bc30-0f4782d040db)

Chest
![image](https://github.com/NovaSector/NovaSector/assets/167525706/62e874d9-9917-4366-bcd6-5e1477c71e08)

Languages removed fine
![image](https://github.com/NovaSector/NovaSector/assets/167525706/a64db98d-3632-4a39-a5d5-52f956bfa8ca)

Also works with Icecat version as its a child

![image](https://github.com/NovaSector/NovaSector/assets/167525706/31bfb993-5587-489d-99c2-af5eff935754)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Ash/Siik translator necklaces can now fit and work in the suit slot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
