### PR TITLE
Updates Lavadyne to account for the new ashwalker faction

### DIFF
--- a/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1.dmm
@@ -162,7 +162,7 @@
 /area/ruin/interdyne_planetary_base/main)
 "bs" = (
 /obj/machinery/porta_turret/syndicate{
-	faction = list("Syndicate","neutral")
+	faction = list("Syndicate","neutral","ashwalker")
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/interdyne_planetary_base)
@@ -1015,7 +1015,7 @@
 /area/lavaland/surface/outdoors)
 "jb" = (
 /obj/machinery/porta_turret/syndicate{
-	faction = list("Syndicate","neutral");
+	faction = list("Syndicate","neutral","ashwalker");
 	dir = 8
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -2172,7 +2172,7 @@
 "su" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 4;
-	faction = list("Syndicate","neutral")
+	faction = list("Syndicate","neutral","ashwalker")
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/interdyne_planetary_base)
@@ -5081,7 +5081,7 @@
 "QD" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 8;
-	faction = list("Syndicate","neutral")
+	faction = list("Syndicate","neutral","ashwalker")
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/interdyne_planetary_base)
@@ -6188,7 +6188,7 @@
 "Ys" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 1;
-	faction = list("Syndicate","neutral")
+	faction = list("Syndicate","neutral","ashwalker")
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/interdyne_planetary_base)


### PR DESCRIPTION

## About The Pull Request

Same reasoning as prior, the turrets aren't meant to be a 'walk by and suddenly die' deal

## How This Contributes To The Nova Sector Roleplay Experience

Adds the appropriate new faction

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: fixes ashwalkers not being whitelisted for interdyne turrets
/:cl:
