### PR TITLE
(BOUNTY) Lithovore Stomach Option

### DIFF
--- a/modular_nova/modules/customization/modules/client/augment/organs.dm
+++ b/modular_nova/modules/customization/modules/client/augment/organs.dm
@@ -63,6 +63,10 @@
 	name = "Cybernetic stomach"
 	path = /obj/item/organ/internal/stomach/cybernetic
 
+/datum/augment_item/organ/stomach/lithovore
+	name = "Lithovore Stomach"
+	path = /obj/item/organ/internal/stomach/lithovore
+
 //EYES
 /datum/augment_item/organ/eyes
 	slot = AUGMENT_SLOT_EYES

--- a/modular_nova/modules/organs/code/stomach.dm
+++ b/modular_nova/modules/organs/code/stomach.dm
@@ -41,3 +41,39 @@
 			var/mob/living/carbon/human/human_target = stomach_owner
 			human_target.electrocution_animation(1 SECONDS)
 	return COMPONENT_LIVING_BLOCK_SHOCK
+
+//lithovore stomach - modified golem
+/obj/item/organ/internal/stomach/lithovore
+	name = "litho-adapted stomach"
+	icon_state = "stomach-p"
+	desc = "An unfamiliar organ which appears to excel in material deconstruction"
+	color = COLOR_GOLEM_GRAY
+	organ_flags = ORGAN_MINERAL
+	organ_traits = list(TRAIT_ROCK_EATER)
+	hunger_modifier = 7 //adjusted so you're not eating stacks of metal every 10 minutes
+	var/min_hunger_slowdown = 0.5
+	var/max_hunger_slowdown = 4
+
+/obj/item/organ/internal/stomach/lithovore/on_mob_insert(mob/living/carbon/organ_owner, special)
+	. = ..()
+	RegisterSignal(owner, COMSIG_CARBON_ATTEMPT_EAT, PROC_REF(try_eating))
+
+/obj/item/organ/internal/stomach/lithovore/on_mob_remove(mob/living/carbon/organ_owner, special)
+	. = ..()
+	UnregisterSignal(organ_owner, COMSIG_CARBON_ATTEMPT_EAT)
+	organ_owner.remove_movespeed_modifier(/datum/movespeed_modifier/golem_hunger)
+	organ_owner.remove_status_effect(/datum/status_effect/golem_statued) // failsafes to ensure you don't get accidentally golem statue'd
+
+/// ROCK EATER
+/obj/item/organ/internal/stomach/lithovore/proc/try_eating(mob/living/carbon/source, atom/eating)
+	SIGNAL_HANDLER
+	if(istype(eating, /obj/item/food/golem_food))
+		return
+
+//actual code, makes sure u don't get the fancy 'golem rocks' from eating the material type
+/obj/item/organ/internal/stomach/lithovore/on_life(delta_time, times_fired)
+	for(var/datum/reagent/consumable/food in reagents.reagent_list)
+		if (istype(food, /datum/reagent/consumable/nutriment/mineral))
+			continue
+		food.nutriment_factor = 0
+	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds in a Lithovore Stomach accessible from the Augments section. A modified version of the Golem stomach that allows the user to ear both materials *and* normal food, while preventing the eater from turning to stone for eating too much, or getting Material Powers from eating specific types of rocks.

## How This Contributes To The Nova Sector Roleplay Experience

If your character is some type of rock person- you can eat materials, now! Bounty for Jason Finch. 

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
![Screenshot_001](https://github.com/NovaSector/NovaSector/assets/68376391/4cb3bba5-720c-4533-9561-9bd16d5de68e)
![Screenshot_002](https://github.com/NovaSector/NovaSector/assets/68376391/285cf9c9-9c04-4769-9474-f6ea1c8ab3e2)

[https://www.youtube.com/watch?v=YT7vnwTrJrE](url)
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new stomach type for Lithovores (Rock Eaters) in the augments menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
