### PR TITLE
Let borgs go through gateway

### DIFF
--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -26,14 +26,9 @@ GLOBAL_LIST_EMPTY(gateway_destinations)
 		. = "Connection desynchronized. Recalibration in progress."
 
 /* Check if the movable is allowed to arrive at this destination (exile implants mostly) */
-/** NOVA EDIT - CYBORGS CANT USE GETWAY
 /datum/gateway_destination/proc/incoming_pass_check(atom/movable/AM)
 	return TRUE
-**/
-// Just a reminder that the home gateway overrides this proc so if a borg someone finds themself in an away mission they can still leave
-/datum/gateway_destination/proc/incoming_pass_check(atom/movable/AM)
-	return !iscyborg(AM)
-// NOVA EDIT - END
+
 /* Get the actual turf we'll arrive at */
 /datum/gateway_destination/proc/get_target_turf()
 	CRASH("get target turf not implemented for this destination type")
@@ -139,19 +134,6 @@ GLOBAL_LIST_EMPTY(gateway_destinations)
 	invisibility = INVISIBILITY_ABSTRACT
 
 /obj/effect/gateway_portal_bumper/Bumped(atom/movable/AM)
-	//NOVA EDIT ADDITION
-	var/list/type_blacklist = list(
-		/obj/item/mmi,
-		/mob/living/silicon,
-	)
-	if(is_type_in_list(AM, type_blacklist))
-		return
-	for(var/atom/movable/content_item as anything in AM.get_all_contents())
-		if(!is_type_in_list(content_item, type_blacklist))
-			continue
-		to_chat(AM, span_warning("[content_item] seems to be blocking you from entering the gateway!"))
-		return
-	//NOVA EDIT END
 	if(get_dir(src,AM) == SOUTH)
 		playsound(src, 'sound/effects/gateway_travel.ogg', 70, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 		gateway.Transfer(AM)
@@ -353,20 +335,6 @@ GLOBAL_LIST_EMPTY(gateway_destinations)
 
 /obj/machinery/gateway/away/interact(mob/user)
 	. = ..()
-	//NOVA EDIT ADDITION
-	var/list/type_blacklist = list(
-		/obj/item/mmi,
-		/mob/living/silicon,
-		/obj/item/borg/upgrade/ai,
-	)
-	if(is_type_in_list(user, type_blacklist))
-		return
-	for(var/atom/movable/content_item as anything in user.get_contents())
-		if(!is_type_in_list(content_item, type_blacklist))
-			continue
-		to_chat(user, span_warning("[content_item] seems to be blocking you from entering the gateway!"))
-		return
-	//NOVA EDIT END
 	if(!target)
 		if(!GLOB.the_gateway)
 			to_chat(user,span_warning("Home gateway is not responding!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the nova edits that prevented borgs from going through the gateway.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

If we're going forward with the idea that gateways are going to be more roleplay centric and less combat/mechanical going forward, then I don't see why borgs should be blocked from them... especially because the last few times that gateways have been ran, the admins have added portals to let the borgs join anyway. Apparently it was restricted because of balance issues, here: https://github.com/Skyrat-SS13/Skyrat-tg/pull/6829
Let's let the borg buddies join us in the beach episodes

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/102194057/eeffe8a3-4116-4d6a-8e7b-8cf2dcad1241)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: let silicons go through the gateway
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
