### PR TITLE
Fix field medic bone saw surgery speed

### DIFF
--- a/modular_nova/modules/exp_corps/code/gear.dm
+++ b/modular_nova/modules/exp_corps/code/gear.dm
@@ -40,7 +40,7 @@
 	righthand_file = 'modular_nova/modules/exp_corps/icons/bonesaw_r.dmi'
 	inhand_icon_state = "bonesaw"
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	toolspeed = 0.2
+	toolspeed = 2
 	throw_range = 3
 	w_class = WEIGHT_CLASS_SMALL
 


### PR DESCRIPTION
## About The Pull Request

Fixes the tool speed of the field medic bone saw. It's supposed to be a slower version, not faster.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl: LT3
fix: Fixed surgery speed of field medic bone saw
/:cl: