### PR TITLE
You can choose the type of footstep sound you make while barefoot

### DIFF
--- a/code/datums/elements/footstep.dm
+++ b/code/datums/elements/footstep.dm
@@ -155,6 +155,20 @@
 
 		if(source.dna.species.special_step_sounds)
 			heard_clients = playsound(source.loc, pick(source.dna.species.special_step_sounds), 50, TRUE, falloff_distance = 1, vary = sound_vary)
+		//NOVA EDIT ADDITION BEGIN - CUSTOMIZABLE FOOTSTEP SOUNDS
+		else if(source.footstep_type == "claws")
+			var/barefoot_type = prepared_steps[FOOTSTEP_MOB_CLAW]
+			heard_clients = playsound(source.loc, pick(GLOB.clawfootstep[barefoot_type][1]),
+				GLOB.clawfootstep[barefoot_type][2] * volume * volume_multiplier,
+				TRUE,
+				GLOB.clawfootstep[barefoot_type][3] + e_range + range_adjustment, falloff_distance = 1, vary = sound_vary)
+		else if(source.footstep_type == "shoes")
+			var/barefoot_type = prepared_steps[FOOTSTEP_MOB_SHOE]
+			heard_clients = playsound(source.loc, pick(GLOB.footstep[barefoot_type][1]),
+				GLOB.footstep[barefoot_type][2] * volume * volume_multiplier,
+				TRUE,
+				GLOB.footstep[barefoot_type][3] + e_range + range_adjustment, falloff_distance = 1, vary = sound_vary)
+		//NOVA EDIT ADDITION END
 		else
 			var/barefoot_type = prepared_steps[FOOTSTEP_MOB_BAREFOOT]
 			var/bare_footstep_sounds = GLOB.barefootstep

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -52,6 +52,9 @@
 	var/age = 30 //Player's age
 	var/chrono_age = 30 // NOVA EDIT ADDITION - Chronological age
 
+	/// What sound to play when the playher is walking barefoot. Can be 'default', 'shoes', or 'claws'.
+	var/footstep_type = "default" // NOVA EDIT ADDITION - Barefoot footstep sound overrides.
+
 	/// Which body type to use
 	var/physique = MALE
 

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -52,7 +52,6 @@
 	var/age = 30 //Player's age
 	var/chrono_age = 30 // NOVA EDIT ADDITION - Chronological age
 
-	/// What sound to play when the playher is walking barefoot. Can be 'default', 'shoes', or 'claws'.
 	var/footstep_type = "default" // NOVA EDIT ADDITION - Barefoot footstep sound overrides.
 
 	/// Which body type to use

--- a/modular_nova/master_files/code/modules/client/preferences/footstep_sound.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/footstep_sound.dm
@@ -1,0 +1,13 @@
+/datum/preference/choiced/footstep_sound
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "footstep_sound"
+
+/datum/preference/choiced/footstep_sound/init_possible_values()
+	return list("Default", "Shoes", "Claws")
+
+/datum/preference/choiced/footstep_sound/create_default_value()
+	return "Default"
+
+/datum/preference/choiced/footstep_sound/apply_to_human(mob/living/carbon/human/target, value)
+	target.footstep_type = lowertext(value)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6548,6 +6548,7 @@
 #include "modular_nova\master_files\code\modules\client\preferences\erp_preferences.dm"
 #include "modular_nova\master_files\code\modules\client\preferences\face_cursor_combat_mode.dm"
 #include "modular_nova\master_files\code\modules\client\preferences\flavor_text.dm"
+#include "modular_nova\master_files\code\modules\client\preferences\footstep_sound.dm"
 #include "modular_nova\master_files\code\modules\client\preferences\genitals.dm"
 #include "modular_nova\master_files\code\modules\client\preferences\ghost.dm"
 #include "modular_nova\master_files\code\modules\client\preferences\headshot.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/footstep_sounds.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/footstep_sounds.tsx
@@ -1,0 +1,9 @@
+// THIS IS A NOVA SECTOR UI FILE
+import { FeatureChoiced } from '../../base';
+import { FeatureDropdownInput } from '../../dropdowns';
+
+export const footstep_sound: FeatureChoiced = {
+  name: 'Footstep Sound',
+  description: 'The type of sound you will make when you walk around barefoot.',
+  component: FeatureDropdownInput,
+};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can now choose the type of footstep sound you make while barefoot. Code from [Floofies/NovaSector](https://github.com/Floofies/NovaSector)

This contains an edit on the footstep element `footstep.dm`:
```byond
//NOVA EDIT ADDITION BEGIN - CUSTOMIZABLE FOOTSTEP SOUNDS
else if(source.footstep_type == "claws")
	var/barefoot_type = prepared_steps[FOOTSTEP_MOB_CLAW]
	heard_clients = playsound(source.loc, pick(GLOB.clawfootstep[barefoot_type][1]),
		GLOB.clawfootstep[barefoot_type][2] * volume * volume_multiplier,
		TRUE,
		GLOB.clawfootstep[barefoot_type][3] + e_range + range_adjustment, falloff_distance = 1, vary = sound_vary)
else if(source.footstep_type == "shoes")
	var/barefoot_type = prepared_steps[FOOTSTEP_MOB_SHOE]
	heard_clients = playsound(source.loc, pick(GLOB.footstep[barefoot_type][1]),
		GLOB.footstep[barefoot_type][2] * volume * volume_multiplier,
		TRUE,
		GLOB.footstep[barefoot_type][3] + e_range + range_adjustment, falloff_distance = 1, vary = sound_vary)
//NOVA EDIT ADDITION END
```
And an edit (new var) on carbon humans `human_defines.dm`:
```byond
var/footstep_type = "default" // NOVA EDIT ADDITION - Barefoot footstep sound overrides.
```
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
I just want to run around barefoot as a Synthetic without making the barefoot "plap" sound. 

Having to walk everywhere as something like a synthetic model that looks better barefoot is very inconvenient.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/NovaSector/NovaSector/assets/88008002/d142ea7e-3b9f-45f9-b15c-2869db48d0c7)
[shoes streamable clip link](https://streamable.com/8gck12) 
[claws streamable clip link](https://streamable.com/sucrtr)
 
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: You can now choose which footstep sound you make when barefoot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
