### PR TITLE
Contractor alt title for assistant

### DIFF
--- a/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -30,7 +30,7 @@
 		"Off-Duty Crew",
 		"Off-Duty Staff",
 		"Colonist",
-		"Mercenary",
+		"Contractor",
 	)
 
 /datum/job/atmospheric_technician


### PR DESCRIPTION
## About The Pull Request

Tin!

## How This Contributes To The Nova Sector Roleplay Experience

Assistant titles are mostly for non-employed guests/civilians on the station. I think this addition fills a gap players could encounter when they want to express their OC is part of a PMC, and had to pick between either 'businessman' and 'freelancer', which is rather vague.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  BOO! 👻
</details>

## Changelog

:cl:
add: Added 'Contractor' alt title for assistant
/:cl:
