### PR TITLE
Improves the Gear Harness slots

### DIFF
--- a/modular_nova/master_files/code/modules/clothing/under/misc.dm
+++ b/modular_nova/master_files/code/modules/clothing/under/misc.dm
@@ -21,7 +21,12 @@
 	body_parts_covered = NONE
 	attachment_slot_override = CHEST
 	can_adjust = FALSE
+	slot_flags = ITEM_SLOT_ICLOTHING | ITEM_SLOT_OCLOTHING
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+
+/obj/item/clothing/under/misc/nova/gear_harness/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.colonist_suit_allowed
 
 /obj/item/clothing/under/misc/nova/gear_harness/eve
 	name = "collection of leaves"

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_machinery/lustwish.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_machinery/lustwish.dm
@@ -60,7 +60,7 @@
 				/obj/item/clothing/shoes/latex_heels/domina_heels = 4,
 				/obj/item/clothing/gloves/evening = 5,
 
-				/obj/item/clothing/under/misc/nova/gear_harness = 6,//Important "not-nude" outfit
+				/obj/item/clothing/under/misc/nova/gear_harness = 20,//Important "not-nude" outfit
 				/obj/item/clothing/shoes/jackboots/knee = 3,
 
 				/obj/item/clothing/under/misc/latex_catsuit = 8,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

You can now equip the gear harness in the exo slot besides the under slot.

The list of items was unespecified, so I followed the lore I knew about them being used as colonist stuff, so, they get the colonist list.

They can also have attachments, which might be interesting in itself.

Lastly, I increased the amount of gear harness in the funny purple vendor to 20, for evident reasons.

Responds to: https://github.com/NovaSector/NovaSector/issues/3448

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

More diversity of customization, allows for some interesting fashion choices without going for full armor

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  show of regular use as exo:
![image](https://github.com/NovaSector/NovaSector/assets/13823244/ed309d79-5029-4088-a9ce-8ca0c20b461c)
show of no posibility of using exo storage when its on under:
![image](https://github.com/NovaSector/NovaSector/assets/13823244/53f7828e-5d2f-4ac7-9664-95eab297169c)
Tested with loadout and getting them through the vendor and through crafting. Everything allright:
![image](https://github.com/NovaSector/NovaSector/assets/13823244/abe5ba1e-e4c1-43cd-b2c8-a26733761e45)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new mechanics or gameplay changes
qol: Purple Vendors now have 20 gear harness in them to accomodate to the new demand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
