### PR TITLE
Hypospray hotfixes [NO GBP]

### DIFF
--- a/modular_nova/modules/hyposprays/code/autolathe_designs.dm
+++ b/modular_nova/modules/hyposprays/code/autolathe_designs.dm
@@ -30,7 +30,7 @@
 	build_path = /obj/item/reagent_containers/cup/vial/large
 
 /datum/design/hypokit
-	name = "Hypospray Kit"
+	name = "Hypospray Case"
 	id = "hypokit"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(
@@ -48,12 +48,13 @@
 	design_ids += list(
 		"large_hypovial",
 		"hypokit",
+		"hypomkii",
 	)
 	return ..()
 
 /// Hyposprays
 /datum/design/hypokit/deluxe
-	name = "Deluxe Hypospray Kit"
+	name = "Deluxe Hypospray Case"
 	id = "hypokit_deluxe"
 	materials = list(
 		/datum/material/plastic = SHEET_MATERIAL_AMOUNT * 6,
@@ -63,7 +64,7 @@
 	build_path = /obj/item/storage/hypospraykit/cmo/empty
 
 /datum/design/hypomkii
-	name = "MkII Hypospray"
+	name = "Hypospray Mk. II"
 	id = "hypomkii"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(
@@ -81,12 +82,12 @@
 /datum/techweb_node/medbay_equip_adv/New()
 	design_ids += list(
 		"hypokit_deluxe",
-		"hypomkii",
+		"hypomkii_advanced",
 	)
 	return ..()
 
 /datum/design/hypomkii/deluxe
-	name = "MkII Hypospray Upgrade Kit"
+	name = "Hypospray Mk. II Deluxe Upgrade"
 	id = "hypomkii_deluxe"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(
@@ -97,18 +98,19 @@
 	build_path = /obj/item/device/custom_kit/deluxe_hypo2
 	category = list(
 		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MEDICAL,
+		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MEDICAL_ADVANCED,
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
 /datum/techweb_node/alien_surgery/New()
 	design_ids += list(
 		"hypomkii_deluxe",
+		"hypomkii_advanced",
 	)
 	return ..()
 
 /datum/design/hypomkii/piercing
-	name = "Advanced MkII Hypospray"
+	name = "Hypospray Mk. II Advanced"
 	id = "hypomkii_advanced"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(
@@ -120,16 +122,15 @@
 	build_path = /obj/item/hypospray/mkii/piercing
 	category = list(
 		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MEDICAL,
+		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MEDICAL_ADVANCED,
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SECURITY | DEPARTMENT_BITFLAG_MEDICAL
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
 // Tarkon and similar get enough to work with, but if they want deluxe kits/hypos they still need to trade with the station for 'em.
 /datum/techweb_node/oldstation_surgery/New()
 	design_ids += list(
 		"hypokit",
 		"hypomkii",
-		"hypomkii_advanced",
 	)
 	return ..()
 

--- a/modular_nova/modules/hyposprays/code/hyposprays_II.dm
+++ b/modular_nova/modules/hyposprays/code/hyposprays_II.dm
@@ -48,7 +48,7 @@
 	var/gags_bodystate = "hypo2_normal"
 
 /obj/item/hypospray/mkii/deluxe
-	name = "hypospray mk.II deluxe"
+	name = "\improper hypospray Mk.II deluxe"
 	allowed_containers = list(/obj/item/reagent_containers/cup/vial/small, /obj/item/reagent_containers/cup/vial/large)
 	icon_state = "bighypo2"
 	gags_bodystate = "hypo2_deluxe"
@@ -56,7 +56,7 @@
 	small_only = FALSE
 
 /obj/item/hypospray/mkii/piercing
-	name = "hypospray Mk.II advanced"
+	name = "\improper hypospray Mk.II advanced"
 	allowed_containers = list(/obj/item/reagent_containers/cup/vial/small)
 	icon_state = "piercinghypo2"
 	gags_bodystate = "hypo2_piercing"
@@ -72,7 +72,7 @@
 
 // Deluxe hypo upgrade Kit
 /obj/item/device/custom_kit/deluxe_hypo2
-	name = "\improper DeForest Hypospray Mk. II Deluxe Bodykit"
+	name = "\improper hypospray Mk.II deluxe bodykit"
 	desc = "Upgrades the DeForest Hypospray Mk. II to support larger vials."
 	// don't tinker with a loaded (medi)gun. fool
 	from_obj = /obj/item/hypospray/mkii
@@ -89,7 +89,7 @@
 	return TRUE
 
 /obj/item/hypospray/mkii/deluxe/cmo
-	name = "hypospray Mk.II deluxe: CMO edition"
+	name = "\improper hypospray Mk.II deluxe: CMO edition"
 	icon_state = "cmo2"
 	gags_bodystate = "hypo2_cmo"
 	desc = "The CMO's prized Hypospray Mk. II Deluxe, able to take both 100u and 50u vials, acting faster and able to deliver more reagents per spray."
@@ -101,7 +101,7 @@
 	penetrates = INJECT_CHECK_PENETRATE_THICK
 
 /obj/item/hypospray/mkii/deluxe/cmo/combat
-	name = "hypospray Mk.II deluxe: combat edition"
+	name = "\improper hypospray Mk.II deluxe: combat edition"
 	icon_state = "combat2"
 	gags_bodystate = "hypo2_tactical"
 	desc = "A variant of the Hypospray Mk. II Deluxe, able to take both 100u and 50u vials, with overcharged applicators and an armor-piercing tip."
@@ -240,10 +240,10 @@
 	if(istype(interacting_with, /obj/item/reagent_containers/cup/vial))
 		insert_vial(interacting_with, user)
 		return ITEM_INTERACT_SUCCESS
-	return do_inject(interacting_with, user, mode=HYPO_INJECT)
+	return do_inject(interacting_with, user, mode=HYPO_SPRAY)
 
 /obj/item/hypospray/mkii/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
-	return do_inject(interacting_with, user, mode=HYPO_SPRAY)
+	return do_inject(interacting_with, user, mode=HYPO_INJECT)
 
 /obj/item/hypospray/mkii/proc/do_inject(mob/living/injectee, mob/living/user, mode)
 	if(!isliving(injectee))
@@ -317,7 +317,7 @@
 
 /obj/item/hypospray/mkii/examine(mob/user)
 	. = ..()
-	. += span_notice("<b>Left-Click</b> on patients to inject, <b>Right-Click</b> to spray.")
+	. += span_notice("<b>Left-Click</b> on patients to spray, <b>Right-Click</b> to inject.")
 
 #undef HYPO_INJECT
 #undef HYPO_SPRAY


### PR DESCRIPTION
## About The Pull Request

- Adjusts some missed item names to match the format in the other PR
- Empty hypospray kits will now be called 'case' on the lathe, implying hypospray not included
- Hypospray primary target method is spray, inject secondary
- Corrected advanced hypospray being available to security and tarkon, but not medical techweb

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/83487515/ec8b735e-fea2-4124-940a-f06547ce4376)

</details>

## Changelog

:cl: LT3
fix: Advanced hypospray is no longer available to security and Tarkon
fix: Advanced hypospray is available to medical
spellcheck: More hypospray text consistency
spellcheck: Empty hypospray kits are now called cases, case/hypospray combos remain kits
qol: Hypospray application method is spray by default
/:cl: