### PR TITLE
[MANUAL MIRROR] - BirdShot Service Department Changes (#84080)

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -43131,7 +43131,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "oEG" = (
-/obj/item/clothing/mask/cigarette,
 /obj/item/storage/fancy/cigarettes/cigpack_robust{
 	pixel_y = 5;
 	pixel_x = 6

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -37,6 +37,14 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
+"aaB" = (
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron,
+/area/station/commons/vacant_room/commissary)
 "aaH" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
@@ -44,6 +52,20 @@
 /obj/structure/window/spawner/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
+"abf" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "abh" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59,6 +81,11 @@
 /obj/machinery/power/tracker,
 /turf/open/space/basic,
 /area/station/solars/aft)
+"abu" = (
+/obj/effect/turf_decal/tile/dark_red/opposingcorners,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
 "abJ" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -95,6 +122,19 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"acQ" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L11";
+	pixel_y = -15
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "acS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -143,26 +183,11 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/hallway)
-"aeq" = (
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/flora/bush/leavy/style_random,
-/obj/structure/flora/bush/stalky/style_random,
-/obj/structure/window/spawner/directional/north,
-/obj/structure/window/spawner/directional/south,
-/turf/open/floor/grass,
-/area/station/hallway/secondary/service)
-"aes" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 4;
-	id = "kitchenshutters";
-	name = "Kitchen Shutters"
-	},
-/obj/item/plate,
-/obj/item/food/sandwich/peanut_butter_jelly,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
+"aec" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/table/wood,
+/turf/open/floor/iron/grimy,
+/area/station/service/bar)
 "aeu" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -187,19 +212,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
-"aeN" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "aeX" = (
 /obj/structure/window/spawner/directional/east,
 /obj/item/kirbyplants/random,
@@ -209,6 +221,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"afi" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	dir = 1;
+	pixel_y = 5
+	},
+/turf/open/floor/carpet,
+/area/station/service/library)
 "afu" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -262,11 +282,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"agp" = (
-/obj/structure/table/wood,
-/obj/item/cigarette/cigar/cohiba,
-/turf/open/floor/carpet,
-/area/station/commons/dorms)
 "agy" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/tank/oxygen{
@@ -275,19 +290,6 @@
 /obj/machinery/light/cold/directional/south,
 /turf/open/floor/plating,
 /area/station/science/ordnance/storage)
-"agC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/sign/departments/vault/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
-"agF" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/chair/sofa/bamboo/right{
-	dir = 1
-	},
-/turf/open/floor/wood/large,
-/area/station/service/chapel)
 "agI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -353,15 +355,6 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/auxiliary)
-"aiE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "aiK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -378,6 +371,40 @@
 	},
 /turf/open/floor/engine/airless,
 /area/station/engineering/atmos)
+"aiN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
+"aiW" = (
+/obj/structure/closet/secure_closet/bar,
+/obj/item/stack/spacecash/c1,
+/obj/item/stack/spacecash/c1,
+/obj/item/stack/spacecash/c1,
+/obj/item/stack/spacecash/c1,
+/obj/item/stack/spacecash/c1,
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/stone,
+/area/station/service/bar/backroom)
+"ajQ" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/griddle,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
+"akb" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "ako" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -411,10 +438,27 @@
 /obj/structure/railing,
 /turf/open/space/basic,
 /area/station/engineering/atmos/space_catwalk)
+"akz" = (
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/requests_console/auto_name/directional/south,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "akF" = (
 /obj/effect/landmark/transport/nav_beacon/tram/nav/immovable_rod,
 /turf/closed/wall,
 /area/station/maintenance/port/aft)
+"akH" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/closed/wall,
+/area/station/service/library)
 "akR" = (
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 1
@@ -458,16 +502,6 @@
 /obj/item/pen,
 /turf/open/floor/carpet/lone,
 /area/station/service/chapel/office)
-"alh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=1.5-PNexus-Vault";
-	location = "1.0-Security-PNexus"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "all" = (
 /obj/structure/table/greyscale,
 /obj/item/folder/yellow{
@@ -499,6 +533,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/small,
 /area/station/maintenance/solars/starboard/aft)
+"alN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "amE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -523,14 +562,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
-"amI" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "amV" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -554,6 +585,14 @@
 /obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
+"anL" = (
+/obj/effect/turf_decal/weather/snow,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 2
+	},
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "aoa" = (
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/circuit,
@@ -572,15 +611,6 @@
 /obj/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"aoy" = (
-/obj/structure/table/wood,
-/obj/machinery/camera/directional/south{
-	c_tag = "Atmospherics - South"
-	},
-/obj/item/stack/cable_coil/five,
-/obj/effect/turf_decal/siding/wideplating_new/terracotta,
-/turf/open/floor/wood/tile,
-/area/station/commons/vacant_room/commissary)
 "aoz" = (
 /obj/structure/closet/secure_closet/captains,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -589,19 +619,29 @@
 /obj/item/storage/lockbox/medal,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/captain/private)
-"aoJ" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "aoL" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"aoU" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 9;
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/condiment/enzyme{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -3
+	},
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "apd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -668,6 +708,13 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"aqJ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "aqV" = (
 /obj/machinery/door/airlock/glass,
 /obj/machinery/door/firedoor,
@@ -757,25 +804,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
-"asn" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/chair/pew/right{
-	dir = 4
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/station/service/theater)
-"asN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"asr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Diner"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/textured_half,
-/area/station/service/cafeteria)
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "asZ" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet{
@@ -810,6 +844,16 @@
 /obj/structure/sign/poster/contraband/lusty_xenomorph/directional/north,
 /turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/station/maintenance/starboard/central)
+"atw" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 10
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/secondary/service)
 "atx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/closet_maintenance,
@@ -843,10 +887,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
-"atM" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "atW" = (
 /turf/open/floor/iron/chapel{
 	dir = 8
@@ -873,6 +913,10 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/smooth,
 /area/station/commons/storage/tools)
+"auu" = (
+/obj/structure/flora/bush/sparsegrass,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "auG" = (
 /obj/structure/chair{
 	dir = 1
@@ -908,6 +952,26 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/command/gateway)
+"auX" = (
+/obj/structure/flora/bush/jungle/c/style_3{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
+"ava" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-entrance"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/textured_half,
+/area/station/security/brig/entrance)
 "ave" = (
 /turf/open/space,
 /area/space)
@@ -948,11 +1012,6 @@
 	},
 /turf/open/floor/tram,
 /area/station/security/tram)
-"aws" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/blue/half,
-/turf/open/floor/iron/white/small,
-/area/station/service/hydroponics)
 "awE" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8
@@ -974,14 +1033,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
-"awN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/clown,
-/turf/open/floor/stone,
-/area/station/service/theater)
 "awO" = (
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
@@ -1004,10 +1055,22 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/misc/sandy_dirt,
 /area/station/hallway/secondary/entry)
+"axa" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/holodeck/rec_center)
 "axj" = (
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"axl" = (
+/obj/effect/turf_decal/siding/wideplating_new/terracotta{
+	dir = 5
+	},
+/turf/open/floor/wood/tile,
+/area/station/maintenance/central/lesser)
 "axq" = (
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
@@ -1022,6 +1085,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
+"axx" = (
+/obj/structure/flora/bush/jungle/c/style_3,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "axz" = (
 /obj/effect/turf_decal/tile/neutral/full,
 /obj/structure/table/glass,
@@ -1086,6 +1156,28 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/engineering/supermatter/room)
+"ayy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/status_display/ai/directional/west,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
+"ayH" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/turf/open/floor/carpet,
+/area/station/service/library)
 "ayK" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
@@ -1226,6 +1318,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"aAP" = (
+/obj/effect/landmark/start/hangover,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/station/service/bar)
 "aAQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction/flip{
@@ -1266,6 +1365,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"aBt" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/rock/pile/jungle/style_3,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "aBu" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -1285,16 +1391,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/small,
 /area/station/medical/morgue)
-"aBy" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "aBK" = (
 /obj/structure/dresser,
 /obj/effect/turf_decal/siding/wood{
@@ -1390,17 +1486,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/central/fore)
-"aEl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/landmark/navigate_destination/teleporter,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "aEq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -1455,6 +1540,15 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
+"aFr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "aFt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1468,6 +1562,16 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark/small,
 /area/station/commons/dorms)
+"aFy" = (
+/obj/structure/window/spawner/directional/east,
+/obj/structure/window/spawner/directional/west,
+/obj/machinery/light/floor,
+/obj/structure/flora/bush/sparsegrass,
+/obj/structure/flora/bush/flowers_br,
+/obj/structure/flora/bush/flowers_pp,
+/obj/structure/flora/bush/flowers_yw,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "aFE" = (
 /obj/item/target,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -1590,6 +1694,10 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"aHy" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "aHJ" = (
 /obj/structure/window/spawner/directional/north,
 /obj/machinery/hydroponics/soil,
@@ -1634,6 +1742,20 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
+"aIM" = (
+/obj/structure/table/reinforced,
+/obj/structure/displaycase/forsale/kitchen{
+	pixel_y = 5
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	name = "Kitchen Shutters";
+	id = "kitchenshutters"
+	},
+/turf/open/floor/plating,
+/area/station/service/kitchen)
 "aIO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1656,6 +1778,13 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/small,
 /area/station/engineering/main)
+"aJg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "aJq" = (
 /turf/closed/mineral/random/stationside,
 /area/space/nearstation)
@@ -1706,6 +1835,9 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/atmos/office)
+"aKu" = (
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "aKx" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/small,
@@ -1804,11 +1936,28 @@
 	},
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
+"aMo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "aMy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
+"aMB" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "aNc" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
@@ -1875,6 +2024,13 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"aOc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 10
+	},
+/turf/open/floor/eighties,
+/area/station/hallway/primary/central/fore)
 "aOz" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -1885,6 +2041,18 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
+"aOF" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/trash,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "aOS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
@@ -1904,12 +2072,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/aft)
-"aPj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth,
-/area/station/cargo/drone_bay)
 "aPx" = (
 /obj/structure/chair{
 	dir = 1
@@ -1950,6 +2112,13 @@
 /obj/machinery/incident_display/tram/directional/north,
 /turf/open/floor/iron,
 /area/station/security/tram)
+"aPO" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/effect/landmark/start/chaplain,
+/turf/open/floor/carpet/lone,
+/area/station/service/chapel/office)
 "aPV" = (
 /obj/effect/spawner/random/structure/crate_abandoned,
 /obj/effect/decal/cleanable/dirt,
@@ -1973,6 +2142,10 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark/small,
 /area/station/security/checkpoint/customs)
+"aQn" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "aQr" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -1981,6 +2154,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/station/medical/cryo)
+"aQE" = (
+/obj/structure/flora/bush/jungle/c/style_3,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "aQF" = (
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 1
@@ -2000,6 +2178,17 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/secondary/exit/departure_lounge)
+"aRm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=1.5-PNexus-Vault";
+	location = "1.0-Security-PNexus"
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "aRo" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 4
@@ -2102,12 +2291,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"aTr" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
 "aTx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -2129,6 +2312,13 @@
 /obj/machinery/recharger,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/escape)
+"aTH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
 "aUA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2161,6 +2351,18 @@
 	dir = 1
 	},
 /area/station/engineering/supermatter/room)
+"aVh" = (
+/obj/effect/turf_decal/siding/wideplating/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_red/half/contrasted{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
 "aVF" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -2219,18 +2421,14 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron/textured_half,
 /area/station/security/execution/transfer)
+"aWl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "aWt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
-"aWw" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/flora/bush/sunny/style_random,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "aWx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/corner{
@@ -2259,12 +2457,40 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/small,
 /area/station/engineering/supermatter/room)
+"aWJ" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
+"aXb" = (
+/obj/structure/flora/tree/jungle/small/style_4,
+/obj/structure/flora/grass/jungle/b/style_random{
+	pixel_y = -3;
+	pixel_x = 3
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "aXy" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 1
 	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/atmos/office)
+"aXC" = (
+/obj/structure/flora/bush/flowers_br/style_random{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/effect/light_emitter/fake_outdoors,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/grass/Airless,
+/area/station/hallway/primary/central/aft)
 "aXI" = (
 /turf/closed/wall/r_wall,
 /area/station/science/lobby)
@@ -2345,6 +2571,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/iron/grimy,
 /area/station/hallway/secondary/entry)
+"aZH" = (
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "aZL" = (
 /obj/structure/table,
 /obj/item/aicard,
@@ -2438,6 +2668,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
+"bbW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wideplating_new/terracotta{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/station/maintenance/central/lesser)
 "bcr" = (
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating/airless,
@@ -2449,6 +2688,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white/small,
 /area/station/medical/medbay/lobby)
+"bcz" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "bcK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2495,6 +2741,23 @@
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"bdt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/primary/port)
 "bdN" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -2521,26 +2784,39 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"beH" = (
-/obj/machinery/bookbinder,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "beK" = (
 /turf/open/floor/iron/smooth,
 /area/station/security/evidence)
-"beR" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/effect/spawner/random/entertainment/arcade,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation/entertainment)
+"beQ" = (
+/obj/structure/table,
+/obj/machinery/light/small/directional/west,
+/obj/item/clothing/head/costume/paper_hat{
+	pixel_y = 12;
+	pixel_x = -4
+	},
+/obj/item/clothing/head/collectable/petehat{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/cigarette/cigar/cohiba{
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/commons/fitness/locker_room)
 "bfe" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/light/warm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
+"bfx" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "bfE" = (
 /obj/effect/turf_decal/siding/green/end{
 	dir = 1
@@ -2548,19 +2824,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/service/abandoned_gambling_den/gaming)
-"bfI" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/brown/full,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1
-	},
-/obj/machinery/requests_console/directional/south{
-	department = "Bar";
-	name = "Bar Requests Console"
-	},
-/obj/effect/mapping_helpers/requests_console/supplies,
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
 "bgg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -2620,11 +2883,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"bgK" = (
-/obj/structure/sink/kitchen/directional/east,
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "bgQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -2657,10 +2915,39 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
+"bif" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
+"biz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/camera/autoname/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "biB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/bridge)
+"biJ" = (
+/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "biM" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
@@ -2708,15 +2995,6 @@
 /obj/structure/marker_beacon/burgundy,
 /turf/open/space/basic,
 /area/space/nearstation)
-"bjV" = (
-/obj/structure/chair/plastic{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
 "bjZ" = (
 /turf/open/floor/tram,
 /area/station/security/tram)
@@ -2816,15 +3094,6 @@
 /obj/effect/spawner/random/engineering/flashlight,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
-"blq" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "bly" = (
 /obj/structure/closet/crate/miningcar,
 /turf/open/floor/iron,
@@ -2880,13 +3149,6 @@
 /mob/living/basic/bot/medbot/autopatrol,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"bmM" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/steam_vent,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "bmN" = (
 /obj/structure/railing{
 	dir = 4
@@ -2906,6 +3168,13 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/tram,
 /area/station/security/tram)
+"bnf" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 1
+	},
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
 "bno" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3206,6 +3475,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"brF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/eighties,
+/area/station/hallway/primary/central/fore)
 "brZ" = (
 /obj/machinery/door/airlock{
 	name = "Maintenance"
@@ -3215,6 +3492,13 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"bsa" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random/directional/west,
+/turf/open/floor/iron/grimy,
+/area/station/service/library)
 "bsn" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -3367,14 +3651,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
-"bxk" = (
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/structure/rack,
-/obj/item/weldingtool/mini,
-/obj/item/tank/internals/emergency_oxygen/empty,
-/obj/item/cigarette/rollie,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/maintenance/central/lesser)
 "bxs" = (
 /obj/structure/railing{
 	dir = 1
@@ -3397,13 +3673,6 @@
 	dir = 8
 	},
 /area/station/engineering/main)
-"bxA" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/end{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "bxI" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -3464,6 +3733,13 @@
 /obj/effect/gibspawner,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
+"bzj" = (
+/obj/machinery/light/floor,
+/obj/structure/flora/bush/flowers_pp,
+/obj/structure/flora/bush/flowers_yw,
+/obj/structure/flora/bush/fullgrass,
+/turf/open/floor/grass,
+/area/station/hallway/primary/central/fore)
 "bzZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
@@ -3539,22 +3815,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmospherics_engine)
-"bBN" = (
-/obj/structure/window/spawner/directional/east,
-/obj/structure/table/wood,
-/obj/machinery/cell_charger{
-	pixel_y = 5
-	},
-/obj/item/stock_parts/power_store/cell/crap{
-	pixel_y = 5
-	},
-/obj/item/cigarette/pipe/cobpipe{
-	pixel_x = 1;
-	pixel_y = -2
-	},
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/wood/tile,
-/area/station/command/corporate_showroom)
 "bBX" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -3616,6 +3876,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/small,
 /area/station/security/office)
+"bCN" = (
+/obj/machinery/camera/directional/east,
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "bCP" = (
 /obj/effect/turf_decal/siding/wideplating/dark,
 /obj/machinery/firealarm/directional/north,
@@ -3630,12 +3901,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/lower)
-"bCX" = (
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "bCZ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -3665,6 +3930,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/cryo)
+"bDm" = (
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random/directional/east,
+/obj/structure/cable,
+/turf/open/floor/eighties/red,
+/area/station/hallway/primary/central/fore)
 "bDq" = (
 /obj/structure/table,
 /obj/item/shovel,
@@ -3731,14 +4007,6 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/station/science/lower)
-"bED" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/item/kirbyplants/random,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation/entertainment)
 "bEN" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
@@ -3834,6 +4102,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
+"bGC" = (
+/obj/structure/flora/grass/jungle/b/style_random,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "bGD" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/red/line{
@@ -3890,6 +4162,22 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
+"bHx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/dark_red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/mail_sorting/security/hos_office,
+/turf/open/floor/iron,
+/area/station/security)
 "bHy" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/scientist,
@@ -3922,6 +4210,14 @@
 /obj/structure/window/spawner/directional/south,
 /turf/open/misc/sandy_dirt,
 /area/station/science/research)
+"bIP" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/structure/flora/bush/flowers_yw/style_2,
+/obj/structure/flora/bush/large/style_random,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "bJn" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -3934,6 +4230,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
+"bJy" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/primary/central/fore)
 "bJA" = (
 /obj/item/kirbyplants/random,
 /obj/structure/disposalpipe/segment{
@@ -4004,22 +4313,6 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/security/tram)
-"bKP" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/item/lighter{
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/item/lighter{
-	pixel_x = -8;
-	pixel_y = -2
-	},
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
 "bKU" = (
 /obj/item/toy/crayon/spraycan{
 	pixel_x = -7
@@ -4091,6 +4384,20 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
+"bNz" = (
+/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
+/obj/machinery/door/airlock/hydroponics/glass{
+	name = "Hydroponics"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/textured_half,
+/area/station/service/hydroponics)
+"bNF" = (
+/obj/structure/flora/bush/flowers_br,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "bNP" = (
 /obj/structure/cable,
 /obj/structure/broken_flooring/pile/directional/east,
@@ -4131,36 +4438,19 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
-"bOg" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"bOx" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/dark_red/fourcorners,
-/obj/effect/turf_decal/siding/wideplating/dark/corner{
-	dir = 1
+/obj/item/pen,
+/obj/machinery/door/poddoor/shutters{
+	id = "meow";
+	name = "Commissary"
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
-/area/station/security/brig/entrance)
-"bOl" = (
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/station/service/chapel)
-"bOp" = (
-/obj/effect/spawner/random/vending/snackvend,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
-/area/station/hallway/primary/central/fore)
+/area/station/commons/vacant_room/commissary)
 "bON" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4176,13 +4466,14 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/misc/sandy_dirt,
 /area/station/hallway/secondary/entry)
-"bOV" = (
-/obj/machinery/newscaster/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+"bOU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/wood/parquet,
-/area/station/service/theater)
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "bOY" = (
 /obj/structure/sign/poster/random/directional/east,
 /obj/machinery/conveyor{
@@ -4190,6 +4481,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningfoundry)
+"bPu" = (
+/obj/machinery/status_display/evac/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "bPU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /turf/open/floor/iron,
@@ -4217,6 +4520,17 @@
 /obj/machinery/computer/records/security,
 /turf/open/floor/wood/tile,
 /area/station/command/bridge)
+"bQq" = (
+/obj/machinery/icecream_vat,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "bQQ" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4305,6 +4619,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
+"bSV" = (
+/obj/structure/sink/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/light/cold/directional/north,
+/turf/open/floor/iron/dark/small,
+/area/station/service/chapel/storage)
 "bSX" = (
 /obj/machinery/flasher/directional/east{
 	id = "AI";
@@ -4339,19 +4662,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
-"bUf" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/light/cold/directional/east,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "bUr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue{
@@ -4360,20 +4670,6 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"bUt" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/corner{
-	dir = 1
-	},
-/area/station/hallway/primary/central/fore)
 "bUv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -4408,20 +4704,12 @@
 /obj/machinery/light/cold/directional/west,
 /turf/open/floor/tram,
 /area/station/security/tram)
-"bVv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=1.0-Security-PNexus";
-	location = "23.2-Evac-Garden"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+"bVB" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/station/hallway/primary/central/fore)
 "bVD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4517,6 +4805,15 @@
 /obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"bWv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "bXb" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4527,6 +4824,17 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/cryo)
+"bXB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "bXG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light_switch/directional/north,
@@ -4781,21 +5089,6 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/small,
 /area/station/medical/storage)
-"cbT" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public/glass{
-	name = "Services Corridor"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/textured_half{
-	dir = 8
-	},
-/area/station/hallway/primary/central/aft)
 "cbU" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 5
@@ -4884,34 +5177,6 @@
 	},
 /turf/open/floor/plating/rust,
 /area/station/engineering/supermatter/room)
-"ccO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
-/obj/structure/table,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating_new/dark,
-/obj/item/radio/intercom/directional/south,
-/obj/item/c_tube{
-	pixel_x = 20
-	},
-/obj/item/clothing/head/cone{
-	pixel_y = 5;
-	pixel_x = -6
-	},
-/obj/item/clothing/head/cone{
-	pixel_y = 7;
-	pixel_x = -6
-	},
-/obj/item/pipe_dispenser{
-	pixel_y = 9;
-	pixel_x = 14
-	},
-/obj/item/cigarette{
-	pixel_y = 2
-	},
-/turf/open/floor/iron/small,
-/area/station/engineering/atmos/pumproom)
 "cdg" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/grass,
@@ -4929,6 +5194,20 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
+"cdR" = (
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=23.1-Evac";
+	location = "22.0-Porthall-Evac"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "cdW" = (
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
@@ -4954,17 +5233,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark/small,
 /area/station/engineering/supermatter/room)
-"ceE" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	name = "Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "ceP" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
@@ -5004,6 +5272,17 @@
 /obj/effect/spawner/structure/window/survival_pod,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/ai)
+"cfl" = (
+/obj/effect/turf_decal/tile/dark_red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/light/cold/directional/south,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/mail_sorting/security/detectives_office,
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
 "cfH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -5025,6 +5304,16 @@
 	},
 /turf/open/space/basic,
 /area/station/engineering/atmos/space_catwalk)
+"cgi" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/small,
+/area/station/hallway/primary/central/fore)
 "cgt" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/decal/cleanable/garbage,
@@ -5110,6 +5399,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
+"chG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "chO" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -5118,11 +5416,6 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/port/aft)
-"chP" = (
-/obj/machinery/deepfryer,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "chU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5132,13 +5425,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/security)
-"cij" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation/entertainment)
 "cip" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/opposingcorners{
@@ -5180,6 +5466,13 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"cjv" = (
+/obj/structure/chair/comfy/brown,
+/obj/structure/sign/painting/library{
+	pixel_x = 30
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "cjz" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
@@ -5290,13 +5583,6 @@
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron/kitchen/small,
 /area/station/maintenance/aft)
-"clc" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/iron/grimy,
-/area/station/service/theater)
 "clf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5326,6 +5612,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/small,
 /area/station/command/heads_quarters/cmo)
+"clB" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/structure/mannequin/plastic,
+/turf/open/floor/carpet/blue,
+/area/station/cargo/boutique)
 "clV" = (
 /obj/structure/table,
 /obj/effect/mapping_helpers/broken_floor,
@@ -5417,15 +5710,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"cmH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/grimy,
-/area/station/service/theater)
 "cmX" = (
 /obj/effect/turf_decal/tile/dark_red{
 	dir = 8
@@ -5450,18 +5734,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"cnu" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/obj/structure/table/glass,
-/obj/item/book/codex_gigas,
-/obj/item/camera{
-	pixel_y = 18
-	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/grimy,
-/area/station/service/library)
 "cnG" = (
 /obj/machinery/suit_storage_unit/rd,
 /turf/open/floor/iron/dark/small,
@@ -5505,15 +5777,11 @@
 	},
 /turf/open/floor/wood,
 /area/station/engineering/atmos)
-"cpc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
+"cpk" = (
+/obj/structure/table/wood,
+/obj/item/food/lizard_fries,
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "cpA" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -5628,6 +5896,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/janitor)
+"crm" = (
+/obj/effect/spawner/random/trash,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "cro" = (
 /obj/structure/cable,
 /obj/structure/chair/sofa/corp/left{
@@ -5653,39 +5930,12 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/security/brig)
-"crV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/smooth,
-/area/station/service/greenroom)
-"crX" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/machinery/duct,
-/turf/open/floor/stone,
-/area/station/service/bar/backroom)
 "csl" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
-"csp" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "css" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
@@ -5752,14 +6002,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/diagonal,
 /area/station/engineering/lobby)
-"ctc" = (
-/obj/structure/cable,
-/obj/item/kirbyplants/random,
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "ctl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5770,6 +6012,16 @@
 "ctH" = (
 /turf/open/floor/iron/herringbone,
 /area/station/commons/dorms)
+"ctS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/central/lesser)
 "cua" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/spawner/random/structure/crate,
@@ -5849,6 +6101,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
+"cwh" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "cwt" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -5881,6 +6139,22 @@
 /obj/effect/spawner/structure/window/survival_pod,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai)
+"cwY" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
+"cxm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/central/lesser)
 "cxy" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction{
@@ -5908,11 +6182,6 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/atmos/office)
-"cxT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/station/cargo/boutique)
 "cyf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -5923,14 +6192,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
-"cyh" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "cyk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
@@ -5995,6 +6256,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"czn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/navigate_destination/hydro,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "czq" = (
 /obj/structure/curtain/cloth,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6007,6 +6279,30 @@
 	dir = 8
 	},
 /area/station/service/janitor)
+"czD" = (
+/obj/machinery/barsign{
+	chosen_sign = "thecavern";
+	icon_state = "thecavern";
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
+"czI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/secondary/service)
 "cAb" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -6042,6 +6338,10 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/explab)
+"cAq" = (
+/obj/structure/flora/bush/flowers_br/style_3,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "cAr" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6164,6 +6464,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
+"cDg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "cDt" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/structure/transport/linear/tram,
@@ -6250,6 +6558,11 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/engineering/break_room)
+"cEE" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "cEF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6305,6 +6618,9 @@
 	},
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai)
+"cEO" = (
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "cEX" = (
 /obj/effect/turf_decal/siding/thinplating_new/terracotta{
 	dir = 1
@@ -6359,6 +6675,17 @@
 	},
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai)
+"cFP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/chair/sofa/bench/left{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/holodeck/rec_center)
 "cFR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6390,6 +6717,13 @@
 /obj/item/clothing/mask/surgical,
 /turf/open/floor/iron/small,
 /area/station/medical/storage)
+"cHo" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "cHp" = (
 /obj/effect/turf_decal/siding/dark_red/corner{
 	dir = 4
@@ -6422,6 +6756,14 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/lawoffice)
+"cHE" = (
+/obj/effect/spawner/random/trash,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "cHO" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/blue/full,
@@ -6454,13 +6796,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/ai_monitored/command/nuke_storage)
-"cIC" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/light/small/directional/east,
-/obj/structure/chair/stool/bar/directional/south,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation/entertainment)
 "cIU" = (
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
@@ -6472,6 +6807,20 @@
 	},
 /turf/open/space/basic,
 /area/station/engineering/atmos/space_catwalk)
+"cJu" = (
+/obj/structure/chair/sofa/bench/right{
+	dir = 1
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Atmospherics - South"
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side,
+/area/station/hallway/primary/central/fore)
 "cJz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6564,6 +6913,19 @@
 /obj/structure/marker_beacon/indigo,
 /turf/open/space/basic,
 /area/space/nearstation)
+"cLp" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/button/door/directional/east{
+	id = "kitchenshutters";
+	name = "Kitchen Shutter Control"
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "cLD" = (
 /obj/structure/window/spawner/directional/north,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -6573,6 +6935,14 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
+"cLH" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/sign/departments/court/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "cLJ" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -6606,6 +6976,13 @@
 /obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs)
+"cMj" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "cMq" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -6620,6 +6997,12 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
+"cMT" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/station/service/bar)
 "cMW" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -6642,25 +7025,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/engine_smes)
+"cNd" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "cNk" = (
 /obj/structure/sign/departments/restroom/directional/south,
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
-"cNu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/status_display/evac/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"cNF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/closet_maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "cNR" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -6681,6 +7056,25 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"cOc" = (
+/obj/structure/flora/bush/flowers_yw/style_3{
+	pixel_y = -3
+	},
+/obj/structure/flora/bush/flowers_br/style_random{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/structure/flora/bush/flowers_pp{
+	pixel_y = -5;
+	pixel_x = -3
+	},
+/obj/machinery/light/floor,
+/obj/effect/light_emitter/fake_outdoors,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/grass/Airless,
+/area/station/hallway/primary/central/aft)
 "cOd" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/flora/rock/pile/style_2{
@@ -6691,10 +7085,32 @@
 /obj/structure/window/spawner/directional/west,
 /turf/open/misc/sandy_dirt,
 /area/station/commons/fitness/recreation/entertainment)
-"cOm" = (
-/obj/effect/turf_decal/tile/brown/full,
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
+"cOv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
+"cOy" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/item/clothing/head/utility/welding,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/station/commons/vacant_room/commissary)
 "cOC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6720,13 +7136,6 @@
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
-"cPd" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "cPe" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/iron/small,
@@ -6738,6 +7147,31 @@
 /obj/effect/turf_decal/siding/blue/corner,
 /turf/open/floor/iron/white/small,
 /area/station/medical/storage)
+"cPm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/primary/central/aft)
+"cPn" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/smooth,
+/area/station/service/greenroom)
 "cPp" = (
 /obj/structure/urinal/directional/east,
 /turf/open/floor/iron/white/small,
@@ -6758,6 +7192,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"cPK" = (
+/obj/structure/flora/rock/pile/jungle/style_4,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "cPN" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/showroomfloor,
@@ -6790,6 +7231,15 @@
 /obj/machinery/light/small/dim/directional/west,
 /turf/open/floor/iron/dark/small,
 /area/station/maintenance/aft)
+"cQN" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/mob/living/basic/frog,
+/obj/structure/flora/bush/flowers_br/style_3,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "cQP" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -6801,6 +7251,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
+"cRb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "cRm" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/spawner/random/maintenance,
@@ -6866,6 +7324,14 @@
 	},
 /turf/open/floor/tram,
 /area/station/security/tram)
+"cSi" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/obj/effect/landmark/start/librarian,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/grimy,
+/area/station/service/library)
 "cSk" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/closet/l3closet,
@@ -6900,6 +7366,16 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/prison/shower)
+"cSB" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 5
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/eighties/red,
+/area/station/hallway/primary/central/fore)
 "cSC" = (
 /turf/closed/wall,
 /area/station/commons/vacant_room/office)
@@ -7009,6 +7485,12 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/service/chapel/storage)
+"cVp" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "cVx" = (
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 4
@@ -7064,6 +7546,13 @@
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/engineering/atmos/office)
+"cWd" = (
+/obj/structure/flora/bush/jungle/c/style_random,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "cWh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7112,14 +7601,15 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
-"cXm" = (
-/obj/structure/cable,
+"cXc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "cXu" = (
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/open/floor/plating,
@@ -7141,6 +7631,15 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/security/prison/shower)
+"cYa" = (
+/obj/item/kirbyplants/random,
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "cYc" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/machinery/light/small/directional/east,
@@ -7160,6 +7659,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"cYz" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "cYD" = (
 /obj/structure/table/wood,
 /obj/item/hemostat{
@@ -7195,6 +7699,14 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/maintenance/department/engine)
+"cYO" = (
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/commons/vacant_room/commissary)
 "cYT" = (
 /obj/structure/hedge,
 /obj/structure/sign/poster/contraband/random/directional/east,
@@ -7350,6 +7862,13 @@
 "dbF" = (
 /turf/open/floor/plating/rust,
 /area/station/ai_monitored/turret_protected/aisat/maint)
+"dbI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/turf/open/floor/iron/grimy,
+/area/station/service/bar)
 "dbN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -7373,6 +7892,10 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"dci" = (
+/obj/machinery/status_display/ai/directional/east,
+/turf/open/floor/glass,
+/area/station/hallway/primary/central/aft)
 "dcx" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 10
@@ -7396,6 +7919,19 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"dcN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L2";
+	pixel_y = -15
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "dcS" = (
 /obj/effect/turf_decal/siding/wideplating/dark/corner{
 	dir = 4
@@ -7514,13 +8050,6 @@
 /obj/structure/window/spawner/directional/south,
 /turf/open/floor/grass,
 /area/station/cargo/storage)
-"dfW" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "dgm" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -7551,6 +8080,20 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/corner,
 /area/station/science/lower)
+"dgN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/primary/central/fore)
 "dgV" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 5
@@ -7562,6 +8105,12 @@
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron/dark/small,
 /area/station/engineering/storage_shared)
+"dha" = (
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/grimy,
+/area/station/service/library)
 "dhh" = (
 /obj/structure/cable,
 /obj/machinery/status_display/ai/directional/north,
@@ -7570,6 +8119,21 @@
 	},
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai)
+"dhj" = (
+/obj/effect/landmark/start/librarian,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
+"dhk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "dhy" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/trunk{
@@ -7662,6 +8226,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /turf/open/space/basic,
 /area/station/engineering/atmos/space_catwalk)
+"diN" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "diS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7704,29 +8272,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/textured_half,
 /area/station/commons/dorms)
-"dks" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/item/reagent_containers/cup/glass/drinkingglass{
-	pixel_x = -5;
-	pixel_y = 22
-	},
-/obj/item/reagent_containers/cup/glass/drinkingglass{
-	pixel_x = -1;
-	pixel_y = 13
-	},
-/obj/item/reagent_containers/cup/glass/drinkingglass{
-	pixel_x = -8;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/cup/glass/drinkingglass{
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/obj/machinery/camera/autoname/directional/south,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
 "dkz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7762,6 +8307,14 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
+"dlb" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/light/floor,
+/obj/structure/table/wood,
+/turf/open/floor/iron/grimy,
+/area/station/service/bar)
 "dlk" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
@@ -7800,6 +8353,16 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
+"dlR" = (
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "dmb" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -7866,6 +8429,24 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/stone,
 /area/station/service/abandoned_gambling_den)
+"dno" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/station/service/bar)
+"dnG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "dnK" = (
 /obj/item/kirbyplants/random,
 /obj/item/storage/briefcase{
@@ -7955,6 +8536,16 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"dow" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/obj/structure/flora/bush/large/style_random,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "doJ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -7993,17 +8584,45 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"dpG" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Study"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/wood/end,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "dpR" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
 	},
 /turf/open/floor/tram,
 /area/station/security/tram)
+"dqb" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "dqj" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"dqo" = (
+/obj/machinery/light/warm/dim,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "dqB" = (
 /obj/structure/table,
 /obj/item/clothing/head/utility/chefhat,
@@ -8128,6 +8747,11 @@
 /obj/item/screwdriver,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"dsK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/floor,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "dsN" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -8140,15 +8764,6 @@
 /obj/structure/tram,
 /turf/open/floor/tram,
 /area/station/maintenance/port/aft)
-"dtj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/dark_red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security/brig/entrance)
 "dtk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall,
@@ -8165,12 +8780,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
-"dty" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/floor,
-/turf/open/floor/wood/large,
-/area/station/service/chapel)
 "dtC" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/purple{
@@ -8247,18 +8856,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/engineering/atmos/office)
-"dvl" = (
-/obj/structure/table,
-/obj/item/reagent_containers/condiment/enzyme{
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/obj/machinery/reagentgrinder{
-	pixel_x = -9;
-	pixel_y = 8
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "dvo" = (
 /obj/machinery/ore_silo,
 /obj/effect/turf_decal/bot_white,
@@ -8274,6 +8871,10 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/space_catwalk)
+"dvB" = (
+/obj/effect/landmark/start/cook,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "dvJ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/dark_red/fourcorners,
@@ -8283,6 +8884,16 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs)
+"dvN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/trash,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "dvO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -8359,6 +8970,20 @@
 /obj/item/hfr_box/core,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
+"dxs" = (
+/obj/structure/statue/sandstone/venus{
+	dir = 8;
+	pixel_y = -15
+	},
+/obj/structure/flora/bush/flowers_pp,
+/obj/structure/flora/bush/flowers_br/style_3,
+/obj/effect/dummy/lighting_obj,
+/obj/effect/light_emitter/fake_outdoors,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/grass/Airless,
+/area/station/hallway/primary/central/aft)
 "dxu" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
@@ -8381,6 +9006,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
+"dxE" = (
+/obj/machinery/door/airlock{
+	name = "Kitchen"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "dxG" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -8410,6 +9042,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"dyk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
 "dyp" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/decal/cleanable/dirt,
@@ -8495,13 +9131,6 @@
 /obj/item/radio/intercom/chapel/directional/east,
 /turf/open/floor/iron/terracotta/diagonal,
 /area/station/service/chapel/office)
-"dzq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation/entertainment)
 "dzA" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
@@ -8520,6 +9149,32 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"dzQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-entrance"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/textured_half,
+/area/station/security/brig/entrance)
+"dAe" = (
+/obj/machinery/door/airlock/multi_tile/public{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/textured_half{
+	dir = 8
+	},
+/area/station/service/bar)
 "dAn" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -8535,6 +9190,15 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"dAD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "dAF" = (
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 4
@@ -8629,27 +9293,6 @@
 /obj/machinery/atmospherics/components/unary/passive_vent,
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai)
-"dCm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Study"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_half{
-	dir = 1
-	},
-/area/station/service/library)
 "dCs" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
@@ -8673,6 +9316,14 @@
 	dir = 8
 	},
 /area/station/security/office)
+"dCW" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/camera/autoname/directional/west,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/hallway/primary/central/aft)
 "dDd" = (
 /obj/structure/table,
 /obj/item/exodrone{
@@ -8743,6 +9394,19 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/textured_half,
 /area/station/commons/fitness/recreation/entertainment)
+"dEr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "dEu" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/kitchen/small,
@@ -8765,30 +9429,51 @@
 	dir = 1
 	},
 /area/station/science/ordnance/testlab)
-"dEV" = (
-/obj/structure/table,
-/obj/item/circuitboard/machine/coffeemaker/impressa,
-/obj/item/coffee_cartridge/decaf{
-	pixel_y = 9
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/commons/vacant_room/commissary)
 "dFN" = (
 /obj/structure/window/spawner/directional/east,
 /obj/structure/window/spawner/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms)
+"dGk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
+"dGv" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 4
+	},
+/obj/effect/landmark/start/botanist,
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
 "dGV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/closed/wall,
 /area/station/engineering/atmos/storage/gas)
-"dHi" = (
-/obj/machinery/door/firedoor,
-/obj/effect/landmark/navigate_destination/bar,
-/turf/open/floor/catwalk_floor/iron,
-/area/station/service/bar)
+"dGY" = (
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
+"dHc" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/bush/jungle/c/style_3{
+	pixel_x = 8
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "dHk" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
@@ -8879,6 +9564,38 @@
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"dJk" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"dJs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
+"dJA" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "dJT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8933,6 +9650,17 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/command/corporate_suite)
+"dKx" = (
+/obj/structure/window/spawner/directional/east,
+/obj/structure/window/spawner/directional/west,
+/obj/structure/flora/bush/sparsegrass,
+/obj/structure/flora/bush/flowers_br,
+/obj/structure/flora/bush/flowers_pp,
+/obj/structure/flora/bush/large/style_random{
+	pixel_y = -1
+	},
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "dKA" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Abandoned Dock Airlock"
@@ -9003,6 +9731,12 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
+"dMo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "dMM" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
@@ -9030,17 +9764,6 @@
 "dNq" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/ai_monitored/aisat/exterior)
-"dNw" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Library"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/textured_half,
-/area/station/service/library)
 "dNy" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
@@ -9055,13 +9778,6 @@
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/station/maintenance/starboard/central)
-"dNI" = (
-/obj/structure/chair/sofa/left/maroon,
-/obj/machinery/light/small/directional/east,
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
 "dNL" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -9098,10 +9814,26 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"dOx" = (
+/obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "dOz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/commons/storage/tools)
+"dON" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/station/service/bar)
 "dOT" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -9156,15 +9888,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
-"dPI" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "dQi" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -9181,6 +9904,20 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/station/holodeck/rec_center)
+"dQs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-entrance"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/textured_half,
+/area/station/security/brig/entrance)
 "dQE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -9193,30 +9930,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/cytology)
-"dRf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	name = "Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/hallway/abandoned_command)
-"dRh" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "dRk" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -9226,6 +9939,16 @@
 	},
 /turf/open/misc/sandy_dirt,
 /area/station/security/tram)
+"dRo" = (
+/obj/effect/spawner/random/trash,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "dRD" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -9278,15 +10001,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/auxiliary)
-"dSK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/central/lesser)
 "dSO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9330,16 +10044,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
-"dTS" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/turf/open/floor/iron/small,
-/area/station/hallway/primary/central/fore)
 "dTW" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/machinery/computer/shuttle/mining{
@@ -9517,19 +10221,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/science/lower)
-"dXo" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/red{
-	dir = 6
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/white/small,
-/area/station/security/warden)
 "dXO" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /obj/structure/disposalpipe/segment{
@@ -9547,22 +10238,11 @@
 	dir = 1
 	},
 /area/station/science/xenobiology)
-"dYc" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/multitool{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/item/cigarette{
-	pixel_x = 5;
-	pixel_y = 2
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/lockers)
+"dXY" = (
+/mob/living/basic/deer,
+/obj/structure/flora/bush/sparsegrass,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "dYj" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/dark_red,
@@ -9573,6 +10253,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
+"dYl" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "dYp" = (
 /obj/structure/table,
 /obj/item/wrench,
@@ -9611,6 +10298,10 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
+"dYT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/station/service/bar)
 "dYW" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -9669,6 +10360,13 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/auxlab/firing_range)
+"dZt" = (
+/obj/structure/flora/tree/jungle/small/style_3,
+/obj/effect/turf_decal/weather/dirt,
+/obj/machinery/light/small/directional/south,
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "dZD" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "AI Chamber - Core";
@@ -9688,6 +10386,12 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/security/prison/shower)
+"dZL" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/machinery/light/small/directional/south,
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "dZT" = (
 /obj/machinery/button/transport/tram/directional/south{
 	id = 2;
@@ -9732,6 +10436,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/fore/greater)
+"eaO" = (
+/obj/machinery/light/small/broken/directional/west,
+/turf/open/floor/iron/dark/small,
+/area/station/maintenance/central/lesser)
 "ebc" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -9759,17 +10467,6 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"ebB" = (
-/obj/effect/turf_decal/tile/green/opposingcorners,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "ebK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -9841,6 +10538,30 @@
 	dir = 1
 	},
 /area/station/science/research)
+"edq" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/grimy,
+/area/station/service/bar)
+"edt" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/textured_half,
+/area/station/service/bar)
+"edw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/navigate_destination/bar,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "edD" = (
 /obj/machinery/light/small/directional/west,
 /obj/item/kirbyplants/random,
@@ -9924,13 +10645,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
-"efj" = (
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "efl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -9968,13 +10682,13 @@
 	dir = 10
 	},
 /area/station/science/lower)
-"efL" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/green{
+"efQ" = (
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
+/obj/structure/chair/stool/directional/west,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "efS" = (
 /obj/machinery/computer/security/qm{
 	dir = 1
@@ -10033,6 +10747,22 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"eho" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/item/clothing/gloves/color/fyellow{
+	pixel_y = 2
+	},
+/obj/item/wrench,
+/obj/item/cigarette/xeno{
+	pixel_x = -3;
+	pixel_y = -9
+	},
+/obj/item/clothing/head/utility/welding,
+/turf/open/floor/iron/small,
+/area/station/maintenance/department/engine/atmos)
 "ehw" = (
 /obj/machinery/computer/atmos_control/carbon_tank,
 /obj/structure/sign/poster/official/random/directional/east,
@@ -10072,6 +10802,15 @@
 /obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"eiz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/directional/north,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "eiC" = (
 /obj/structure/cable/multilayer/connected,
 /obj/structure/rack,
@@ -10113,16 +10852,13 @@
 "eiU" = (
 /turf/open/floor/plating/rust,
 /area/station/maintenance/department/engine/atmos)
-"ejc" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/dark_red/half/contrasted{
-	dir = 4
+"eiW" = (
+/obj/structure/flora/grass/jungle/b/style_3{
+	pixel_y = -6;
+	pixel_x = -5
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security)
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "ejn" = (
 /obj/item/stack/cable_coil/five,
 /obj/effect/decal/cleanable/cobweb,
@@ -10134,6 +10870,18 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/cargo/bitrunning/den)
+"eju" = (
+/obj/structure/table,
+/obj/item/stack/package_wrap,
+/obj/item/hand_labeler,
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/iron,
+/area/station/commons/vacant_room/commissary)
 "ejx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -10297,6 +11045,12 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/secondary/exit/departure_lounge)
+"elB" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 9
+	},
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
 "elC" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/records/medical/laptop{
@@ -10384,15 +11138,6 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
-"enD" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/machinery/camera/autoname/directional/west,
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "enE" = (
 /obj/item/cultivator/rake,
 /obj/structure/cable,
@@ -10476,6 +11221,16 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
+"epN" = (
+/obj/structure/table/wood,
+/obj/structure/displaycase/forsale/kitchen{
+	pixel_y = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "eqg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10515,16 +11270,6 @@
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
-"eqP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/obj/effect/landmark/start/chaplain,
-/turf/open/floor/carpet/lone,
-/area/station/service/chapel/office)
 "eqS" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -10628,6 +11373,18 @@
 /obj/structure/sign/departments/medbay/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"esR" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Public Shrine"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/station/hallway/primary/central/fore)
 "etl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 5
@@ -10741,6 +11498,22 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/engine)
+"evn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/secondary/service)
 "evq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10774,15 +11547,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/small,
 /area/station/maintenance/department/engine)
-"ewi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/cold/directional/west,
-/obj/machinery/duct,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "ewo" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -10871,6 +11635,13 @@
 /obj/structure/sink/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"eyf" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/plating,
+/area/station/hallway/primary/central/fore)
 "eyB" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -10888,6 +11659,11 @@
 	dir = 1
 	},
 /area/station/ai_monitored/turret_protected/aisat/maint)
+"eyS" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "eyZ" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/firealarm/directional/west,
@@ -11032,17 +11808,6 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai)
-"eAX" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/dark_red/fourcorners,
-/obj/effect/landmark/start/security_officer,
-/turf/open/floor/iron,
-/area/station/security/brig/entrance)
 "eAY" = (
 /turf/open/floor/grass,
 /area/station/science/xenobiology)
@@ -11065,6 +11830,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
+"eBE" = (
+/obj/structure/table,
+/turf/open/floor/iron/dark/small,
+/area/station/maintenance/central/lesser)
 "eBH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11100,6 +11869,13 @@
 	},
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai)
+"eCl" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "eCJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -11114,6 +11890,19 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/engineering/main)
+"eCS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "eDe" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Maintenance"
@@ -11304,6 +12093,14 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"eFH" = (
+/obj/effect/turf_decal/tile/neutral/full,
+/obj/structure/rack,
+/obj/item/weldingtool/mini,
+/obj/item/tank/internals/emergency_oxygen/empty,
+/obj/item/cigarette/rollie,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/maintenance/central/lesser)
 "eFO" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -11360,14 +12157,20 @@
 	dir = 1
 	},
 /area/station/science/lobby)
-"eGl" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+"eGe" = (
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
+"eGj" = (
 /obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/chair/wood{
 	dir = 4
 	},
-/obj/machinery/photocopier,
-/turf/open/floor/iron/smooth,
-/area/station/service/library)
+/turf/open/floor/iron/grimy,
+/area/station/service/bar)
 "eGw" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Engineering - Public Desk"
@@ -11392,6 +12195,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/prison/mess)
+"eGM" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "eGT" = (
 /obj/structure/table,
 /obj/machinery/fax{
@@ -11405,10 +12216,25 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
+"eGU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "eHa" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/barber)
+"eHb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "eHe" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -11448,6 +12274,15 @@
 /obj/structure/holosign/barrier/atmos/tram,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"eHH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "eHN" = (
 /obj/structure/cable,
 /turf/open/floor/wood/tile,
@@ -11489,6 +12324,16 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"eIN" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L3";
+	pixel_y = -15
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "eIT" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/stripes/line{
@@ -11542,13 +12387,6 @@
 /obj/effect/turf_decal/stripes/asteroid/end,
 /turf/open/floor/circuit/green,
 /area/station/science/robotics/mechbay)
-"eJY" = (
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
 "eKf" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets/donkpocketpizza,
@@ -11579,6 +12417,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"eLb" = (
+/obj/structure/flora/tree/jungle/style_5,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "eLn" = (
 /obj/machinery/door/airlock/glass{
 	name = "Gold Standard Law Firm"
@@ -11606,6 +12448,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"eLR" = (
+/obj/structure/chair/sofa/bench/left{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/hallway/primary/central/fore)
 "eLZ" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -11636,6 +12487,15 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"eMp" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "eMQ" = (
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
@@ -11711,6 +12571,14 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai)
+"eOg" = (
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/commons/vacant_room/commissary)
 "eOh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/effect/landmark/event_spawn,
@@ -11746,6 +12614,10 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/coldroom)
+"ePl" = (
+/obj/machinery/light/floor,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "ePn" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small/directional/south,
@@ -11807,12 +12679,6 @@
 "eQt" = (
 /turf/closed/wall,
 /area/station/command/heads_quarters/rd)
-"eQv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/carpet/lone,
-/area/station/service/theater)
 "eQC" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/spawner/random/structure/girder,
@@ -11862,6 +12728,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/science/lower)
+"eSs" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/floor,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "eSV" = (
 /obj/structure/bed/maint,
 /turf/open/floor/iron/small,
@@ -11908,19 +12784,6 @@
 /obj/item/kirbyplants/random/fullysynthetic,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"eTt" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/mail_sorting/service/hydroponics,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/landmark/navigate_destination/hydro,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "eTT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11986,10 +12849,15 @@
 	dir = 1
 	},
 /area/station/engineering/supermatter/room)
-"eUW" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
+"eUT" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
 "eUZ" = (
 /obj/effect/turf_decal/tile/dark_red{
 	dir = 1
@@ -12099,15 +12967,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/small,
 /area/station/engineering/atmos/pumproom)
-"eWA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "eWB" = (
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 1
@@ -12146,6 +13005,13 @@
 /obj/machinery/light/cold/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
+"eWZ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "eXo" = (
 /turf/closed/wall/r_wall,
 /area/station/tcommsat/server)
@@ -12163,6 +13029,13 @@
 	},
 /turf/open/floor/stone,
 /area/station/maintenance/aft)
+"eXU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/iron/grimy,
+/area/station/service/bar)
 "eXW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12202,6 +13075,13 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/turret_protected/aisat/equipment)
+"eYv" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "eYD" = (
 /obj/structure/railing{
 	dir = 8
@@ -12224,19 +13104,13 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/station/science/lower)
-"eYT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	name = "Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"eYS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/commons/fitness/recreation/entertainment)
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "eYY" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/window/spawner/directional/east,
@@ -12254,19 +13128,53 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/engineering/engine_smes)
-"eZJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
+"eZy" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "eZM" = (
 /obj/structure/cable/layer3,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/turret_protected/ai)
+"eZO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
+"eZX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/tile,
+/area/station/maintenance/central/lesser)
+"faa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
+"fat" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/wood{
+	name = "Bar Backroom"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/turf/open/floor/iron/textured_half{
+	dir = 8
+	},
+/area/station/service/bar)
 "fav" = (
 /obj/item/kirbyplants/random/fullysynthetic,
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
@@ -12281,6 +13189,14 @@
 	dir = 4
 	},
 /area/station/maintenance/starboard/greater)
+"faH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "meow";
+	name = "Commissary"
+	},
+/turf/open/floor/plating,
+/area/station/commons/vacant_room/commissary)
 "faQ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -12317,6 +13233,10 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/command)
+"fbq" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/misc/dirt/jungle,
+/area/station/service/chapel)
 "fbs" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
@@ -12364,6 +13284,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"fbS" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/bush/jungle/a/style_random{
+	pixel_y = -5
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "fca" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
@@ -12397,14 +13326,6 @@
 /obj/structure/sign/warning/vacuum/external/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/space_catwalk)
-"fcM" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/camera/autoname/directional/east,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "fcU" = (
 /obj/structure/window/spawner/directional/south,
 /obj/structure/flora/bush/large/style_random{
@@ -12489,6 +13410,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
+"feB" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/primary/central/fore)
 "ffp" = (
 /obj/structure/closet/firecloset,
 /obj/effect/spawner/random/maintenance,
@@ -12509,15 +13439,9 @@
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"ffX" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 4;
-	id = "kihall"
-	},
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
+"ffY" = (
+/turf/closed/wall,
+/area/station/holodeck/rec_center)
 "fgk" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/status_display/door_timer{
@@ -12586,22 +13510,31 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/security/office)
-"fhC" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
+"fhJ" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/iron/dark/small,
+/area/station/maintenance/central/lesser)
 "fhT" = (
 /obj/structure/sink/directional/east,
 /obj/structure/mirror/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/auxiliary)
+"fhV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/dark_red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security)
 "fhX" = (
 /obj/structure/table/greyscale,
 /obj/item/lightreplacer{
@@ -12684,17 +13617,6 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/station/commons/dorms)
-"fju" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"fjF" = (
-/obj/effect/turf_decal/bot_red,
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
 "fjL" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -12783,6 +13705,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/small,
 /area/station/engineering/atmos/storage/gas)
+"flH" = (
+/obj/structure/chair/sofa/bench/right{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/white/side,
+/area/station/hallway/primary/central/aft)
 "flM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12790,6 +13721,17 @@
 /obj/item/kirbyplants/organic/applebush,
 /turf/open/floor/wood/tile,
 /area/station/command/corporate_showroom)
+"flO" = (
+/obj/machinery/door/airlock{
+	name = "Kitchen"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "flX" = (
 /obj/item/flashlight/lantern,
 /turf/open/floor/plating/rust,
@@ -12845,6 +13787,17 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
+"fny" = (
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=1.0-Security-PNexus";
+	location = "23.2-Evac-Garden"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "fnz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -12881,6 +13834,16 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron/textured_large,
 /area/station/security/brig/entrance)
+"fnQ" = (
+/obj/machinery/door/airlock/public{
+	name = "Arcade"
+	},
+/obj/effect/turf_decal/siding/thinplating,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/iron/textured_half,
+/area/station/hallway/primary/central/fore)
 "foe" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -12966,6 +13929,19 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"fpx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/landmark/navigate_destination/hop,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "fpB" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock{
@@ -12987,6 +13963,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/disposal/incinerator)
+"fpN" = (
+/obj/machinery/door/airlock{
+	name = "Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/hallway/abandoned_command)
 "fpO" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/ce)
@@ -13005,17 +13994,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/side,
 /area/station/science/research)
-"fqL" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "fqQ" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -13036,6 +14014,14 @@
 /obj/item/defibrillator/loaded,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"frq" = (
+/obj/machinery/smartfridge,
+/obj/machinery/door/poddoor/shutters{
+	name = "Kitchen Shutters";
+	id = "kitchenshutters"
+	},
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "frC" = (
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/dark/smooth_large,
@@ -13313,6 +14299,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"fwt" = (
+/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "fwF" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -13387,6 +14380,16 @@
 	},
 /turf/open/floor/iron/kitchen/small,
 /area/station/security/breakroom)
+"fyr" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/eighties/red,
+/area/station/hallway/primary/central/fore)
 "fyt" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
@@ -13436,6 +14439,12 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
+"fyQ" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/textured_half{
+	dir = 8
+	},
+/area/station/service/bar)
 "fyZ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -13451,11 +14460,6 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
-"fzf" = (
-/obj/machinery/vending/boozeomat,
-/obj/machinery/light/cold/directional/east,
-/turf/closed/wall,
-/area/station/service/bar)
 "fzq" = (
 /obj/structure/closet/crate/trashcart/filled,
 /turf/open/floor/plating,
@@ -13674,14 +14678,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
-"fDp" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/service)
+"fDm" = (
+/obj/effect/turf_decal/weather/dirt,
+/mob/living/basic/deer,
+/obj/structure/flora/bush/flowers_yw,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "fDI" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
@@ -13794,6 +14796,13 @@
 "fEC" = (
 /turf/closed/wall,
 /area/station/maintenance/port/lesser)
+"fET" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/structure/flora/bush/flowers_yw/style_3,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "fEU" = (
 /obj/structure/table,
 /obj/item/multitool{
@@ -13827,6 +14836,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/space/basic,
 /area/station/engineering/atmos/space_catwalk)
+"fFk" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "fFt" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -13837,6 +14853,15 @@
 "fFu" = (
 /turf/open/floor/iron/stairs/medium,
 /area/station/engineering/atmos)
+"fFz" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/secondary/service)
 "fFD" = (
 /obj/effect/turf_decal/siding/blue,
 /obj/effect/landmark/start/paramedic,
@@ -13917,6 +14942,28 @@
 	},
 /turf/open/floor/plating/rust,
 /area/station/ai_monitored/turret_protected/aisat/maint)
+"fGt" = (
+/turf/open/misc/dirt/jungle,
+/area/station/service/chapel)
+"fGC" = (
+/obj/effect/mapping_helpers/airlock/access/any/service/general,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Service Hallway"
+	},
+/turf/open/floor/iron/textured_half,
+/area/station/hallway/secondary/service)
+"fGP" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_red{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
 "fGU" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -13927,12 +14974,6 @@
 /obj/structure/sign/warning/pods/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
-"fHb" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
 "fHf" = (
 /obj/structure/bed/maint,
 /obj/effect/spawner/random/maintenance,
@@ -13993,6 +15034,17 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/science/cubicle)
+"fIv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "fIw" = (
 /obj/effect/landmark/navigate_destination/dockescpod,
 /turf/open/floor/plating,
@@ -14108,13 +15160,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
-"fKO" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/sign/departments/court/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "fKP" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -14123,6 +15168,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/science/lower)
+"fKQ" = (
+/obj/machinery/door/airlock/multi_tile/public{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/textured_half,
+/area/station/service/bar)
 "fKR" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/machinery/disposal/bin,
@@ -14222,6 +15274,18 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
+"fLB" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "fLC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -14242,6 +15306,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"fLG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "fLI" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron/dark/small,
@@ -14273,18 +15348,6 @@
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/starboard/fore)
-"fMj" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "fMs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14325,9 +15388,6 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/mineral/titanium,
 /area/station/command/heads_quarters/ce)
-"fMD" = (
-/turf/open/floor/iron/white/small,
-/area/station/service/hydroponics)
 "fMP" = (
 /obj/structure/table/reinforced/titaniumglass,
 /obj/item/binoculars{
@@ -14354,6 +15414,19 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/secondary/exit/departure_lounge)
+"fMT" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "fNb" = (
 /obj/effect/turf_decal/arrows{
 	dir = 8
@@ -14427,6 +15500,10 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"fOH" = (
+/obj/structure/closet/secure_closet/freezer/empty,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "fOQ" = (
 /obj/structure/cable,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -14442,6 +15519,18 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"fPN" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/rack,
+/obj/item/storage/toolbox/emergency{
+	pixel_x = -2;
+	pixel_y = -3
+	},
+/obj/item/cigarette/cigar,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/smooth,
+/area/station/command/bridge)
 "fPO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -14592,14 +15681,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"fSq" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/rack,
-/obj/item/scalpel,
-/obj/item/wirecutters,
-/obj/machinery/light/small/broken/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "fSx" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -14627,6 +15708,17 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
+"fSV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/sign/departments/holy/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "fSX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14694,12 +15786,6 @@
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
-"fUj" = (
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
 "fUo" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -14714,6 +15800,30 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"fUs" = (
+/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
+"fUz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/item/trash/flare{
+	pixel_x = 11;
+	pixel_y = 21
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/central/fore)
 "fUI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -14780,10 +15890,27 @@
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron/small,
 /area/station/security/checkpoint/engineering)
+"fVE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "fVG" = (
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs)
+"fVP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/dark/small,
+/area/station/service/chapel/storage)
 "fVU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14791,15 +15918,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
-"fVV" = (
-/obj/structure/sink/kitchen/directional/west,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/camera/directional/east,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "fWe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -14944,10 +16062,6 @@
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/disposal/incinerator)
-"fYp" = (
-/obj/effect/landmark/navigate_destination/vault,
-/turf/open/floor/glass,
-/area/station/hallway/secondary/spacebridge)
 "fYr" = (
 /obj/structure/table,
 /obj/item/extinguisher/empty,
@@ -14966,22 +16080,15 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/misc/asteroid,
 /area/station/maintenance/department/engine/atmos)
-"fYX" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
+"fZn" = (
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/machinery/door/airlock/security{
-	name = "Warden's Office"
-	},
-/turf/open/floor/iron/textured_half{
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
-/area/station/security/warden)
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "fZp" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -14993,6 +16100,18 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/server)
+"fZq" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-entrance"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/textured_half,
+/area/station/security/brig/entrance)
 "fZG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -15019,6 +16138,14 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
+"fZX" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
 "gad" = (
 /obj/structure/table/bronze,
 /obj/item/food/grown/cannabis{
@@ -15051,25 +16178,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hop)
-"gal" = (
-/obj/structure/table,
-/obj/item/reagent_containers/condiment/saltshaker{
-	desc = "Salt. From space oceans, presumably. A staple of modern medicine.";
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/radio/intercom/directional/east,
-/obj/effect/spawner/random/food_or_drink/condiment{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
 "gan" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/research{
@@ -15079,6 +16187,29 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor/flat_white,
 /area/station/science/robotics/mechbay)
+"gav" = (
+/obj/structure/rack,
+/obj/item/holosign_creator/robot_seat/restaurant,
+/obj/item/book/manual/chef_recipes,
+/obj/item/stack/package_wrap{
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/condiment/enzyme{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/machinery/light_switch/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "gaF" = (
 /obj/machinery/stasis{
 	dir = 4
@@ -15182,6 +16313,15 @@
 "gcz" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/fore/lesser)
+"gcE" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/flora/bush/flowers_yw/style_3,
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/light/small/directional/south,
+/obj/machinery/camera/directional/south,
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "gcL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/crate_abandoned,
@@ -15209,6 +16349,19 @@
 	},
 /turf/open/space/basic,
 /area/station/engineering/atmos/space_catwalk)
+"gcW" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/station/service/bar)
+"gdf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "gdn" = (
 /obj/item/kirbyplants/organic/applebush,
 /obj/effect/turf_decal/tile/red{
@@ -15268,6 +16421,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"gdY" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/directional/east,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "geb" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/flashlight/lamp/green,
@@ -15288,13 +16448,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/medical/treatment_center)
-"geC" = (
-/obj/structure/reagent_dispensers/beerkeg,
-/obj/structure/sign/picture_frame/portrait/bar{
-	pixel_y = 32
-	},
-/turf/open/floor/stone,
-/area/station/service/bar/backroom)
 "geE" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -15337,6 +16490,15 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"gfc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "gfs" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/command)
@@ -15399,17 +16561,6 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"ggq" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "ggw" = (
 /obj/effect/turf_decal/stripes/white/end{
 	dir = 1
@@ -15425,6 +16576,9 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/explab)
+"ggV" = (
+/turf/open/floor/iron/smooth,
+/area/station/service/library)
 "ggX" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
@@ -15446,6 +16600,20 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"ghd" = (
+/obj/machinery/modular_computer/preset/cargochat/service{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/requests_console/auto_name/directional/east,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/secondary/service)
 "ghs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15513,16 +16681,6 @@
 /obj/structure/cable,
 /turf/open/floor/stone,
 /area/station/service/abandoned_gambling_den)
-"gih" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "giq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -15569,6 +16727,32 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/station/science/xenobiology)
+"gjj" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
+"gjl" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
+"gjw" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/bush/flowers_yw,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "gjL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -15654,6 +16838,22 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/port/aft)
+"gkx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/machinery/door/airlock/security{
+	name = "Warden's Office"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 8
+	},
+/area/station/security/warden)
 "gky" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -15675,14 +16875,28 @@
 "gla" = (
 /turf/open/floor/iron/grimy,
 /area/station/commons)
-"glb" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/brown/full,
-/obj/structure/reagent_dispensers/beerkeg,
-/obj/effect/turf_decal/bot_red/left,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
+"glm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/grunge{
+	name = "Vacant Comissary"
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/station/maintenance/central/lesser)
+"glG" = (
+/obj/structure/table/wood,
+/obj/item/pen/red{
+	pixel_x = 3;
+	pixel_y = 12
+	},
+/obj/item/pen/blue{
+	pixel_x = -6;
+	pixel_y = 12
+	},
+/turf/open/floor/carpet,
+/area/station/service/library)
 "glJ" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/effect/turf_decal/siding/wideplating,
@@ -15714,6 +16928,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
+"glW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/navigate_destination/library,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "glY" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/rack,
@@ -15745,9 +16971,19 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/medical/cryo)
+"gmz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark/small,
+/area/station/service/chapel/storage)
 "gnd" = (
 /turf/closed/wall,
 /area/station/engineering/atmos/office)
+"gni" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/dark/side,
+/area/station/hallway/primary/central/fore)
 "gnA" = (
 /obj/structure/cable,
 /obj/machinery/light/small/directional/north,
@@ -15776,6 +17012,12 @@
 	},
 /turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/station/maintenance/starboard/central)
+"gnZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/iron/dark/small,
+/area/station/service/chapel/storage)
 "gom" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
@@ -15883,6 +17125,16 @@
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/carpet/orange,
 /area/station/commons/dorms)
+"gqa" = (
+/obj/machinery/door/airlock{
+	name = "Kitchen"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/service/bar/backroom)
 "gqb" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -15966,6 +17218,15 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white/small,
 /area/station/science/lab)
+"gsE" = (
+/mob/living/basic/frog,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/obj/structure/flora/rock/pile/jungle/style_4,
+/obj/structure/flora/bush/flowers_pp/style_2,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "gsY" = (
 /turf/open/floor/iron/smooth,
 /area/station/engineering/break_room)
@@ -15984,6 +17245,11 @@
 	dir = 1
 	},
 /area/station/science/research)
+"gtp" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white/small,
+/area/station/medical/medbay/lobby)
 "gtr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/cigarette,
@@ -16064,26 +17330,9 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark/small,
 /area/station/security/brig)
-"guR" = (
-/obj/machinery/modular_computer/preset/curator,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "guY" = (
 /turf/closed/wall,
 /area/station/service/chapel/storage)
-"gvn" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "sci-entrance"
-	},
-/turf/open/floor/iron/textured_half,
-/area/station/security/brig/entrance)
 "gvB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -16106,6 +17355,19 @@
 "gvY" = (
 /turf/closed/wall/r_wall,
 /area/space)
+"gvZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/hallway/primary/central/fore)
 "gwa" = (
 /obj/structure/chair{
 	dir = 1
@@ -16123,6 +17385,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/small,
 /area/station/engineering/atmos/storage/gas)
+"gwB" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/machinery/restaurant_portal/restaurant,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "gwQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/east,
@@ -16147,6 +17416,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"gwW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/stack/spacecash/c1,
+/obj/item/cigarette/cigar/havana,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/station/maintenance/starboard/central)
 "gxb" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/surgical{
@@ -16234,6 +17510,15 @@
 	},
 /turf/open/misc/sandy_dirt,
 /area/station/security/tram)
+"gxG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "gxK" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/clothing/suit/hooded/wintercoat/engineering,
@@ -16251,6 +17536,17 @@
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/medical/treatment_center)
+"gxQ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "gxR" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -16298,13 +17594,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"gzj" = (
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/beebox,
-/obj/machinery/camera/autoname/directional/north,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/grass,
-/area/station/service/hydroponics)
 "gzs" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 5
@@ -16484,6 +17773,14 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/wood/tile,
 /area/station/command/bridge)
+"gCh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "gCo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16685,6 +17982,11 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/command/bridge)
+"gFk" = (
+/obj/machinery/status_display/evac/directional/north,
+/obj/machinery/camera/directional/north,
+/turf/open/misc/dirt/jungle,
+/area/station/service/chapel)
 "gFm" = (
 /obj/machinery/light/dim/directional/south,
 /obj/effect/turf_decal/tile/neutral,
@@ -16794,6 +18096,14 @@
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/iron/smooth_large,
 /area/station/science/robotics/mechbay)
+"gGO" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "gGQ" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -16814,6 +18124,12 @@
 /obj/item/melee/chainofcommand,
 /turf/open/floor/iron/smooth,
 /area/station/command/bridge)
+"gHg" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/station/service/bar)
 "gHl" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
@@ -16821,12 +18137,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs)
-"gHt" = (
-/obj/structure/kitchenspike,
-/obj/effect/turf_decal/bot_red,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
 "gHD" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/decal/cleanable/dirt,
@@ -16854,6 +18164,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/command)
+"gIi" = (
+/obj/machinery/light/floor,
+/obj/structure/flora/bush/flowers_br,
+/turf/open/floor/grass,
+/area/station/hallway/primary/central/fore)
 "gIj" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -16941,6 +18256,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/greater)
+"gIU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L12";
+	pixel_y = -15
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "gIV" = (
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 1
@@ -16976,13 +18304,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/corporate_suite)
-"gJQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/stack/spacecash/c1,
-/obj/item/cigarette/cigar/havana,
-/turf/open/floor/light/colour_cycle/dancefloor_b,
-/area/station/maintenance/starboard/central)
 "gJS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17080,6 +18401,20 @@
 /obj/effect/turf_decal/siding/wideplating/dark,
 /turf/open/floor/iron,
 /area/station/security)
+"gLL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel Office"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
+/turf/open/floor/iron/textured_half,
+/area/station/service/chapel/office)
 "gLM" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -17209,16 +18544,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/space_catwalk)
-"gNU" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/red/line,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/turf/open/floor/iron/small,
-/area/station/hallway/primary/central/fore)
 "gNV" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/stairs{
@@ -17238,6 +18563,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
+"gOA" = (
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "gOK" = (
 /obj/structure/fermenting_barrel/gunpowder,
 /obj/structure/barricade/wooden/crude,
@@ -17342,6 +18678,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/small,
 /area/station/engineering/supermatter/room)
+"gQN" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/ai_monitored/command/nuke_storage)
 "gRp" = (
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/door/airlock/security{
@@ -17351,16 +18691,6 @@
 	dir = 1
 	},
 /area/station/security/tram)
-"gRG" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron/freezer,
-/area/station/command/heads_quarters/captain/private)
 "gRL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -17462,6 +18792,15 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/port/aft)
+"gTh" = (
+/obj/effect/spawner/random/vending/snackvend,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/white/side,
+/area/station/hallway/primary/central/aft)
 "gTi" = (
 /obj/structure/table/glass,
 /obj/item/aicard{
@@ -17516,15 +18855,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
-"gTV" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "gTW" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/iron,
@@ -17609,22 +18939,18 @@
 /obj/structure/sign/departments/medbay/alt/directional/east,
 /turf/open/floor/plating,
 /area/station/medical/medbay/lobby)
+"gVm" = (
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "gVp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
 /area/station/command/corporate_suite)
-"gVq" = (
-/obj/structure/table/wood,
-/obj/machinery/firealarm/directional/east,
-/obj/item/gun/ballistic/shotgun/doublebarrel,
-/obj/item/holosign_creator/robot_seat/bar{
-	pixel_x = 2;
-	pixel_y = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/stone,
-/area/station/service/bar/backroom)
 "gVA" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -17711,11 +19037,6 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
-"gXD" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "gXL" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock{
@@ -17742,37 +19063,23 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
-"gYg" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/wood{
-	name = "Bar Backroom"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/duct,
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/service/bar)
 "gYq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/greater)
+"gYy" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/eighties,
+/area/station/hallway/primary/central/fore)
 "gYH" = (
 /obj/machinery/vending/wardrobe/robo_wardrobe,
 /turf/open/floor/catwalk_floor/flat_white,
 /area/station/science/robotics/augments)
-"gYK" = (
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"gYX" = (
-/turf/open/floor/iron/dark/small,
-/area/station/commons/vacant_room/commissary)
 "gZf" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -17798,15 +19105,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"gZo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/central/lesser)
 "gZt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -17826,6 +19124,13 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
+"gZB" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/displaycase/trophy,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "gZM" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/cold/directional/east,
@@ -17834,9 +19139,6 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/entry)
-"gZR" = (
-/turf/open/floor/stone,
-/area/station/service/bar/backroom)
 "gZS" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -17885,6 +19187,14 @@
 /obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
+"haK" = (
+/obj/effect/turf_decal/weather/snow,
+/obj/machinery/gibber,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 6
+	},
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "haO" = (
 /obj/effect/turf_decal/stripes/white/end,
 /obj/machinery/door/poddoor/shutters{
@@ -17902,6 +19212,16 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark/small,
 /area/station/ai_monitored/security/armory)
+"hbh" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "hbk" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding{
@@ -18074,12 +19394,6 @@
 /obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/iron/dark/small,
 /area/station/ai_monitored/security/armory)
-"hcB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "hcE" = (
 /obj/effect/turf_decal/siding/thinplating_new/terracotta{
 	dir = 1
@@ -18090,6 +19404,14 @@
 /obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/wood/tile,
 /area/station/command/bridge)
+"hcI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "hcT" = (
 /obj/machinery/computer/slot_machine{
 	pixel_y = 2
@@ -18140,6 +19462,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"hdw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
 "hdz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -18169,6 +19503,18 @@
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/command/bridge)
+"hdJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/primary/central/fore)
 "hdQ" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -18185,15 +19531,6 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"hee" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/item/storage/fancy/candle_box,
-/obj/machinery/light_switch/directional/west,
-/obj/structure/rack/skeletal,
-/turf/open/floor/iron/grimy,
-/area/station/service/library)
 "hei" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -18215,6 +19552,18 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"heD" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 2
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit/departure_lounge)
 "heF" = (
 /obj/machinery/light/small/directional/west,
 /obj/item/kirbyplants/random,
@@ -18289,6 +19638,16 @@
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"hfw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "hfC" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -18365,11 +19724,16 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
-"hgE" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+"hgx" = (
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/eighties/red,
+/area/station/hallway/primary/central/fore)
 "hgF" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -18438,6 +19802,15 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"hhK" = (
+/obj/structure/sign/clock/directional/north,
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/service/bar)
 "hhL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18464,6 +19837,11 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood/large,
 /area/station/command/corporate_suite)
+"hil" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "hiq" = (
 /obj/structure/closet{
 	name = "Evidence Closet 1"
@@ -18615,12 +19993,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
-"hkJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/service/chapel/storage)
 "hkL" = (
 /obj/structure/cable,
 /turf/open/floor/wood/large,
@@ -18650,12 +20022,6 @@
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/ai_monitored/command/nuke_storage)
-"hlo" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/camera/autoname/directional/north,
-/obj/machinery/light/cold/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "hlE" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 4
@@ -18686,6 +20052,15 @@
 	dir = 8
 	},
 /area/station/engineering/supermatter/room)
+"hlQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "hlX" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Old Command Hallway"
@@ -18742,6 +20117,13 @@
 /obj/effect/spawner/random/contraband/prison,
 /turf/open/floor/iron,
 /area/station/security/prison/work)
+"hmw" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/obj/structure/flora/bush/large/style_3,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "hmB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -18769,6 +20151,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/tools)
+"hmY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "hnf" = (
 /obj/item/bikehorn/rubberducky{
 	pixel_x = -6;
@@ -18780,6 +20172,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
+"hnF" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 8
+	},
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
 "hnG" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
 	dir = 8;
@@ -18837,6 +20235,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/science/lobby)
+"hom" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/stool/bamboo,
+/turf/open/floor/carpet/lone,
+/area/station/service/chapel/office)
 "hon" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 8
@@ -18870,21 +20273,6 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/misc/sandy_dirt,
 /area/station/medical/medbay/lobby)
-"hoU" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/light_switch/directional/south,
-/obj/machinery/camera/directional/south{
-	c_tag = "Atmospherics - South"
-	},
-/turf/open/floor/iron/smooth,
-/area/station/service/greenroom)
 "hoV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -18929,13 +20317,6 @@
 /obj/effect/turf_decal/siding,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
-"hpP" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/obj/structure/flora/tree/jungle/small/style_random,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "hpQ" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/window/spawner/directional/south,
@@ -19068,6 +20449,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"hrG" = (
+/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
+/obj/machinery/door/airlock/hydroponics/glass{
+	name = "Hydroponics"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/textured_half,
+/area/station/service/hydroponics)
 "hrL" = (
 /obj/structure/lattice,
 /obj/structure/railing{
@@ -19110,6 +20505,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/small,
 /area/station/engineering/break_room)
+"hsx" = (
+/obj/structure/flora/grass/jungle/b/style_random,
+/turf/open/misc/dirt/jungle,
+/area/station/service/chapel)
 "hsy" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -19162,26 +20561,6 @@
 "htp" = (
 /turf/closed/wall,
 /area/station/service/barber)
-"htt" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/table/wood,
-/obj/machinery/light/small/built/directional/north,
-/obj/item/stack/sheet/iron/ten,
-/obj/effect/turf_decal/siding/wideplating_new/terracotta{
-	dir = 9
-	},
-/turf/open/floor/wood/tile,
-/area/station/commons/vacant_room/commissary)
-"htI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock{
-	name = "Backstage Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
-/turf/open/floor/stone,
-/area/station/maintenance/central/greater)
 "htM" = (
 /obj/effect/turf_decal/tile/dark_red{
 	dir = 4
@@ -19222,24 +20601,28 @@
 	dir = 8
 	},
 /area/station/engineering/supermatter/room)
-"htV" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/dark_red/half/contrasted{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/mail_sorting/security/general,
-/obj/effect/turf_decal/siding/wideplating/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security)
+"htR" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/closed/wall,
+/area/station/hallway/primary/central/aft)
 "hua" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"hug" = (
+/obj/effect/spawner/random/entertainment/lighter,
+/obj/item/cigarette/rollie/mindbreaker{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/item/cigarette/rollie/trippy{
+	pixel_x = 4
+	},
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "huh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19314,12 +20697,14 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/grass,
 /area/station/medical/virology)
-"hvM" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral,
+"hvO" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/port)
 "hvT" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -19357,18 +20742,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"hwe" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/blue/half,
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/iron/white/small,
-/area/station/service/hydroponics)
 "hwh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white/small,
 /area/station/science/ordnance/storage)
+"hwj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "hwn" = (
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/showroomfloor,
@@ -19413,6 +20798,18 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"hwA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wideplating/dark,
+/obj/effect/turf_decal/tile/dark_red/half/contrasted{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
 "hwG" = (
 /obj/machinery/door/window/left/directional/south,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
@@ -19422,13 +20819,6 @@
 "hwJ" = (
 /turf/closed/wall/rust,
 /area/space/nearstation)
-"hwN" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/chem_heater/withbuffer,
-/turf/open/floor/iron/white,
-/area/station/maintenance/central/greater)
 "hwZ" = (
 /obj/structure/chair/bronze{
 	dir = 8
@@ -19516,26 +20906,6 @@
 /obj/machinery/digital_clock/directional/north,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
-"hyl" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/red/line,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/small,
-/area/station/hallway/secondary/spacebridge)
-"hym" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/trash/cnds,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "hyv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -19587,10 +20957,27 @@
 "hzm" = (
 /turf/closed/wall/rust,
 /area/station/cargo/miningoffice)
+"hzv" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/commons/fitness/locker_room)
+"hzz" = (
+/obj/structure/bookcase/random,
+/obj/structure/sign/painting/library{
+	pixel_x = -30
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "hzK" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"hzO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
 "hzV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -19603,28 +20990,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/cargo/miningoffice)
-"hzY" = (
-/obj/structure/cable,
-/obj/machinery/light/directional/east,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
-"hAd" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/reagent_containers/cup/watering_can,
-/obj/machinery/light/small/directional/west,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "hAu" = (
 /obj/machinery/door/airlock{
 	name = "Maintenance"
@@ -19674,19 +21039,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/plating,
 /area/station/commons/storage/tools)
-"hBr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 4;
-	id = "kitchenshutters";
-	name = "Kitchen Shutters"
-	},
-/obj/item/plate,
-/obj/item/food/sandwich/peanut_butter_jelly,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "hBt" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 8
@@ -19706,17 +21058,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/cmo)
-"hBK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/red/line{
+"hBH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/small,
-/area/station/hallway/primary/central/fore)
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "hBR" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
@@ -19812,11 +21159,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/diagonal,
 /area/station/engineering/lobby)
-"hDm" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/chair/stool/bar/directional/north,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation/entertainment)
 "hDt" = (
 /obj/structure/toilet{
 	pixel_y = 8
@@ -19848,6 +21190,34 @@
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"hDZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
+/obj/structure/table,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/item/radio/intercom/directional/south,
+/obj/item/c_tube{
+	pixel_x = 20
+	},
+/obj/item/clothing/head/cone{
+	pixel_y = 5;
+	pixel_x = -6
+	},
+/obj/item/clothing/head/cone{
+	pixel_y = 7;
+	pixel_x = -6
+	},
+/obj/item/pipe_dispenser{
+	pixel_y = 9;
+	pixel_x = 14
+	},
+/obj/item/cigarette{
+	pixel_y = 2
+	},
+/turf/open/floor/iron/small,
+/area/station/engineering/atmos/pumproom)
 "hEi" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -19859,6 +21229,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"hEj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/landmark/navigate_destination/chapel,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "hEl" = (
 /obj/structure/table/rolling,
 /obj/effect/turf_decal/siding/yellow,
@@ -20026,6 +21405,15 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/command/gateway)
+"hIw" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/flora/bush/flowers_yw/style_2,
+/obj/structure/flora/bush/large/style_random{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "hIE" = (
 /obj/structure/table/glass,
 /obj/machinery/light/small/directional/east,
@@ -20043,6 +21431,16 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrous_output,
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos/space_catwalk)
+"hJn" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/libraryconsole{
+	dir = 1
+	},
+/obj/structure/sign/painting/library{
+	pixel_x = 30
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "hJp" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/ai_monitored/turret_protected/ai)
@@ -20109,6 +21507,18 @@
 /obj/structure/sign/warning/no_smoking/circle/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/augments)
+"hKg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/maintenance{
+	name = "Crematorium"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/turf/open/floor/iron/textured_half{
+	dir = 8
+	},
+/area/station/security/brig/entrance)
 "hKs" = (
 /obj/effect/turf_decal/box/corners,
 /obj/effect/turf_decal/stripes/white/line{
@@ -20232,20 +21642,53 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron,
 /area/station/security/lockers)
-"hMz" = (
-/obj/machinery/computer/order_console/cook,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+"hMx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "hMA" = (
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"hME" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/flora/bush/sparsegrass,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "hMK" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/item/kirbyplants/organic/applebush,
 /obj/machinery/light/cold/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/command/bridge)
+"hMR" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/obj/machinery/light/small/directional/west,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/smooth,
+/area/station/service/greenroom)
+"hMX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "hNb" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -20265,6 +21708,15 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/bitrunning/den)
+"hNz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "hNA" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/iron,
@@ -20287,13 +21739,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"hNT" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "hNU" = (
 /obj/structure/table/reinforced,
 /obj/structure/spider/stickyweb,
@@ -20328,6 +21773,16 @@
 "hOp" = (
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
+"hOD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "hOF" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/structure/chair/office{
@@ -20338,6 +21793,13 @@
 	dir = 1
 	},
 /area/station/security/execution/transfer)
+"hOO" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "hOX" = (
 /obj/item/chair,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -20387,6 +21849,10 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/engine,
 /area/station/engineering/gravity_generator)
+"hPv" = (
+/obj/machinery/chem_master/condimaster,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "hPU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20451,6 +21917,49 @@
 /obj/item/binoculars,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"hRg" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/structure/flora/bush/sparsegrass{
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
+"hRw" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 10
+	},
+/obj/structure/table,
+/obj/item/cigarette,
+/obj/item/toy/toy_dagger,
+/obj/item/clothing/head/collectable/paper,
+/obj/item/toy/figure/roboticist{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/toy/figure/syndie{
+	pixel_y = 5;
+	pixel_x = -6
+	},
+/obj/item/toy/figure/md{
+	pixel_x = 10
+	},
+/obj/item/toy/figure/hop{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/toy/figure/ian{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/toy/figure/lawyer{
+	pixel_x = -10
+	},
+/obj/item/toy/figure/detective,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "hRA" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
 	dir = 4
@@ -20485,6 +21994,12 @@
 	},
 /turf/open/misc/sandy_dirt,
 /area/station/security/tram)
+"hSF" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/station/service/bar)
 "hSG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -20511,6 +22026,10 @@
 	dir = 8
 	},
 /area/station/command/corporate_showroom)
+"hSM" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall,
+/area/station/hallway/primary/port)
 "hSP" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
@@ -20522,6 +22041,18 @@
 	},
 /turf/open/floor/iron/diagonal,
 /area/station/engineering/lobby)
+"hSR" = (
+/obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "hTr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance{
@@ -20556,6 +22087,14 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"hTU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "hTW" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/vehicle/ridden/janicart,
@@ -20579,6 +22118,21 @@
 /obj/structure/table/glass,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/command)
+"hUt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "vaco";
+	name = "Comissary Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/lesser)
 "hUC" = (
 /obj/structure/toilet,
 /obj/machinery/light/small/directional/north,
@@ -20619,6 +22173,19 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/plating,
 /area/station/security/prison/work)
+"hVd" = (
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/obj/machinery/door/airlock/wood{
+	name = "Bar Backroom"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/station/service/bar)
 "hVh" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20668,6 +22235,17 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"hVQ" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/machinery/light/small/dim/directional/west,
+/turf/open/floor/eighties/red,
+/area/station/hallway/primary/central/fore)
 "hVX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
@@ -20722,11 +22300,6 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/security)
-"hWQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/tile,
-/area/station/service/bar)
 "hWU" = (
 /obj/machinery/door/airlock{
 	name = "Maintenance"
@@ -20790,13 +22363,6 @@
 /obj/effect/landmark/navigate_destination/research,
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/starboard)
-"hYm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/floor,
-/turf/open/floor/iron/large,
-/area/station/hallway/secondary/spacebridge)
 "hYn" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -20899,6 +22465,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
+"hZR" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/iron/grimy,
+/area/station/service/bar)
 "hZT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20989,6 +22561,16 @@
 /obj/item/emptysandbag,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
+"ibg" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock{
+	name = "Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "ibo" = (
 /obj/structure/bed,
 /obj/item/bedsheet/centcom,
@@ -21140,6 +22722,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/small,
 /area/station/maintenance/department/engine)
+"idI" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L9";
+	pixel_y = -15
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "idJ" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
@@ -21198,6 +22790,36 @@
 /obj/machinery/light/dim/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
+"ifo" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/bush/flowers_yw/style_3,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/camera/directional/north,
+/turf/open/floor/grass,
+/area/station/service/chapel)
+"ify" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/light/small/directional/north,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "ifI" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/line{
@@ -21264,6 +22886,14 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/command/teleporter)
+"ihe" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/flora/bush/jungle/a/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/window/spawner/directional/east,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "ihh" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/decal/cleanable/dirt,
@@ -21292,11 +22922,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain)
-"iho" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall,
-/area/station/hallway/secondary/spacebridge)
 "ihq" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -21369,6 +22994,14 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"iiq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "iix" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
@@ -21392,17 +23025,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"ijm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/light/cold/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "ijn" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 5
@@ -21414,6 +23036,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/small,
 /area/station/commons/toilet/restrooms)
+"ijA" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/flora/bush/jungle/c/style_3{
+	pixel_x = -7
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "ijB" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 8
@@ -21424,6 +23053,17 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/plating,
 /area/station/science/ordnance/storage)
+"ijC" = (
+/obj/machinery/computer/slot_machine{
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "ijF" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
@@ -21538,22 +23178,6 @@
 	},
 /turf/open/space/basic,
 /area/station/engineering/atmos/space_catwalk)
-"ild" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/dark_red/half/contrasted{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/mail_sorting/security/hos_office,
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security)
 "ill" = (
 /obj/structure/frame/machine,
 /obj/item/circuitboard/computer/security,
@@ -21660,6 +23284,10 @@
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
+"ioi" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/small,
+/area/station/maintenance/central/lesser)
 "iok" = (
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -21678,6 +23306,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"ioE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "ioN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
 /obj/effect/turf_decal/tile/brown{
@@ -21786,10 +23422,6 @@
 	dir = 8
 	},
 /area/station/command/bridge)
-"ipt" = (
-/obj/effect/spawner/random/engineering/atmospherics_portable,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "ipx" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -21905,16 +23537,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
-"iqN" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/directional/west,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "iqY" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -22043,6 +23665,15 @@
 	dir = 1
 	},
 /area/station/command/gateway)
+"isJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "isK" = (
 /obj/structure/sign/directions/evac{
 	dir = 8
@@ -22073,6 +23704,24 @@
 "itb" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/ai_monitored/turret_protected/aisat/maint)
+"itg" = (
+/obj/machinery/light/small/directional/east,
+/obj/structure/sign/poster/official/random/directional/north,
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/hallway/primary/central/aft)
+"itq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/holodeck/rec_center)
 "itv" = (
 /obj/structure/transit_tube/horizontal{
 	dir = 2
@@ -22094,6 +23743,13 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"itJ" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/iron/grimy,
+/area/station/service/bar)
 "itL" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/machinery/computer/security{
@@ -22140,6 +23796,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
+"ius" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/wood,
+/area/station/cargo/boutique)
 "iut" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22150,11 +23813,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/research,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"iuL" = (
-/obj/machinery/vending/games,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
+"iuT" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/flora/bush/flowers_yw,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "iuW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/west,
@@ -22170,6 +23833,11 @@
 /obj/item/melee/baseball_bat,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
+"ivh" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/flora/rock/pile/jungle/style_2,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "ivk" = (
 /obj/machinery/atmospherics/components/tank/air{
 	dir = 8
@@ -22213,6 +23881,24 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"ivH" = (
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/primary/central/aft)
 "ivT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -22228,20 +23914,6 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
-"iwa" = (
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "iwi" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -22253,10 +23925,34 @@
 	},
 /turf/open/space/basic,
 /area/station/engineering/atmos/space_catwalk)
+"iwt" = (
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/commons/vacant_room/commissary)
 "iwz" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/break_room)
+"iwB" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/holodeck/rec_center)
+"iwD" = (
+/obj/machinery/light/small/directional/south,
+/obj/machinery/firealarm/directional/south,
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "iwJ" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small/directional/south,
@@ -22274,14 +23970,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/ce)
-"iwZ" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "ixl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22376,6 +24064,15 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/science/lab)
+"iyx" = (
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "iyC" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/purple{
@@ -22387,6 +24084,14 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
+"iyZ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/bush/flowers_pp,
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "izh" = (
 /obj/item/shovel,
 /turf/open/floor/plating,
@@ -22404,19 +24109,6 @@
 	},
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos/space_catwalk)
-"izw" = (
-/obj/machinery/transport/tram_controller/tcomms{
-	configured_transport_id = "bird_2"
-	},
-/turf/open/floor/circuit,
-/area/station/tcommsat/server)
-"izB" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/sign/painting/library{
-	pixel_y = 32
-	},
-/turf/open/floor/iron/smooth,
-/area/station/service/library)
 "izD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22451,6 +24143,12 @@
 /obj/machinery/field/generator,
 /turf/open/floor/iron/dark/small,
 /area/station/engineering/storage_shared)
+"iAr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "iAu" = (
 /obj/structure/bed{
 	dir = 4
@@ -22517,6 +24215,18 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
+"iAO" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 5
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/small,
+/area/station/hallway/secondary/service)
 "iAS" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/chair/stool/directional/north,
@@ -22542,11 +24252,6 @@
 /obj/machinery/power/shieldwallgen,
 /turf/open/floor/iron/smooth_large,
 /area/station/command/teleporter)
-"iBg" = (
-/obj/structure/table,
-/obj/item/trash/candle,
-/turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
 "iBj" = (
 /obj/structure/table/glass,
 /obj/item/folder/red{
@@ -22575,6 +24280,25 @@
 /obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/maintenance/port/lesser)
+"iBN" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"iBT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/cold/directional/east,
+/obj/effect/turf_decal/tile/neutral,
+/obj/item/radio/intercom/directional/east,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "iBZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -22657,6 +24381,25 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/textured_half,
 /area/station/engineering/atmos)
+"iCO" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/obj/effect/landmark/start/hangover,
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
+"iDg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "iDk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22724,17 +24467,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/engine,
 /area/station/science/explab)
-"iEE" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "iEG" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/dark/side{
@@ -22761,20 +24493,6 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/wood/large,
 /area/station/command/corporate_suite)
-"iEX" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/window/spawner/directional/north,
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/structure/disposaloutlet{
-	dir = 4;
-	name = "Cargo Deliveries"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/service)
 "iFb" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -22794,6 +24512,14 @@
 /obj/structure/window/spawner/directional/east,
 /turf/open/misc/sandy_dirt,
 /area/station/medical/medbay/lobby)
+"iFt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "iFE" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/chair/office{
@@ -22881,6 +24607,23 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"iHu" = (
+/obj/structure/table/wood,
+/obj/item/holosign_creator/robot_seat/bar{
+	pixel_x = 2;
+	pixel_y = 9
+	},
+/obj/structure/sign/picture_frame/portrait/bar{
+	pixel_y = 32
+	},
+/obj/item/roulette_wheel_beacon,
+/obj/machinery/light/small/directional/north,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/stone,
+/area/station/service/bar/backroom)
 "iHw" = (
 /obj/effect/spawner/random/structure/barricade,
 /turf/open/floor/plating,
@@ -22889,12 +24632,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/stone,
 /area/station/service/abandoned_gambling_den)
-"iHL" = (
-/obj/structure/bookcase/random,
-/obj/machinery/camera/autoname/directional/south,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "iHM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22903,6 +24640,13 @@
 	dir = 1
 	},
 /area/station/science/lower)
+"iIm" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/toilet/auxiliary)
 "iIs" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -22927,6 +24671,16 @@
 /obj/item/wrench,
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
+"iIz" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/station/service/bar)
 "iIA" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -23086,9 +24840,6 @@
 /obj/structure/sign/warning/no_smoking/circle/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"iJN" = (
-/turf/open/floor/iron/grimy,
-/area/station/service/library)
 "iJO" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -23165,10 +24916,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"iLq" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/small,
-/area/station/commons/vacant_room/commissary)
 "iLC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23188,14 +24935,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/central/fore)
-"iLK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/sign/departments/holy/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "iLN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23440,6 +25179,17 @@
 /obj/effect/spawner/random/structure/crate_abandoned,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"iPa" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/effect/landmark/start/security_officer,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
 "iPg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -23512,6 +25262,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating/elevatorshaft,
 /area/station/commons/dorms)
+"iQK" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/structure/flora/bush/sparsegrass,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "iQT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -23538,6 +25295,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/small,
 /area/station/commons/fitness/locker_room)
+"iRj" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/grimy,
+/area/station/service/bar)
 "iRl" = (
 /obj/structure/table/wood,
 /obj/item/food/grown/citrus/lemon{
@@ -23560,6 +25325,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos/office)
+"iRv" = (
+/obj/structure/flora/bush/flowers_pp{
+	pixel_y = 3
+	},
+/obj/effect/dummy/lighting_obj,
+/obj/effect/light_emitter/fake_outdoors,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/grass/Airless,
+/area/station/hallway/primary/central/aft)
 "iRz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -23615,6 +25389,25 @@
 /obj/structure/sign/warning/pods/directional/west,
 /turf/open/floor/iron/checker,
 /area/station/security/breakroom)
+"iSQ" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood/large,
+/area/station/service/bar)
+"iSR" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/service/chapel)
+"iSY" = (
+/obj/structure/sink/kitchen/directional/east,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "iTe" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 6
@@ -23720,6 +25513,16 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
+"iVf" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/freezer,
+/area/station/command/heads_quarters/captain/private)
 "iVq" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
@@ -23845,6 +25648,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"iWt" = (
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/glass,
+/area/station/hallway/primary/central/aft)
 "iWE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23889,6 +25696,15 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"iXb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "iXc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23984,19 +25800,24 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/command/teleporter)
+"iYJ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/structure/flora/bush/sparsegrass,
+/turf/open/floor/grass,
+/area/station/service/chapel)
+"iYL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "iYY" = (
 /obj/structure/cable,
 /turf/open/floor/iron/small,
 /area/station/security/processing)
-"iZc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/machinery/holopad,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "iZu" = (
 /obj/effect/turf_decal/tile/neutral/full,
 /obj/item/kirbyplants/random,
@@ -24035,16 +25856,6 @@
 /obj/effect/spawner/random/food_or_drink/seed,
 /turf/open/misc/sandy_dirt,
 /area/station/maintenance/starboard/aft)
-"iZI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
 "iZK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -24076,6 +25887,26 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/engineering/main)
+"jai" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sign/departments/holy/directional/west,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
+"jap" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "jar" = (
 /obj/machinery/drone_dispenser,
 /turf/open/misc/asteroid,
@@ -24174,11 +26005,6 @@
 	},
 /turf/open/floor/tram,
 /area/station/maintenance/department/medical/central)
-"jbL" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "jbV" = (
 /obj/machinery/photocopier,
 /turf/open/floor/iron/dark,
@@ -24263,6 +26089,18 @@
 "jeh" = (
 /turf/open/floor/noslip,
 /area/station/security/tram)
+"jen" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"jeo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/closed/wall,
+/area/station/hallway/primary/central/fore)
 "jeC" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -24278,13 +26116,6 @@
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/smooth_large,
 /area/station/science/ordnance/storage)
-"jeV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/white/corner,
-/area/station/hallway/secondary/exit/departure_lounge)
 "jeW" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/sign/departments/medbay/alt/directional/west,
@@ -24334,6 +26165,21 @@
 /obj/machinery/light/dim/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/security/evidence)
+"jge" = (
+/obj/structure/chair/stool/directional/north,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/station/service/bar)
+"jgs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
 "jgF" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
@@ -24343,6 +26189,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
+"jgP" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/eighties,
+/area/station/hallway/primary/central/fore)
 "jgQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -24382,6 +26235,23 @@
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/plating,
 /area/station/cargo/miningoffice)
+"jhD" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/stone,
+/area/station/service/bar)
 "jhJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -24475,23 +26345,14 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/maintenance/department/engine/atmos)
-"jiN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock{
-	name = "Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "jiR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
+"jiS" = (
+/obj/machinery/vending/games,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "jiT" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white/corner{
@@ -24541,17 +26402,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
-"jjS" = (
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=23.1-Evac";
-	location = "22.0-Porthall-Evac"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "jkz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -24662,12 +26512,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
-"jme" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/effect/landmark/navigate_destination,
-/turf/open/floor/iron/textured_half,
-/area/station/service/theater)
 "jmi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -24726,6 +26570,12 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/small,
 /area/station/ai_monitored/command/storage/eva)
+"jnj" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "jnk" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/effect/turf_decal/siding/green{
@@ -24755,6 +26605,18 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron/small,
 /area/station/engineering/atmos/storage/gas)
+"jnD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "jnN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -24773,10 +26635,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/corporate_showroom)
-"joy" = (
-/obj/structure/cable,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "joS" = (
 /obj/machinery/light/broken/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -24828,16 +26686,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/station/science/auxlab/firing_range)
-"jpK" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
+"jpH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/effect/landmark/navigate_destination/chapel,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "jpM" = (
 /obj/structure/closet{
 	name = "Evidence Closet 3"
@@ -24924,12 +26780,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/diagonal,
 /area/station/engineering/lobby)
-"jqQ" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
 "jqZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -24942,6 +26792,10 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"jri" = (
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "jrj" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/components/unary/passive_vent{
@@ -25005,19 +26859,17 @@
 	dir = 1
 	},
 /area/station/cargo/office)
-"jrZ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/flora/tree/jungle/small/style_random,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "jsa" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
 /area/station/science/xenobiology)
+"jsq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/lone,
+/area/station/service/chapel/office)
 "jsv" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
@@ -25077,6 +26929,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"jto" = (
+/obj/structure/table/wood,
+/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wideplating_new/terracotta{
+	dir = 10
+	},
+/turf/open/floor/wood/tile,
+/area/station/maintenance/central/lesser)
 "jts" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25087,6 +26948,11 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/diagonal,
 /area/station/command/heads_quarters/hop)
+"jtA" = (
+/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "jtD" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron/showroomfloor,
@@ -25175,6 +27041,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"jvG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/tile,
+/area/station/service/bar)
+"jvJ" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "jvN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
@@ -25229,6 +27106,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
+"jwg" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/eighties,
+/area/station/hallway/primary/central/fore)
 "jwh" = (
 /obj/structure/broken_flooring/pile/directional/east,
 /obj/effect/spawner/random/trash/graffiti{
@@ -25301,12 +27185,6 @@
 "jxp" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
-"jxy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/navigate_destination/library,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "jxC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25455,14 +27333,6 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
-"jza" = (
-/obj/machinery/rnd/production/techfab/department/service,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
 "jzg" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -25539,6 +27409,10 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/security/tram)
+"jBk" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "jBo" = (
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 6
@@ -25587,9 +27461,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"jCA" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/table,
+"jCw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "jCP" = (
@@ -25652,22 +27528,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/command/corporate_dock)
-"jDP" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/storage/box{
-	pixel_x = -8;
-	pixel_y = 15
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
 "jDS" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -25737,6 +27597,12 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/station/security/tram)
+"jEF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/floor,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "jEG" = (
 /obj/structure/sign/directions/science{
 	dir = 1;
@@ -25782,24 +27648,22 @@
 	dir = 8
 	},
 /area/station/commons/storage/tools)
-"jEU" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/landmark/start/chaplain,
-/turf/open/floor/wood/large,
-/area/station/service/chapel)
 "jEZ" = (
 /obj/structure/hedge,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/command)
-"jFf" = (
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
+"jFb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/exit/departure_lounge)
 "jFh" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -25832,6 +27696,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"jFE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
 "jFF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25840,11 +27713,16 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"jFY" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/floor,
-/turf/open/floor/iron/smooth,
-/area/station/service/library)
+"jGa" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/eighties/red,
+/area/station/hallway/primary/central/fore)
 "jGc" = (
 /obj/structure/window/spawner/directional/east,
 /turf/open/floor/iron/showroomfloor,
@@ -25875,6 +27753,16 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
+"jGF" = (
+/obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
 "jGK" = (
 /obj/structure/chair/wood,
 /obj/structure/cable,
@@ -25945,6 +27833,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"jHl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "jHq" = (
 /obj/structure/table,
 /obj/item/storage/box/prisoner{
@@ -26118,6 +28016,16 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron/grimy,
 /area/station/engineering/main)
+"jJO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "jJP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26157,30 +28065,6 @@
 	dir = 1
 	},
 /area/station/science/xenobiology)
-"jKh" = (
-/obj/machinery/vending/hydroseeds{
-	slogan_delay = 700
-	},
-/obj/effect/turf_decal/delivery/white{
-	color = "#52B4E9"
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white/small,
-/area/station/service/hydroponics)
-"jKm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/dark_red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/light/cold/directional/south,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
-/area/station/security/brig/entrance)
 "jKq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26227,16 +28111,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
-"jLh" = (
-/obj/machinery/light/small/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/terracotta{
-	dir = 6
-	},
-/turf/open/floor/wood/tile,
-/area/station/commons/vacant_room/commissary)
 "jLl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26255,6 +28129,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"jLs" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "jLB" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -26282,6 +28162,16 @@
 "jLR" = (
 /turf/open/floor/iron/small,
 /area/station/command/teleporter)
+"jLT" = (
+/obj/structure/sign/departments/botany/alt1/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "jLV" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
@@ -26388,13 +28278,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
-"jNJ" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/tile,
-/area/station/commons/vacant_room/commissary)
 "jNL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -26454,6 +28337,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"jOm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "jOs" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/flora/bush/lavendergrass/style_2,
@@ -26465,6 +28357,16 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/misc/sandy_dirt,
 /area/station/hallway/primary/central/fore)
+"jOA" = (
+/obj/machinery/door/airlock{
+	name = "Kitchen"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "jOF" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light_switch/directional/west,
@@ -26505,6 +28407,26 @@
 /obj/effect/spawner/random/techstorage/security_all,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
+"jQd" = (
+/obj/structure/kitchenspike,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 5
+	},
+/obj/effect/turf_decal/weather/snow,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
+"jQe" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/mob/living/basic/deer,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "jQf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26513,15 +28435,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
-"jQg" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wideplating_new/terracotta{
-	dir = 10
-	},
-/turf/open/floor/wood/tile,
-/area/station/commons/vacant_room/commissary)
 "jQj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26542,6 +28455,20 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/small,
 /area/station/commons/fitness/locker_room)
+"jQF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/cargo/boutique)
+"jQK" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 4
+	},
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
 "jQW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -26549,6 +28476,12 @@
 	},
 /turf/open/floor/iron/textured_half,
 /area/station/hallway/primary/central/fore)
+"jQZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "jRk" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -26583,10 +28516,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/security)
-"jRI" = (
-/obj/structure/table,
-/turf/open/floor/iron/dark/small,
-/area/station/commons/vacant_room/commissary)
+"jRH" = (
+/obj/machinery/door/airlock{
+	name = "Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/turf/open/floor/plating,
+/area/station/maintenance/central/lesser)
 "jRR" = (
 /obj/machinery/atmospherics/components/binary/crystallizer{
 	dir = 4
@@ -26615,14 +28551,14 @@
 /obj/item/bedsheet/brown,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
+"jSq" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/glass,
+/area/station/hallway/primary/central/aft)
 "jSw" = (
 /obj/structure/railing,
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/secondary/entry)
-"jSK" = (
-/obj/structure/table/wood,
-/turf/open/floor/glass,
-/area/station/hallway/secondary/spacebridge)
 "jSQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/kirbyplants/random,
@@ -26662,6 +28598,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/textured_half,
 /area/station/security/detectives_office)
+"jTn" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "jTu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26672,6 +28615,13 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
+"jTw" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/table/wood,
+/turf/open/floor/iron/grimy,
+/area/station/service/bar)
 "jTA" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/camera/autoname/directional/north,
@@ -26735,16 +28685,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/commons)
+"jUV" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "jVe" = (
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/command)
-"jVg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "jVs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26785,6 +28738,18 @@
 "jVM" = (
 /turf/closed/wall,
 /area/station/maintenance/central/greater)
+"jVT" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "jVY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -26851,6 +28816,18 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/dock)
+"jWQ" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "jWZ" = (
 /obj/machinery/mineral/ore_redemption{
 	dir = 4;
@@ -26965,6 +28942,18 @@
 	},
 /turf/open/misc/sandy_dirt,
 /area/station/security/tram)
+"jYy" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "jYF" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26975,6 +28964,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/small,
 /area/station/service/janitor)
+"jYQ" = (
+/obj/structure/table/wood,
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "jYU" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hopqueue";
@@ -26998,6 +28996,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/command/teleporter)
+"jZb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "jZc" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -27038,11 +29042,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
-"kai" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/iron/smooth,
-/area/station/cargo/drone_bay)
+"kab" = (
+/obj/structure/chair/sofa/bench/left{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/white/side,
+/area/station/hallway/primary/central/aft)
 "kam" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/disposal/delivery_chute{
@@ -27055,19 +29063,6 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
 /area/station/service/janitor)
-"kar" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/door/airlock/public/glass{
-	name = "Chapel Office"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
-/turf/open/floor/iron/textured_half,
-/area/station/service/chapel/office)
 "kat" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -27152,6 +29147,15 @@
 /obj/item/stock_parts/power_store/cell,
 /turf/open/floor/iron/white,
 /area/station/science/auxlab/firing_range)
+"kbU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "kci" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27165,11 +29169,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
-"kcs" = (
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/obj/effect/landmark/navigate_destination/kitchen,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
 "kcA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -27178,28 +29177,49 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/surgery/theatre)
+"kcP" = (
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/commons/vacant_room/commissary)
 "kcQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 1
 	},
 /turf/open/floor/iron/white/small,
 /area/station/science/ordnance/storage)
+"kcU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "kcW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
-"kdl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/sign/departments/vault/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
 "kdn" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"kdy" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/door/airlock{
+	name = "Kitchen"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "kdH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -27219,6 +29239,19 @@
 	dir = 9
 	},
 /area/station/science/lower)
+"kdR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "kea" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27254,9 +29287,6 @@
 "ket" = (
 /turf/open/floor/iron,
 /area/station/security/prison/work)
-"kev" = (
-/turf/closed/wall,
-/area/station/hallway/secondary/spacebridge)
 "keO" = (
 /obj/effect/spawner/random/trash,
 /obj/effect/turf_decal/siding/white{
@@ -27277,6 +29307,15 @@
 	},
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos/space_catwalk)
+"keX" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "keY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -27284,17 +29323,6 @@
 /obj/machinery/power/energy_accumulator/tesla_coil,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"keZ" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/dark_red/fourcorners,
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron,
-/area/station/security/brig/entrance)
 "kft" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27388,16 +29416,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
-"kgz" = (
+"kgy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/port)
 "kgG" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -27418,6 +29444,16 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
 /area/station/service/chapel/funeral)
+"kgP" = (
+/obj/effect/turf_decal/siding/wideplating/dark/corner,
+/obj/effect/turf_decal/tile/dark_red/half/contrasted{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
 "kgT" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
@@ -27440,6 +29476,14 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/wood,
 /area/station/service/chapel/funeral)
+"khh" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/cigarettes/cigars/cohiba{
+	pixel_x = 2;
+	pixel_y = 10
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "khl" = (
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/tram,
@@ -27477,15 +29521,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"khE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/sign/departments/holy/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "khG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27565,6 +29600,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"kiP" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Public Shrine"
+	},
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/stone,
+/area/station/hallway/primary/port)
 "kiQ" = (
 /obj/structure/cable,
 /obj/machinery/power/smes/super/full,
@@ -27592,6 +29637,15 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"kju" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/bot,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "kjw" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -27602,6 +29656,11 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/dock)
+"kjA" = (
+/obj/structure/flora/bush/sparsegrass,
+/obj/structure/flora/bush/flowers_yw,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "kjO" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/siding/white{
@@ -27644,6 +29703,22 @@
 /obj/machinery/light/small/dim/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
+"kkv" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
+"kkI" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "kkK" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/spawner/random/maintenance,
@@ -27688,6 +29763,20 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/kitchen/small,
 /area/station/security/prison/mess)
+"klv" = (
+/obj/structure/flora/bush/jungle/a/style_3,
+/turf/open/floor/grass,
+/area/station/service/chapel)
+"klA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sign/directions/vault/directional/west{
+	dir = 2
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "klF" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
@@ -27723,6 +29812,11 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/disposal/incinerator)
+"klQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "klY" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/spawner/random/maintenance,
@@ -27751,6 +29845,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
+"kml" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
+/area/station/hallway/primary/central/aft)
 "kmn" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -27891,6 +29991,13 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"koB" = (
+/obj/structure/mannequin/plastic,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/station/cargo/boutique)
 "koD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -27944,6 +30051,16 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/small,
 /area/station/engineering/supermatter/room)
+"kpB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "kpF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/hangover,
@@ -27986,11 +30103,6 @@
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
-"kqo" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/station/hallway/secondary/spacebridge)
 "kqr" = (
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -28017,6 +30129,16 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/kitchen/small,
 /area/station/security/prison/mess)
+"kqH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "kqK" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -28130,6 +30252,19 @@
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/solars/starboard/aft)
+"krP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/primary/central/fore)
 "krW" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/siding/wood{
@@ -28173,15 +30308,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
-"kst" = (
-/obj/structure/chair/plastic{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
 "ksv" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -28227,6 +30353,12 @@
 	},
 /turf/open/floor/catwalk_floor/iron,
 /area/station/engineering/gravity_generator)
+"ksM" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "ksN" = (
 /obj/structure/transit_tube/station/dispenser,
 /obj/effect/decal/cleanable/dirt,
@@ -28560,6 +30692,18 @@
 /obj/effect/turf_decal/trimline/neutral/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"kyX" = (
+/obj/machinery/door/airlock/multi_tile/public{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 8
+	},
+/area/station/service/library)
 "kyZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -28573,13 +30717,15 @@
 /obj/effect/turf_decal/trimline/neutral/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"kzd" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"kzm" = (
+/obj/machinery/light/small/directional/south,
+/obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/turf/open/floor/carpet/lone,
-/area/station/service/chapel/office)
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "kzu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28632,6 +30778,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
+"kAm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "kAn" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -28669,6 +30828,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/small,
 /area/station/command/teleporter)
+"kBx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "kBA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28774,6 +30943,12 @@
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/carpet/purple,
 /area/station/commons/dorms)
+"kDB" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "kDY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/machinery/door/airlock/public/glass{
@@ -28825,6 +31000,12 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
+"kEU" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "kFg" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/wood,
@@ -28834,6 +31015,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/command/heads_quarters/qm)
+"kFl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "kFq" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -28933,9 +31118,23 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
-"kGS" = (
-/turf/open/floor/iron/white,
-/area/station/maintenance/central/greater)
+"kGJ" = (
+/obj/effect/turf_decal/weather/snow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 2
+	},
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
+"kGM" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/stone,
+/area/station/service/bar)
 "kGY" = (
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/bot,
@@ -29060,6 +31259,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"kII" = (
+/obj/effect/turf_decal/tile/dark_red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/firealarm/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
 "kIO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29102,6 +31312,10 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/medical/medbay/lobby)
+"kIX" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/iron,
+/area/station/holodeck/rec_center)
 "kIY" = (
 /obj/structure/broken_flooring/singular/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -29119,6 +31333,18 @@
 	dir = 8
 	},
 /area/station/hallway/primary/central/fore)
+"kJd" = (
+/obj/structure/table/wood,
+/obj/item/pai_card,
+/obj/item/storage/crayons,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "kJj" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -29146,6 +31372,17 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/smooth_edge,
 /area/station/engineering/supermatter/room)
+"kJD" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "kJJ" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
@@ -29160,6 +31397,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
+"kJV" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/end,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "kJW" = (
@@ -29195,6 +31437,16 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
+"kLd" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/secondary/service)
 "kLk" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -29314,6 +31566,22 @@
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/port/aft)
+"kOn" = (
+/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/status_display/evac/directional/east,
+/obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/stripes/end,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/effect/turf_decal/tile/green/fourcorners,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/secondary/service)
 "kOG" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
@@ -29424,6 +31692,14 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"kQq" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/iron/grimy,
+/area/station/service/bar)
 "kQr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 4
@@ -29433,18 +31709,6 @@
 "kQt" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/aft)
-"kQA" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
-/obj/machinery/requests_console/directional/south{
-	department = "Kitchen";
-	name = "Kitchen Requests Console"
-	},
-/obj/effect/mapping_helpers/requests_console/supplies,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "kQM" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -29562,6 +31826,12 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_command)
+"kSF" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "kSO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29570,17 +31840,6 @@
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
-"kSV" = (
-/obj/structure/chair/stool/bamboo{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
-"kTd" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "kTp" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -29634,6 +31893,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/service/chapel/funeral)
+"kUn" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "kUF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -29702,18 +31969,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/small,
 /area/station/security/office)
-"kWF" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/window/right/directional/north{
-	name = "Kitchen Delivery Access";
-	req_access = list("kitchen")
-	},
-/obj/effect/turf_decal/delivery/white{
-	color = "#52B4E9"
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
 "kWJ" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 1
@@ -29770,13 +32025,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"kXO" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/frame/machine,
-/obj/item/circuitboard/machine/chem_dispenser,
-/obj/item/stack/cable_coil/five,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "kXQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29958,18 +32206,16 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/port/aft)
-"lbh" = (
-/obj/structure/sign/directions/evac,
-/obj/structure/sign/directions/engineering{
-	dir = 1;
-	pixel_y = 8
+"lbt" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
 	},
-/obj/structure/sign/directions/medical{
-	dir = 4;
-	pixel_y = -9
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
 	},
-/turf/closed/wall,
-/area/station/hallway/primary/central/fore)
+/turf/open/floor/iron/small,
+/area/station/hallway/primary/central/aft)
 "lbF" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -30001,15 +32247,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
-"lca" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock{
-	name = "Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "lce" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 9
@@ -30048,6 +32285,14 @@
 /obj/effect/landmark/navigate_destination/chemfactory,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
+"lcA" = (
+/obj/structure/table/wood,
+/obj/item/plate,
+/obj/item/food/cheesynachos{
+	pixel_y = 2
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "lcC" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -30095,15 +32340,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/textured_half,
 /area/station/security/brig)
-"ldZ" = (
+"ldU" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/red/line,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
+/obj/effect/spawner/random/trash,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron/small,
-/area/station/hallway/primary/central/fore)
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "lee" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
@@ -30112,17 +32359,31 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
-"lej" = (
-/obj/structure/kitchenspike,
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
 "lek" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner{
 	dir = 8
 	},
 /area/station/hallway/primary/starboard)
+"lel" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Main Engineering"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/break_room)
+"leo" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/camera/autoname/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "ley" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30130,39 +32391,6 @@
 	dir = 1
 	},
 /area/station/medical/treatment_center)
-"leB" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/dark_red,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/food/gumball{
-	pixel_x = 5;
-	pixel_y = 9
-	},
-/obj/item/cigarette/candy{
-	pixel_x = -3;
-	pixel_y = 10
-	},
-/obj/item/food/gumball{
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/item/weldingtool/mini{
-	pixel_x = 5;
-	pixel_y = -11
-	},
-/obj/item/screwdriver{
-	pixel_x = 2;
-	pixel_y = -3
-	},
-/obj/item/storage/box/prisoner{
-	pixel_x = 5;
-	pixel_y = -12
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/processing)
 "leC" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
@@ -30171,6 +32399,19 @@
 "leP" = (
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"leT" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel Office"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/textured_half,
+/area/station/service/chapel/office)
 "leU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30205,6 +32446,12 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron/white/small,
 /area/station/medical/treatment_center)
+"lfh" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "lfi" = (
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 6
@@ -30229,6 +32476,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
+"lfu" = (
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating,
+/obj/structure/sign/poster/official/random/directional/south,
+/turf/open/floor/eighties/red,
+/area/station/hallway/primary/central/fore)
 "lfv" = (
 /obj/structure/hedge,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -30390,20 +32645,6 @@
 /obj/item/camera,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
-"lhg" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery/red,
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay Clinic"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "medlock";
-	name = "Lockdown Shutters"
-	},
-/turf/open/floor/iron/white/small,
-/area/station/medical/medbay/lobby)
 "lhl" = (
 /obj/effect/spawner/random/trash/graffiti{
 	pixel_x = 32;
@@ -30675,17 +32916,6 @@
 "lkV" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance)
-"lkZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "llg" = (
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/iron/dark,
@@ -30752,12 +32982,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/donk,
 /area/station/command/heads_quarters/qm)
-"lmo" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "lmv" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/kirbyplants/random,
@@ -30778,6 +33002,15 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"lnw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/dark_red/opposingcorners,
+/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/light/small/directional/west,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
 "lnz" = (
 /obj/effect/turf_decal/tile/dark_red,
 /obj/machinery/light_switch/directional/west,
@@ -30795,6 +33028,18 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
+"lnN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "lnW" = (
 /obj/effect/turf_decal/tile/neutral/full,
 /obj/structure/chair{
@@ -30802,6 +33047,15 @@
 	},
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
+/area/station/maintenance/central/lesser)
+"lnX" = (
+/obj/structure/table/wood,
+/obj/machinery/camera/directional/south{
+	c_tag = "Atmospherics - South"
+	},
+/obj/item/stack/cable_coil/five,
+/obj/effect/turf_decal/siding/wideplating_new/terracotta,
+/turf/open/floor/wood/tile,
 /area/station/maintenance/central/lesser)
 "lnZ" = (
 /obj/effect/turf_decal/tile/dark_red,
@@ -30863,14 +33117,18 @@
 /obj/machinery/holopad,
 /turf/open/floor/stone,
 /area/station/command/heads_quarters/hos)
-"lpa" = (
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/structure/bookcase/random,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "lpC" = (
 /turf/open/floor/plating,
 /area/station/service/chapel/funeral)
+"lpH" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "lpJ" = (
 /obj/structure/hedge,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -30956,17 +33214,6 @@
 "lqC" = (
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/starboard/aft)
-"lqF" = (
-/obj/structure/table,
-/obj/item/camera_film{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/item/camera_film{
-	pixel_y = 9
-	},
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "lqL" = (
 /obj/effect/landmark/transport/nav_beacon/tram/platform/birdshot/prison_wing,
 /turf/open/floor/tram,
@@ -31034,14 +33281,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/small,
 /area/station/service/barber)
-"lsJ" = (
-/obj/structure/window/spawner/directional/north,
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/service)
 "lsK" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
@@ -31053,6 +33292,20 @@
 	dir = 1
 	},
 /area/station/science/lower)
+"lsS" = (
+/obj/structure/sign/poster/official/random/directional/north,
+/obj/structure/table/wood,
+/obj/item/gun/ballistic/shotgun/doublebarrel,
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/structure/reagent_dispensers/beerkeg{
+	pixel_y = 5
+	},
+/obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/stone,
+/area/station/service/bar/backroom)
 "lsY" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/structure/closet/secure_closet/security/sec,
@@ -31060,11 +33313,6 @@
 	dir = 1
 	},
 /area/station/security/execution/transfer)
-"lti" = (
-/obj/machinery/libraryscanner,
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "lto" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -31080,14 +33328,6 @@
 /obj/structure/holosign/barrier/atmos/tram,
 /turf/open/floor/plating,
 /area/station/security/tram)
-"lty" = (
-/obj/structure/cable,
-/obj/machinery/door/morgue{
-	name = "Secret Corridor";
-	req_access = list("library")
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/service/library)
 "ltz" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 4
@@ -31119,6 +33359,39 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
+"ltW" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/dark_red,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/food/gumball{
+	pixel_x = 5;
+	pixel_y = 9
+	},
+/obj/item/cigarette/candy{
+	pixel_x = -3;
+	pixel_y = 10
+	},
+/obj/item/food/gumball{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/weldingtool/mini{
+	pixel_x = 5;
+	pixel_y = -11
+	},
+/obj/item/screwdriver{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/item/storage/box/prisoner{
+	pixel_x = 5;
+	pixel_y = -12
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/processing)
 "luc" = (
 /obj/machinery/door/airlock{
 	id_tag = "ShowerToilet1";
@@ -31149,13 +33422,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tcomms)
-"lus" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/service/library)
 "lut" = (
 /obj/structure/table/wood/fancy/red,
 /obj/structure/sign/painting/large/library{
@@ -31170,6 +33436,13 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/service/greenroom)
+"luB" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/spawner/random/food_or_drink/cake_ingredients,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "luC" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -31183,11 +33456,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
-"luU" = (
-/obj/machinery/smartfridge/food,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
+"luP" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/station/maintenance/port/greater)
 "lvc" = (
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/escape)
@@ -31262,18 +33535,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
-"lwa" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/station/hallway/primary/central/fore)
 "lwc" = (
 /obj/structure/table/optable,
 /obj/structure/cable,
@@ -31370,15 +33631,6 @@
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/iron/small,
 /area/station/maintenance/port/lesser)
-"lxK" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/door/window/right/directional/west{
-	name = "Bar Delivery";
-	req_access = list("bar")
-	},
-/obj/machinery/duct,
-/turf/open/floor/stone,
-/area/station/service/bar/backroom)
 "lxN" = (
 /obj/structure/broken_flooring/pile/directional/east,
 /turf/open/floor/plating,
@@ -31468,6 +33720,32 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
+"lyZ" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/structure/table,
+/obj/item/reagent_containers/cup/bottle/mutagen{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_x = -3;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/cup/watering_can{
+	pixel_x = 7;
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/obj/machinery/light/small/directional/west,
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "lzg" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/machinery/airalarm/directional/north,
@@ -31498,18 +33776,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"lzv" = (
+"lzq" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
+"lzs" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/camera/directional/north,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/sign/departments/botany/alt1/directional/north,
 /turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/area/station/hallway/primary/central/fore)
 "lzA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -31520,6 +33804,15 @@
 "lzM" = (
 /turf/closed/wall,
 /area/station/security/tram)
+"lzR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "lzT" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/command{
@@ -31559,6 +33852,23 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"lAF" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
+"lAL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/directional/east,
+/obj/machinery/status_display/evac/directional/east,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "lAO" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
@@ -31712,6 +34022,19 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/security/warden)
+"lCu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/secondary/service)
 "lCw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31822,6 +34145,13 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/stone,
 /area/station/command/heads_quarters/captain/private)
+"lEM" = (
+/obj/effect/turf_decal/siding/thinplating_new/light,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
 "lEN" = (
 /obj/structure/chair/sofa/right{
 	dir = 8
@@ -31843,6 +34173,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/hallway/abandoned_command)
+"lFo" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Airlock"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/structure/cable,
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/break_room)
 "lFE" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
@@ -31867,6 +34207,18 @@
 /obj/structure/sign/warning/engine_safety/directional/north,
 /turf/open/floor/iron/small,
 /area/station/engineering/break_room)
+"lFP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/primary/central/fore)
 "lFT" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/table/reinforced/titaniumglass,
@@ -32132,16 +34484,32 @@
 	dir = 8
 	},
 /area/station/science/xenobiology)
-"lJc" = (
-/obj/machinery/door/firedoor,
-/obj/effect/landmark/navigate_destination,
-/turf/open/floor/iron/textured_half,
-/area/station/service/cafeteria)
 "lJe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/station/command/heads_quarters/captain/private)
+"lJk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/secondary/service)
+"lJl" = (
+/obj/structure/table/wood,
+/obj/item/cigarette/cigar/premium{
+	pixel_y = 5
+	},
+/turf/open/floor/stone,
+/area/station/service/abandoned_gambling_den)
 "lJF" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
@@ -32149,6 +34517,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"lJP" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "lJV" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
@@ -32161,13 +34540,6 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/qm)
-"lJY" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "lKg" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/wood,
@@ -32178,24 +34550,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
-"lKt" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/spawner/random/trash,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
-"lKu" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "lKA" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -32262,6 +34616,13 @@
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"lLy" = (
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/station/service/bar)
 "lLA" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
@@ -32290,15 +34651,28 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
-"lLJ" = (
-/obj/structure/table,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "lLL" = (
 /turf/open/floor/iron/dark/side{
 	dir = 9
 	},
 /area/station/hallway/secondary/construction)
+"lLT" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/displaycase/trophy,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
+"lLU" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "lLX" = (
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/surgery/theatre)
@@ -32347,30 +34721,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"lMy" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/table/glass,
-/obj/item/storage/photo_album/library,
-/turf/open/floor/iron/grimy,
-/area/station/service/library)
-"lMz" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/table/glass,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen/invisible{
-	pixel_x = -2;
-	pixel_y = 7
-	},
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/grimy,
-/area/station/service/library)
 "lMF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -32397,17 +34747,13 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/grimy,
 /area/station/service/library)
-"lMK" = (
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
-"lMN" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+"lMQ" = (
+/obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "lNf" = (
 /obj/effect/turf_decal/siding/blue,
 /turf/open/floor/iron/white/small,
@@ -32465,19 +34811,6 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/engineering/atmos)
-"lNF" = (
-/obj/effect/spawner/random/entertainment/lighter,
-/obj/item/cigarette/rollie/mindbreaker{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/item/cigarette/rollie/trippy{
-	pixel_x = 4
-	},
-/obj/effect/mapping_helpers/burnt_floor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "lNJ" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 6
@@ -32487,6 +34820,30 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/diagonal,
 /area/station/engineering/lobby)
+"lNK" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/rag{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass{
+	pixel_x = 10;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass{
+	pixel_x = 5;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/cup/glass/shaker{
+	pixel_x = -7;
+	pixel_y = 15
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/service/bar)
 "lNN" = (
 /obj/structure/table,
 /obj/item/toy/foamblade,
@@ -32568,6 +34925,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"lPv" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/grimy,
+/area/station/service/bar)
 "lPw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer2{
 	dir = 5
@@ -32693,6 +35059,28 @@
 	dir = 8
 	},
 /area/station/science/xenobiology)
+"lRp" = (
+/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/light/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
+"lRw" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "lRz" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "Waste to Filter"
@@ -32705,13 +35093,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
-"lRD" = (
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/siding/wideplating_new/terracotta,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood/tile,
-/area/station/commons/vacant_room/commissary)
 "lRV" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/dark_red{
@@ -32720,6 +35101,31 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/stone,
 /area/station/command/heads_quarters/hos)
+"lRX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/secondary/service)
+"lRY" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/flowers_pp,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north{
+	low_power_nightshift_lights = 1
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "lSb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -32747,16 +35153,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
-"lSw" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/structure/chair,
-/obj/effect/landmark/start/hangover,
-/obj/machinery/light/cold/directional/west,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "lSF" = (
 /obj/effect/decal/cleanable/generic,
 /obj/machinery/light/cold/directional/south,
@@ -32801,6 +35197,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
+"lTy" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "lTA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
@@ -32835,13 +35238,10 @@
 	},
 /turf/open/floor/tram,
 /area/station/maintenance/department/medical/central)
-"lTZ" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/duct,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+"lTW" = (
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/stone,
-/area/station/service/bar/backroom)
+/area/station/service/bar)
 "lUo" = (
 /turf/open/floor/iron,
 /area/station/science/lobby)
@@ -32908,14 +35308,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
-"lVm" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/green/opposingcorners,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "lVv" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/turf_decal/siding/yellow{
@@ -32942,18 +35334,6 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
-"lVL" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "lVN" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/spawner/random/maintenance,
@@ -32975,31 +35355,13 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
-"lWb" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/sign/warning/no_smoking/circle/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "lWk" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central/fore)
-"lWp" = (
-/obj/structure/table,
-/obj/machinery/light/small/directional/west,
-/obj/item/clothing/head/costume/paper_hat{
-	pixel_y = 12;
-	pixel_x = -4
-	},
-/obj/item/clothing/head/collectable/petehat{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/obj/item/cigarette/cigar/cohiba{
-	pixel_y = 4
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/commons/fitness/locker_room)
+"lWs" = (
+/turf/closed/wall/rust,
+/area/station/cargo/drone_bay)
 "lWz" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -33051,6 +35413,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/security/checkpoint/supply)
+"lXd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/light/cold/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "lXf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
@@ -33111,6 +35484,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"lXS" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/station/service/bar)
 "lXT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
@@ -33130,6 +35512,19 @@
 /obj/item/banner/cargo,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/qm)
+"lYc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/primary/central/fore)
 "lYf" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -33143,23 +35538,6 @@
 "lYj" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/fore)
-"lYt" = (
-/obj/structure/table/wood/fancy/green,
-/obj/item/storage/wallet{
-	pixel_x = -3;
-	pixel_y = 10
-	},
-/obj/item/cigarette/cigar{
-	pixel_x = -1;
-	pixel_y = -2
-	},
-/obj/item/lighter{
-	pixel_x = 11;
-	pixel_y = -7
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/grimy,
-/area/station/command/heads_quarters/qm)
 "lYw" = (
 /obj/structure/hedge,
 /obj/item/radio/intercom/directional/south,
@@ -33189,17 +35567,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"lYU" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "lYV" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 4
@@ -33270,22 +35637,6 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
-"lZD" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/directional/east,
-/obj/structure/sign/directions/security/directional/east{
-	dir = 2
-	},
-/obj/structure/sign/directions/medical/directional/east{
-	pixel_y = 8
-	},
-/obj/structure/sign/directions/science/directional/east{
-	pixel_y = -8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "lZH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33313,31 +35664,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
-"maa" = (
-/obj/structure/table,
-/obj/item/tape,
-/obj/item/pen/red{
-	pixel_x = 3;
-	pixel_y = 12
-	},
-/obj/item/pen/blue{
-	pixel_x = -6;
-	pixel_y = 12
-	},
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
-"mad" = (
-/obj/structure/table,
-/obj/item/taperecorder{
-	pixel_x = -16;
-	pixel_y = 3
-	},
-/obj/item/flashlight/lamp/green{
-	pixel_x = 8;
-	pixel_y = 3
-	},
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "maf" = (
 /turf/closed/wall/rust,
 /area/station/hallway/primary/fore)
@@ -33353,26 +35679,12 @@
 /obj/machinery/keycard_auth/directional/south,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain)
-"mam" = (
-/obj/structure/table,
-/obj/machinery/computer/libraryconsole/bookmanagement{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "mau" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/white/small,
 /area/station/science/cubicle)
-"maz" = (
-/obj/structure/chair/office,
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "maE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33389,6 +35701,14 @@
 	},
 /turf/open/floor/sepia,
 /area/station/maintenance/aft)
+"mbd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "mbp" = (
 /obj/structure/hedge,
 /obj/machinery/light_switch/directional/east,
@@ -33404,12 +35724,15 @@
 /obj/structure/fluff/broken_canister_frame,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
-"mbK" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
+"mbJ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/right/directional/south,
+/obj/machinery/door/poddoor/shutters{
+	name = "Kitchen Shutters";
+	id = "kitchenshutters"
 	},
-/turf/open/floor/iron/grimy,
-/area/station/service/library)
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "mbV" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/eighties/red,
@@ -33462,6 +35785,10 @@
 /obj/item/phone,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
+"mcL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "mcP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33480,8 +35807,23 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
-"mdj" = (
-/obj/machinery/portable_atmospherics/scrubber,
+"mdc" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/light/small/directional/east,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
+"mdi" = (
+/obj/machinery/door/airlock{
+	name = "Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "mdm" = (
@@ -33498,22 +35840,14 @@
 "mdt" = (
 /turf/closed/wall/r_wall,
 /area/station/science/robotics/mechbay)
-"mdG" = (
-/obj/structure/chair{
+"mdA" = (
+/obj/structure/flora/grass/jungle/b/style_3,
+/obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/toilet/auxiliary)
-"mdU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/camera/directional/north,
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "mdX" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/conveyor_switch{
@@ -33522,6 +35856,14 @@
 	},
 /turf/open/floor/wood,
 /area/station/cargo/miningfoundry)
+"mec" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "meh" = (
 /obj/structure/railing{
 	dir = 4
@@ -33560,6 +35902,18 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/entry)
+"meT" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Public Shrine"
+	},
+/obj/effect/turf_decal/siding/wood/end,
+/obj/machinery/door/firedoor,
+/turf/open/floor/stone,
+/area/station/hallway/primary/port)
+"mfk" = (
+/obj/structure/dresser,
+/turf/open/floor/wood,
+/area/station/cargo/boutique)
 "mfl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/west,
@@ -33622,6 +35976,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"mgh" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/r_wall,
+/area/station/command/teleporter)
 "mgt" = (
 /obj/machinery/vending/boozeomat,
 /obj/machinery/firealarm/directional/south,
@@ -33635,6 +35993,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
+"mgV" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/station/maintenance/hallway/abandoned_command)
 "mhk" = (
 /turf/closed/wall,
 /area/station/maintenance/port/greater)
@@ -33647,6 +36009,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"mhO" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "mhV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33678,6 +36047,20 @@
 /obj/structure/reagent_dispensers/wall/virusfood/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"miy" = (
+/obj/effect/turf_decal/tile/dark_red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/light/cold/directional/south,
+/obj/machinery/airalarm/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
 "miz" = (
 /obj/structure/table/glass,
 /obj/item/wrench,
@@ -33732,23 +36115,18 @@
 /obj/item/clothing/under/costume/skeleton,
 /turf/open/floor/eighties,
 /area/station/service/abandoned_gambling_den/gaming)
-"mjs" = (
-/obj/structure/chair/office,
-/obj/machinery/light/directional/north,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
-"mjB" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
 "mjF" = (
 /obj/structure/table/glass,
 /obj/item/clothing/suit/costume/cyborg_suit,
 /obj/item/clothing/head/costume/tv_head,
 /turf/open/floor/eighties,
 /area/station/service/abandoned_gambling_den/gaming)
+"mjI" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "mjN" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -33791,6 +36169,14 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
+"mkm" = (
+/obj/machinery/processor{
+	pixel_y = 6
+	},
+/obj/machinery/camera/autoname/directional/west,
+/obj/structure/table,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "mks" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
@@ -33803,12 +36189,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
-"mku" = (
-/obj/structure/chair/sofa/bench/right,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "mkA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33827,6 +36207,16 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/supply)
+"mkL" = (
+/obj/machinery/door/window/left/directional/south{
+	name = "Bio-Generator";
+	req_access = list("hydroponics")
+	},
+/obj/machinery/biogenerator,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/service/hydroponics)
 "mkN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33898,15 +36288,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
-"mmp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/status_display/ai/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "mms" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -33992,23 +36373,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"mnn" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/sign/painting/library{
-	pixel_y = 32
-	},
-/turf/open/floor/iron/smooth,
-/area/station/service/library)
-"mnu" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "mnw" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/machinery/firealarm/directional/east,
@@ -34056,6 +36420,12 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/cargo/drone_bay)
+"mnH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "mnN" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -34096,6 +36466,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"moL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/grimy,
+/area/station/service/bar)
 "mpk" = (
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/circuit/green,
@@ -34113,18 +36490,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
-"mpC" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/pen{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "mpE" = (
 /obj/machinery/light/cold/dim/directional/north,
 /obj/structure/disposalpipe/segment{
@@ -34133,17 +36498,6 @@
 /obj/structure/sign/poster/official/moth_piping/directional/north,
 /turf/open/floor/iron/small,
 /area/station/engineering/break_room)
-"mpO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "mpQ" = (
 /obj/structure/bed{
 	dir = 4
@@ -34155,12 +36509,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/small,
 /area/station/security/brig)
-"mqc" = (
-/obj/structure/table,
-/obj/item/pai_card,
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "mql" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
@@ -34196,6 +36544,19 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/port/aft)
+"mqN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L6";
+	pixel_y = -15
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "mqO" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -34222,6 +36583,15 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
+"mrM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "mrP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -34248,6 +36618,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"msb" = (
+/obj/machinery/door/airlock/vault{
+	name = "Vault"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/vault,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/herringbone,
+/area/station/hallway/primary/central/aft)
 "msg" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34271,6 +36653,12 @@
 "msJ" = (
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
+"mtM" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/right/directional/east,
+/turf/open/floor/plating,
+/area/station/service/hydroponics)
 "mtP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34279,17 +36667,6 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"mtV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock{
-	name = "Theater Greenroom"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
-/turf/open/floor/iron/textured_half{
-	dir = 8
-	},
-/area/station/service/greenroom)
 "mud" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock{
@@ -34458,13 +36835,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"mwP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
 "mxa" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/glass/reinforced,
@@ -34492,18 +36862,19 @@
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/warden)
+"mxh" = (
+/obj/structure/chair/sofa/bench{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/white/side,
+/area/station/hallway/primary/central/aft)
 "mxM" = (
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/noslip,
 /area/station/maintenance/port/aft)
-"mxN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "mxP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34597,21 +36968,14 @@
 /obj/item/paper/fluff/jobs/engineering/frequencies,
 /turf/open/floor/carpet/executive,
 /area/station/command/meeting_room)
-"mzc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+"mze" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Fore Primary Hallway"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters{
-	dir = 4;
-	id = "vaco";
-	name = "Comissary Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/commons/vacant_room/commissary)
+/turf/open/floor/iron/textured_half,
+/area/station/hallway/primary/central/fore)
 "mzf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -34651,22 +37015,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron,
 /area/station/maintenance/fore/greater)
-"mAn" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
-"mAo" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "mAs" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
@@ -34718,18 +37066,24 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
-"mBy" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
+"mBz" = (
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 1
 	},
-/obj/item/kirbyplants/random/fullysynthetic,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/white,
-/area/station/maintenance/central/greater)
+/obj/effect/turf_decal/siding/thinplating,
+/turf/open/floor/eighties/red,
+/area/station/hallway/primary/central/fore)
 "mBC" = (
 /obj/structure/sign/poster/official/soft_cap_pop_art/directional/north,
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
+"mBG" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "mCb" = (
 /obj/machinery/computer/cargo{
 	dir = 1
@@ -34794,15 +37148,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"mDq" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/sign/departments/cargo/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "mDG" = (
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 1
@@ -35005,22 +37350,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
-"mGn" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/item/clothing/gloves/color/fyellow{
-	pixel_y = 2
-	},
-/obj/item/wrench,
-/obj/item/cigarette/xeno{
-	pixel_x = -3;
-	pixel_y = -9
-	},
-/obj/item/clothing/head/utility/welding,
-/turf/open/floor/iron/small,
-/area/station/maintenance/department/engine/atmos)
 "mGp" = (
 /obj/structure/table/glass,
 /obj/item/gun/ballistic/automatic/c20r/toy/unrestricted,
@@ -35215,6 +37544,14 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
+"mJN" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/steam_vent,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "mJO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -35227,16 +37564,6 @@
 /obj/effect/spawner/random/food_or_drink/seed,
 /turf/open/misc/sandy_dirt,
 /area/station/maintenance/starboard/aft)
-"mJW" = (
-/obj/machinery/biogenerator,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/left/directional/south{
-	name = "Bio-Generator";
-	req_access = list("hydroponics")
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/textured_large,
-/area/station/service/hydroponics)
 "mJX" = (
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
@@ -35263,13 +37590,11 @@
 	dir = 1
 	},
 /area/station/hallway/primary/aft)
-"mKs" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/item/kirbyplants/random,
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation/entertainment)
+"mKA" = (
+/obj/structure/flora/bush/jungle/c/style_random,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "mKB" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -35286,17 +37611,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"mKH" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/disposal/bin,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "mKK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -35326,15 +37640,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/supply)
-"mLi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/sign/departments/botany/alt1/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "mLk" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -35349,6 +37654,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/processing)
+"mLu" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=23.2-Evac-Garden";
+	location = "23.4-Evac"
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 2
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "mLA" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -35437,6 +37754,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
+"mMX" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "mMY" = (
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 1
@@ -35447,6 +37770,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/security)
+"mNa" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 5
+	},
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
+"mNp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table/wood,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/cargo/boutique)
 "mNu" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/line,
@@ -35503,6 +37841,14 @@
 	dir = 10
 	},
 /area/station/science/xenobiology)
+"mOn" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/light/small/directional/east,
+/obj/structure/chair/stool/bar/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/holodeck/rec_center)
 "mOq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35540,6 +37886,32 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/station/maintenance/starboard/central)
+"mOZ" = (
+/obj/structure/window/spawner/directional/east,
+/obj/structure/table/wood,
+/obj/machinery/cell_charger{
+	pixel_y = 5
+	},
+/obj/item/stock_parts/power_store/cell/crap{
+	pixel_y = 5
+	},
+/obj/item/cigarette/pipe/cobpipe{
+	pixel_x = 1;
+	pixel_y = -2
+	},
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/wood/tile,
+/area/station/command/corporate_showroom)
+"mPb" = (
+/obj/machinery/door/window/right/directional/south{
+	name = "Seed Extractor";
+	req_access = list("hydroponics")
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/machinery/smartfridge,
+/turf/open/floor/plating,
+/area/station/service/hydroponics)
 "mPe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
 	dir = 4
@@ -35557,6 +37929,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/security)
+"mPs" = (
+/obj/machinery/food_cart,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 9
+	},
+/obj/effect/turf_decal/weather/snow,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "mPu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35620,14 +38000,15 @@
 	dir = 8
 	},
 /area/station/command/heads_quarters/hos)
-"mRp" = (
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
+"mQJ" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance"
 	},
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/structure/hedge,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lesser)
 "mRA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron/stairs/left,
@@ -35672,10 +38053,6 @@
 	},
 /turf/open/space/basic,
 /area/station/engineering/atmos/space_catwalk)
-"mSi" = (
-/obj/structure/mannequin/plastic,
-/turf/open/floor/plating,
-/area/station/cargo/boutique)
 "mSH" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/spawner/random/maintenance,
@@ -35737,11 +38114,17 @@
 "mTl" = (
 /turf/closed/wall,
 /area/station/cargo/sorting)
-"mTq" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
+"mTp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/dark_red/half/contrasted,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "mTs" = (
@@ -35865,11 +38248,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"mVa" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "mVm" = (
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 1
@@ -35888,6 +38266,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/small,
 /area/station/ai_monitored/security/armory)
+"mVw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/sign/departments/holy/directional/north,
+/obj/machinery/camera/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "mVC" = (
 /obj/machinery/door/airlock/external{
 	name = "Departure Lounge Airlock"
@@ -35918,11 +38305,6 @@
 	dir = 4
 	},
 /area/station/medical/medbay/central)
-"mVY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall,
-/area/station/hallway/secondary/spacebridge)
 "mWc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35970,6 +38352,13 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/storage)
+"mXu" = (
+/obj/effect/turf_decal/siding/thinplating_new/light,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
 "mXx" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -35984,6 +38373,15 @@
 /obj/item/stack/sheet/mineral/titanium,
 /turf/open/floor/tram,
 /area/station/security/tram)
+"mXO" = (
+/obj/structure/chair/stool/bar/directional/north,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/station/hallway/primary/central/aft)
 "mXT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36032,6 +38430,22 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"mYx" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/lesser)
+"mYN" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/random/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
 "mYP" = (
 /obj/structure/table,
 /obj/item/storage/bag/tray/cafeteria{
@@ -36043,15 +38457,6 @@
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
-"mYS" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/machinery/camera/autoname/directional/north,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "mYT" = (
 /obj/structure/table,
 /obj/item/assembly/igniter{
@@ -36072,6 +38477,11 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"mYV" = (
+/obj/structure/bed/maint,
+/obj/effect/spawner/random/trash,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "mYW" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Zoo";
@@ -36119,13 +38529,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"mZh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/status_display/evac/directional/north,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+"mZi" = (
+/obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/station/hallway/primary/central/fore)
 "mZj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -36153,12 +38571,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/starboard/aft)
-"nau" = (
-/obj/structure/disposalpipe/junction,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "nay" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/public/glass{
@@ -36179,11 +38591,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
-"naE" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/stairs,
-/area/station/maintenance/port/greater)
 "naF" = (
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 1
@@ -36197,17 +38604,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
-"naI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/storage/box{
-	pixel_x = -8;
-	pixel_y = 15
-	},
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/stone,
-/area/station/service/theater)
 "naN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock{
@@ -36216,13 +38612,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/auxiliary)
-"naO" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth,
-/area/station/service/library)
 "nbj" = (
 /obj/structure/railing{
 	dir = 1
@@ -36233,11 +38622,6 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/engineering/supermatter/room)
-"nbu" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/holopad,
-/turf/open/floor/iron/smooth,
-/area/station/service/library)
 "nbF" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small/directional/west,
@@ -36253,13 +38637,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"nbZ" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/station/service/library)
 "ncb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -36306,13 +38683,6 @@
 /obj/effect/landmark/start/lawyer,
 /turf/open/floor/wood/tile,
 /area/station/service/lawoffice)
-"ncs" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/autoname/directional/east,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation/entertainment)
 "ncD" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
@@ -36349,16 +38719,6 @@
 	},
 /turf/open/floor/tram,
 /area/station/maintenance/department/medical/central)
-"ndq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/morgue{
-	name = "Secret Corridor";
-	req_access = list("library")
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/central/greater)
 "ndM" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron,
@@ -36383,6 +38743,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
+"nen" = (
+/obj/machinery/holopad,
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
+"nez" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/stone,
+/area/station/service/bar)
 "neL" = (
 /obj/structure/closet/crate{
 	name = "Materials Crate"
@@ -36404,6 +38774,27 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/atmos)
+"neV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"neW" = (
+/obj/effect/turf_decal/tile/dark_red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating/dark/corner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/mail_sorting/security/general,
+/turf/open/floor/iron,
+/area/station/security)
 "nfg" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/siding/thinplating{
@@ -36480,6 +38871,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"nho" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "nhu" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/flashlight,
@@ -36521,6 +38920,12 @@
 	},
 /turf/open/floor/iron/smooth_edge,
 /area/station/engineering/supermatter/room)
+"nhT" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "nhU" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -36613,6 +39018,14 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/service/barber)
+"niY" = (
+/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "niZ" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -36637,6 +39050,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"nji" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/grass/jungle/b/style_3,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "nju" = (
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
@@ -36751,6 +39171,18 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/command/meeting_room)
+"nlm" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "nln" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36824,18 +39256,42 @@
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/tram)
-"nnk" = (
-/obj/machinery/camera/motion/directional/north{
-	c_tag = "Vault Exterior";
-	id_tag = list("vault")
+"nns" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/camera/autoname/directional/east,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 8
 	},
-/turf/open/space/basic,
-/area/space)
-"nnR" = (
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/eighties/red,
+/area/station/hallway/primary/central/fore)
+"nnH" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/primary/central/fore)
+"nnZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/central/lesser)
 "noe" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -36843,6 +39299,22 @@
 	dir = 8
 	},
 /area/station/science/lab)
+"nom" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L4";
+	pixel_y = -15
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "noq" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/smooth,
@@ -36895,6 +39367,16 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/meeting_room)
+"noL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/cold/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "noN" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -36937,9 +39419,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
-"npF" = (
-/turf/closed/wall/rust,
-/area/station/maintenance/port/greater)
 "npH" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/iron,
@@ -36951,33 +39430,12 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
-"npS" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/general,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "npV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/lawoffice)
-"npY" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/red/line,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/small,
-/area/station/hallway/secondary/spacebridge)
 "npZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
@@ -37036,6 +39494,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"nqZ" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/service/bar)
 "nra" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/window/spawner/directional/south,
@@ -37057,6 +39522,13 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/supply)
+"nrP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "nsa" = (
 /turf/closed/wall,
 /area/station/engineering/atmospherics_engine)
@@ -37075,6 +39547,9 @@
 /obj/item/target/alien,
 /turf/open/floor/plating,
 /area/station/science/auxlab/firing_range)
+"nsf" = (
+/turf/open/floor/carpet/lone,
+/area/station/service/chapel/office)
 "nsr" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 6
@@ -37092,13 +39567,6 @@
 "nsy" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/engineering/hallway)
-"nsH" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation/entertainment)
 "nsL" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red{
@@ -37159,14 +39627,16 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"ntw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Shrine"
+"ntD" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/table/wood,
+/obj/machinery/light/small/built/directional/north,
+/obj/item/stack/sheet/iron/ten,
+/obj/effect/turf_decal/siding/wideplating_new/terracotta{
+	dir = 9
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/textured_half,
-/area/station/hallway/primary/port)
+/turf/open/floor/wood/tile,
+/area/station/maintenance/central/lesser)
 "ntF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/status_display/ai/directional/south,
@@ -37188,6 +39658,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
+"ntS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "ntW" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/vending/wardrobe/coroner_wardrobe,
@@ -37196,15 +39674,6 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/medical/morgue)
-"ntY" = (
-/obj/structure/hedge,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/smooth,
-/area/station/service/library)
 "ntZ" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Recreation"
@@ -37250,15 +39719,6 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/engineering/break_room)
-"nuv" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "nuC" = (
 /obj/effect/turf_decal/siding,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37290,14 +39750,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/starboard/aft)
-"nuX" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/obj/structure/mannequin/plastic,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/carpet/blue,
-/area/station/cargo/boutique)
 "nuY" = (
 /obj/structure/broken_flooring/pile/directional/east,
 /obj/structure/alien/weeds/node,
@@ -37331,6 +39783,17 @@
 	},
 /turf/open/floor/iron/recharge_floor,
 /area/station/maintenance/port/aft)
+"nwc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/status_display/ai/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "nwj" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -37352,11 +39815,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"nwS" = (
-/obj/structure/flora/ash/tall_shroom,
-/obj/structure/sign/poster/random/directional/north,
-/turf/open/floor/grass,
-/area/station/service/hydroponics)
 "nxo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37433,17 +39891,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"nys" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/sign/directions/vault/directional/west{
-	dir = 2
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "nyx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37479,6 +39926,13 @@
 "nyH" = (
 /turf/closed/wall,
 /area/station/hallway/primary/aft)
+"nyK" = (
+/obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "nyQ" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
@@ -37563,11 +40017,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"nAi" = (
-/obj/structure/table,
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/wood,
-/area/station/service/theater)
 "nAn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -37580,10 +40029,6 @@
 /obj/machinery/light/small/broken/directional/west,
 /turf/open/misc/sandy_dirt,
 /area/station/maintenance/starboard/aft)
-"nAx" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "nAy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37599,22 +40044,15 @@
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
-"nAO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth,
-/area/station/service/greenroom)
 "nBd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
+"nBj" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall,
+/area/station/maintenance/central/greater)
 "nBq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37652,6 +40090,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"nBJ" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/trash,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "nBL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -37765,6 +40211,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/bitrunning/den)
+"nEo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "nEx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -37828,6 +40283,16 @@
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/carpet/lone,
 /area/station/service/abandoned_gambling_den)
+"nFd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/cargo/boutique)
 "nFo" = (
 /turf/closed/wall,
 /area/station/cargo/bitrunning/den)
@@ -37954,15 +40419,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
-"nGJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "nGP" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -38013,16 +40469,14 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"nHB" = (
-/obj/structure/disposalpipe/segment,
+"nHL" = (
+/obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/red/line,
-/turf/open/floor/iron/small,
-/area/station/hallway/primary/central/fore)
+/turf/open/floor/iron/grimy,
+/area/station/service/bar)
 "nHN" = (
 /obj/structure/table,
 /obj/item/stack/pipe_cleaner_coil/random,
@@ -38119,14 +40573,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/small,
 /area/station/engineering/atmos)
-"nIS" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock{
-	name = "Library Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "nIT" = (
 /obj/structure/railing{
 	dir = 6
@@ -38178,37 +40624,24 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/server)
-"nKk" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 4
+"nKo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L8";
+	pixel_y = -15
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/mail_sorting/service/kitchen,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
-"nKm" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/effect/landmark/observer_start,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "nKz" = (
 /obj/machinery/light/floor,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/command)
-"nKL" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/random/trash,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "nKO" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -38216,10 +40649,10 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"nKX" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+"nKP" = (
+/obj/machinery/holopad,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "nLH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38239,12 +40672,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
-"nLN" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "nMn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -38259,6 +40686,12 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"nMr" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "nMA" = (
 /obj/machinery/door/airlock{
 	name = "Construction Maintenance"
@@ -38299,16 +40732,6 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/station/holodeck/rec_center)
-"nNb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/dark_red,
-/obj/structure/sign/warning/no_smoking/circle/directional/north,
-/turf/open/floor/iron,
-/area/station/security)
 "nNe" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/dark/textured_half{
@@ -38337,6 +40760,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
+"nOk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/dark_red,
+/obj/structure/sign/warning/no_smoking/circle/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/security)
 "nOH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38346,6 +40779,14 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/command/gateway)
+"nOY" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/structure/table/wood,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/grimy,
+/area/station/service/bar)
 "nPd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -38522,6 +40963,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/bridge)
+"nRi" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/primary/central/aft)
 "nRr" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -38599,17 +41050,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"nTj" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "nTt" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/computer/shuttle/mining/common{
@@ -38648,6 +41088,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/station/engineering/main)
+"nUn" = (
+/obj/structure/chair/stool/bar/directional/west,
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "nUo" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/effect/turf_decal/siding/green{
@@ -38690,6 +41134,13 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/brown/visible,
 /turf/open/space/basic,
 /area/station/engineering/atmos/space_catwalk)
+"nUJ" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/machinery/holopad,
+/turf/open/floor/eighties,
+/area/station/hallway/primary/central/fore)
 "nUQ" = (
 /obj/structure/chair{
 	dir = 8
@@ -38751,6 +41202,9 @@
 	dir = 1
 	},
 /area/station/science/xenobiology)
+"nVz" = (
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "nVA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38759,25 +41213,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_command)
-"nVD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/chair{
-	pixel_x = 2;
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "nVF" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/tcommsat/server)
+"nVT" = (
+/obj/structure/displaycase/trophy,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "nWh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/closed/wall/r_wall,
@@ -38846,6 +41294,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
+"nXW" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/obj/structure/flora/bush/large/style_random,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "nYg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38936,6 +41391,13 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/cargo/drone_bay)
+"nZj" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/station/maintenance/central/greater)
 "nZq" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -39015,17 +41477,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms)
-"oaV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public/glass{
-	name = "Cargo Botique"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/textured_half{
-	dir = 1
-	},
-/area/station/hallway/primary/central/fore)
 "oaY" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/line{
@@ -39056,11 +41507,11 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/break_room)
-"obm" = (
-/obj/structure/disposalpipe/segment,
+"obp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "obq" = (
@@ -39092,10 +41543,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/textured_half,
 /area/station/hallway/secondary/dock)
-"obU" = (
-/obj/structure/reagent_dispensers/plumbed,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "obW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -39172,15 +41619,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white/small,
 /area/station/command/heads_quarters/cmo)
-"oeF" = (
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/obj/machinery/door/airlock{
-	name = "Abandoned Treatment Room"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "oeI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39209,26 +41647,23 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/grimy,
 /area/station/hallway/secondary/entry)
-"ofk" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
-"ofo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "ofu" = (
 /obj/effect/turf_decal/stripes/white/end{
 	dir = 8
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/department/medical/central)
+"ofM" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "ofZ" = (
 /turf/closed/mineral/random/stationside,
 /area/station/maintenance/port/lesser)
@@ -39247,11 +41682,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"ogu" = (
-/obj/effect/turf_decal/siding/white,
-/obj/structure/railing,
-/turf/open/floor/stone,
-/area/station/service/theater)
 "ogv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39310,10 +41740,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
-"ogX" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall,
-/area/station/hallway/primary/port)
 "ohb" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -39392,6 +41818,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"ohB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock{
+	name = "Theater Greenroom"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 8
+	},
+/area/station/service/greenroom)
 "ohM" = (
 /obj/structure/chair{
 	dir = 8
@@ -39420,6 +41862,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
+"oin" = (
+/obj/structure/flora/bush/flowers_pp/style_2,
+/obj/structure/flora/bush/large/style_3,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "ois" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 6
@@ -39484,10 +41931,6 @@
 /obj/structure/alien/weeds,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
-"ojl" = (
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "ojz" = (
 /obj/structure/railing{
 	dir = 1
@@ -39559,16 +42002,6 @@
 /obj/machinery/status_display/ai,
 /turf/closed/wall,
 /area/station/hallway/secondary/entry)
-"okp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/textured_half,
-/area/station/service/library)
 "okt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 4
@@ -39586,14 +42019,6 @@
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"okK" = (
-/obj/structure/chair/stool/bamboo,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/landmark/start/bartender,
-/turf/open/floor/stone,
-/area/station/service/bar/backroom)
 "okW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39656,20 +42081,12 @@
 /obj/machinery/light/small/dim/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
-"omA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
-"omU" = (
-/obj/machinery/light/small/broken/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+"oms" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/herringbone,
+/area/station/ai_monitored/command/nuke_storage)
 "omW" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron/white/corner,
@@ -39684,12 +42101,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"ono" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "onv" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden{
@@ -39722,6 +42133,24 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/chemistry)
+"onH" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/stone,
+/area/station/service/bar)
+"onJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/service/greenroom)
 "onP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
@@ -39786,6 +42215,16 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"ooL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "ooO" = (
 /obj/effect/turf_decal/trimline/blue/warning{
 	dir = 4
@@ -39800,6 +42239,14 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron/small,
 /area/station/engineering/atmos)
+"opl" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/structure/flora/bush/flowers_yw/style_3,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "opn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39825,6 +42272,18 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"opC" = (
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 10;
+	pixel_x = -5
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "opH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39847,6 +42306,29 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
+"opQ" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 8
+	},
+/obj/effect/landmark/start/botanist,
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
+"opR" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/left/directional/south{
+	name = "Hydroponics Desk"
+	},
+/obj/machinery/door/firedoor,
+/obj/item/paper/guides/jobs/hydroponics,
+/obj/item/pen{
+	pixel_x = 4
+	},
+/obj/machinery/door/window/right/directional/north{
+	name = "Hydroponics Desk";
+	req_access = list("hydroponics")
+	},
+/turf/open/floor/plating,
+/area/station/service/hydroponics)
 "opW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39874,13 +42356,27 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
-"oqE" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+"oqy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
-/area/station/service/chapel)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
+"oqB" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/primary/port)
 "oqK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/random,
@@ -39909,14 +42405,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/starboard/fore)
-"orH" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/structure/reagent_dispensers/beerkeg,
-/obj/effect/turf_decal/bot_red/left,
-/obj/structure/sign/clock/directional/north,
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
 "orW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
@@ -40005,6 +42493,13 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
+"otE" = (
+/obj/machinery/oven/range,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "otG" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/machinery/status_display/supply{
@@ -40038,27 +42533,9 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"ouf" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/red/line,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/turf/open/floor/iron/small,
-/area/station/hallway/primary/starboard)
 "ouj" = (
 /turf/closed/wall,
 /area/station/engineering/engine_smes)
-"oup" = (
-/obj/structure/chair/sofa/right/maroon{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/south,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
 "ouz" = (
 /turf/open/floor/iron/dark/small,
 /area/station/command/heads_quarters/rd)
@@ -40115,6 +42592,19 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor/flat_white,
 /area/station/science/cytology)
+"ovl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L10";
+	pixel_y = -15
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "ovt" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance"
@@ -40126,6 +42616,9 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"ovu" = (
+/turf/closed/wall/r_wall,
+/area/station/hallway/primary/central/aft)
 "ovB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/alien/weeds,
@@ -40133,6 +42626,25 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
+"ovC" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L1";
+	pixel_y = -15
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
+"ovF" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/grimy,
+/area/station/service/bar)
 "ovQ" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -40263,11 +42775,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/cytology)
-"oxS" = (
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
 "oyn" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/public/glass{
@@ -40279,6 +42786,18 @@
 /obj/machinery/light/warm/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
+"oyz" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
+"oyA" = (
+/obj/machinery/light/floor,
+/obj/effect/landmark/start/cook,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "oyQ" = (
 /turf/closed/wall,
 /area/station/science/auxlab/firing_range)
@@ -40302,13 +42821,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/qm)
-"ozd" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L8"
-	},
-/turf/open/floor/glass,
-/area/station/hallway/secondary/spacebridge)
 "ozn" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -40316,10 +42828,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"ozo" = (
-/obj/structure/window/spawner/directional/south,
-/turf/open/floor/grass,
-/area/station/service/hydroponics)
 "ozs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -40338,6 +42846,16 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos/space_catwalk)
+"ozF" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "ozM" = (
 /obj/structure/railing,
 /obj/structure/railing{
@@ -40362,15 +42880,10 @@
 	dir = 8
 	},
 /area/station/maintenance/starboard/greater)
-"oAk" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+"ozX" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/station/service/library)
 "oAn" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 10
@@ -40378,11 +42891,6 @@
 /obj/structure/steam_vent,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
-"oAp" = (
-/obj/structure/chair/sofa/right/maroon,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
 "oAr" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/structure/closet/bombcloset/security,
@@ -40394,11 +42902,19 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
-"oAF" = (
-/obj/effect/spawner/random/vending/colavend,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+"oAC" = (
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/machinery/door/airlock{
+	name = "Maintenance"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "oAY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -40419,11 +42935,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer4,
 /turf/open/space/basic,
 /area/space/nearstation)
-"oBm" = (
-/obj/structure/chair/sofa/bench/left,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "oBv" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -40448,11 +42959,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"oBV" = (
-/obj/structure/cable,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/service/library)
 "oBX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -40467,15 +42973,24 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
-"oCc" = (
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/service/library)
 "oCg" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/medical_all,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
+"oCn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/plaque{
+	icon_state = "L14";
+	pixel_y = -15
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "oCq" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -40515,15 +43030,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"oDs" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Fore Primary Hallway"
-	},
-/turf/open/floor/iron/textured_half,
-/area/station/hallway/primary/central/fore)
 "oDB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40537,14 +43043,27 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"oDK" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock{
-	name = "Hydroponics Maintenance"
+"oDN" = (
+/obj/machinery/door/airlock/wood{
+	name = "Bar Backroom"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/station/service/bar)
+"oDV" = (
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/mail_sorting/service/library,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "oDY" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -40566,6 +43085,21 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"oEg" = (
+/obj/structure/sink/kitchen/directional/south,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/light/floor,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/stone,
+/area/station/service/bar)
 "oEk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40577,36 +43111,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
-"oEr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/status_display/ai/directional/south,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"oEt" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/requests_console/directional/north{
-	department = "Chief Engineer's Desk";
-	name = "Chief Engineer's Requests Console";
-	pixel_y = -32
-	},
-/obj/effect/mapping_helpers/requests_console/announcement,
-/obj/effect/mapping_helpers/requests_console/information,
-/turf/open/floor/iron/stairs/old{
-	dir = 4
-	},
-/area/station/command/heads_quarters/ce)
+"oEp" = (
+/turf/open/floor/carpet,
+/area/station/service/library)
 "oEB" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/box/red/corners{
@@ -40623,13 +43130,38 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"oEN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+"oEG" = (
+/obj/item/clothing/mask/cigarette,
+/obj/item/storage/fancy/cigarettes/cigpack_robust{
+	pixel_y = 5;
+	pixel_x = 6
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/obj/item/lighter,
+/obj/structure/sign/poster/official/random/directional/east,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 6
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/secondary/service)
+"oEL" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
+"oES" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/bookcase/random/adult,
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/iron/grimy,
+/area/station/service/library)
 "oFc" = (
 /obj/effect/spawner/random/trash,
 /obj/machinery/light/small/directional/west,
@@ -40662,6 +43194,14 @@
 /obj/structure/window/spawner/directional/west,
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
+"oFn" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/steam_vent,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "oFu" = (
 /turf/closed/wall,
 /area/station/security/office)
@@ -40735,6 +43275,13 @@
 /obj/structure/flora/rock/pile/style_2,
 /turf/open/misc/sandy_dirt,
 /area/station/science/research)
+"oHm" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 5
+	},
+/obj/effect/landmark/start/botanist,
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
 "oHw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40794,6 +43341,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron/small,
 /area/station/maintenance/department/electrical)
+"oIk" = (
+/obj/machinery/vending/wardrobe/chef_wardrobe,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
+"oIm" = (
+/obj/structure/flora/bush/flowers_br,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/service/chapel)
+"oIs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "oIx" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/showroomfloor,
@@ -40842,18 +43405,6 @@
 /obj/item/circuitboard/machine/biogenerator,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
-"oJl" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Main Engineering"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/break_room)
 "oJn" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
@@ -40929,6 +43480,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
+"oJX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/small,
+/area/station/medical/medbay/lobby)
 "oKb" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -40936,6 +43500,21 @@
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
+"oKi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 9
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/secondary/service)
 "oKn" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/floor,
@@ -40956,6 +43535,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
 /turf/open/floor/iron/textured_half,
 /area/station/security/warden)
+"oKK" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 6
+	},
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
 "oKP" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -40991,12 +43576,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/station/solars/starboard/aft)
-"oMC" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/white/small,
-/area/station/service/hydroponics)
 "oMF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral,
@@ -41009,6 +43588,18 @@
 /mob/living/basic/slime,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"oMQ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/small,
+/area/station/hallway/primary/central/fore)
 "oNd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/blue/corner{
@@ -41018,6 +43609,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white/small,
 /area/station/medical/storage)
+"oNn" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/flora/bush/flowers_yw/style_3,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "oNs" = (
 /turf/open/floor/iron/stairs/left{
 	dir = 1
@@ -41054,6 +43650,23 @@
 	dir = 8
 	},
 /area/station/science/research)
+"oNP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock{
+	name = "Library Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/service/library)
 "oNX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41191,6 +43804,16 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/rd,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/command/heads_quarters/rd)
+"oPK" = (
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
+	},
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "oPM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41218,6 +43841,14 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/security/prison/workout)
+"oPZ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/flora/bush/sparsegrass,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "oQj" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/window/spawner/directional/east,
@@ -41253,16 +43884,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
-"oQD" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/button/door/directional/north{
-	id = "vaco";
-	name = "Comissary Shutters";
-	pixel_x = 29
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/small,
-/area/station/commons/vacant_room/commissary)
 "oQF" = (
 /turf/closed/wall/r_wall,
 /area/station/security/execution/transfer)
@@ -41290,6 +43911,23 @@
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
+"oRq" = (
+/obj/structure/table/wood/fancy/green,
+/obj/item/storage/wallet{
+	pixel_x = -3;
+	pixel_y = 10
+	},
+/obj/item/cigarette/cigar{
+	pixel_x = -1;
+	pixel_y = -2
+	},
+/obj/item/lighter{
+	pixel_x = 11;
+	pixel_y = -7
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/grimy,
+/area/station/command/heads_quarters/qm)
 "oRr" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -41352,11 +43990,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"oSh" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "oSv" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/computer/rdconsole{
@@ -41383,33 +44016,11 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"oSP" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
-"oSS" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "oTj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"oTo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/catwalk_floor/iron,
-/area/station/service/bar)
 "oTH" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -41431,11 +44042,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
-"oTO" = (
-/obj/structure/dresser,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/wood,
-/area/station/cargo/boutique)
 "oTT" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -41472,16 +44078,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
-"oUx" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=23.2-Evac-Garden";
-	location = "23.4-Evac"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "oUz" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
@@ -41520,15 +44116,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/security/evidence)
-"oUO" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/stairs{
-	dir = 8
-	},
-/area/station/maintenance/port/greater)
 "oVt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden,
 /obj/effect/turf_decal/tile/yellow,
@@ -41542,6 +44129,14 @@
 /mob/living/basic/mining/lobstrosity,
 /turf/open/misc/asteroid/airless,
 /area/station/maintenance/department/engine)
+"oVI" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/trash,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/lesser)
 "oVK" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -41562,12 +44157,10 @@
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain)
-"oWb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/cold/directional/east,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+"oWd" = (
+/obj/structure/flora/tree/jungle/style_2,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "oWg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41587,12 +44180,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/hallway/abandoned_command)
-"oWp" = (
-/obj/structure/chair{
-	pixel_y = -2
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/commons/vacant_room/commissary)
 "oWr" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock{
@@ -41623,20 +44210,25 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
+"oXq" = (
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/button/door/directional/north{
+	name = "Door Bolt Control";
+	id = "commiss2";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/vacant_room/commissary)
 "oXs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
-"oXt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "oXK" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -41662,23 +44254,25 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"oXZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
+"oXY" = (
+/obj/machinery/vending/hydroseeds{
+	slogan_delay = 700
+	},
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 8
 	},
-/obj/machinery/camera/autoname/directional/west,
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/service/hydroponics)
 "oYj" = (
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
-"oYu" = (
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "oYv" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41785,21 +44379,6 @@
 /obj/structure/tram,
 /turf/open/floor/tram,
 /area/station/security/tram)
-"paL" = (
-/obj/structure/fireplace,
-/obj/effect/turf_decal/siding/wood/end,
-/obj/machinery/camera/directional/east,
-/turf/open/floor/stone,
-/area/station/service/bar)
-"paV" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "paW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 8
@@ -41861,11 +44440,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"pbu" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "pbE" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -41892,13 +44466,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
-"pbZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/stone,
-/area/station/service/theater)
 "pcb" = (
 /obj/effect/turf_decal/tile/dark_red{
 	dir = 4
@@ -41944,6 +44511,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
+"pcV" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay Clinic"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "medlock";
+	name = "Lockdown Shutters"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white/small,
+/area/station/medical/medbay/lobby)
 "pdf" = (
 /obj/structure/transport/linear/tram,
 /obj/effect/landmark/transport/transport_id/birdshot/line_2,
@@ -42039,15 +44620,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"pev" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "peN" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion/directional/north{
@@ -42166,29 +44738,10 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/atmos)
-"pfO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/directional/east,
-/obj/machinery/status_display/evac/directional/east,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "pfT" = (
 /obj/structure/training_machine,
 /turf/open/floor/iron/smooth_large,
 /area/station/science/auxlab/firing_range)
-"pfU" = (
-/obj/machinery/door/airlock{
-	name = "Kitchen Cold Room"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/barricade/wooden/crude,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/welded,
-/turf/open/floor/iron/textured_half{
-	dir = 8
-	},
-/area/station/service/bar/backroom)
 "pfW" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -42232,17 +44785,36 @@
 /obj/item/kirbyplants/fern,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
+"pgS" = (
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/button/door/directional/north{
+	id = "meow";
+	name = "Comissary Shutters";
+	pixel_x = 29
+	},
+/turf/open/floor/iron,
+/area/station/commons/vacant_room/commissary)
+"pgT" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "pgU" = (
 /obj/structure/steam_vent,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
-"pgW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
 "phd" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 4
@@ -42348,6 +44920,14 @@
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/chemistry)
+"piJ" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/landmark/start/bartender,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "piL" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -42355,14 +44935,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"piZ" = (
-/obj/structure/chair/sofa/right/maroon{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
 "pjb" = (
 /obj/structure/broken_flooring/singular/directional/south,
 /turf/open/floor/iron,
@@ -42453,6 +45025,18 @@
 /obj/structure/window/spawner/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/command/corporate_showroom)
+"pkk" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/glass,
+/area/station/hallway/primary/central/aft)
+"pkl" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "pks" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/green/opposingcorners{
@@ -42487,6 +45071,12 @@
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/wood/tile,
 /area/station/service/lawoffice)
+"plc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/junction,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "plf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42523,6 +45113,13 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/service/lawoffice)
+"pma" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "pmg" = (
 /obj/structure/table/reinforced/titaniumglass,
 /obj/effect/turf_decal/bot,
@@ -42534,6 +45131,19 @@
 	},
 /turf/open/floor/catwalk_floor/titanium,
 /area/station/command/heads_quarters/ce)
+"pmm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
+"pmo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "pmq" = (
 /obj/structure/bed/maint,
 /obj/effect/decal/cleanable/dirt,
@@ -42591,6 +45201,13 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
+"pnA" = (
+/obj/structure/flora/bush/flowers_br,
+/obj/structure/flora/bush/flowers_pp,
+/obj/structure/flora/bush/flowers_yw,
+/obj/structure/flora/bush/pale,
+/turf/open/floor/grass,
+/area/station/hallway/primary/central/fore)
 "pnQ" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
@@ -42625,19 +45242,13 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/freezer,
 /area/station/command/corporate_suite)
-"poh" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/oven/range,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
-"pot" = (
-/obj/structure/table/wood,
-/obj/item/cigarette/cigar/premium{
-	pixel_y = 5
+"pov" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/stone,
-/area/station/service/abandoned_gambling_den)
+/area/station/service/bar)
 "pox" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42669,6 +45280,18 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/station/security/checkpoint/escape)
+"poH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 10
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/light/small/directional/south,
+/obj/effect/landmark/start/botanist,
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
 "poL" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -42710,6 +45333,23 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/atmos/office)
+"poY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
+"ppa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sign/departments/cargo/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "ppk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -42727,6 +45367,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
+"ppn" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 1
+	},
+/turf/open/floor/stone,
+/area/station/service/bar)
 "ppp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42767,6 +45416,18 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
+"ppE" = (
+/obj/structure/flora/bush/flowers_yw/style_3{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/machinery/light/floor,
+/obj/effect/light_emitter/fake_outdoors,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/grass/Airless,
+/area/station/hallway/primary/central/aft)
 "ppL" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
@@ -42815,6 +45476,13 @@
 	dir = 1
 	},
 /area/station/engineering/supermatter/room)
+"pqu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "pqv" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -42879,17 +45547,32 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
+"prs" = (
+/obj/structure/sign/directions/engineering{
+	dir = 1;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/command{
+	dir = 1
+	},
+/obj/structure/sign/directions/supply{
+	dir = 1;
+	pixel_y = -8
+	},
+/turf/closed/wall,
+/area/station/service/library)
+"prF" = (
+/obj/structure/chair/sofa/bench/right{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/hallway/primary/central/fore)
 "prI" = (
 /turf/closed/wall,
 /area/station/engineering/hallway)
-"prQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "prV" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
@@ -43001,15 +45684,20 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/diagonal,
 /area/station/science/auxlab/firing_range)
-"ptk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "ptl" = (
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
+"pto" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "ptt" = (
 /obj/structure/chair/wood/wings,
 /obj/effect/turf_decal/siding/wood{
@@ -43028,6 +45716,16 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/stone,
 /area/station/command/corporate_suite)
+"ptw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "ptz" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/structure/cable,
@@ -43048,35 +45746,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
-"ptZ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/grass,
-/area/station/service/chapel)
-"pug" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
-"puj" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
-"pup" = (
-/obj/structure/chair/sofa/right,
-/obj/machinery/light/small/directional/west,
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/wood,
-/area/station/hallway/secondary/service)
 "pus" = (
 /obj/effect/turf_decal/box/red/corners,
 /obj/effect/turf_decal/stripes/white/line{
@@ -43084,23 +45753,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"puv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/hydroponics{
-	name = "Hydroponics Supply Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
-/turf/open/floor/iron/textured_half,
-/area/station/service/hydroponics)
-"puw" = (
-/obj/machinery/door/morgue{
-	name = "Private Study";
-	req_access = list("library")
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/service/library)
 "pux" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -43108,12 +45760,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/diagonal,
 /area/station/command/heads_quarters/hop)
-"puD" = (
-/obj/structure/bookcase/random/nonfiction,
-/obj/machinery/newscaster/directional/west,
-/obj/machinery/digital_clock/directional/north,
-/turf/open/floor/wood/tile,
-/area/station/service/bar)
 "puI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -43129,17 +45775,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/space_catwalk)
-"puY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/dark_red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/camera/autoname/directional/south,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/station/security/brig/entrance)
 "pvk" = (
 /obj/structure/closet/boxinggloves,
 /obj/effect/turf_decal/stripes/red/line{
@@ -43148,6 +45783,16 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
+"pvy" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "pvB" = (
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/herringbone,
@@ -43175,24 +45820,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/atmos)
-"pvR" = (
-/obj/structure/table/wood,
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/stone,
-/area/station/service/bar/backroom)
-"pvS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/broken_floor,
-/obj/item/radio/intercom/directional/south,
-/obj/machinery/duct,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/landmark/start/cook,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
 "pvY" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 1
@@ -43215,14 +45842,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/closed/wall,
 /area/station/engineering/atmos)
-"pww" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/duct,
-/obj/effect/landmark/generic_maintenance_landmark,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
 "pwA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -43259,21 +45878,18 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"pxg" = (
-/obj/machinery/light/small/broken/directional/west,
-/turf/open/floor/iron/dark/small,
-/area/station/commons/vacant_room/commissary)
 "pxj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/execution/education)
-"pxl" = (
-/obj/machinery/smartfridge,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
+"pxk" = (
+/obj/machinery/vending/dinnerware,
+/obj/machinery/requests_console/auto_name/directional/south,
+/obj/effect/mapping_helpers/requests_console/supplies,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "pxx" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -43298,13 +45914,11 @@
 	dir = 1
 	},
 /area/station/security/prison/safe)
-"pxO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+"pxI" = (
+/obj/structure/cable,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "pxW" = (
 /obj/structure/table,
 /obj/machinery/cell_charger{
@@ -43318,11 +45932,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
-"pya" = (
-/obj/structure/chair/sofa/right/maroon,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
 "pyh" = (
 /obj/structure/cable,
 /obj/structure/broken_flooring/singular/directional/east,
@@ -43352,20 +45961,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_command)
-"pyS" = (
-/obj/structure/chair/sofa/left/maroon,
-/obj/effect/landmark/start/assistant,
-/obj/machinery/camera/autoname/directional/east,
-/turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
-"pyY" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/weldingtool/mini,
-/turf/open/floor/iron/white,
-/area/station/maintenance/central/greater)
 "pzb" = (
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 1
@@ -43381,17 +45976,15 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/hallway)
-"pzn" = (
-/obj/structure/table,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+"pzk" = (
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/door/airlock/freezer{
+	name = "Freezer"
 	},
-/obj/item/toy/foamfinger,
-/obj/item/toy/eightball{
-	pixel_y = 13
-	},
-/turf/open/floor/plating,
-/area/station/service/theater)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "pzy" = (
 /obj/structure/table,
 /obj/item/storage/box/prisoner{
@@ -43413,6 +46006,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/customs/auxiliary)
+"pzM" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/small,
+/area/station/hallway/primary/central/fore)
 "pzN" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 5
@@ -43420,16 +46024,6 @@
 /obj/item/stack/sheet/mineral/titanium,
 /turf/open/floor/tram,
 /area/station/maintenance/department/medical/central)
-"pzX" = (
-/obj/structure/railing,
-/obj/structure/table,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/white,
-/obj/effect/spawner/random/entertainment/toy,
-/turf/open/floor/plating,
-/area/station/service/theater)
 "pAa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/structure/barricade,
@@ -43465,6 +46059,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/security)
+"pAq" = (
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/vacant_room/commissary)
 "pAs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/directional/south{
@@ -43480,6 +46084,15 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"pAD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "pAH" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -43621,11 +46234,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"pCX" = (
-/obj/structure/chair/stool/directional/west,
-/obj/effect/landmark/start/clown,
-/turf/open/floor/carpet/lone,
-/area/station/service/theater)
+"pCW" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/plating,
+/area/station/hallway/primary/central/fore)
 "pDr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43694,6 +46309,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"pDW" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/tree/jungle/small/style_4,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "pDX" = (
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/iron/herringbone,
@@ -43779,10 +46401,6 @@
 /obj/structure/alien/weeds,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
-"pFr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet/lone,
-/area/station/service/theater)
 "pFI" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -43964,16 +46582,18 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation)
-"pHN" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/flora/bush/sunny/style_random,
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "pHS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"pHX" = (
+/obj/structure/bookcase/random,
+/obj/structure/sign/poster/official/random/directional/west,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "pId" = (
 /obj/structure/reagent_dispensers/plumbed,
 /turf/open/floor/iron/kitchen/small,
@@ -43990,20 +46610,6 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/commons/fitness/locker_room)
-"pIg" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/dark_red/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating/dark/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/brig/entrance)
 "pIi" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/rack,
@@ -44054,6 +46660,13 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"pIQ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/bush/sparsegrass,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "pIS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -44124,6 +46737,16 @@
 /obj/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"pJS" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L5";
+	pixel_y = -15
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "pJT" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer5,
@@ -44258,24 +46881,20 @@
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/secondary/exit/departure_lounge)
-"pMg" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "pMs" = (
 /obj/structure/transit_tube/horizontal,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
-"pMu" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
+"pMv" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/screwdriver,
+/obj/effect/turf_decal/siding/wideplating_new/terracotta{
+	dir = 8
 	},
-/turf/open/floor/grass,
-/area/station/service/chapel)
+/turf/open/floor/wood/tile,
+/area/station/maintenance/central/lesser)
 "pMA" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -44313,12 +46932,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/gravity_generator)
-"pNa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "pNh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44338,13 +46951,18 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/command/corporate_showroom)
-"pNy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+"pNs" = (
+/obj/effect/turf_decal/siding/thinplating_new/light,
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
+"pNB" = (
+/obj/machinery/door/airlock{
+	name = "Maintenance"
 	},
-/obj/effect/spawner/random/engineering/atmospherics_portable,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/area/station/maintenance/central/lesser)
 "pNC" = (
 /turf/open/floor/iron/dark/side{
 	dir = 1
@@ -44367,20 +46985,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/small,
 /area/station/science/lab)
+"pNR" = (
+/obj/machinery/vending/cola,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/dark/side,
+/area/station/hallway/primary/central/fore)
 "pNZ" = (
 /obj/structure/sign/directions/dorms{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/station/commons/fitness/locker_room)
-"pOb" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "pOg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44407,18 +47025,6 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/engineering/main)
-"pOj" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	name = "Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/general,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "pOm" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -44461,14 +47067,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
-"pOK" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
 "pOX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -44498,6 +47096,17 @@
 /obj/item/airlock_painter,
 /turf/open/floor/iron/small,
 /area/station/engineering/atmos/storage/gas)
+"pPx" = (
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "pPH" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Atmospherics Project Bay"
@@ -44509,26 +47118,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/command)
-"pPT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "pPZ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"pQe" = (
-/obj/structure/chair/sofa/left{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/wood/tile,
-/area/station/service/bar)
 "pQj" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -44559,11 +47152,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/hallway/secondary/entry)
-"pQO" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/effect/spawner/random/entertainment/arcade,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation/entertainment)
 "pQY" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
@@ -44609,22 +47197,18 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
 /turf/open/floor/iron/textured_half,
 /area/station/security/checkpoint/customs/auxiliary)
-"pRP" = (
-/obj/machinery/icecream_vat,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
 "pRQ" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"pRU" = (
-/obj/machinery/gibber,
-/obj/effect/turf_decal/bot_red,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+"pRY" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "pSc" = (
 /obj/item/bikehorn/rubberducky{
 	pixel_x = 6;
@@ -44644,40 +47228,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
-"pSm" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/cup/beaker{
-	pixel_x = 5;
-	pixel_y = 17
-	},
-/obj/item/reagent_containers/syringe/epinephrine,
-/obj/item/reagent_containers/syringe{
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/obj/machinery/light/small/red/directional/west,
-/turf/open/floor/iron/white,
-/area/station/maintenance/central/greater)
 "pSq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/structure/broken_flooring/pile/directional/east,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
-"pSr" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/obj/structure/table,
-/obj/item/reagent_containers/dropper{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/crowbar/large/emergency,
-/turf/open/floor/iron/white,
-/area/station/maintenance/central/greater)
 "pSs" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -44695,13 +47251,6 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/destructible/cult/item_dispenser/archives/library,
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/grimy,
-/area/station/service/library)
-"pSK" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/obj/structure/bookcase/random/adult,
 /turf/open/floor/iron/grimy,
 /area/station/service/library)
 "pSN" = (
@@ -44722,32 +47271,6 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
-"pTc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/turf/open/floor/iron/small,
-/area/station/hallway/primary/port)
-"pTl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/mime,
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/stone,
-/area/station/service/theater)
 "pTp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 4
@@ -44784,13 +47307,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/lawoffice)
-"pTC" = (
-/obj/structure/disposalpipe/sorting/mail{
+"pTP" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/mail_sorting/service/theater,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "pTZ" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
@@ -45147,14 +47673,14 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/explab)
-"pYE" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/grass,
-/area/station/service/chapel)
+"pYz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "pYP" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -45175,14 +47701,6 @@
 	dir = 4
 	},
 /area/station/science/lower)
-"pZi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "pZu" = (
 /obj/structure/hedge,
 /turf/open/floor/plating,
@@ -45210,13 +47728,6 @@
 /obj/item/shard/titanium,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
-"qaA" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood/large,
-/area/station/service/chapel)
 "qaF" = (
 /obj/structure/sink/directional/south,
 /obj/structure/mirror/directional/north,
@@ -45229,11 +47740,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/herringbone,
 /area/station/commons/dorms)
-"qbi" = (
-/obj/machinery/photocopier,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "qbj" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/structure/closet/secure_closet/security/sec,
@@ -45260,14 +47766,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/checker,
 /area/station/security/breakroom)
-"qbr" = (
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "qbv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/structure/disposalpipe/segment{
@@ -45275,37 +47773,15 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/engineering/atmos)
-"qbw" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "qby" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/supply)
-"qbC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
 "qbE" = (
 /obj/item/stack/tile/catwalk_tile/iron,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
-"qbK" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
 "qbN" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -45342,10 +47818,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/secondary/construction)
-"qcl" = (
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/wood,
-/area/station/hallway/secondary/service)
 "qcr" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /mob/living/carbon/human/species/monkey,
@@ -45366,6 +47838,14 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
+"qcG" = (
+/obj/structure/hedge,
+/obj/effect/turf_decal/siding/wood/end,
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/station/service/library)
 "qcQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45382,16 +47862,6 @@
 	},
 /turf/open/misc/sandy_dirt,
 /area/station/security/tram)
-"qdm" = (
-/turf/open/floor/wood,
-/area/station/hallway/secondary/service)
-"qdp" = (
-/obj/structure/chair/sofa/right{
-	dir = 4
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood/tile,
-/area/station/service/bar)
 "qdu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45402,15 +47872,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
-"qdC" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/machinery/duct,
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
 "qdJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -45469,6 +47930,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"qdX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "qdZ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -45478,15 +47947,6 @@
 "qei" = (
 /turf/closed/wall,
 /area/station/science/ordnance/storage)
-"qej" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Library"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/textured_half{
-	dir = 1
-	},
-/area/station/service/library)
 "qen" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/boxing,
@@ -45498,6 +47958,25 @@
 /obj/structure/fluff/broken_canister_frame,
 /turf/open/misc/asteroid,
 /area/station/maintenance/department/engine/atmos)
+"qeA" = (
+/obj/machinery/shieldgen,
+/obj/item/clothing/gloves/color/black{
+	pixel_y = -3;
+	pixel_x = -2
+	},
+/obj/item/cigarette{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/clothing/mask/gas{
+	pixel_y = 5
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = 1;
+	pixel_y = 15
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "qeP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45524,6 +48003,16 @@
 	},
 /turf/open/floor/iron/diagonal,
 /area/station/engineering/lobby)
+"qeX" = (
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "qfn" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 9
@@ -45541,6 +48030,17 @@
 /obj/structure/sign/departments/lawyer/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
+"qft" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 9
+	},
+/obj/effect/turf_decal/weather/snow,
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 2
+	},
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "qfv" = (
 /obj/structure/flora/rock/pile/jungle/style_random,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -45592,14 +48092,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/lower)
-"qgr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "qgs" = (
 /obj/structure/cable,
 /obj/item/kirbyplants/random/fullysynthetic,
@@ -45627,24 +48119,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"qgA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
-"qgH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "qgJ" = (
 /obj/machinery/light/dim/directional/west,
 /obj/machinery/duct,
@@ -45659,14 +48133,10 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/commons/storage/tools)
-"qgN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable,
+"qgO" = (
+/obj/machinery/libraryscanner,
+/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
 "qhh" = (
@@ -45687,27 +48157,6 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
-"qhi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/siding/wideplating_new/terracotta{
-	dir = 1
-	},
-/turf/open/floor/wood/tile,
-/area/station/commons/vacant_room/commissary)
-"qhm" = (
-/obj/structure/table,
-/obj/item/storage/crayons,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
-"qhp" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "qhs" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -45871,12 +48320,27 @@
 /obj/structure/table/reinforced/plastitaniumglass,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
+"qjL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/navigate_destination/vault,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "qjT" = (
 /obj/structure/cable,
 /obj/item/kirbyplants/random,
 /obj/item/clothing/suit/toggle/owlwings/griffinwings,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/port/aft)
+"qjU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "qka" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -45906,15 +48370,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
-"qkv" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/floor,
-/turf/open/floor/wood/large,
-/area/station/service/chapel)
-"qkw" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood/large,
-/area/station/service/chapel)
 "qkI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 1
@@ -45926,6 +48381,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"qkR" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "qlc" = (
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 1
@@ -45972,6 +48434,14 @@
 	},
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
+"qlB" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "qlP" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/stripes/line{
@@ -45994,16 +48464,6 @@
 /obj/structure/broken_flooring/corner/directional/south,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
-"qme" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood/tile,
-/area/station/service/bar)
-"qmf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/cold/directional/east,
-/turf/open/floor/carpet/lone,
-/area/station/service/theater)
 "qmo" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -46019,35 +48479,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
-"qmx" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/item/storage/fancy/cigarettes/cigars/cohiba{
-	pixel_x = 2;
-	pixel_y = 10
-	},
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
 "qmz" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/station/cargo/boutique)
-"qmI" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/brown/full,
-/obj/machinery/duct,
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
-"qmO" = (
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/machinery/duct,
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
 "qmZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46075,58 +48510,12 @@
 	},
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/starboard/fore)
-"qnu" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/door/airlock/public/glass{
-	name = "Chapel Office"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
-/turf/open/floor/iron/textured_half,
-/area/station/service/chapel/office)
-"qnz" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/dark_red/half/contrasted,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"qnA" = (
-/obj/structure/table,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "barki";
-	name = "Shutters"
-	},
-/turf/open/floor/catwalk_floor/iron,
-/area/station/service/kitchen)
 "qnJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white/small,
 /area/station/science/ordnance/storage)
-"qnL" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
-"qoi" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
 "qoj" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/window/right/directional/west{
@@ -46143,11 +48532,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmos)
-"qon" = (
-/obj/machinery/vending/wardrobe/chef_wardrobe,
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "qop" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -46171,6 +48555,18 @@
 "qoD" = (
 /turf/closed/wall/r_wall,
 /area/station/command/corporate_showroom)
+"qoT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/hallway/primary/central/fore)
 "qpe" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -46183,12 +48579,6 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/white/small,
 /area/station/service/janitor)
-"qpg" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L3"
-	},
-/turf/open/floor/glass,
-/area/station/hallway/secondary/spacebridge)
 "qpu" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 9
@@ -46196,6 +48586,22 @@
 /obj/structure/steam_vent,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/aft)
+"qpA" = (
+/obj/effect/turf_decal/siding/wideplating_new/terracotta{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/station/maintenance/central/lesser)
+"qpM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_red/half/contrasted,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "qpO" = (
 /obj/structure/chair{
 	dir = 1
@@ -46212,13 +48618,6 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/escape)
-"qpX" = (
-/obj/machinery/door/airlock{
-	name = "Kitchen"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/turf/open/floor/catwalk_floor/flat_white,
-/area/station/service/kitchen)
 "qqd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46226,22 +48625,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"qqh" = (
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/structure/table,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
-"qqq" = (
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/obj/machinery/light/small/directional/north,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
 "qqr" = (
 /obj/machinery/atmospherics/components/binary/pump/off/general/visible{
 	dir = 4;
@@ -46300,34 +48683,11 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/eighties,
 /area/station/service/abandoned_gambling_den/gaming)
-"qrw" = (
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/item/trash/popcorn{
-	pixel_x = 17;
-	pixel_y = 14
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "qrB" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
-"qrI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/textured_half{
-	dir = 1
-	},
-/area/station/service/cafeteria)
-"qrN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/turf/open/floor/iron/grimy,
-/area/station/service/theater)
 "qsa" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera/directional/south{
@@ -46354,15 +48714,25 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
-"qsA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
+"qst" = (
+/obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/grimy,
-/area/station/service/theater)
+/obj/structure/flora/rock/pile/jungle/style_5{
+	pixel_y = -5;
+	pixel_x = -8
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
+"qsH" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "qsR" = (
 /obj/structure/table/reinforced,
 /obj/effect/mapping_helpers/broken_floor,
@@ -46381,10 +48751,6 @@
 "qtd" = (
 /turf/open/floor/wood/tile,
 /area/station/command/corporate_showroom)
-"qtl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/spacebridge)
 "qto" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -46449,16 +48815,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"qtW" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/iron/stairs{
-	dir = 8
-	},
-/area/station/service/theater)
-"qui" = (
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/wood/parquet,
-/area/station/service/theater)
 "qul" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/light_switch/directional/east,
@@ -46471,13 +48827,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
-"quo" = (
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood/parquet,
-/area/station/service/theater)
 "quq" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/crate/cardboard,
@@ -46500,12 +48849,6 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/maintenance/aft)
-"quJ" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/light/small/directional/south,
-/obj/structure/flora/tree/jungle/small/style_random,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "quO" = (
 /obj/structure/reagent_dispensers/wall/peppertank/directional/east,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -46549,6 +48892,13 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/commons/toilet/restrooms)
+"qve" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/structure/flora/bush/jungle/a/style_3,
+/turf/open/misc/dirt/jungle,
+/area/station/service/chapel)
 "qvr" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -46569,16 +48919,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/grimy,
 /area/station/hallway/secondary/entry)
-"qvQ" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron/dark/small,
-/area/station/service/chapel/storage)
 "qwa" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -46734,6 +49074,11 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/engineering/atmos/pumproom)
+"qyd" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/flora/bush/flowers_pp/style_2,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "qyx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/chair{
@@ -46753,6 +49098,12 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/stone,
 /area/station/command/corporate_suite)
+"qyA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/station/service/chapel/office)
 "qyB" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/reagent_dispensers/watertank,
@@ -46916,17 +49267,31 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
-"qAE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/generic_maintenance_landmark,
-/obj/structure/table,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+"qAw" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/eighties/red,
+/area/station/hallway/primary/central/fore)
 "qAJ" = (
 /obj/effect/spawner/random/structure/closet_private,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/carpet/purple,
 /area/station/commons/dorms)
+"qAL" = (
+/obj/structure/table,
+/obj/item/stack/sheet/iron/five,
+/obj/item/stack/cable_coil/five,
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron,
+/area/station/commons/vacant_room/commissary)
 "qAQ" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/helium_output{
@@ -46942,6 +49307,14 @@
 /obj/machinery/atmospherics/components/tank,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
+"qAW" = (
+/obj/structure/table,
+/obj/item/circuitboard/machine/coffeemaker/impressa,
+/obj/item/coffee_cartridge/decaf{
+	pixel_y = 9
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/maintenance/central/lesser)
 "qBc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46971,11 +49344,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/security/tram)
-"qBj" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating,
-/area/station/cargo/boutique)
 "qBl" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Holodeck - Fore";
@@ -46985,15 +49353,19 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/station/holodeck/rec_center)
-"qBy" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L5"
+"qBw" = (
+/obj/machinery/vending/hydronutrients,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
 	},
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
+/area/station/service/hydroponics)
 "qBz" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/mannequin/plastic,
@@ -47055,17 +49427,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
-"qCg" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/station/service/chapel)
-"qCi" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood/large,
-/area/station/service/chapel)
 "qCj" = (
 /obj/machinery/airalarm/directional/south,
 /obj/item/kirbyplants/organic/applebush,
@@ -47081,10 +49442,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"qCC" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
-/turf/open/floor/iron/white,
-/area/station/maintenance/central/greater)
 "qCJ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
@@ -47104,9 +49461,6 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/command/heads_quarters/hop)
-"qCR" = (
-/turf/open/floor/wood/large,
-/area/station/service/chapel)
 "qCT" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -47141,6 +49495,25 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/tcommsat/server)
+"qDe" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
+"qDf" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "qDi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47151,14 +49524,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/hidden,
 /turf/open/floor/wood/tile,
 /area/station/tcommsat/server)
-"qDp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "qDq" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -47241,20 +49606,28 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"qEa" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock{
-	name = "Bar Backroom Maintenence"
+"qDT" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+/obj/structure/flora/bush/jungle/c/style_3,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "qEe" = (
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
 /area/station/science/lobby)
+"qEf" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/flora/bush/large/style_random{
+	pixel_x = -17;
+	pixel_y = 2
+	},
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/window/spawner/directional/east,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "qEk" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/blue{
@@ -47271,23 +49644,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
-"qEp" = (
-/obj/machinery/chem_master/condimaster{
-	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
-	name = "BrewMaster 2199"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "qEz" = (
 /obj/machinery/door/window/brigdoor/left/directional/west{
 	name = "Holding Cell";
@@ -47317,6 +49673,14 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/white/side,
 /area/station/science/lower)
+"qFe" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "qFh" = (
 /obj/effect/turf_decal/tile/dark_red{
 	dir = 4
@@ -47344,20 +49708,6 @@
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/engineering/atmos)
-"qFB" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/item/paper/guides/jobs/hydroponics,
-/obj/item/pen{
-	pixel_x = 11
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "qGk" = (
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/plating,
@@ -47370,20 +49720,6 @@
 	},
 /turf/open/floor/stone,
 /area/station/command/heads_quarters/hos)
-"qGw" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
-"qGA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/green/opposingcorners,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "qGB" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -47404,35 +49740,6 @@
 /obj/effect/turf_decal/siding/wideplating/dark/corner,
 /turf/open/floor/iron,
 /area/station/security)
-"qGU" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/libraryconsole{
-	dir = 4
-	},
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
-"qGY" = (
-/obj/effect/landmark/start/cook,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
-"qHm" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 4;
-	id = "kitchenshutters";
-	name = "Kitchen Shutters"
-	},
-/obj/structure/desk_bell{
-	pixel_x = 8;
-	pixel_y = 11
-	},
-/obj/effect/spawner/random/food_or_drink/condiment{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "qHt" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -47451,6 +49758,22 @@
 	},
 /turf/open/floor/iron/kitchen/small,
 /area/station/security/prison/mess)
+"qHP" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	location = "QM #2"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/light/small/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "qHY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47461,20 +49784,6 @@
 "qIf" = (
 /turf/closed/wall,
 /area/station/medical/cryo)
-"qIg" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/item/kirbyplants/random,
-/obj/machinery/light/small/directional/west,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/smooth,
-/area/station/service/greenroom)
 "qIk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -47515,18 +49824,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
-"qIP" = (
-/obj/machinery/food_cart,
-/obj/machinery/button/door/directional/west{
-	id = "barki";
-	name = "Shutters Control"
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "qIQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
+"qIY" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "qIZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47534,13 +49846,6 @@
 /obj/structure/broken_flooring/pile/directional/east,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
-"qJa" = (
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/restaurant_portal/restaurant,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "qJq" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -47605,26 +49910,23 @@
 /obj/structure/window/spawner/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms)
+"qKB" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/structure/flora/bush/flowers_pp/style_2,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "qKD" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 6
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
-"qKE" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/service/cafeteria)
 "qKI" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron/small,
 /area/station/maintenance/port/aft)
-"qKN" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/station/service/theater)
 "qKS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47636,6 +49938,16 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
 /turf/open/floor/iron/white/small,
 /area/station/command/heads_quarters/cmo)
+"qLg" = (
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/hydroponics/constructable,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "qLj" = (
 /obj/structure/bed{
 	dir = 4
@@ -47657,6 +49969,17 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/courtroom)
+"qLv" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/mining{
+	name = "Drone Bay"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/cargo/drone_bay)
 "qLA" = (
 /obj/structure/chair{
 	dir = 4
@@ -47732,6 +50055,11 @@
 "qMK" = (
 /turf/closed/wall,
 /area/station/command/bridge)
+"qML" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/wood/tile,
+/area/station/service/bar)
 "qMP" = (
 /obj/structure/closet/firecloset,
 /obj/structure/sign/poster/official/random/directional/north,
@@ -47747,13 +50075,6 @@
 /obj/structure/hedge,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"qNz" = (
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash,
-/turf/open/floor/plating,
-/area/station/maintenance/central/lesser)
 "qNF" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/spawner/random/maintenance,
@@ -47781,6 +50102,12 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
+"qNY" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/stone,
+/area/station/service/bar/backroom)
 "qOm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/corner{
@@ -47788,17 +50115,24 @@
 	},
 /turf/open/floor/plating,
 /area/station/commons/storage/tools)
-"qOp" = (
-/obj/structure/table/wood,
-/obj/item/book/bible,
-/turf/open/floor/wood/large,
-/area/station/service/chapel)
-"qOt" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/cold/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+"qOF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/primary/central/aft)
 "qOJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -47809,6 +50143,15 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
+"qOL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "qON" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/table,
@@ -47843,6 +50186,25 @@
 	},
 /turf/open/space/basic,
 /area/station/engineering/atmos/space_catwalk)
+"qPm" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
+"qPD" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/station/service/bar)
 "qPJ" = (
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron,
@@ -47907,6 +50269,15 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/maintenance/department/electrical)
+"qQJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/mail_sorting/service/bar,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "qQK" = (
 /turf/open/floor/iron/white/corner{
 	dir = 1
@@ -47919,6 +50290,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"qQZ" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/item/kirbyplants/random,
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/holodeck/rec_center)
 "qRh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -47990,13 +50368,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
-"qSv" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "qSC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line,
@@ -48024,15 +50395,6 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/supply)
-"qSU" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L9"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
 "qSZ" = (
 /obj/structure/hedge,
 /obj/machinery/light/cold/directional/west,
@@ -48059,6 +50421,18 @@
 	dir = 8
 	},
 /area/station/science/research)
+"qTj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/public/glass{
+	name = "Departure Lounge"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit/departure_lounge)
 "qTk" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -48100,27 +50474,13 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"qTL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"qTO" = (
+/obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/iron/grimy,
-/area/station/service/theater)
-"qTM" = (
-/turf/open/floor/glass,
-/area/station/hallway/secondary/spacebridge)
-"qTP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/grunge{
-	name = "Vacant Comissary"
-	},
-/turf/open/floor/iron/textured_half{
-	dir = 1
-	},
-/area/station/commons/vacant_room/commissary)
+/turf/open/floor/stone,
+/area/station/service/bar)
 "qTR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
@@ -48292,6 +50652,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood,
 /area/station/cargo/boutique)
+"qWf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "qWg" = (
 /obj/machinery/door/airlock{
 	name = "Bathrooms"
@@ -48309,20 +50675,17 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/command/corporate_showroom)
-"qWm" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/red/line,
-/turf/open/floor/iron/small,
-/area/station/hallway/primary/central/fore)
 "qWo" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/medical/psychology)
+"qWs" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/bookcase/random,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "qWC" = (
 /obj/structure/railing{
 	dir = 4
@@ -48340,6 +50703,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side,
 /area/station/science/research)
+"qWK" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Library"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/textured_half,
+/area/station/service/library)
 "qWL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -48486,17 +50863,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/atmos)
-"qYu" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
 "qYv" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -48553,18 +50919,17 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
-"qZf" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 2
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/white/corner{
+"qZi" = (
+/obj/machinery/rnd/production/techfab/department/service,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1
 	},
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/secondary/service)
 "qZm" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -48590,12 +50955,6 @@
 	dir = 8
 	},
 /area/station/commons/fitness/locker_room)
-"qZB" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "qZE" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Office"
@@ -48619,6 +50978,12 @@
 	},
 /turf/open/floor/tram,
 /area/station/maintenance/port/aft)
+"qZR" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/spawner/random/entertainment/arcade,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/iron,
+/area/station/holodeck/rec_center)
 "qZU" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /obj/effect/turf_decal/stripes/white/line{
@@ -48641,10 +51006,6 @@
 	},
 /turf/open/floor/tram,
 /area/station/security/tram)
-"ram" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/wood/large,
-/area/station/service/chapel)
 "rao" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 9
@@ -48658,14 +51019,22 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"raC" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/assistant,
-/obj/structure/chair/sofa/bamboo/left{
-	dir = 1
+"raz" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_x = 6;
+	pixel_y = 9
 	},
-/turf/open/floor/wood/large,
-/area/station/service/chapel)
+/obj/item/multitool{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/cigarette{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/lockers)
 "raE" = (
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -48697,13 +51066,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
-"raX" = (
-/obj/effect/landmark/start/assistant,
-/obj/structure/chair/sofa/bamboo/right{
-	dir = 1
-	},
-/turf/open/floor/wood/large,
-/area/station/service/chapel)
 "raZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48711,10 +51073,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
-"rba" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/wood/large,
-/area/station/service/chapel)
 "rbc" = (
 /obj/structure/transport/linear/tram,
 /obj/structure/tram,
@@ -48726,25 +51084,12 @@
 "rbg" = (
 /turf/open/floor/iron/smooth,
 /area/station/engineering/atmos)
-"rbh" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "rbl" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light/cold/dim/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/grimy,
 /area/station/engineering/main)
-"rbo" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/small,
-/area/station/medical/medbay/lobby)
 "rbp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -48782,14 +51127,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"rbU" = (
+"rbQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/neutral/line,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/line,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "rce" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Cell 3";
@@ -48824,41 +51170,12 @@
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"rco" = (
-/obj/machinery/shieldgen,
-/obj/item/clothing/gloves/color/black{
-	pixel_y = -3;
-	pixel_x = -2
+"rcO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/obj/item/cigarette{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/clothing/mask/gas{
-	pixel_y = 5
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = 1;
-	pixel_y = 15
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
-"rcr" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/crowbar/red,
-/obj/item/reagent_containers/cup/watering_can,
-/obj/item/circuitboard/machine/biogenerator,
-/obj/item/wirecutters,
-/obj/item/wrench,
-/obj/item/shovel/spade,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/green/opposingcorners,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
+/turf/open/floor/iron/white,
+/area/station/hallway/primary/central/aft)
 "rcQ" = (
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
@@ -48866,13 +51183,16 @@
 /obj/machinery/light/small/dim/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
-"rdo" = (
-/obj/structure/window/spawner/directional/west,
-/obj/structure/flora/bush/jungle/a/style_random,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/structure/window/spawner/directional/east,
-/turf/open/misc/sandy_dirt,
-/area/station/service/hydroponics)
+"rdi" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/right/directional/west,
+/obj/machinery/door/poddoor/shutters{
+	name = "Kitchen Shutters";
+	id = "kitchenshutters"
+	},
+/turf/open/floor/iron,
+/area/station/service/kitchen)
 "rds" = (
 /obj/machinery/computer/slot_machine{
 	pixel_y = 2
@@ -48886,24 +51206,12 @@
 /obj/machinery/keycard_auth/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/station/command/heads_quarters/ce)
-"rdK" = (
-/obj/structure/chair/office,
-/obj/effect/landmark/start/botanist,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "rdM" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
 	},
 /turf/open/floor/engine,
 /area/station/science/cytology)
-"ree" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/wood/tile,
-/area/station/service/bar)
 "reg" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -48925,6 +51233,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
+"reu" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/station/service/bar)
 "rex" = (
 /obj/effect/turf_decal/tile/neutral/full,
 /obj/effect/decal/cleanable/dirt,
@@ -48986,6 +51301,16 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
+"reP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/warm/dim,
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "reS" = (
 /obj/effect/spawner/random/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -48993,25 +51318,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
-"reT" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wideplating/dark,
-/obj/effect/turf_decal/tile/dark_red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security/brig/entrance)
-"reW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/stool/bar/directional/east,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/wood/tile,
-/area/station/service/bar)
 "reZ" = (
 /obj/effect/turf_decal/tile/dark_red{
 	dir = 4
@@ -49019,6 +51325,12 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"rfc" = (
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/smooth,
+/area/station/service/library)
 "rfi" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -49046,13 +51358,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
-"rfI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/landmark/start/bartender,
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
 "rfJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
@@ -49067,28 +51372,20 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
-"rgc" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
-"rgf" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/station/maintenance/central/greater)
-"rgx" = (
-/obj/structure/table,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "rgA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"rgB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
 "rgK" = (
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 8
@@ -49107,16 +51404,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/small,
 /area/station/maintenance/department/engine/atmos)
-"rgT" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/turf/open/floor/iron/small,
-/area/station/hallway/primary/port)
 "rhg" = (
 /obj/machinery/air_sensor/engine_chamber,
 /obj/effect/turf_decal/stripes/white/line{
@@ -49131,39 +51418,15 @@
 /obj/structure/broken_flooring/corner/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"rhm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 10
-	},
-/obj/structure/table,
-/obj/item/cigarette,
-/obj/item/toy/toy_dagger,
-/obj/item/clothing/head/collectable/paper,
-/obj/item/toy/figure/roboticist{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/toy/figure/syndie{
-	pixel_y = 5;
-	pixel_x = -6
-	},
-/obj/item/toy/figure/md{
-	pixel_x = 10
-	},
-/obj/item/toy/figure/hop{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/toy/figure/ian{
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/item/toy/figure/lawyer{
-	pixel_x = -10
-	},
-/obj/item/toy/figure/detective,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+"rhq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/south,
+/obj/machinery/status_display/ai/directional/south,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "rhu" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 5
@@ -49175,6 +51438,22 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos/space_catwalk)
+"rhx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Crematorium"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
+/turf/open/floor/iron/textured_half{
+	dir = 8
+	},
+/area/station/service/chapel/storage)
 "rhy" = (
 /obj/structure/chair{
 	dir = 1
@@ -49183,16 +51462,21 @@
 /obj/structure/thermoplastic,
 /turf/open/floor/tram,
 /area/station/security/tram)
+"rhA" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "rhC" = (
 /obj/structure/chair/office,
 /turf/open/floor/iron/smooth,
 /area/station/cargo/drone_bay)
-"rhD" = (
-/obj/structure/cable,
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "rhH" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -49221,24 +51505,6 @@
 /obj/machinery/door/poddoor/massdriver_chapel,
 /turf/open/floor/plating,
 /area/station/service/chapel/funeral)
-"rij" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/effect/landmark/start/cook,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
-"ril" = (
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/holopad,
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "riq" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 4
@@ -49253,53 +51519,12 @@
 "rir" = (
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
-"riu" = (
-/obj/machinery/vending/coffee,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
-"riM" = (
-/turf/open/floor/iron/textured_half{
-	dir = 1
-	},
-/area/station/service/cafeteria)
 "riV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/cargo/drone_bay)
-"riZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/mining{
-	name = "Drone Bay"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
-"rjb" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/chair/pew{
-	dir = 4
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/station/service/theater)
-"rje" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "rji" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -49337,27 +51562,10 @@
 /obj/structure/sign/poster/official/random/directional/east,
 /turf/open/floor/iron/dark/small,
 /area/station/hallway/primary/fore)
-"rjz" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L11"
-	},
-/turf/open/floor/glass,
-/area/station/hallway/secondary/spacebridge)
 "rjE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"rjH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/status_display/ai/directional/north,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "rjN" = (
 /obj/structure/cable,
 /obj/structure/chair{
@@ -49365,15 +51573,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
-"rkb" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/chair/pew{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/station/service/theater)
 "rkk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -49383,10 +51582,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"rkF" = (
-/obj/effect/spawner/random/structure/musician/piano/random_piano,
-/turf/open/floor/carpet/lone,
-/area/station/service/theater)
 "rkI" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet{
@@ -49397,10 +51592,14 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating,
 /area/station/medical/morgue)
-"rkR" = (
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/cargo/boutique)
+"rkJ" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/smooth,
+/area/station/service/greenroom)
 "rkS" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
@@ -49469,17 +51668,6 @@
 "rlr" = (
 /turf/closed/wall,
 /area/station/medical/storage)
-"rlz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/station/cargo/boutique)
-"rlB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/wood,
-/area/station/cargo/boutique)
 "rlH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49491,11 +51679,6 @@
 /obj/machinery/air_sensor/ordnance_burn_chamber,
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
-"rlN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/station/cargo/boutique)
 "rma" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 6
@@ -49513,12 +51696,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/engine_smes)
-"rmG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/wood,
-/area/station/cargo/boutique)
 "rmM" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/edge{
@@ -49541,11 +51718,18 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/courtroom)
-"rnw" = (
-/obj/machinery/vending/wardrobe/bar_wardrobe,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/stone,
-/area/station/service/bar/backroom)
+"rnm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "rnD" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -49563,15 +51747,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/surgery/theatre)
-"rnY" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/mail_sorting/service/library,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "rnZ" = (
 /obj/structure/transport/linear/tram,
 /obj/effect/landmark/transport/nav_beacon/tram/nav/birdshot/maint,
@@ -49604,17 +51779,21 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"rok" = (
+/obj/machinery/door/airlock{
+	name = "Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "roq" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/wood/tile,
 /area/station/maintenance/port/lesser)
-"row" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/plumbed{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "roz" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -49631,16 +51810,16 @@
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
+"roJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/central/lesser)
 "roS" = (
 /obj/structure/cable,
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
-"roV" = (
-/obj/machinery/vending/cigarette,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/wood,
-/area/station/hallway/secondary/service)
 "roZ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/computer/rdconsole{
@@ -49671,14 +51850,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/smooth,
 /area/station/security/evidence)
-"rpy" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "rpV" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/spawner/random/maintenance,
@@ -49719,6 +51890,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
+"rqO" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/white/side,
+/area/station/hallway/primary/central/aft)
 "rqR" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -49744,6 +51925,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/science/xenobiology)
+"rre" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "rro" = (
 /obj/structure/railing,
 /obj/structure/disposalpipe/segment{
@@ -49769,21 +51957,13 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/science/robotics/augments)
-"rrx" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L13"
+"rrB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/glass,
-/area/station/hallway/secondary/spacebridge)
-"rrC" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/holodeck/rec_center)
 "rrG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -49806,12 +51986,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/lawoffice)
-"rrV" = (
-/obj/effect/turf_decal/siding/wideplating_new/terracotta{
-	dir = 5
-	},
-/turf/open/floor/wood/tile,
-/area/station/commons/vacant_room/commissary)
 "rrZ" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/random/trash/garbage,
@@ -49885,24 +52059,6 @@
 "rsL" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/fore)
-"rsQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/landmark/navigate_destination/chapel,
-/obj/effect/landmark/transport/nav_beacon/tram/nav/immovable_rod,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"rsV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock{
-	name = "Coldroom Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "rsZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -49929,6 +52085,13 @@
 "rtQ" = (
 /turf/closed/wall/r_wall,
 /area/station/security/tram)
+"rtU" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "rtZ" = (
 /obj/structure/sign/directions/dorms{
 	dir = 1
@@ -50012,14 +52175,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/escape)
-"rvH" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/light/small/directional/east,
-/obj/structure/chair/stool/bar/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation/entertainment)
 "rvX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/south{
@@ -50162,6 +52317,11 @@
 /obj/item/modular_computer/laptop,
 /turf/open/floor/iron/grimy,
 /area/station/science/cubicle)
+"rxW" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "rxX" = (
 /obj/structure/closet{
 	name = "Paramedic Supplies"
@@ -50180,6 +52340,16 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/command)
+"ryd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "ryi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50195,22 +52365,6 @@
 	dir = 1
 	},
 /area/station/science/research)
-"rym" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Shrine"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/textured_half{
-	dir = 1
-	},
-/area/station/hallway/secondary/exit/departure_lounge)
-"ryp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "ryt" = (
 /obj/machinery/light/dim/directional/north,
 /obj/effect/turf_decal/tile/neutral{
@@ -50238,6 +52392,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
+"rzc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/cargo/boutique)
 "rzd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50250,22 +52411,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"rzu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/floor,
-/turf/open/floor/wood/large,
-/area/station/service/chapel)
-"rzG" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/dark_red/half/contrasted{
-	dir = 4
-	},
-/mob/living/simple_animal/bot/secbot/beepsky/officer,
-/obj/effect/turf_decal/siding/wideplating/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security)
+"rzm" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/dark/small,
+/area/station/maintenance/central/lesser)
 "rzJ" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
@@ -50291,24 +52440,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
-"rAb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/turf/open/floor/grass,
-/area/station/service/chapel)
-"rAn" = (
-/obj/structure/closet/secure_closet/hydroponics,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/green/opposingcorners,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "rAt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50413,19 +52544,6 @@
 	dir = 8
 	},
 /area/station/commons)
-"rBx" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/green/opposingcorners,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/wardrobe/hydro_wardrobe,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "rBy" = (
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
@@ -50445,16 +52563,6 @@
 /obj/effect/landmark/secequipment,
 /turf/open/floor/iron,
 /area/station/security/tram)
-"rBG" = (
-/obj/structure/window/spawner/directional/west,
-/obj/structure/flora/bush/large/style_random{
-	pixel_x = -17;
-	pixel_y = 2
-	},
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/structure/window/spawner/directional/east,
-/turf/open/misc/sandy_dirt,
-/area/station/service/hydroponics)
 "rBI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
@@ -50463,18 +52571,6 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"rBK" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/chair/sofa/bench/right{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation/entertainment)
-"rBN" = (
-/obj/effect/landmark/start/botanist,
-/turf/open/floor/iron/white/small,
-/area/station/service/hydroponics)
 "rBO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -50484,10 +52580,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"rBQ" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/white/small,
-/area/station/service/hydroponics)
 "rBY" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -50501,12 +52593,6 @@
 	dir = 1
 	},
 /area/station/science/ordnance/testlab)
-"rCd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "rCj" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
@@ -50522,6 +52608,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
+"rCz" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 9
+	},
+/obj/structure/sign/poster/official/tactical_game_cards/directional/west,
+/turf/open/floor/eighties/red,
+/area/station/hallway/primary/central/fore)
 "rCS" = (
 /obj/structure/chair/stool/bar/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -50553,13 +52646,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/station/engineering/break_room)
-"rDf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "rDj" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
@@ -50570,12 +52656,6 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/entry)
-"rDy" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "rDD" = (
 /obj/structure/railing{
 	dir = 1
@@ -50625,6 +52705,16 @@
 "rEd" = (
 /turf/open/floor/iron,
 /area/station/maintenance/fore/greater)
+"rEG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/item/storage/fancy/candle_box,
+/obj/machinery/light_switch/directional/west,
+/obj/structure/rack/skeletal,
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron/grimy,
+/area/station/service/library)
 "rEH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 4
@@ -50636,6 +52726,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/atmos)
+"rET" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/landmark/start/librarian,
+/turf/open/floor/carpet,
+/area/station/service/library)
 "rEY" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/pdapainter{
@@ -50741,12 +52838,6 @@
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"rFQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/wood/tile,
-/area/station/service/bar)
 "rFV" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
@@ -50801,11 +52892,6 @@
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"rGt" = (
-/obj/machinery/exodrone_launcher,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/smooth,
-/area/station/cargo/drone_bay)
 "rGB" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -50833,11 +52919,6 @@
 /obj/item/screwdriver,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/construction)
-"rHd" = (
-/obj/effect/turf_decal/tile/brown/full,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
 "rHe" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -50848,15 +52929,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
-"rHm" = (
-/obj/effect/turf_decal/tile/brown/full,
-/obj/machinery/chem_master/condimaster{
-	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
-	name = "HoochMaster Deluxe";
-	pixel_x = -4
-	},
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
 "rHp" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/landmark/event_spawn,
@@ -50894,22 +52966,11 @@
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
-"rHL" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/turf_decal/delivery,
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/machinery/modular_computer/preset/cargochat/service,
-/turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
 "rHO" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_command)
-"rHQ" = (
-/obj/machinery/deepfryer,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "rIb" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/structure/closet/secure_closet/security/sec,
@@ -50918,10 +52979,6 @@
 /obj/structure/reagent_dispensers/wall/peppertank/directional/north,
 /turf/open/floor/iron,
 /area/station/security/lockers)
-"rIg" = (
-/obj/machinery/griddle,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "rIn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
@@ -50935,45 +52992,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/service/abandoned_gambling_den/gaming)
-"rIH" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/dark_red/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security)
 "rIJ" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/station/engineering/gravity_generator)
-"rIS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "rIY" = (
 /turf/closed/wall/r_wall,
 /area/station/construction/mining/aux_base)
-"rJh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
-"rJl" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 4;
-	id = "kitchenshutters";
-	name = "Kitchen Shutters"
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "rJo" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -50985,26 +53010,30 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
-"rJv" = (
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/structure/chair/stool/bar/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "rJw" = (
 /mob/living/carbon/human/species/monkey{
 	name = "George"
 	},
 /turf/open/floor/grass,
 /area/station/science/xenobiology)
-"rJT" = (
-/obj/structure/chair/sofa/left/maroon,
-/turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
+"rJI" = (
+/obj/structure/flora/tree/jungle/small/style_4,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/grass,
+/area/station/service/chapel)
+"rJO" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "rJW" = (
 /obj/machinery/suit_storage_unit/hos,
 /obj/effect/decal/cleanable/dirt,
@@ -51014,22 +53043,21 @@
 /obj/structure/broken_flooring/singular/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
+"rKw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "rKC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/science/cytology)
-"rKL" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/chair/pew{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/wood,
-/area/station/service/theater)
 "rKR" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -51084,16 +53112,6 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"rLw" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "rLx" = (
 /obj/effect/turf_decal/siding/thinplating/terracotta,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51117,11 +53135,6 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/ai_monitored/command/nuke_storage)
-"rLT" = (
-/obj/effect/turf_decal/siding/wood/corner,
-/obj/structure/flora/tree/jungle/small/style_random,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "rMb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/generic_maintenance_landmark,
@@ -51183,6 +53196,22 @@
 	},
 /turf/open/misc/sandy_dirt,
 /area/station/security/tram)
+"rMu" = (
+/obj/structure/flora/rock/pile/jungle/style_5{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
+"rMB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "rMH" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -51190,15 +53219,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"rMM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wideplating_new/terracotta{
-	dir = 4
-	},
-/turf/open/floor/wood/tile,
-/area/station/commons/vacant_room/commissary)
 "rMR" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 10
@@ -51210,28 +53230,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/diagonal,
 /area/station/engineering/lobby)
-"rMV" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
-"rMY" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/steam_vent,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "rNd" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock{
@@ -51240,6 +53238,21 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"rNk" = (
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/machinery/door/airlock{
+	name = "Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
+"rNm" = (
+/obj/effect/landmark/start/chaplain,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "rNn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51250,16 +53263,12 @@
 /obj/machinery/digital_clock/directional/north,
 /turf/open/floor/iron,
 /area/station/security)
-"rNq" = (
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Theatre"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/textured_half,
-/area/station/service/theater)
-"rNA" = (
-/turf/open/floor/wood,
-/area/station/service/theater)
+"rNy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "rNB" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/catwalk_floor/iron_smooth,
@@ -51277,35 +53286,13 @@
 /obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
-"rOb" = (
+"rNR" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/central/greater)
-"rOm" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/chair/pew{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/wood,
-/area/station/service/theater)
-"rOx" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/floor/wood/parquet,
-/area/station/service/theater)
-"rOy" = (
-/obj/structure/chair/plastic{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/glass,
-/area/station/hallway/secondary/spacebridge)
+/area/station/hallway/primary/central/aft)
 "rOG" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -51408,10 +53395,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/station/engineering/atmos/space_catwalk)
-"rQt" = (
-/obj/effect/landmark/start/mime,
-/turf/open/floor/carpet/lone,
-/area/station/service/theater)
 "rQw" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine,
@@ -51488,11 +53471,16 @@
 	dir = 1
 	},
 /area/station/security/courtroom)
-"rRn" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/space/basic,
-/area/space/nearstation)
+"rRp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/dark_red/opposingcorners,
+/obj/machinery/flasher/directional/west{
+	id = "brigentry"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
 "rRq" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
@@ -51527,14 +53515,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/escape)
-"rSj" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock{
-	name = "Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/security/general,
-/turf/open/floor/plating,
-/area/station/maintenance/central/lesser)
 "rSt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -51598,15 +53578,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
-"rTt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth,
-/area/station/service/greenroom)
 "rTy" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -51717,12 +53688,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"rUB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/large,
-/area/station/hallway/secondary/spacebridge)
 "rUD" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -51755,12 +53720,6 @@
 /obj/effect/spawner/random/structure/table_or_rack,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"rUS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "rUV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51821,6 +53780,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"rVK" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/structure/flora/bush/sparsegrass,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "rVQ" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/window/spawner/directional/west,
@@ -51967,12 +53933,6 @@
 "rYc" = (
 /turf/open/floor/iron/small,
 /area/station/maintenance/port/lesser)
-"rYd" = (
-/obj/structure/chair/sofa/left,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/wood,
-/area/station/hallway/secondary/service)
 "rYm" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/chair/office/light{
@@ -51994,11 +53954,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
-"rYv" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "rYx" = (
 /obj/effect/turf_decal/siding/wideplating/dark,
 /obj/structure/cable,
@@ -52006,11 +53961,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/small,
 /area/station/service/barber)
-"rYD" = (
+"rYz" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
+"rYE" = (
 /obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/red{
+	dir = 6
+	},
+/obj/machinery/firealarm/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white/small,
+/area/station/security/warden)
 "rYG" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -52026,6 +53994,13 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
+"rYM" = (
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "rZc" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box/white{
@@ -52037,6 +54012,20 @@
 /obj/structure/railing/corner/end/flip,
 /turf/open/floor/plating,
 /area/station/cargo/miningfoundry)
+"rZg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/secondary/service)
 "rZi" = (
 /obj/structure/cable,
 /obj/machinery/power/solar{
@@ -52085,27 +54074,20 @@
 /obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
-"rZK" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "rZM" = (
 /obj/structure/table/wood,
 /obj/item/clothing/glasses/eyepatch/medical,
 /turf/open/floor/carpet/orange,
 /area/station/commons/dorms)
-"rZN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"sak" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown/full,
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
+/obj/structure/sign/directions/vault/directional/south{
+	dir = 8
+	},
+/turf/closed/wall,
+/area/station/hallway/primary/central/aft)
 "sas" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/blue,
@@ -52122,25 +54104,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
-"say" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/white/small,
-/area/station/service/hydroponics)
 "saY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/robotics/augments)
-"saZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "sbf" = (
 /obj/structure/railing{
 	dir = 1
@@ -52153,11 +54121,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/atmos)
-"sbm" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/station/maintenance/central/greater)
 "sbq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
@@ -52242,6 +54205,16 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
+"scm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "sco" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/decal/cleanable/dirt,
@@ -52258,38 +54231,36 @@
 /obj/machinery/light/small/broken/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
-"scz" = (
+"scS" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/service/greenroom)
+"scT" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"scC" = (
-/obj/machinery/chem_master/condimaster{
-	name = "CondiMaster Neo"
-	},
-/obj/machinery/camera/autoname/directional/north,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "sdf" = (
 /obj/item/kirbyplants/random/fullysynthetic,
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
-"sdg" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+"sdB" = (
+/obj/machinery/camera/directional/south,
+/obj/structure/flora/bush/flowers_pp/style_2,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
 	},
 /turf/open/floor/grass,
 /area/station/service/chapel)
@@ -52300,20 +54271,22 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
-"sdQ" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance"
+"sdJ" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
-"sdT" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/iron/white/small,
-/area/station/service/hydroponics)
+/turf/open/floor/iron,
+/area/station/holodeck/rec_center)
+"sdX" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/spawner/random/entertainment/arcade,
+/turf/open/floor/iron,
+/area/station/holodeck/rec_center)
+"sdY" = (
+/obj/structure/flora/grass/jungle/b/style_2,
+/turf/open/misc/dirt/jungle,
+/area/station/service/chapel)
 "sea" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52328,18 +54301,15 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
-"sei" = (
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 8
+"sem" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/sign/departments/holy/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
-/area/station/service/hydroponics)
-"sel" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
+/area/station/hallway/primary/port)
 "ser" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52375,25 +54345,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
+"sfc" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "sfd" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 10
 	},
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos/space_catwalk)
-"sfh" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/brown/full,
-/obj/item/reagent_containers/cup/glass/shaker{
-	pixel_x = 5;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/cup/rag{
-	pixel_x = 7;
-	pixel_y = -1
-	},
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
 "sfk" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
@@ -52435,34 +54404,21 @@
 	dir = 8
 	},
 /area/station/engineering/main)
-"sfK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
-"sfL" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
-"sfX" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/steam_vent,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "sge" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/item/clothing/head/costume/festive,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
+"sgk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "sgw" = (
 /obj/machinery/mass_driver/ordnance{
 	dir = 1
@@ -52495,6 +54451,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"sgM" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "sgO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/smooth_edge{
@@ -52511,19 +54476,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"sgS" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/machinery/reagentgrinder{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
 "sgY" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/recreation)
+"shd" = (
+/obj/structure/flora/tree/jungle/small/style_2,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "shf" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plating,
@@ -52535,26 +54498,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"shw" = (
-/obj/structure/table,
-/obj/item/reagent_containers/cup/glass/sillycup{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/cup/glass/sillycup{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/cup/glass/sillycup{
-	pixel_x = 7
-	},
-/obj/item/reagent_containers/cup/glass/sillycup,
-/obj/item/reagent_containers/cup/glass/mug/coco{
-	pixel_x = -6;
-	pixel_y = 9
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "shD" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/recreation)
@@ -52580,38 +54523,24 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"shU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/cook,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "sib" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/construction)
-"sih" = (
-/obj/structure/table,
-/obj/item/reagent_containers/condiment/saltshaker{
-	desc = "Salt. From space oceans, presumably. A staple of modern medicine.";
-	pixel_x = 8;
-	pixel_y = 7
+"sic" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/flora/bush/flowers_yw/style_2,
+/obj/structure/flora/tree/jungle/style_5,
+/turf/open/floor/grass,
+/area/station/service/chapel)
+"sif" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/reagent_containers/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/effect/spawner/random/food_or_drink/condiment{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "sio" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
 	dir = 4
@@ -52634,26 +54563,6 @@
 "sis" = (
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
-"siv" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/chair/pew/left{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/station/service/theater)
-"siz" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
-"siC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "siG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
 	dir = 1
@@ -52665,10 +54574,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
-"siP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/wood,
-/area/station/service/theater)
 "sjl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52730,10 +54635,9 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
-"skI" = (
-/obj/structure/cable,
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/wood/parquet,
+"skL" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/smooth,
 /area/station/service/library)
 "skP" = (
 /obj/effect/spawner/structure/window,
@@ -52772,15 +54676,6 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"skY" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/chair/pew/left{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/station/service/theater)
 "slp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -52794,14 +54689,19 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/medical/virology)
-"slv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet/lone,
-/area/station/service/theater)
 "slw" = (
 /turf/closed/wall,
 /area/station/cargo/drone_bay)
+"slA" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
+/obj/item/clothing/mask/gas,
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/camera/directional/west,
+/turf/open/floor/iron,
+/area/station/commons/vacant_room/commissary)
 "slC" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -52810,6 +54710,12 @@
 /obj/item/hfr_box/corner,
 /turf/open/floor/plating,
 /area/station/engineering/atmospherics_engine)
+"slF" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/station/service/bar)
 "slG" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -52901,14 +54807,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
-"snc" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+"smX" = (
+/obj/structure/flora/grass/jungle/a/style_4,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "snj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -53066,6 +54968,18 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating/elevatorshaft,
 /area/station/engineering/atmos)
+"spb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
+"spd" = (
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/glass,
+/area/station/hallway/primary/central/aft)
 "spg" = (
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
 /obj/machinery/door/airlock/security{
@@ -53104,17 +55018,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs/auxiliary)
-"spW" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "sqa" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -53122,17 +55025,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"sqe" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "sqg" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/closed/wall/r_wall,
@@ -53197,6 +55089,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
+"sqW" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/bush/jungle/a,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "sqY" = (
 /obj/structure/flora/bush/large/style_random{
 	pixel_x = -20;
@@ -53290,6 +55191,16 @@
 "ssz" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/science/xenobiology)
+"ssE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/effect/turf_decal/siding/wideplating/dark/corner{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
 "ssP" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
 /turf/closed/wall/r_wall,
@@ -53356,6 +55267,11 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/station/commons/dorms)
+"suf" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/dark/side,
+/area/station/hallway/primary/central/fore)
 "sul" = (
 /obj/effect/turf_decal/siding{
 	dir = 1
@@ -53363,14 +55279,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/white/small,
 /area/station/science/lab)
-"suq" = (
-/obj/structure/chair/plastic{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/glass,
-/area/station/hallway/secondary/spacebridge)
 "suw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/south,
@@ -53482,6 +55390,15 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/pharmacy)
+"svY" = (
+/obj/effect/turf_decal/tile/dark_red/half/contrasted{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
 "swb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external{
@@ -53544,13 +55461,6 @@
 /obj/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"swL" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/effect/turf_decal/bot_red,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
 "swO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53591,24 +55501,24 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
-"sxd" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+"swY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/bot,
-/obj/machinery/button/door/directional/south{
-	id = "kihall";
-	name = "Hallway Cutoff";
-	pixel_x = -7
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/machinery/button/door/directional/south{
-	id = "kitchenshutters";
-	name = "Kitchen Shutters";
-	pixel_x = 7
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
+"sxf" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
 	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
+/obj/machinery/light/floor,
+/obj/structure/table/wood,
+/turf/open/floor/iron/grimy,
+/area/station/service/bar)
 "sxm" = (
 /turf/closed/wall,
 /area/station/tcommsat/server)
@@ -53629,14 +55539,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"sxw" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "sxA" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -53662,17 +55564,6 @@
 	dir = 8
 	},
 /area/station/science/research)
-"sxL" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/dark_red/fourcorners,
-/turf/open/floor/iron,
-/area/station/security/brig/entrance)
 "sxT" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -53723,10 +55614,6 @@
 "syk" = (
 /turf/closed/wall,
 /area/station/security/warden)
-"syv" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "syx" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -53751,8 +55638,24 @@
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/misc/sandy_dirt,
 /area/station/medical/medbay/lobby)
-"syG" = (
-/obj/effect/spawner/xmastree,
+"syE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
+"syJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/smooth,
+/area/station/cargo/drone_bay)
+"syL" = (
+/obj/structure/flora/rock/pile/jungle/style_4,
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "syN" = (
@@ -53767,81 +55670,17 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/security/brig)
-"sze" = (
-/obj/structure/chair/sofa/left/maroon{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
-"szy" = (
-/obj/effect/spawner/random/engineering/tracking_beacon,
+"sza" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/flora/tree/jungle/style_5,
 /turf/open/floor/grass,
 /area/station/service/chapel)
-"szz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
-"szG" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+"szR" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/machinery/duct,
-/obj/effect/landmark/start/botanist,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
-"szH" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/right/directional/west{
-	name = "Hydroponics Desk";
-	req_access = list("hydroponics")
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/duct,
-/turf/open/floor/iron/textured_large,
-/area/station/hallway/primary/central/fore)
-"szM" = (
-/obj/machinery/computer/slot_machine{
-	pixel_y = 2
-	},
-/obj/machinery/newscaster/directional/east,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/wood/tile,
-/area/station/service/bar)
-"szS" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
-"szZ" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/brown/full,
-/obj/item/reagent_containers/cup/glass/waterbottle/large{
-	pixel_x = 7;
-	pixel_y = 17
-	},
-/obj/item/reagent_containers/cup/glass/waterbottle/large{
-	pixel_x = -6;
-	pixel_y = 15
-	},
-/obj/item/reagent_containers/cup/glass/waterbottle/large{
-	pixel_x = 4;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/cup/glass/waterbottle/large{
-	pixel_x = -7;
-	pixel_y = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/smooth_large,
 /area/station/service/bar)
 "sAb" = (
 /obj/structure/lattice,
@@ -53851,6 +55690,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
+"sAj" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "sAM" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/effect/turf_decal/siding/wideplating{
@@ -53862,6 +55706,31 @@
 /obj/item/clothing/suit/hooded/wintercoat/engineering/atmos,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"sAO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/mail_sorting/service/hydroponics,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
+"sAU" = (
+/obj/machinery/status_display/ai/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
+"sAV" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/holodeck/rec_center)
 "sAW" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -53888,22 +55757,6 @@
 /obj/structure/thermoplastic/light,
 /turf/open/floor/tram,
 /area/station/maintenance/port/aft)
-"sBp" = (
-/obj/structure/table,
-/obj/machinery/processor{
-	pixel_y = 6
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
-"sBz" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/machinery/light/small/directional/south,
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron/grimy,
-/area/station/service/theater)
 "sBL" = (
 /obj/structure/sign/directions/science{
 	dir = 4;
@@ -53918,6 +55771,10 @@
 	},
 /turf/closed/wall,
 /area/station/commons/storage/art)
+"sBO" = (
+/obj/structure/chair/stool/bar/directional/north,
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "sBP" = (
 /obj/structure/reagent_dispensers/plumbed{
 	dir = 1
@@ -53967,6 +55824,23 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/medbay/central)
+"sCr" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "sCu" = (
 /obj/machinery/computer/prisoner/management{
 	dir = 8
@@ -53981,6 +55855,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
+"sCx" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/bush/flowers_yw,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/camera/directional/north,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "sCB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/public{
@@ -53988,10 +55872,33 @@
 	},
 /turf/open/floor/iron/textured_half,
 /area/station/commons/fitness/recreation)
+"sCG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/ammo_casing/spent{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/ammo_casing/spent,
+/obj/item/ammo_casing/spent{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "sCH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
+"sCP" = (
+/obj/machinery/status_display/ai/directional/west,
+/obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "sCR" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/modular_computer/preset/research{
@@ -54001,6 +55908,31 @@
 /obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"sCU" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	name = "Kitchen Shutters";
+	id = "kitchenshutters"
+	},
+/turf/open/floor/plating,
+/area/station/service/kitchen)
+"sCX" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 6
+	},
+/obj/machinery/light/small/directional/south,
+/obj/structure/sign/poster/official/random/directional/east,
+/turf/open/floor/eighties/red,
+/area/station/hallway/primary/central/fore)
 "sDh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -54014,6 +55946,17 @@
 	dir = 4
 	},
 /area/station/engineering/supermatter/room)
+"sDi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "sDj" = (
 /turf/closed/wall/r_wall,
 /area/station/science/cytology)
@@ -54074,13 +56017,6 @@
 	dir = 4
 	},
 /area/station/science/lab)
-"sDT" = (
-/obj/machinery/firealarm/directional/north,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
 "sDZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/line{
@@ -54126,13 +56062,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
-"sED" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/iron/grimy,
-/area/station/service/theater)
 "sES" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Creature Pen"
@@ -54152,25 +56081,15 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
-"sFH" = (
+"sFW" = (
+/obj/machinery/light/warm/dim,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"sFJ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/obj/machinery/light/small/directional/south,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/grimy,
-/area/station/service/theater)
+/area/station/hallway/primary/central/aft)
 "sGh" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/stripes/white/line{
@@ -54186,6 +56105,16 @@
 	},
 /turf/open/misc/sandy_dirt,
 /area/station/security/tram)
+"sGr" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Public Shrine"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/station/hallway/primary/central/fore)
 "sGt" = (
 /obj/structure/table/reinforced,
 /obj/item/scalpel{
@@ -54218,6 +56147,21 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"sHt" = (
+/obj/structure/table/reinforced,
+/obj/structure/desk_bell{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	name = "Kitchen Shutters";
+	id = "kitchenshutters"
+	},
+/turf/open/floor/plating,
+/area/station/service/kitchen)
 "sHH" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/portable_atmospherics/canister/plasma,
@@ -54254,12 +56198,6 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/engine,
 /area/station/science/cytology)
-"sIh" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/floor/iron/stairs{
-	dir = 8
-	},
-/area/station/service/theater)
 "sIj" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -54268,6 +56206,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
+"sIl" = (
+/obj/machinery/skill_station,
+/obj/structure/sign/painting/library{
+	pixel_x = 30
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "sIA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -54280,21 +56225,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
-"sIG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/directions/evac/directional/west,
-/obj/structure/sign/directions/science/directional/west{
-	dir = 4;
-	pixel_y = -8
-	},
-/obj/structure/sign/directions/security/directional/west{
-	pixel_y = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "sIO" = (
 /obj/structure/grille/broken,
 /obj/item/shard/titanium,
@@ -54381,21 +56311,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"sKD" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
-/obj/structure/cable,
-/obj/effect/landmark/navigate_destination,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/machinery/door/airlock/engineering{
-	name = "Main Engineering"
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/break_room)
 "sKE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/small,
 /area/station/security/warden)
+"sKR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "sKS" = (
 /obj/structure/sign/poster/official/pda_ad/directional/north,
 /obj/structure/tank_holder/extinguisher,
@@ -54403,14 +56328,6 @@
 /obj/effect/gibspawner,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
-"sLc" = (
-/obj/structure/cable,
-/obj/machinery/door/window/right/directional/north{
-	name = "Library Desk Door";
-	req_access = list("library")
-	},
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "sLu" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -54438,6 +56355,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"sLC" = (
+/obj/effect/turf_decal/tile/dark_red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/security)
 "sLD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 9
@@ -54454,6 +56381,11 @@
 /obj/structure/closet/secure_closet/security/med,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs/auxiliary)
+"sLN" = (
+/obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "sLS" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -54473,6 +56405,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
+"sLX" = (
+/obj/structure/table/wood,
+/obj/item/cigarette/cigar/cohiba,
+/turf/open/floor/carpet,
+/area/station/commons/dorms)
 "sMh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/research{
@@ -54490,14 +56427,6 @@
 	dir = 1
 	},
 /area/station/science/research)
-"sMi" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "sMq" = (
 /obj/machinery/light/warm/directional/west,
 /turf/open/floor/iron,
@@ -54510,13 +56439,6 @@
 "sMD" = (
 /turf/closed/wall,
 /area/station/science/server)
-"sMG" = (
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/steam_vent,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "sMT" = (
 /obj/structure/table,
 /obj/item/emergency_bed{
@@ -54579,18 +56501,6 @@
 /obj/effect/spawner/random/armory/dragnet,
 /turf/open/floor/iron/dark/small,
 /area/station/ai_monitored/security/armory)
-"sNv" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "sNz" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -54672,16 +56582,6 @@
 /obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/textured_half,
 /area/station/commons/storage/art)
-"sOW" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
 "sPa" = (
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/machinery/door/airlock/grunge{
@@ -54708,42 +56608,17 @@
 	dir = 4
 	},
 /area/station/engineering/main)
-"sPt" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "sPx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/pile/directional/east,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
-"sPE" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/light/cold/directional/north,
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
 "sPO" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"sPT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/mob/living/basic/goat/pete,
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
 "sQa" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -54800,12 +56675,6 @@
 /obj/structure/alien/weeds,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
-"sQA" = (
-/obj/effect/turf_decal/siding/white,
-/obj/structure/bed/maint,
-/obj/structure/railing,
-/turf/open/floor/stone,
-/area/station/service/theater)
 "sQI" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/modular_computer/preset/id,
@@ -54844,13 +56713,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/science/explab)
-"sQU" = (
-/obj/machinery/vending/hydronutrients,
-/obj/effect/turf_decal/delivery/white{
-	color = "#52B4E9"
-	},
-/turf/open/floor/iron/white/small,
-/area/station/service/hydroponics)
 "sQX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54860,16 +56722,14 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/science/ordnance/storage)
-"sQY" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+"sRc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/siding/wideplating_new/terracotta{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
+/turf/open/floor/wood/tile,
+/area/station/maintenance/central/lesser)
 "sRf" = (
 /obj/machinery/power/turbine/inlet_compressor{
 	dir = 8
@@ -54888,15 +56748,6 @@
 	dir = 8
 	},
 /area/station/science/lobby)
-"sRv" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/west{
-	name = "Hydroponics Desk";
-	req_access = list("hydroponics")
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/textured_large,
-/area/station/hallway/primary/central/fore)
 "sRD" = (
 /obj/machinery/shower/directional/west,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -54905,6 +56756,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
+"sRJ" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/tile,
+/area/station/maintenance/central/lesser)
 "sRL" = (
 /turf/closed/wall,
 /area/station/service/janitor)
@@ -54937,18 +56795,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
-"sSr" = (
-/obj/machinery/door/airlock{
-	name = "Kitchen"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/turf/open/floor/catwalk_floor/flat_white,
-/area/station/service/kitchen)
-"sSt" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/service/kitchen)
 "sSx" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs/cable{
@@ -55028,9 +56874,6 @@
 /obj/structure/broken_flooring/singular/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
-"sTp" = (
-/turf/closed/wall,
-/area/station/service/cafeteria)
 "sTq" = (
 /obj/structure/railing{
 	dir = 10
@@ -55075,6 +56918,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"sUs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/cook,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "sUy" = (
 /turf/closed/wall/r_wall,
 /area/station/command/meeting_room)
@@ -55101,6 +56949,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/checker,
 /area/station/security/breakroom)
+"sUL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "sUV" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -55127,16 +56984,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
-"sVl" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/green/opposingcorners,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/landmark/start/botanist,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "sVp" = (
 /obj/structure/table,
 /obj/structure/sign/poster/official/corporate_perks_vacation/directional/east,
@@ -55172,6 +57019,11 @@
 /obj/machinery/chem_master,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"sWi" = (
+/obj/item/flashlight/lantern/on,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "sWA" = (
 /obj/machinery/door/airlock/glass{
 	name = "Gold Standard Law Firm"
@@ -55187,20 +57039,6 @@
 /obj/machinery/light/broken/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"sWJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "sci-entrance"
-	},
-/turf/open/floor/iron/textured_half,
-/area/station/security/brig/entrance)
 "sWQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55211,10 +57049,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
-"sXk" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/service/theater)
 "sXm" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -55222,20 +57056,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
-"sXo" = (
-/obj/structure/sign/directions/engineering{
-	dir = 1;
-	pixel_y = 8
-	},
-/obj/structure/sign/directions/command{
-	dir = 1
-	},
-/obj/structure/sign/directions/supply{
-	dir = 1;
-	pixel_y = -8
-	},
-/turf/closed/wall,
-/area/station/service/theater)
 "sXq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55350,37 +57170,6 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/white/small,
 /area/station/medical/cryo)
-"sYF" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/station/service/chapel)
-"sYK" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/structure/flora/bush/sunny/style_random,
-/turf/open/floor/grass,
-/area/station/service/chapel)
-"sZj" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
-"sZn" = (
-/obj/structure/table,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/item/toy/windup_toolbox,
-/obj/machinery/light/small/directional/north,
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/plating,
-/area/station/service/theater)
 "sZx" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/trunk{
@@ -55414,16 +57203,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
-"sZQ" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown/full,
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/bot,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
 "tab" = (
 /obj/structure/rack,
 /obj/item/restraints/handcuffs,
@@ -55459,15 +57238,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/break_room)
-"tax" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/opposingcorners{
+"taw" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
-/obj/structure/chair/stool/bar/directional/west,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/secondary/service)
 "taB" = (
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
@@ -55504,6 +57285,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"taQ" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/misc/dirt/jungle,
+/area/station/service/chapel)
 "taZ" = (
 /obj/structure/flora/bush/large/style_random{
 	pixel_y = -3
@@ -55512,6 +57297,12 @@
 /obj/machinery/camera/directional/west,
 /turf/open/misc/sandy_dirt,
 /area/station/hallway/secondary/recreation)
+"tba" = (
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/maintenance/central/lesser)
 "tbb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -55533,12 +57324,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/science/explab)
-"tbq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/wood,
-/area/station/hallway/secondary/service)
 "tbr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -55616,18 +57401,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/engineering/main)
-"tcB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/hydroponics/glass{
-	name = "Service Breakroom"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/general,
-/obj/machinery/duct,
-/turf/open/floor/iron/textured_half{
-	dir = 8
-	},
-/area/station/hallway/secondary/service)
 "tcC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55636,24 +57409,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
-"tcP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/duct,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
+"tcS" = (
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/corner{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/area/station/hallway/primary/central/fore)
+/turf/open/floor/wood/tile,
+/area/station/service/bar)
 "tcZ" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 6
@@ -55665,11 +57429,6 @@
 	},
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos/space_catwalk)
-"tdg" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "tdh" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
@@ -55677,6 +57436,12 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood/large,
 /area/station/command/corporate_suite)
+"tdk" = (
+/obj/machinery/modular_computer/preset/curator{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/station/service/library)
 "tdu" = (
 /obj/structure/lattice,
 /obj/structure/railing{
@@ -55740,6 +57505,14 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/department/medical/central)
+"tdR" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_red/half/contrasted,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "tdS" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -55766,6 +57539,13 @@
 /obj/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"ter" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/holodeck/rec_center)
 "tey" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /obj/machinery/computer/records/security{
@@ -55806,20 +57586,43 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
-"tfa" = (
+"teO" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/stone,
+/area/station/service/bar/backroom)
 "tfc" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/stone,
 /area/station/service/abandoned_gambling_den)
+"tfd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/light/cold/directional/north,
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/camera/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"tfe" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/structure/flora/bush/large/style_random{
+	pixel_y = 0
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "tff" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -55844,6 +57647,21 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/rd,
 /turf/open/floor/catwalk_floor/flat_white,
 /area/station/science/server)
+"tfk" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/open/floor/iron/grimy,
+/area/station/service/bar)
+"tfo" = (
+/obj/structure/water_source/puddle,
+/turf/open/floor/grass,
+/area/station/service/chapel)
+"tft" = (
+/obj/effect/spawner/random/trash,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "tfy" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/red{
@@ -55893,6 +57711,14 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/hop)
+"tgB" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/grimy,
+/area/station/service/library)
 "tgD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -55908,24 +57734,6 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/medical/cryo)
-"tgR" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
-"tgS" = (
-/obj/structure/table,
-/obj/item/trash/cheesie{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
 "thb" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/turf_decal/siding/yellow{
@@ -55943,16 +57751,6 @@
 	dir = 1
 	},
 /area/station/science/research)
-"thv" = (
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/right/directional/south{
-	name = "Seed Extractor";
-	req_access = list("hydroponics")
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/textured_large,
-/area/station/service/hydroponics)
 "thx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -56081,11 +57879,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/white/small,
 /area/station/medical/medbay/central)
-"tjb" = (
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "tjd" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /obj/machinery/door/poddoor/preopen{
@@ -56123,15 +57916,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
-"tkp" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Services Corridor"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/textured_half{
-	dir = 8
-	},
-/area/station/hallway/primary/central/aft)
 "tkq" = (
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
@@ -56190,11 +57974,11 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"tmc" = (
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
+"tmj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "tmk" = (
 /obj/machinery/power/emitter,
 /obj/effect/turf_decal/stripes/line{
@@ -56206,6 +57990,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"tmw" = (
+/obj/structure/bookcase/random,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "tmL" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/curved/flipped{
@@ -56241,11 +58030,6 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/maintenance/port/lesser)
-"tmV" = (
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
 "tnb" = (
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
@@ -56410,13 +58194,25 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"toY" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
+"tpe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/generic_maintenance_landmark,
+/obj/structure/table,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/dark_red/half/contrasted,
-/turf/open/floor/iron,
-/area/station/security/brig/entrance)
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
+"tph" = (
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/siding/thinplating/light/end{
+	dir = 8
+	},
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
 "tpk" = (
 /obj/machinery/vending/wardrobe/law_wardrobe,
 /obj/effect/turf_decal/siding/wood{
@@ -56433,6 +58229,17 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/noslip,
 /area/station/security/tram)
+"tpw" = (
+/obj/machinery/status_display/ai/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/white/side,
+/area/station/hallway/primary/central/aft)
 "tpG" = (
 /obj/structure/closet/athletic_mixed,
 /obj/effect/turf_decal/stripes/red/line{
@@ -56485,11 +58292,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"tqq" = (
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
 "tqs" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 1
@@ -56497,11 +58299,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
-"tqz" = (
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
 "tqD" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -56513,11 +58310,15 @@
 /obj/structure/window/spawner/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"tqK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
+"tqO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/wood,
+/area/station/service/chapel/office)
 "tqV" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 5
@@ -56543,22 +58344,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/dock)
-"trc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/chair/sofa/bench/left{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation/entertainment)
-"trl" = (
-/obj/effect/spawner/random/structure/tank_holder,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron/smooth,
-/area/station/cargo/drone_bay)
 "tro" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/smooth,
@@ -56566,6 +58351,11 @@
 "trp" = (
 /turf/closed/wall,
 /area/station/maintenance/port/aft)
+"trx" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/chair/stool/bar/directional/north,
+/turf/open/floor/iron,
+/area/station/holodeck/rec_center)
 "trz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56641,16 +58431,10 @@
 	},
 /turf/open/space/basic,
 /area/station/engineering/atmos/space_catwalk)
-"ttA" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/iron/grimy,
-/area/station/service/theater)
-"ttC" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
+"ttk" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "ttD" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 9
@@ -56736,6 +58520,16 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/stone,
 /area/station/command/heads_quarters/hos)
+"tvy" = (
+/obj/machinery/computer/slot_machine{
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "tvM" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
@@ -56765,13 +58559,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"twf" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "twg" = (
 /obj/structure/railing{
 	dir = 5
@@ -56785,16 +58572,14 @@
 /obj/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
-"twj" = (
-/obj/machinery/vending/coffee,
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"twl" = (
-/obj/effect/spawner/structure/window,
+"twm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/hallway/primary/starboard)
+/area/station/maintenance/port/greater)
 "two" = (
 /obj/structure/table/reinforced,
 /obj/structure/desk_bell{
@@ -56876,11 +58661,32 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/starboard)
+"txm" = (
+/obj/structure/table,
+/obj/item/storage/bag/tray,
+/obj/item/knife/kitchen{
+	pixel_y = 2
+	},
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "txC" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/herringbone,
 /area/station/commons/dorms)
+"txG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "txN" = (
 /turf/closed/wall,
 /area/station/security/prison/workout)
@@ -57037,10 +58843,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
-"tzJ" = (
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "tzZ" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -57141,6 +58943,13 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/server)
+"tAZ" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "tBm" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/grass,
@@ -57189,13 +58998,6 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron/small,
 /area/station/security/office)
-"tCk" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "tCm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/red{
@@ -57289,23 +59091,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
-"tDJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"tDP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
-"tDT" = (
-/turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
 "tEg" = (
 /obj/structure/transport/linear/tram,
 /obj/effect/turf_decal/stripes/white/line{
@@ -57323,6 +59108,12 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"tEq" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/station/cargo/boutique)
 "tEt" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags{
@@ -57333,10 +59124,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/security/tram)
-"tEI" = (
-/mob/living/simple_animal/hostile/retaliate/goose/vomit,
-/turf/open/floor/wood/tile,
-/area/station/service/bar)
 "tEL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57346,37 +59133,26 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"tET" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+"tEP" = (
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
+"tFq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"tEU" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/grass,
-/area/station/service/chapel)
-"tEW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"tFg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/tile,
-/area/station/commons/vacant_room/commissary)
 "tFs" = (
 /obj/structure/table/glass,
 /obj/item/storage/medkit/regular{
@@ -57396,19 +59172,6 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"tFG" = (
-/obj/effect/turf_decal/tile/brown/full,
-/obj/machinery/door/window/right/directional/west{
-	name = "Bar Access";
-	req_access = list("bar")
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/north,
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
 "tFH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57431,17 +59194,6 @@
 /obj/machinery/chem_master,
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
-"tFY" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "tGp" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine,
@@ -57496,18 +59248,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/storage_shared)
-"tHh" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock{
-	name = "Kitchen Cold Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/machinery/duct,
-/turf/open/floor/catwalk_floor/flat_white,
-/area/station/service/kitchen/coldroom)
 "tHi" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/human/species/monkey/punpun,
@@ -57519,6 +59259,13 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/security/tram)
+"tHB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "tHK" = (
 /turf/closed/wall,
 /area/station/security/prison/shower)
@@ -57544,17 +59291,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
-"tIc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "tIz" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -57562,16 +59298,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/wood,
 /area/station/service/chapel/funeral)
-"tIA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
 "tIB" = (
 /obj/item/clothing/head/cone{
 	pixel_x = 16;
@@ -57584,19 +59310,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"tII" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
-"tIL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
 "tIN" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow{
@@ -57651,42 +59364,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/brig/entrance)
-"tJD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
-"tJF" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/rack,
-/obj/item/storage/toolbox/emergency{
-	pixel_x = -2;
-	pixel_y = -3
-	},
-/obj/item/cigarette/cigar,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron/smooth,
-/area/station/command/bridge)
-"tJG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 4;
-	id = "kihall"
-	},
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
 "tJX" = (
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
@@ -57702,26 +59379,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"tKm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
-"tKC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
 "tKG" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/broken_floor,
@@ -57775,6 +59432,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"tLv" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall,
+/area/station/hallway/primary/central/aft)
 "tMh" = (
 /obj/structure/fireaxecabinet/directional/south,
 /obj/machinery/door/window/brigdoor/left/directional/north{
@@ -57785,29 +59448,6 @@
 	dir = 1
 	},
 /area/station/command/bridge)
-"tMi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public/glass{
-	name = "Services Corridor"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/textured_half{
-	dir = 8
-	},
-/area/station/hallway/primary/central/aft)
-"tMj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "tMm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57826,17 +59466,6 @@
 	},
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
-"tMy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "tMJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -57844,17 +59473,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"tMR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "tMS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57865,9 +59483,12 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
-"tNc" = (
-/turf/open/floor/wood/parquet,
-/area/station/service/theater)
+"tMW" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "tNn" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock{
@@ -57953,21 +59574,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/dark/side,
 /area/station/science/xenobiology)
-"tNS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/rack,
-/obj/machinery/door/poddoor/shutters{
-	dir = 4;
-	id = "vaco";
-	name = "Comissary Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/commons/vacant_room/commissary)
 "tNT" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/kitchen/small,
@@ -58028,14 +59634,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/misc/sandy_dirt,
 /area/station/service/lawoffice)
-"tOS" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/stone,
-/area/station/service/bar/backroom)
 "tOZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/cold/directional/north,
@@ -58056,14 +59654,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/cargo/miningfoundry)
-"tPd" = (
-/obj/structure/chair/sofa/left/maroon{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/obj/machinery/light/cold/directional/south,
-/turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
 "tPf" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
@@ -58197,15 +59787,24 @@
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/medical/central)
-"tSe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+"tRX" = (
+/obj/structure/sign/directions/evac/directional/west,
+/obj/structure/sign/directions/science/directional/west{
+	dir = 4;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/security/directional/west{
+	pixel_y = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/stripes/red/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/small,
 /area/station/hallway/primary/central/fore)
 "tSg" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
@@ -58216,10 +59815,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"tSh" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood,
-/area/station/hallway/secondary/service)
 "tSi" = (
 /obj/machinery/light/cold/directional/west,
 /obj/machinery/disposal/bin,
@@ -58329,15 +59924,6 @@
 /obj/machinery/light/very_dim/directional/east,
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
-"tTG" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "tTK" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -58349,6 +59935,10 @@
 	dir = 1
 	},
 /area/station/science/xenobiology)
+"tTU" = (
+/obj/machinery/light/floor,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "tTW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -58425,12 +60015,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
-"tUD" = (
-/obj/machinery/transport/tram_controller/tcomms{
-	configured_transport_id = "bird_1"
-	},
-/turf/open/floor/circuit,
-/area/station/tcommsat/server)
 "tUH" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -58445,25 +60029,29 @@
 	},
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
-"tUK" = (
+"tUU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
-/obj/item/storage/box{
-	pixel_x = -8;
-	pixel_y = 15
-	},
-/obj/item/trash/flare{
-	pixel_x = 11;
-	pixel_y = 21
+/obj/effect/turf_decal/tile/dark_red/half/contrasted,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
+"tUX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/corner{
+/obj/effect/landmark/navigate_destination/teleporter,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "tUZ" = (
 /obj/structure/cable,
@@ -58536,19 +60124,6 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"tWE" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/dark_red/fourcorners,
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security/brig/entrance)
 "tWG" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -58557,15 +60132,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
-"tWL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/hallway/primary/central/fore)
 "tWQ" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Departure Lounge"
@@ -58574,6 +60140,14 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
+"tWZ" = (
+/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
+/obj/machinery/door/airlock/hydroponics/glass{
+	name = "Hydroponics"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/small,
+/area/station/service/hydroponics)
 "tXl" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/table/bronze,
@@ -58595,6 +60169,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"tXM" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/grimy,
+/area/station/service/bar)
 "tXP" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/green/opposingcorners{
@@ -58610,39 +60194,6 @@
 /obj/item/clothing/suit/hooded/wintercoat/engineering,
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/supermatter/room)
-"tXT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"tYb" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"tYd" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=2.0-Vault-SNexus";
-	location = "1.5-PNexus-Vault"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "tYj" = (
 /obj/item/exodrone,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -58677,11 +60228,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/small,
 /area/station/engineering/atmos/storage/gas)
-"tYH" = (
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "tYL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -58699,19 +60245,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
-"tYQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/hallway/primary/central/fore)
 "tYT" = (
 /turf/open/misc/asteroid/airless,
 /area/space/nearstation)
@@ -58719,21 +60252,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/hallway/primary/central/aft)
-"tZd" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock{
-	name = "Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
+"tZb" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/central/lesser)
+/area/station/maintenance/port/greater)
 "tZi" = (
 /obj/structure/sign/poster/contraband/got_wood/directional/north,
 /turf/open/floor/light/colour_cycle/dancefloor_b,
@@ -58775,15 +60300,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
-"tZG" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=3.0-StarboardHall-TechStorage";
-	location = "2.5-SNexus-StarboardHall"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "tZI" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -58806,35 +60322,6 @@
 /obj/machinery/light/cold/dim/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"tZR" = (
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
-"tZU" = (
-/obj/effect/turf_decal/siding/wideplating_new/terracotta{
-	dir = 1
-	},
-/turf/open/floor/wood/tile,
-/area/station/commons/vacant_room/commissary)
-"tZV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/end{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"uaa" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "uab" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58855,13 +60342,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmospherics_engine)
-"uao" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
-/obj/structure/flora/tree/stump,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "uax" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -58871,13 +60351,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs)
-"uaE" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/flora/tree/jungle/small/style_random,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "uaF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58938,15 +60411,6 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
-"ubf" = (
-/obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "ubh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -58978,11 +60442,6 @@
 "uby" = (
 /turf/closed/wall,
 /area/station/security/prison/garden)
-"ubB" = (
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/structure/sign/poster/random/directional/north,
-/turf/open/floor/grass,
-/area/station/service/hydroponics)
 "ubK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -59022,23 +60481,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/explab)
-"ucr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
-"ucw" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation/entertainment)
 "ucy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/red{
@@ -59053,19 +60495,6 @@
 /obj/structure/chair/wood,
 /turf/open/floor/iron/small,
 /area/station/service/barber)
-"ucH" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "ucJ" = (
 /obj/machinery/door/window/left/directional/south{
 	req_access = list("chapel_office")
@@ -59083,13 +60512,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/prison/shower)
-"ucV" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/machinery/light/cold/directional/south,
-/turf/open/floor/wood/tile,
-/area/station/service/bar)
 "ucY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59110,12 +60532,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"udt" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "udv" = (
 /obj/machinery/telecomms/receiver/preset_right,
 /turf/open/floor/circuit,
@@ -59180,9 +60596,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/space_catwalk)
-"uej" = (
-/turf/closed/wall,
-/area/station/hallway/secondary/service)
 "uek" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
@@ -59251,6 +60664,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_half,
 /area/station/hallway/primary/central/fore)
+"ufe" = (
+/obj/structure/table/wood,
+/obj/machinery/fax/auto_name,
+/turf/open/floor/carpet,
+/area/station/service/library)
 "uff" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood/large,
@@ -59423,6 +60841,14 @@
 /obj/structure/chair/bronze,
 /turf/open/floor/wood/tile,
 /area/station/maintenance/port/lesser)
+"uhx" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_red/half/contrasted,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
 "uhy" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
@@ -59453,6 +60879,15 @@
 "uhT" = (
 /turf/open/floor/iron,
 /area/station/maintenance/aft)
+"uhW" = (
+/obj/structure/table/reinforced,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/shutters{
+	id = "meow";
+	name = "Commissary"
+	},
+/turf/open/floor/iron,
+/area/station/commons/vacant_room/commissary)
 "uia" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59492,12 +60927,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
-"uio" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/turf/open/floor/iron/grimy,
-/area/station/service/theater)
 "uiz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59520,14 +60949,6 @@
 	dir = 1
 	},
 /area/station/science/research)
-"uiW" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock{
-	name = "Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/central/lesser)
 "uiY" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -59581,6 +61002,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"ujX" = (
+/obj/structure/flora/bush/flowers_yw/style_3,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "ujZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59594,6 +61019,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/station/cargo/miningfoundry)
+"ukr" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/autoname/directional/east,
+/turf/open/floor/iron,
+/area/station/holodeck/rec_center)
 "uku" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -59744,11 +61176,13 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"umM" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/central/lesser)
+"umK" = (
+/obj/machinery/photocopier,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "unc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59764,15 +61198,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs/auxiliary)
-"uny" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "unG" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -59780,19 +61205,27 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"unI" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "unK" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
-"unM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public/glass{
-	name = "Departure Lounge"
+"unN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/turf/open/floor/iron/textured_half{
+/obj/effect/turf_decal/trimline/neutral/line{
 	dir = 1
 	},
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "unT" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -59829,24 +61262,20 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_command)
-"uoM" = (
-/obj/structure/disposalpipe/segment{
+"uoS" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/grass,
+/area/station/service/chapel)
+"uoV" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"uoW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "upe" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -59872,20 +61301,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron/small,
-/area/station/hallway/primary/port)
-"upj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/ammo_casing/spent{
-	pixel_x = 5;
-	pixel_y = 6
-	},
-/obj/item/ammo_casing/spent,
-/obj/item/ammo_casing/spent{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "upr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59935,6 +61350,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
+"upY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/warm/dim,
+/obj/machinery/camera/autoname/directional/south,
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "uqc" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash,
@@ -60051,11 +61476,6 @@
 	dir = 8
 	},
 /area/station/engineering/main)
-"urh" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "urk" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
@@ -60065,6 +61485,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
+"url" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "urm" = (
 /obj/structure/table/glass,
 /obj/item/gun/energy/laser/practice,
@@ -60156,11 +61583,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/command/heads_quarters/qm)
-"usl" = (
-/obj/machinery/status_display/evac/directional/south,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
 "usF" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/easel,
@@ -60185,6 +61607,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
+"usW" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "utf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -60195,12 +61626,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"uth" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L2"
-	},
-/turf/open/floor/glass,
-/area/station/hallway/secondary/spacebridge)
 "utm" = (
 /turf/closed/wall/r_wall,
 /area/station/science/auxlab/firing_range)
@@ -60216,14 +61641,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/space_catwalk)
-"uty" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "utD" = (
 /obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/stripes/corner{
@@ -60290,12 +61707,6 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark/small,
 /area/station/engineering/supermatter/room)
-"uuv" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L4"
-	},
-/turf/open/floor/glass,
-/area/station/hallway/secondary/spacebridge)
 "uuN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60322,6 +61733,10 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/medical/storage)
+"uvb" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/smooth,
+/area/station/service/library)
 "uvf" = (
 /obj/structure/cable,
 /obj/machinery/button/door/directional/south{
@@ -60331,20 +61746,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"uvh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/vault{
-	name = "Vault"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/access/all/supply/vault,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/ai_monitored/command/nuke_storage)
 "uvo" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -60379,28 +61780,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
-"uwl" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L6"
-	},
-/obj/effect/turf_decal/tile/neutral{
+"uwz" = (
+/obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=2.5-SNexus-StarboardHall";
-	location = "2.0-Vault-SNexus"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
-"uwx" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L10"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
+/turf/open/floor/wood/tile,
+/area/station/service/bar)
 "uwB" = (
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 4
@@ -60417,16 +61802,6 @@
 /obj/effect/landmark/transport/nav_beacon/tram/nav/immovable_rod,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"uwU" = (
-/obj/structure/closet/secure_closet/hydroponics,
-/obj/effect/turf_decal/bot,
-/obj/structure/window/spawner/directional/east,
-/obj/effect/turf_decal/tile/green/opposingcorners,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "uxd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60436,12 +61811,25 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
-"uxi" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L12"
+"uxp" = (
+/obj/effect/spawner/random/trash,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
+"uxu" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
+"uxH" = (
+/obj/structure/sign/warning/no_smoking/circle/directional/north,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/turf/open/floor/glass,
-/area/station/hallway/secondary/spacebridge)
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "uxJ" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /obj/machinery/door/firedoor,
@@ -60457,26 +61845,22 @@
 /obj/structure/trap/stun,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
+"uxM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "uya" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
-"uye" = (
-/obj/machinery/door/window/right/directional/south,
-/turf/open/floor/grass,
-/area/station/service/hydroponics)
-"uyg" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L14"
-	},
-/turf/open/floor/glass,
-/area/station/hallway/secondary/spacebridge)
-"uyp" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "uyA" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -60505,22 +61889,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
-"uzd" = (
-/obj/structure/table,
-/obj/effect/turf_decal/bot,
-/obj/machinery/reagentgrinder{
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
+"uzg" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "uzj" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -60568,18 +61941,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"uAb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/sign/directions/vault/directional/south{
-	dir = 8
-	},
-/turf/open/floor/iron/white/corner,
-/area/station/hallway/primary/starboard)
 "uAi" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/lone,
@@ -60593,26 +61954,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"uAw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side,
-/area/station/hallway/primary/starboard)
-"uAF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/turf/open/floor/wood/tile,
-/area/station/service/bar)
-"uAH" = (
-/obj/structure/bed/medical{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/item/bedsheet/medical,
-/turf/open/floor/iron/white,
-/area/station/maintenance/central/greater)
 "uAK" = (
 /obj/machinery/computer/security,
 /obj/effect/turf_decal/siding/red{
@@ -60621,24 +61962,22 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood/tile,
 /area/station/command/bridge)
+"uAQ" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "uAT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 9
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/engineering/supermatter)
-"uAV" = (
-/obj/structure/cable,
-/obj/machinery/duct,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
-"uAX" = (
-/obj/structure/chair/stool/bar/directional/east,
-/turf/open/floor/wood/tile,
-/area/station/service/bar)
 "uAY" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
@@ -60663,18 +62002,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/aft)
-"uBn" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/brown/full,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/item/plate,
-/obj/item/food/cheesynachos{
-	pixel_y = 2
-	},
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
 "uBo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -60750,29 +62077,11 @@
 /obj/item/mop,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"uCh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/full,
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
 "uCp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white/side,
 /area/station/hallway/primary/starboard)
-"uCv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/effect/spawner/xmastree,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "uCE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 5
@@ -60789,16 +62098,6 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/storage/gas)
-"uCJ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/chair/pew/right{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/wood,
-/area/station/service/theater)
 "uCL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -60809,11 +62108,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
-"uCS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/holopad,
-/turf/open/floor/wood/parquet,
-/area/station/service/theater)
 "uDg" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -60884,10 +62178,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"uEg" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/lone,
-/area/station/service/theater)
 "uEh" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/siding/wood,
@@ -60895,6 +62185,16 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/stone,
 /area/station/command/corporate_suite)
+"uEi" = (
+/obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/terracotta{
+	dir = 6
+	},
+/turf/open/floor/wood/tile,
+/area/station/maintenance/central/lesser)
 "uEw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -60905,6 +62205,18 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/catwalk_floor/flat_white,
 /area/station/science/robotics/augments)
+"uEB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/red{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "uEC" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/box/red/corners{
@@ -61041,6 +62353,15 @@
 	dir = 4
 	},
 /area/station/engineering/atmos/office)
+"uGi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "uGj" = (
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /obj/structure/table/glass,
@@ -61051,11 +62372,6 @@
 /obj/effect/mapping_helpers/requests_console/ore_update,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"uGp" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/sign/warning/no_smoking/circle/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "uGy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/grimy,
@@ -61258,14 +62574,15 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
 /area/station/medical/treatment_center)
-"uIt" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+"uIu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light_switch/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/turf/open/floor/wood,
+/area/station/cargo/boutique)
 "uIv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61281,17 +62598,26 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
+"uIE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
+"uIM" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 8
+	},
+/area/station/service/library)
 "uIT" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/hallway/abandoned_command)
-"uIW" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "uIX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/modular_computer/preset/civilian{
@@ -61353,6 +62679,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"uKm" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/jungle/b/style_2,
+/obj/machinery/light/small/directional/north,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "uKv" = (
 /obj/effect/turf_decal/trimline/blue/warning{
 	dir = 1
@@ -61386,6 +62722,10 @@
 	dir = 1
 	},
 /area/station/science/research)
+"uKI" = (
+/obj/structure/flora/grass/jungle/b/style_3,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "uKN" = (
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
@@ -61411,21 +62751,16 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
+"uKZ" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/machinery/light/small/directional/south,
+/obj/item/radio/intercom/directional/south,
+/obj/structure/flora/bush/flowers_yw,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "uLj" = (
 /turf/closed/wall,
 /area/station/commons/toilet/auxiliary)
-"uLn" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
-"uLu" = (
-/obj/machinery/status_display/ai/directional/south,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
 "uLO" = (
 /obj/item/stack/sheet/cardboard{
 	amount = 14
@@ -61479,12 +62814,15 @@
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/tram)
-"uMC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
+"uMD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/spacebridge)
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/status_display/evac/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "uME" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/greyscale,
@@ -61499,15 +62837,6 @@
 "uMH" = (
 /turf/open/floor/iron/white/side,
 /area/station/science/research)
-"uMI" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "uMN" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/hedge,
@@ -61539,14 +62868,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"uMW" = (
-/obj/effect/spawner/random/vending/snackvend,
-/turf/open/floor/glass,
-/area/station/hallway/secondary/spacebridge)
-"uMX" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/glass,
-/area/station/hallway/secondary/spacebridge)
 "uNa" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -61570,10 +62891,6 @@
 /obj/machinery/shower/directional/east,
 /turf/open/floor/iron/dark/small,
 /area/station/engineering/break_room)
-"uNn" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
 "uNz" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/dark_red{
@@ -61595,10 +62912,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
-"uNW" = (
-/obj/machinery/barsign,
-/turf/closed/wall,
-/area/station/service/bar)
 "uNX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -61611,14 +62924,6 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/primary/aft)
-"uOh" = (
-/obj/structure/chair{
-	dir = 1;
-	pixel_y = -2
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/glass,
-/area/station/hallway/secondary/spacebridge)
 "uOk" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/window/spawner/directional/south,
@@ -61646,14 +62951,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood/tile,
 /area/station/command/meeting_room)
-"uPd" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "uPf" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -61663,13 +62960,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/workout)
-"uPs" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
 "uPw" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
@@ -61679,6 +62969,14 @@
 	},
 /turf/open/floor/tram,
 /area/station/security/tram)
+"uPC" = (
+/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "uPJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61691,6 +62989,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"uPL" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "uPM" = (
 /obj/structure/urinal/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -61701,10 +63005,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall,
 /area/station/engineering/supermatter/room)
-"uPO" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
 "uPX" = (
 /obj/structure/railing{
 	dir = 8
@@ -61747,20 +63047,40 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/security/brig)
-"uQC" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/iron/white,
-/area/station/hallway/primary/starboard)
 "uQG" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
-"uQR" = (
-/obj/machinery/exodrone_launcher,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/smooth,
-/area/station/cargo/drone_bay)
+"uQH" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Library"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/textured_half,
+/area/station/service/library)
+"uQT" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/stone,
+/area/station/service/chapel)
+"uQW" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/button/door/directional/north{
+	id = "vaco";
+	name = "Comissary Shutters";
+	pixel_x = 29
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/small,
+/area/station/maintenance/central/lesser)
 "uRe" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/turf_decal/tile/red{
@@ -61825,14 +63145,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/small,
 /area/station/security/execution/education)
-"uRX" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/structure/flora/tree/jungle/small/style_random,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "uRY" = (
 /obj/effect/spawner/random/structure/table_or_rack,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -61876,14 +63188,6 @@
 /obj/effect/landmark/navigate_destination/tcomms,
 /turf/open/floor/iron,
 /area/station/science/lower)
-"uSC" = (
-/obj/effect/landmark/start/assistant,
-/obj/effect/landmark/start/assistant,
-/obj/structure/chair/sofa/bamboo/left{
-	dir = 1
-	},
-/turf/open/floor/wood/large,
-/area/station/service/chapel)
 "uSG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -61895,12 +63199,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/wood,
 /area/station/cargo/boutique)
-"uSM" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "uSN" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -61994,55 +63292,30 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"uUE" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "uUG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/iron/small,
 /area/station/engineering/supermatter/room)
-"uUI" = (
-/obj/structure/table,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/green{
+"uUR" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/item/reagent_containers/cup/watering_can{
-	pixel_x = 7;
-	pixel_y = 13
-	},
-/obj/item/reagent_containers/cup/bottle/mutagen{
-	pixel_x = -5;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/syringe{
-	pixel_x = -3;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_x = 6;
-	pixel_y = 1
-	},
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/small,
 /area/station/service/hydroponics)
-"uVb" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/wood,
-/area/station/cargo/boutique)
+"uUU" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/station/service/bar)
 "uVo" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -62060,15 +63333,10 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/construction)
-"uVE" = (
-/obj/structure/table,
-/obj/item/storage/bag/tray{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/food/cake/apple,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
+"uVL" = (
+/obj/structure/flora/grass/jungle/b/style_5,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "uVO" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/broken_floor,
@@ -62135,16 +63403,6 @@
 	dir = 1
 	},
 /area/station/security/prison/safe)
-"uWB" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "uWG" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/status_display/ai/directional/south,
@@ -62164,9 +63422,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"uXb" = (
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "uXs" = (
 /obj/structure/window/spawner/directional/east,
 /obj/structure/window/spawner/directional/west,
@@ -62175,17 +63430,6 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
 /area/station/medical/treatment_center)
-"uXw" = (
-/obj/structure/table,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
-"uXB" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "uXC" = (
 /turf/closed/wall,
 /area/station/science/lower)
@@ -62196,10 +63440,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
-"uXN" = (
-/obj/structure/altar_of_gods,
-/turf/open/floor/wood/large,
-/area/station/service/chapel)
 "uXS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
@@ -62268,18 +63508,6 @@
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron/small,
 /area/station/commons/fitness/locker_room)
-"uZb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/dark_red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security/brig/entrance)
 "uZc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -62316,12 +63544,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
-"uZY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/service/library)
 "vaf" = (
 /obj/item/kirbyplants/random/fullysynthetic,
 /obj/machinery/status_display/ai/directional/south,
@@ -62381,6 +63603,13 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/starboard)
+"vbF" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/grimy,
+/area/station/service/bar)
 "vbK" = (
 /turf/closed/wall,
 /area/station/science/research)
@@ -62456,14 +63685,6 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/courtroom)
-"vcP" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "vcR" = (
 /turf/open/floor/iron/stairs/medium{
 	dir = 1
@@ -62606,6 +63827,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
+"vec" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 8
+	},
+/obj/effect/landmark/navigate_destination/kitchen,
+/turf/open/floor/wood,
+/area/station/hallway/primary/central/aft)
 "veg" = (
 /obj/effect/turf_decal/siding{
 	dir = 6
@@ -62664,6 +63892,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
+"veX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/grimy,
+/area/station/service/library)
 "vfc" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
@@ -62675,6 +63909,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
+"vfh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "vfi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -62729,6 +63970,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"vfP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "vfT" = (
 /obj/structure/table/glass,
 /obj/machinery/light/cold/directional/west,
@@ -62739,13 +63986,18 @@
 /obj/item/toy/crayon/purple,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"vgc" = (
-/obj/structure/chair/sofa/right/maroon{
-	dir = 1
+"vfX" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 4
 	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "vgp" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Maintenance"
@@ -62782,19 +64034,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"vgJ" = (
-/obj/structure/table,
-/obj/effect/turf_decal/bot,
-/obj/machinery/light/small/directional/north,
-/obj/item/pen{
-	pixel_x = 11
-	},
-/obj/item/paper_bin{
-	pixel_x = -7;
-	pixel_y = 6
-	},
-/turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
 "vgN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -62820,6 +64059,17 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"vhw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/station/service/bar)
 "vhC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62842,6 +64092,35 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"vhQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
+"vhV" = (
+/mob/living/basic/goat/pete,
+/obj/effect/turf_decal/weather/snow,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 2
+	},
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
+"vhW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/station/maintenance/port/greater)
 "vid" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -62943,16 +64222,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"vjc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation/entertainment)
 "vjp" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
@@ -63024,10 +64293,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/research)
-"vkz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/large,
-/area/station/service/chapel)
 "vkD" = (
 /obj/structure/table,
 /obj/item/stack/ore/gold{
@@ -63039,12 +64304,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"vkG" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "vkJ" = (
 /obj/item/book/manual/wiki/security_space_law{
 	pixel_x = 9;
@@ -63062,6 +64321,11 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/qm)
+"vkP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/station/service/chapel/office)
 "vkS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63156,6 +64420,14 @@
 /obj/item/radio/intercom/chapel/directional/west,
 /turf/open/floor/iron/terracotta/diagonal,
 /area/station/service/chapel/office)
+"vmf" = (
+/obj/machinery/door/window/right/directional/north{
+	name = "Library Desk Door";
+	req_access = list("library")
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/carpet,
+/area/station/service/library)
 "vmh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -63194,13 +64466,6 @@
 	},
 /turf/open/floor/iron/terracotta/diagonal,
 /area/station/service/chapel/office)
-"vmz" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "vmB" = (
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -63238,16 +64503,21 @@
 /obj/vehicle/sealed/mecha/ripley/paddy/preset,
 /turf/open/floor/iron,
 /area/station/security/tram)
+"vmW" = (
+/obj/structure/chair/greyscale,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/secondary/service)
 "vmX" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
 /area/station/service/chapel/office)
-"vnb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/spacebridge)
 "vne" = (
 /turf/open/floor/wood,
 /area/station/service/chapel/office)
@@ -63285,13 +64555,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
-"vnn" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood,
-/area/station/service/chapel/office)
 "vnp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 9
@@ -63363,16 +64626,6 @@
 "vnI" = (
 /turf/closed/mineral/random/stationside,
 /area/station/maintenance/department/engine)
-"vnK" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/red/line,
-/obj/structure/cable,
-/turf/open/floor/iron/small,
-/area/station/hallway/primary/central/fore)
 "vnN" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -63384,15 +64637,6 @@
 /obj/machinery/medical_kiosk,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"voa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/morgue{
-	name = "Secret Corridor";
-	req_access = list("library")
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/service/library)
 "voe" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 1
@@ -63421,13 +64665,6 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/smooth,
 /area/station/commons/storage/tools)
-"voF" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks,
-/obj/machinery/light/cold/directional/north,
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "voJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
@@ -63440,10 +64677,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/station/security)
-"voL" = (
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "voO" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -63491,10 +64724,6 @@
 /obj/machinery/smartfridge/petri/preloaded,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
-"vpN" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/catwalk_floor/iron,
-/area/station/service/bar)
 "vpP" = (
 /obj/effect/spawner/random/structure/closet_private,
 /obj/machinery/light/small/directional/south,
@@ -63525,18 +64754,9 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/primary/central/fore)
-"vpU" = (
+"vpX" = (
 /obj/structure/table/wood,
-/obj/effect/turf_decal/tile/brown/full,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/item/food/lizard_fries,
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
-"vpY" = (
-/obj/effect/turf_decal/tile/neutral/full,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/grimy,
 /area/station/service/bar)
 "vpZ" = (
 /obj/effect/turf_decal/siding/yellow{
@@ -63562,9 +64782,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
-"vqp" = (
-/turf/open/floor/carpet/lone,
-/area/station/service/theater)
 "vqw" = (
 /obj/effect/decal/cleanable/glass/titanium,
 /obj/item/stack/rods/two,
@@ -63630,12 +64847,6 @@
 /obj/machinery/computer/records/security,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
-"vrv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/carpet/lone,
-/area/station/service/theater)
 "vrz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -63713,15 +64924,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation)
-"vsl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/status_display/ai/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "vso" = (
 /obj/effect/landmark/start/scientist,
 /obj/structure/chair{
@@ -63731,20 +64933,18 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"vsq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/radio/intercom/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/stone,
-/area/station/service/theater)
 "vsx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"vsP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "vsQ" = (
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -63753,6 +64953,16 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/starboard/aft)
+"vsT" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "vsW" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/box/red/corners{
@@ -63763,25 +64973,16 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"vtc" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig"
+"vtr" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "sci-entrance"
+/obj/structure/flora/bush/jungle/c/style_3{
+	pixel_x = 6;
+	pixel_y = -6
 	},
-/turf/open/floor/iron/textured_half,
-/area/station/security/brig/entrance)
-"vtv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/hallway/primary/port)
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "vtw" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -63842,9 +65043,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/starboard/aft)
-"vuo" = (
-/turf/closed/wall/r_wall,
-/area/station/commons/vacant_room/commissary)
 "vuq" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -63866,6 +65064,20 @@
 /obj/machinery/deepfryer,
 /turf/open/floor/iron/kitchen/small,
 /area/station/security/prison/mess)
+"vuA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/secondary/exit/departure_lounge)
 "vuB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
@@ -63875,6 +65087,16 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/science/xenobiology)
+"vuD" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L13";
+	pixel_y = -15
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "vuH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -63894,17 +65116,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"vuL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "vuR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64022,11 +65233,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"vwg" = (
-/obj/structure/bookcase/random/nonfiction,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/wood/tile,
-/area/station/service/bar)
 "vwh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/public/glass{
@@ -64046,6 +65252,16 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/tcommsat/server)
+"vwD" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "vwE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -64123,6 +65339,14 @@
 "vxt" = (
 /turf/closed/wall,
 /area/station/maintenance/department/engine)
+"vxL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "vxM" = (
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
@@ -64178,6 +65402,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
+"vyN" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "vyR" = (
 /turf/open/floor/glass,
 /area/station/command/corporate_dock)
@@ -64233,11 +65466,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
-"vzI" = (
-/obj/machinery/skill_station,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
+"vzH" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "vzK" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/helium_output{
@@ -64246,18 +65481,6 @@
 	},
 /turf/open/floor/engine/helium,
 /area/station/ai_monitored/turret_protected/ai)
-"vzM" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/brown/full,
-/obj/structure/sink/kitchen/directional/south,
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
-"vzP" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "vzV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64266,14 +65489,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/tram)
-"vzW" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/chair/sofa/bamboo/left{
-	dir = 1
-	},
-/turf/open/floor/wood/large,
-/area/station/service/chapel)
 "vzX" = (
 /obj/machinery/door/airlock/command{
 	name = "Centcom Dock"
@@ -64346,14 +65561,6 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/security/tram)
-"vAA" = (
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/chair/sofa/bamboo/left{
-	dir = 1
-	},
-/turf/open/floor/wood/large,
-/area/station/service/chapel)
 "vAC" = (
 /obj/structure/flora/bush/large/style_random{
 	pixel_y = -3
@@ -64376,14 +65583,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"vAR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "vAT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64406,11 +65605,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white/textured_half,
 /area/station/science/lobby)
-"vBm" = (
-/obj/machinery/holopad,
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/turf/open/floor/iron/white/small,
-/area/station/service/hydroponics)
+"vBc" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/bush/large/style_3,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "vBG" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -64496,6 +65697,21 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron/grimy,
 /area/station/engineering/main)
+"vDo" = (
+/obj/structure/flora/bush/flowers_yw/style_3{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/structure/flora/bush/flowers_br/style_random{
+	pixel_y = -5;
+	pixel_x = 3
+	},
+/obj/effect/light_emitter/fake_outdoors,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/grass/Airless,
+/area/station/hallway/primary/central/aft)
 "vDB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64515,6 +65731,31 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/disposal/incinerator)
+"vDG" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock{
+	name = "Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/central/lesser)
+"vDO" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/camera/autoname/directional/north,
+/obj/structure/cable,
+/obj/structure/sign/painting/large/library{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "vDQ" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /turf/open/floor/iron,
@@ -64546,11 +65787,6 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/dock)
-"vEq" = (
-/obj/structure/chair/stool/bar/directional/east,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood/tile,
-/area/station/service/bar)
 "vEz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -64572,14 +65808,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"vEI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "vEP" = (
 /turf/closed/wall/r_wall,
 /area/station/security/brig)
@@ -64652,15 +65880,6 @@
 	dir = 6
 	},
 /area/station/hallway/secondary/construction)
-"vFv" = (
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "vFy" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -64688,27 +65907,12 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
-"vFE" = (
-/obj/structure/table,
-/obj/item/trash/energybar,
-/turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
 "vFG" = (
 /obj/machinery/computer/rdservercontrol{
 	dir = 8
 	},
 /turf/open/floor/iron/white/small,
 /area/station/science/server)
-"vFQ" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
-	location = "QM #2"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/camera/autoname/directional/south,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "vFR" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/siding/red{
@@ -64734,6 +65938,21 @@
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/station/engineering/supermatter)
+"vGb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "vaco";
+	name = "Comissary Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/lesser)
 "vGe" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -64742,6 +65961,15 @@
 /obj/effect/landmark/start/clown,
 /turf/open/floor/iron/smooth,
 /area/station/service/greenroom)
+"vGh" = (
+/obj/machinery/vending/wardrobe/bar_wardrobe,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/stone,
+/area/station/service/bar/backroom)
 "vGp" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small/red/dim/directional/south,
@@ -64789,6 +66017,15 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"vHA" = (
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
+	},
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "vHH" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/siding/thinplating_new{
@@ -64799,14 +66036,6 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/courtroom)
-"vHL" = (
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/obj/effect/turf_decal/plaque{
-	icon_state = "L7"
-	},
-/obj/effect/landmark/observer_start,
-/turf/open/floor/glass,
-/area/station/hallway/secondary/spacebridge)
 "vHT" = (
 /obj/effect/turf_decal/box/red/corners{
 	dir = 8
@@ -64829,20 +66058,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner,
 /area/station/science/lower)
-"vIg" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/station/service/chapel/office)
-"vIh" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/service/chapel/office)
 "vIp" = (
 /obj/structure/table,
 /obj/item/folder/yellow{
@@ -64880,12 +66095,6 @@
 "vIF" = (
 /turf/closed/wall,
 /area/station/engineering/atmos/pumproom)
-"vII" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/parquet,
-/area/station/service/theater)
 "vIJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
@@ -64897,6 +66106,23 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/central/fore)
+"vIK" = (
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
+"vIP" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/exodrone_launcher,
+/turf/open/floor/iron/smooth,
+/area/station/cargo/drone_bay)
 "vIX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64924,6 +66150,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"vJf" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "vJn" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/window/spawner/directional/west,
@@ -65098,16 +66330,6 @@
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"vLf" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/dark_red/opposingcorners,
-/obj/machinery/flasher/directional/west{
-	id = "brigentry"
-	},
-/turf/open/floor/iron,
-/area/station/security/brig/entrance)
 "vLi" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/effect/turf_decal/siding/green{
@@ -65118,6 +66340,14 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
+"vLp" = (
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "vLs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool/directional/east,
@@ -65145,25 +66375,6 @@
 /obj/item/gavelhammer,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
-"vLO" = (
-/obj/structure/table,
-/obj/item/reagent_containers/condiment/saltshaker{
-	desc = "Salt. From space oceans, presumably. A staple of modern medicine.";
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/machinery/newscaster/directional/east,
-/obj/effect/spawner/random/food_or_drink/condiment{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/service/cafeteria)
 "vLP" = (
 /turf/closed/wall/rust,
 /area/station/command/heads_quarters/qm)
@@ -65235,11 +66446,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/aft)
-"vML" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "vMT" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/food/grown/mushroom/libertycap,
@@ -65297,6 +66503,12 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
+"vNG" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "vOf" = (
 /obj/structure/cable,
 /obj/structure/chair{
@@ -65306,14 +66518,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/science/lower)
-"vOh" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/red/line,
-/turf/open/floor/iron/small,
-/area/station/hallway/secondary/spacebridge)
 "vOm" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -65388,16 +66592,26 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/hallway/secondary/recreation)
-"vPC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/hallway/secondary/spacebridge)
+"vPA" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/large/style_3,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "vPJ" = (
 /obj/structure/broken_flooring/singular/directional/east,
 /obj/structure/alien/weeds,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
+"vPN" = (
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/siding/wideplating_new/terracotta,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood/tile,
+/area/station/maintenance/central/lesser)
 "vPP" = (
 /turf/closed/wall,
 /area/station/command/corporate_suite)
@@ -65443,14 +66657,13 @@
 /obj/structure/flora/bush/large/style_random,
 /turf/open/misc/sandy_dirt,
 /area/station/medical/medbay/lobby)
-"vQA" = (
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/camera/autoname/directional/north,
-/obj/structure/sign/warning/no_smoking/circle/directional/north,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
+"vQS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "vRd" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/dark_red,
@@ -65475,12 +66688,6 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
-"vRE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/brown/full,
-/turf/open/floor/iron/smooth_large,
-/area/station/service/bar)
 "vRH" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/plating,
@@ -65503,6 +66710,27 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"vSq" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/requests_console/directional/north{
+	department = "Chief Engineer's Desk";
+	name = "Chief Engineer's Requests Console";
+	pixel_y = -32;
+	pixel_x = 2
+	},
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/information,
+/turf/open/floor/iron/stairs/old{
+	dir = 4
+	},
+/area/station/command/heads_quarters/ce)
 "vSw" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -65515,12 +66743,6 @@
 	},
 /turf/open/floor/iron/kitchen/small,
 /area/station/security/prison/mess)
-"vSE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "vSL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
@@ -65531,20 +66753,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"vST" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/white/small,
-/area/station/service/hydroponics)
 "vSW" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"vSX" = (
-/obj/structure/flora/bush/sunny/style_random,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "vSY" = (
 /obj/structure/table,
 /obj/item/chisel{
@@ -65638,11 +66850,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/corporate_dock)
-"vTN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/small,
-/area/station/service/hydroponics)
 "vTV" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/hos)
@@ -65657,6 +66864,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"vTZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "vUe" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -65676,11 +66893,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"vUq" = (
-/obj/machinery/restaurant_portal/bar,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/wood/tile,
-/area/station/service/bar)
 "vUz" = (
 /obj/structure/table_frame,
 /obj/effect/decal/cleanable/glass,
@@ -65691,18 +66903,6 @@
 	},
 /turf/open/floor/eighties,
 /area/station/service/abandoned_gambling_den/gaming)
-"vUG" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 4;
-	id = "kitchenshutters";
-	name = "Kitchen Shutters"
-	},
-/obj/structure/displaycase/forsale/kitchen{
-	pixel_y = 8
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "vUM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -65733,13 +66933,6 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/security/prison/safe)
-"vUZ" = (
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "vVo" = (
 /obj/machinery/light/cold/directional/south,
 /obj/structure/table/reinforced,
@@ -65747,12 +66940,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/escape)
-"vVw" = (
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "vVx" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/food/grown/mushroom/plumphelmet,
@@ -65828,6 +67015,12 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white/corner,
 /area/station/science/lobby)
+"vWo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/herringbone,
+/area/station/ai_monitored/command/nuke_storage)
 "vWr" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "permaouter";
@@ -65884,6 +67077,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"vWW" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/grimy,
+/area/station/service/library)
 "vWY" = (
 /obj/structure/cable,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -65891,6 +67091,10 @@
 /obj/item/clothing/gloves/boxing/blue,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
+"vWZ" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "vXi" = (
 /obj/structure/table,
 /obj/item/reagent_containers/cup/bowl,
@@ -65900,14 +67104,6 @@
 /obj/item/wirecutters,
 /turf/open/floor/iron/white/diagonal,
 /area/station/maintenance/department/science/xenobiology)
-"vXo" = (
-/obj/effect/turf_decal/siding/wood/corner,
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/obj/effect/landmark/start/librarian,
-/turf/open/floor/iron/grimy,
-/area/station/service/library)
 "vXr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -65945,28 +67141,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security)
-"vXW" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "vYj" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"vYt" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/end,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "vYx" = (
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 1
@@ -66089,6 +67268,14 @@
 /obj/effect/decal/cleanable/glass/plasma,
 /turf/open/floor/engine,
 /area/station/engineering/atmos)
+"vZR" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/service/bar)
 "vZW" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
@@ -66123,18 +67310,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
-"wav" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
-"waw" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
 "way" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -66162,17 +67337,6 @@
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/wood,
 /area/station/service/chapel/office)
-"waS" = (
-/obj/structure/table,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/item/toy/foamblade,
-/obj/item/toy/dummy,
-/obj/machinery/light/small/directional/north,
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/plating,
-/area/station/service/theater)
 "waX" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66191,6 +67355,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"wbn" = (
+/turf/open/floor/glass,
+/area/station/hallway/primary/central/aft)
 "wbp" = (
 /obj/item/kirbyplants/random,
 /obj/item/radio/intercom/directional/south,
@@ -66223,6 +67390,16 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/science/lab)
+"wbT" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L7";
+	pixel_y = -15
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "wco" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66315,6 +67492,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"wdx" = (
+/obj/effect/landmark/start/bartender,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/stone,
+/area/station/service/bar/backroom)
 "wdB" = (
 /obj/structure/railing{
 	dir = 4
@@ -66333,12 +67518,6 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
-"wdV" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/stool/bamboo,
-/turf/open/floor/carpet/lone,
-/area/station/service/chapel/office)
 "wdY" = (
 /obj/effect/spawner/random/structure/table,
 /turf/open/floor/plating,
@@ -66386,14 +67565,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"wfb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/stool/bamboo,
-/turf/open/floor/carpet/lone,
-/area/station/service/chapel/office)
 "wfi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/green{
@@ -66404,9 +67575,26 @@
 "wfk" = (
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
+"wfl" = (
+/obj/machinery/vending/wardrobe/hydro_wardrobe,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 5
+	},
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
 "wfn" = (
 /turf/closed/wall,
 /area/station/engineering/break_room)
+"wfo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "wfr" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/pharmacy)
@@ -66430,39 +67618,12 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_command)
-"wfP" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig"
+"wfI" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "sci-entrance"
-	},
-/turf/open/floor/iron/textured_half,
-/area/station/security/brig/entrance)
-"wfU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/small,
-/area/station/medical/medbay/lobby)
-"wgj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/lone,
-/area/station/service/chapel/office)
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "wgl" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -66548,14 +67709,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos/storage/gas)
-"wht" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "whu" = (
 /obj/structure/cable,
 /obj/machinery/blackbox_recorder,
@@ -66579,6 +67732,16 @@
 /obj/machinery/research/anomaly_refinery,
 /turf/open/floor/iron/white/small,
 /area/station/science/ordnance/storage)
+"whE" = (
+/obj/machinery/light/floor,
+/obj/structure/altar_of_gods,
+/obj/item/book/bible,
+/obj/effect/landmark/start/hangover,
+/obj/item/flashlight/lantern{
+	pixel_y = 5
+	},
+/turf/open/floor/wood/tile,
+/area/station/service/chapel)
 "whF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/corner{
@@ -66615,16 +67778,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/security/brig/entrance)
-"wix" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/newscaster/directional/west,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/dark/side,
-/area/station/hallway/primary/central/fore)
 "wiC" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -66653,13 +67806,6 @@
 /obj/structure/cable,
 /turf/closed/wall,
 /area/station/engineering/engine_smes)
-"wiU" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/effect/landmark/start/librarian,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "wja" = (
 /turf/closed/wall/r_wall,
 /area/station/commons/toilet/auxiliary)
@@ -66677,13 +67823,17 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/iron/dark/small,
 /area/station/security/detectives_office)
-"wjK" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
+"wjV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/dark_red/half/contrasted{
+	dir = 4
 	},
-/obj/structure/flora/bush/sunny/style_random,
-/turf/open/floor/grass,
-/area/station/service/chapel)
+/obj/effect/turf_decal/siding/wideplating/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
 "wjZ" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -66704,13 +67854,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/command/bridge)
-"wkk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "wkF" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -66725,6 +67868,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"wkH" = (
+/obj/structure/flora/bush/jungle/a/style_random,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "wkU" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -66738,45 +67885,32 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/chapel,
 /area/station/maintenance/starboard/greater)
-"wlf" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/glass,
-/area/station/hallway/secondary/spacebridge)
 "wlk" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"wlu" = (
-/obj/structure/closet/secure_closet/bar,
-/obj/item/stack/spacecash/c100,
-/obj/item/stack/spacecash/c10,
-/obj/item/stack/spacecash/c1,
-/obj/item/stack/spacecash/c1,
-/obj/item/stack/spacecash/c1,
-/obj/machinery/light/small/directional/north,
-/obj/structure/sign/poster/official/random/directional/north,
-/obj/item/radio/intercom/directional/east,
+"wlq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
 /turf/open/floor/stone,
 /area/station/service/bar/backroom)
-"wlF" = (
-/obj/structure/disposalpipe/segment,
+"wlK" = (
+/obj/structure/chair/stool/bar/directional/north,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/grass,
-/area/station/service/chapel)
-"wlL" = (
-/obj/machinery/firealarm/directional/north,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
-"wlQ" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
-/area/station/service/chapel)
+/turf/open/floor/wood,
+/area/station/hallway/primary/central/aft)
 "wlS" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -66810,16 +67944,6 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"wms" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/newscaster/directional/north,
-/obj/machinery/duct,
-/turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
 "wmu" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -66868,6 +67992,16 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/surgery/theatre)
+"wmF" = (
+/obj/effect/landmark/start/assistant,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "wmS" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/red/corner{
@@ -66882,11 +68016,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"wmY" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
 "wnd" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -66919,12 +68048,6 @@
 /obj/machinery/light/small/broken/directional/north,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
-"wnB" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L1"
-	},
-/turf/open/floor/glass,
-/area/station/hallway/secondary/spacebridge)
 "wnE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66932,19 +68055,30 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
-"wnK" = (
-/obj/structure/table,
-/obj/effect/spawner/random/entertainment/toy,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/wood,
-/area/station/service/theater)
-"wnO" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
+"wnH" = (
+/obj/structure/sign/poster/official/random/directional/south,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/restaurant_portal/bar,
+/turf/open/floor/stone,
+/area/station/service/bar)
+"wnP" = (
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "wnR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66953,6 +68087,15 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/engineering/break_room)
+"wnS" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/landmark/start/hangover,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "wnY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66963,6 +68106,16 @@
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/chemistry)
+"woh" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock{
+	name = "Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/central/lesser)
 "woi" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/starboard/fore)
@@ -66971,22 +68124,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/tcommsat/server)
-"wow" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
-"woB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "woD" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -67046,6 +68183,19 @@
 /obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"wpE" = (
+/obj/effect/turf_decal/siding/thinplating_new/light,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/light/small/directional/south,
+/obj/machinery/requests_console/auto_name/directional/south,
+/obj/effect/mapping_helpers/requests_console/supplies,
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
 "wpO" = (
 /turf/closed/wall/r_wall,
 /area/station/security/processing)
@@ -67076,15 +68226,6 @@
 "wqj" = (
 /turf/closed/wall,
 /area/station/commons/toilet/restrooms)
-"wqs" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "barki";
-	name = "Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/service/kitchen)
 "wqD" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/decal/cleanable/dirt,
@@ -67113,6 +68254,14 @@
 "wqP" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/department/electrical)
+"wqU" = (
+/obj/structure/window/spawner/directional/east,
+/obj/structure/window/spawner/directional/west,
+/obj/structure/flora/bush/large/style_2,
+/obj/structure/flora/bush/sparsegrass,
+/obj/structure/flora/bush/flowers_yw,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "wqW" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 1
@@ -67228,6 +68377,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"wsK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	name = "Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/holodeck/rec_center)
 "wsL" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/spawner/random/maintenance,
@@ -67244,12 +68406,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"wsX" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/chair/stool/bar/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation/entertainment)
+"wsY" = (
+/obj/structure/flora/tree/jungle/style_4,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "wtc" = (
 /obj/structure/cable,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -67259,6 +68420,13 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/station/science/xenobiology)
+"wtd" = (
+/obj/structure/flora/bush/jungle/a/style_random,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "wte" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -67392,11 +68560,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/command/gateway)
-"wuw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "wuH" = (
 /obj/structure/broken_flooring/singular/directional/south,
 /obj/effect/landmark/generic_maintenance_landmark,
@@ -67417,13 +68580,12 @@
 "wuM" = (
 /turf/closed/wall,
 /area/station/command/heads_quarters/qm)
-"wvn" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/service/library)
+"wvp" = (
+/obj/machinery/light/small/directional/south,
+/obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "wvv" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -67436,21 +68598,20 @@
 /obj/structure/hedge,
 /turf/open/floor/iron/grimy,
 /area/station/science/cubicle)
+"wvH" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/carpet,
+/area/station/service/library)
 "wvM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/floor,
 /turf/open/floor/iron/white/small,
 /area/station/science/cubicle)
-"wvP" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/screwdriver,
-/obj/effect/turf_decal/siding/wideplating_new/terracotta{
-	dir = 8
-	},
-/turf/open/floor/wood/tile,
-/area/station/commons/vacant_room/commissary)
 "wvT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 10
@@ -67472,6 +68633,14 @@
 	dir = 1
 	},
 /area/station/security/execution/transfer)
+"wwv" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/bush/flowers_br/style_3,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "wwz" = (
 /obj/structure/cable,
 /obj/machinery/computer/mech_bay_power_console{
@@ -67547,6 +68716,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
+"wxt" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "wxu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
@@ -67674,12 +68849,6 @@
 /obj/machinery/meter,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"wyY" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/lone,
-/area/station/service/chapel/office)
 "wyZ" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 4
@@ -67692,11 +68861,6 @@
 "wzj" = (
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
-"wzk" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/hallway/primary/port)
 "wzo" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/landmark/start/cargo_technician,
@@ -67790,15 +68954,15 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
+"wAT" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "wAW" = (
 /turf/closed/wall,
-/area/station/hallway/primary/port)
-"wAZ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Shrine"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/textured_half,
 /area/station/hallway/primary/port)
 "wBa" = (
 /turf/open/floor/iron/dark/smooth_corner,
@@ -67874,6 +69038,24 @@
 /obj/machinery/computer/arcade/orion_trail/kobayashi,
 /turf/open/floor/wood/tile,
 /area/station/maintenance/port/lesser)
+"wCF" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen/invisible{
+	pixel_x = -2;
+	pixel_y = 7
+	},
+/obj/machinery/newscaster/directional/north,
+/obj/item/storage/photo_album/library,
+/obj/item/book/codex_gigas,
+/turf/open/floor/iron/grimy,
+/area/station/service/library)
 "wCH" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
@@ -67930,6 +69112,23 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"wDt" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/stone,
+/area/station/service/chapel)
+"wDx" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/hallway/primary/central/aft)
 "wDA" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -67941,17 +69140,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
-"wDJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/status_display/ai/directional/north,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "wDM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -67959,19 +69147,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
-"wDV" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"wDZ" = (
-/obj/item/radio/intercom/directional/south,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
 "wEc" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
@@ -67992,10 +69167,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"wEp" = (
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
 "wEs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -68005,6 +69176,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_command)
+"wEv" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 10
+	},
+/turf/open/floor/iron/white/small,
+/area/station/service/hydroponics)
 "wEC" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -68024,12 +69201,6 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
-"wEI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
 "wER" = (
 /obj/effect/spawner/random/trash,
 /obj/machinery/duct,
@@ -68062,15 +69233,6 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_command)
-"wFl" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/red/line,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/turf/open/floor/iron/small,
-/area/station/hallway/primary/starboard)
 "wFq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -68149,23 +69311,36 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"wGO" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "wGU" = (
 /obj/structure/table,
 /obj/effect/spawner/random/techstorage/ai_all,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
+"wHe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/secondary/service)
 "wHg" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/iron/grimy,
 /area/station/science/cubicle)
-"wHE" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "wHH" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner/end{
@@ -68213,29 +69388,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"wHX" = (
-/obj/item/radio/intercom/directional/south,
-/obj/effect/landmark/start/hangover,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/spacebridge)
 "wIc" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/flora/rock/pile/jungle/style_random,
 /turf/open/misc/sandy_dirt,
 /area/station/medical/medbay/lobby)
-"wId" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/dark_red/fourcorners,
-/turf/open/floor/iron,
-/area/station/security/brig/entrance)
 "wIm" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Centcom Dock"
@@ -68290,6 +69447,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
+"wJl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/primary/central/aft)
 "wJn" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/small,
@@ -68331,14 +69500,6 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"wJV" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/sign/painting/large/library{
-	dir = 1
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/smooth,
-/area/station/service/library)
 "wJX" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/iron/herringbone,
@@ -68450,17 +69611,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/court,
 /turf/open/floor/plating,
 /area/station/security/courtroom)
-"wLA" = (
-/obj/machinery/holopad,
-/turf/open/floor/wood,
-/area/station/service/theater)
-"wLJ" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "wLM" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -68485,6 +69635,16 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/service/library)
+"wMs" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "wMA" = (
 /obj/machinery/camera/directional/west,
 /obj/structure/bookcase/random/religion,
@@ -68539,6 +69699,12 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/science/lobby)
+"wMS" = (
+/obj/machinery/deepfryer,
+/obj/structure/sign/poster/official/random/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen)
 "wMT" = (
 /obj/structure/table,
 /turf/open/floor/iron/smooth,
@@ -68585,6 +69751,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"wNp" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/item/kirbyplants/random,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/iron,
+/area/station/holodeck/rec_center)
 "wNv" = (
 /obj/effect/landmark/navigate_destination/bridge,
 /turf/open/floor/iron/smooth_half,
@@ -68623,15 +69797,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"wNR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "wNS" = (
 /obj/structure/rack,
 /obj/structure/transport/linear/tram,
@@ -68881,6 +70046,14 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
+"wQf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/flashlight/lantern/on,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "wQi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 4
@@ -68987,16 +70160,6 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_freezer_chamber_input,
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/freezerchamber)
-"wRD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/smooth,
-/area/station/service/greenroom)
 "wRN" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -69035,6 +70198,15 @@
 /obj/machinery/smartfridge/organ,
 /turf/open/floor/plating,
 /area/station/medical/morgue)
+"wRY" = (
+/obj/machinery/door/morgue{
+	name = "Private Study";
+	req_access = list("library")
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "wSf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -69095,6 +70267,12 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain/private)
+"wTe" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/blue,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/dark/side,
+/area/station/hallway/primary/central/fore)
 "wTm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -69112,6 +70290,17 @@
 /obj/structure/tank_dispenser,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
+"wTE" = (
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
+	},
+/obj/machinery/chem_master/condimaster{
+	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
+	name = "BrewMaster 2199"
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "wTH" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -69215,6 +70404,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/security)
+"wUs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "wUS" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -69228,6 +70428,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/small,
 /area/station/service/janitor)
+"wVc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron/smooth,
+/area/station/service/greenroom)
+"wVf" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/barricade/wooden/crude,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/cargo/boutique)
 "wVg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
@@ -69267,22 +70487,6 @@
 /obj/machinery/light/small/dim/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
-"wVZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
-"wWa" = (
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "wWb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/structure/railing{
@@ -69324,16 +70528,6 @@
 "wWS" = (
 /turf/open/floor/iron,
 /area/station/security/prison)
-"wWT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "wWU" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash,
@@ -69389,31 +70583,12 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/security/brig)
-"wXO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "wXV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"wXZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/red/line,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/turf/open/floor/iron/small,
-/area/station/hallway/primary/central/fore)
 "wYa" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -69428,18 +70603,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
-"wYr" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
+"wYm" = (
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "wYv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 9
@@ -69453,26 +70625,6 @@
 "wYA" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/chemistry)
-"wYD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/landmark/navigate_destination/hop,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
-"wYF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/grown/bananapeel,
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
 "wYH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -69485,17 +70637,6 @@
 	},
 /turf/open/misc/sandy_dirt,
 /area/station/security/tram)
-"wYV" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
 "wZa" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -69516,15 +70657,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/hallway/secondary/exit/departure_lounge)
-"wZd" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/dark_red/opposingcorners,
-/obj/machinery/camera/autoname/directional/west,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron,
-/area/station/security/brig/entrance)
 "wZk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -69537,16 +70669,6 @@
 "wZl" = (
 /turf/closed/wall,
 /area/station/commons)
-"wZo" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/green/diagonal_centre,
-/turf/open/floor/iron/diagonal,
-/area/station/hallway/primary/central/aft)
 "wZp" = (
 /obj/effect/turf_decal/arrows{
 	dir = 8
@@ -69562,6 +70684,36 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/maintenance/department/engine/atmos)
+"wZx" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/item/reagent_containers/cup/bowl{
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/cup/bowl{
+	pixel_y = 8;
+	pixel_x = 3
+	},
+/obj/machinery/door/poddoor/shutters{
+	name = "Kitchen Shutters";
+	id = "kitchenshutters"
+	},
+/turf/open/floor/plating,
+/area/station/service/kitchen)
+"wZz" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/trash,
+/turf/open/floor/iron/stairs{
+	dir = 8
+	},
+/area/station/maintenance/port/greater)
 "wZA" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -69570,14 +70722,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
-"wZE" = (
-/obj/structure/disposalpipe/junction,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "wZF" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -69697,6 +70841,10 @@
 	},
 /turf/open/floor/plating/airless,
 /area/station/cargo/miningoffice)
+"xbb" = (
+/obj/structure/chair/stool/bar/directional/east,
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "xbe" = (
 /obj/structure/cable,
 /turf/open/floor/grass,
@@ -69720,18 +70868,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"xbP" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/public/glass{
-	name = "Vault Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/vault,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/secondary/spacebridge)
 "xbR" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/hedge,
@@ -69810,6 +70946,10 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
+"xdm" = (
+/obj/effect/spawner/xmastree,
+/turf/open/misc/dirt/jungle,
+/area/station/service/chapel)
 "xdo" = (
 /obj/machinery/firealarm/directional/north,
 /obj/item/kirbyplants/random/fullysynthetic,
@@ -69845,18 +70985,6 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
-"xdD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/sink/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/directional/north,
-/obj/machinery/light/cold/directional/north,
-/turf/open/floor/iron/dark/small,
-/area/station/service/chapel/storage)
 "xdJ" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engine Airlock"
@@ -69897,13 +71025,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmos)
-"xen" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "xeo" = (
 /obj/structure/window/spawner/directional/south,
 /obj/structure/lattice,
@@ -69939,6 +71060,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"xeF" = (
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "xeM" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -69996,12 +71125,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/research)
-"xeY" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/dark/small,
-/area/station/commons/vacant_room/commissary)
 "xfa" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -70027,12 +71150,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
-"xfw" = (
-/obj/structure/table,
-/obj/item/flashlight/lantern,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "xfy" = (
 /obj/structure/transport/linear/tram,
 /obj/structure/fluff/tram_rail/floor{
@@ -70070,13 +71187,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security)
-"xfU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/lone,
-/area/station/service/chapel/office)
 "xfV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70139,53 +71249,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"xgN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/holopad,
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"xhe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
-"xhj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/station/service/chapel/office)
-"xhA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Crematorium"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
-/turf/open/floor/iron/textured_half{
-	dir = 8
-	},
-/area/station/service/chapel/storage)
 "xhD" = (
 /obj/structure/table,
 /obj/item/clothing/shoes/ducky_shoes{
@@ -70203,30 +71266,11 @@
 /obj/effect/landmark/navigate_destination/lawyer,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
-"xhH" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/mail_sorting/service/chapel,
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "xhM" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/tcomms,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
-"xhQ" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "xhU" = (
 /obj/structure/flora/bush/large/style_random{
 	pixel_x = -18;
@@ -70271,14 +71315,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
-"xiA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark/small,
-/area/station/service/chapel/storage)
 "xiE" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/virology)
@@ -70290,13 +71326,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"xiL" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "xiN" = (
 /obj/machinery/door/window/left/directional/north{
 	name = "Equipment Storage";
@@ -70329,6 +71358,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
+"xiX" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "xjb" = (
 /turf/open/floor/iron/white/side{
 	dir = 5
@@ -70346,17 +71383,6 @@
 "xjg" = (
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
-"xjh" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "xjo" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -70368,15 +71394,6 @@
 	dir = 8
 	},
 /area/station/science/lower)
-"xjq" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "xjz" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/garden)
@@ -70441,16 +71458,19 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"xkg" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
+"xkk" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/barsign{
+	chosen_sign = "thecavern";
+	icon_state = "thecavern";
+	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/dark_red/half/contrasted,
-/turf/open/floor/iron,
-/area/station/security/brig/entrance)
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/service/bar)
 "xkn" = (
 /obj/structure/steam_vent,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -70483,10 +71503,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
-"xkS" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "xkU" = (
 /obj/effect/turf_decal/siding/thinplating_new/terracotta{
 	dir = 9
@@ -70494,16 +71510,6 @@
 /obj/machinery/power/shieldwallgen,
 /turf/open/floor/iron/smooth_large,
 /area/station/command/teleporter)
-"xkW" = (
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth,
-/area/station/service/greenroom)
 "xkX" = (
 /obj/effect/turf_decal/tile/yellow/diagonal_centre,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70697,6 +71703,9 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
+"xoO" = (
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "xoS" = (
 /obj/effect/turf_decal/siding/thinplating_new/terracotta{
 	dir = 9
@@ -70730,6 +71739,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"xoY" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "xpb" = (
 /obj/structure/transit_tube/station/dispenser{
 	dir = 1
@@ -70790,13 +71806,6 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"xpT" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "xpU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -70837,6 +71846,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"xqj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/tcommsat/server)
 "xqn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70914,6 +71927,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
+"xro" = (
+/obj/machinery/door/airlock{
+	id_tag = "commiss2";
+	name = "Commissary"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/commons/vacant_room/commissary)
 "xru" = (
 /obj/item/kirbyplants/random/fullysynthetic,
 /obj/machinery/airalarm/directional/east,
@@ -70927,14 +71953,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"xrz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/stairs{
-	dir = 8
-	},
-/area/station/service/theater)
 "xrA" = (
 /obj/structure/sign/warning/pods/directional/west,
 /turf/open/floor/plating,
@@ -71132,15 +72150,6 @@
 "xtW" = (
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
-"xtZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "xug" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /obj/effect/turf_decal/tile/brown/opposingcorners,
@@ -71216,10 +72225,6 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms)
-"xuU" = (
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "xuW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -71299,6 +72304,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
+"xvN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "xvT" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/maint)
@@ -71313,9 +72326,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"xvW" = (
-/turf/closed/wall,
-/area/station/service/theater)
 "xwd" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
@@ -71386,6 +72396,15 @@
 /obj/structure/tram,
 /turf/open/floor/tram,
 /area/station/security/tram)
+"xwP" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/west,
+/obj/machinery/camera/directional/west,
+/obj/machinery/status_display/ai/directional/west,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "xwQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
@@ -71416,6 +72435,17 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"xxu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "xxA" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -71429,21 +72459,6 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/iron,
 /area/station/commons/fitness/locker_room)
-"xxE" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/maintenance{
-	name = "Crematorium"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/iron/textured_half{
-	dir = 8
-	},
-/area/station/security/brig/entrance)
 "xxL" = (
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
 /turf/open/floor/iron/checker{
@@ -71455,18 +72470,27 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hos)
-"xye" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"xxZ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/dark_red/fourcorners,
-/obj/machinery/holopad,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
-/area/station/security/brig/entrance)
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/grass,
+/area/station/service/chapel)
+"xyg" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/camera/autoname/directional/west,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/tile/neutral/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 8
+	},
+/turf/open/floor/iron/small,
+/area/station/hallway/secondary/service)
 "xyh" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -71510,10 +72534,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
-"xyJ" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "xyQ" = (
 /obj/structure/cable,
 /obj/machinery/light_switch/directional/south,
@@ -71527,11 +72547,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/secondary/entry)
-"xyY" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/displaycase/trophy,
-/turf/open/floor/iron/smooth,
-/area/station/service/library)
 "xyZ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -71574,11 +72589,16 @@
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/hallway/secondary/exit/departure_lounge)
-"xzp" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/wood/parquet,
-/area/station/service/theater)
+"xzw" = (
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 10
+	},
+/obj/structure/sign/poster/official/random/directional/south,
+/turf/open/floor/eighties/red,
+/area/station/hallway/primary/central/fore)
 "xzE" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/dark_red,
@@ -71594,6 +72614,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
+"xzK" = (
+/turf/open/floor/iron/white/side,
+/area/station/hallway/primary/central/aft)
 "xzQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/west,
@@ -71630,6 +72653,14 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"xAu" = (
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/vacant_room/commissary)
 "xAv" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -71660,16 +72691,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"xAP" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "xAR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -71758,30 +72779,14 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"xBK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
+"xBL" = (
+/obj/structure/flora/tree/jungle/style_3,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "xBV" = (
 /obj/effect/spawner/random/structure/chair_flipped,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"xBZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/turf/open/floor/iron/small,
-/area/station/hallway/secondary/exit/departure_lounge)
 "xCc" = (
 /obj/machinery/modular_computer/preset/id{
 	dir = 8
@@ -71798,19 +72803,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/stairs,
 /area/station/hallway/primary/central/fore)
-"xCu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
-"xCz" = (
-/obj/effect/spawner/random/structure/crate,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "xCH" = (
 /obj/structure/railing{
 	dir = 9
@@ -71947,6 +72939,14 @@
 /obj/structure/flora/bush/flowers_yw,
 /turf/open/floor/grass,
 /area/station/science/xenobiology)
+"xEp" = (
+/obj/machinery/vending/boozeomat,
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4
+	},
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/station/service/bar)
 "xEq" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -71957,12 +72957,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
-"xEC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "xEM" = (
 /obj/structure/window/spawner/directional/north,
 /obj/structure/flora/bush/large/style_random{
@@ -72066,14 +73060,6 @@
 /obj/structure/hedge,
 /turf/open/floor/iron/herringbone,
 /area/station/commons/dorms)
-"xFO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "xFT" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/pod/old,
@@ -72086,15 +73072,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"xGc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "xGf" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
@@ -72180,16 +73157,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/station/commons/dorms)
-"xHB" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/table,
-/obj/effect/turf_decal/bot,
-/obj/machinery/light_switch/directional/north,
-/obj/machinery/camera/autoname/directional/west,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
 "xHD" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -72245,14 +73212,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/science/lobby)
-"xIl" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "xIr" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -72277,11 +73236,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"xIy" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "xIA" = (
 /obj/effect/turf_decal/arrows{
 	dir = 8
@@ -72306,22 +73260,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/plating,
 /area/station/engineering/gravity_generator)
-"xIK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side,
-/area/station/hallway/primary/starboard)
-"xIM" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side,
-/area/station/hallway/primary/starboard)
 "xIP" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/construction)
@@ -72329,6 +73267,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"xJa" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/vault{
+	name = "Vault"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/all/supply/vault,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/herringbone,
+/area/station/ai_monitored/command/nuke_storage)
 "xJi" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/spawner/random/vending/snackvend,
@@ -72354,12 +73304,10 @@
 "xJB" = (
 /turf/closed/wall,
 /area/station/security/courtroom)
-"xJR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+"xJQ" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/camera/autoname/directional/south,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "xJZ" = (
@@ -72375,13 +73323,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/white/small,
 /area/station/medical/medbay/central)
-"xKa" = (
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/structure/chair/stool/bar/directional/west,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/cafeteria)
 "xKg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -72421,15 +73362,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/processing)
-"xKx" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/iron/dark/small,
-/area/station/service/chapel/storage)
 "xKz" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/effect/turf_decal/siding/wideplating,
@@ -72512,10 +73444,15 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"xLO" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+"xLG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/stone,
+/area/station/service/chapel)
 "xLY" = (
 /obj/item/reagent_containers/cup/glass/bottle/beer{
 	pixel_y = 11
@@ -72571,6 +73508,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"xMt" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/seed_extractor,
+/obj/machinery/door/window/right/directional/east,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "xMv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -72611,6 +73554,21 @@
 /obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron,
 /area/station/security/lockers)
+"xNl" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/machinery/light_switch/directional/south,
+/obj/machinery/camera/directional/south{
+	c_tag = "Atmospherics - South"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/station/service/greenroom)
 "xNw" = (
 /turf/closed/wall,
 /area/station/science/breakroom)
@@ -72626,23 +73584,6 @@
 /obj/item/clothing/gloves/color/red/insulated,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
-"xNI" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/dark_red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/brig/entrance)
-"xNL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/wood/parquet,
-/area/station/service/theater)
 "xNV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72657,16 +73598,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor/flat_white,
 /area/station/science/auxlab/firing_range)
-"xNZ" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/dark_red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/light/cold/directional/south,
+"xOe" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/light/small/directional/east,
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/station/security/brig/entrance)
+/area/station/holodeck/rec_center)
 "xOm" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
@@ -72690,12 +73628,6 @@
 /obj/effect/landmark/start/research_director,
 /turf/open/floor/iron/dark/small,
 /area/station/command/heads_quarters/rd)
-"xOB" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/iron/grimy,
-/area/station/service/theater)
 "xOE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72725,16 +73657,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
-"xOP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating/dark/corner,
-/obj/effect/turf_decal/tile/dark_red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security/brig/entrance)
 "xOR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/mix_output{
 	dir = 8
@@ -72753,6 +73675,10 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
+"xOX" = (
+/obj/structure/flora/bush/flowers_yw/style_2,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "xPd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72800,9 +73726,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"xPR" = (
-/obj/structure/flora/tree/jungle/small/style_random,
-/turf/open/floor/grass,
+"xPV" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/misc/dirt/jungle,
 /area/station/service/chapel)
 "xPW" = (
 /obj/item/kirbyplants/random/fullysynthetic,
@@ -72887,6 +73813,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"xQC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "xQD" = (
 /obj/structure/chair/wood/wings,
 /obj/effect/turf_decal/siding/wood{
@@ -72954,6 +73892,10 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/cmo)
+"xRe" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white/side,
+/area/station/hallway/primary/central/aft)
 "xRg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -73044,10 +73986,6 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den/gaming)
-"xRZ" = (
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "xSd" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/red,
@@ -73071,13 +74009,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/atmos)
-"xSp" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "xSt" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/stripes/white/line{
@@ -73224,6 +74155,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"xUo" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/commons/vacant_room/commissary)
 "xUr" = (
 /obj/structure/rack,
 /obj/machinery/flasher/directional/west,
@@ -73248,13 +74186,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"xUG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "xUL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73330,12 +74261,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
-"xVo" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
 "xVv" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white/small,
@@ -73462,6 +74387,13 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
+"xXd" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/stairs,
+/area/station/maintenance/port/greater)
 "xXi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73645,6 +74577,14 @@
 	},
 /turf/closed/wall,
 /area/station/maintenance/port/fore)
+"xZl" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "xZs" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -73669,6 +74609,20 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"xZI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/public/glass{
+	name = "Cargo Botique"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/station/hallway/primary/central/fore)
 "xZJ" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix{
 	dir = 8
@@ -73711,6 +74665,17 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"yah" = (
+/obj/effect/turf_decal/tile/dark_red/half/contrasted{
+	dir = 4
+	},
+/mob/living/simple_animal/bot/secbot/beepsky/officer,
+/obj/effect/turf_decal/siding/wideplating/dark/corner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/security)
 "yal" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -73736,6 +74701,15 @@
 	},
 /turf/open/space/basic,
 /area/station/engineering/atmos/space_catwalk)
+"yay" = (
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/structure/cable,
+/obj/machinery/door/airlock{
+	id_tag = "commiss2";
+	name = "Commissary"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
 "yaB" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -73752,12 +74726,6 @@
 /mob/living/basic/spider/giant/sgt_araneus,
 /turf/open/floor/stone,
 /area/station/command/heads_quarters/hos)
-"yaG" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood/large,
-/area/station/service/chapel)
 "yaI" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -73783,6 +74751,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"ybc" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/side,
+/area/station/hallway/primary/central/aft)
 "ybh" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -73834,6 +74808,16 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"ybH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/status_display/evac/directional/west,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "ybJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -73846,18 +74830,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /turf/open/floor/iron/textured_half,
 /area/station/security/brig)
-"ybL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "ybM" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/window/spawner/directional/east,
@@ -73868,6 +74840,15 @@
 "ybO" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
+"ybV" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/structure/flora/bush/flowers_yw/style_3,
+/obj/structure/flora/bush/jungle/c/style_random,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "ycd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -73912,21 +74893,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"ycx" = (
-/obj/structure/chair/sofa/bench/right{
-	dir = 1
-	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Atmospherics - South"
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/south,
-/turf/open/floor/iron/dark/side,
-/area/station/hallway/primary/central/fore)
 "ycC" = (
 /turf/closed/wall/r_wall,
 /area/station/command/bridge)
@@ -73945,15 +74911,19 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/smooth_edge,
 /area/station/engineering/supermatter/room)
-"ycZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
+"yda" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/hallway/primary/central/fore)
 "ydf" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -73995,15 +74965,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood/tile,
 /area/station/command/bridge)
-"ydu" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/mail_sorting/service/bar,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "ydH" = (
 /obj/effect/turf_decal/box/corners,
 /obj/effect/turf_decal/box/corners{
@@ -74070,17 +75031,6 @@
 /obj/structure/sign/warning/test_chamber/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/augments)
-"yeu" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/hydroponics/glass{
-	name = "Hydroponics"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/textured_half,
-/area/station/service/hydroponics)
 "yeD" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -74141,12 +75091,6 @@
 	dir = 8
 	},
 /area/station/maintenance/starboard/greater)
-"yfj" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/hallway/primary/starboard)
 "yfs" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/item/storage/bag/xeno,
@@ -74174,15 +75118,6 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/commons/fitness/locker_room)
-"yfH" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/displaycase/trophy,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/smooth,
-/area/station/service/library)
 "yfJ" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -74209,6 +75144,28 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"yfV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/mail_sorting/service/kitchen,
+/turf/open/floor/plating,
+/area/station/maintenance/central/greater)
+"yfW" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "yfY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -74219,15 +75176,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security)
-"yga" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/hallway/primary/starboard)
-"ygd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/engineering/atmospherics_portable,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
+"ygc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/turf/open/floor/eighties/red,
+/area/station/hallway/primary/central/fore)
 "ygf" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Xenobiology Lab - Test Chamber";
@@ -74238,16 +75195,6 @@
 "ygu" = (
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/starboard)
-"ygB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/bronze{
-	name = "Backstage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
-/turf/open/floor/wood/parquet,
-/area/station/service/theater)
 "ygK" = (
 /obj/structure/table,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -74285,6 +75232,12 @@
 /obj/effect/spawner/random/aimodule/harmless,
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"yhc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "yhq" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral{
@@ -74307,6 +75260,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"yhG" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/station/maintenance/central/greater)
 "yhH" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/newscaster/directional/south,
@@ -74401,6 +75358,15 @@
 	},
 /turf/open/floor/iron/white/side,
 /area/station/hallway/primary/starboard)
+"yir" = (
+/obj/structure/chair/stool/directional/north,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/west,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/stone,
+/area/station/service/bar)
 "yis" = (
 /obj/structure/cable,
 /obj/item/kirbyplants/random,
@@ -74419,15 +75385,6 @@
 /obj/item/clothing/head/utility/welding,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
-"yiv" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/door/airlock{
-	name = "Greenroom Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "yiL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -74464,12 +75421,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/white/small,
 /area/station/science/cubicle)
-"yjD" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "yjE" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/engine)
@@ -74520,6 +75471,17 @@
 /obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
+"ykc" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/neutral/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "ykd" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -85281,7 +86243,7 @@ jxJ
 slw
 dDd
 vuj
-aPj
+syJ
 rhC
 pee
 qyT
@@ -85289,7 +86251,7 @@ pLZ
 pWF
 fMQ
 qCb
-qZf
+heD
 yaI
 qRN
 erg
@@ -85297,7 +86259,7 @@ sNg
 yaI
 wRN
 yaI
-oUx
+mLu
 yaI
 xQy
 qRN
@@ -85539,7 +86501,7 @@ slw
 qtJ
 qdu
 tyD
-kai
+vIP
 sor
 whL
 sYs
@@ -85554,7 +86516,7 @@ jch
 wZS
 tCm
 onw
-jeV
+jFb
 gun
 mKD
 snZ
@@ -85795,7 +86757,7 @@ pZK
 npA
 tYj
 riV
-rGt
+slw
 mhk
 mhk
 mhk
@@ -85811,7 +86773,7 @@ gdn
 qyT
 tDb
 ttX
-xBZ
+vuA
 qyT
 nvK
 xBe
@@ -86049,26 +87011,26 @@ oRr
 poM
 uzJ
 mKB
-npA
-trl
-riV
-uQR
-mhk
-spW
+lWs
+slw
+qLv
+slw
+sUL
+pYz
 ozn
 ozn
 pXC
-xYJ
 mhk
+mhk
+qyT
 whL
-rym
 whL
-rym
 whL
+qyT
 qyT
 tDE
 tWQ
-unM
+qTj
 qyT
 sbx
 lgj
@@ -86305,27 +87267,27 @@ owl
 oSb
 ppk
 mjQ
-vFQ
-npF
-mhk
-riZ
-npF
-mhk
-pev
-mhk
+qHP
+kJD
+nFX
+nFX
+ozn
+aWJ
 mhk
 mhk
 mhk
 mhk
-uRX
-vzP
-vzP
-vzP
-wjK
+mhk
+opl
+xwP
+kDB
+iQK
+qDT
+wAT
 wBm
 wXk
 xKG
-qHH
+iXb
 yea
 yea
 yea
@@ -86562,27 +87524,27 @@ lkI
 oSg
 lWF
 mjV
-qbw
-npS
-nFX
-nFX
-ozn
-ozn
-sqe
+uEB
 mhk
-pMg
-pYE
-vzP
-aWw
-vkG
+tft
+ozt
+gjj
+sqz
+mhk
+fGt
+xoY
+xxZ
+lTy
+vPA
+lfh
+lfh
 xYD
-xPR
-tzJ
-xRZ
-wBm
+oWd
+uKZ
+wAW
 wXk
 oOy
-xOS
+neV
 uHI
 vlY
 vGp
@@ -86780,7 +87742,7 @@ oUq
 sav
 gIM
 amH
-ccO
+hDZ
 bNq
 olj
 gBh
@@ -86822,24 +87784,24 @@ qby
 qby
 mhk
 mhk
-xYJ
-udt
-rXw
-sqz
 mhk
-yjD
-xYD
-rLT
-qCg
-qZB
-cPd
-wWa
-xYD
-quJ
-wAW
+twm
+mhk
+mhk
+gFk
+gjw
+uVL
+cQN
+fGt
+fGt
+fGt
+hmw
+smX
+qyd
+wBm
 hDT
 glM
-xOS
+neV
 wEG
 wEG
 wEG
@@ -87080,23 +88042,23 @@ mLh
 nry
 qRq
 mhk
-xLO
+jCw
 mhk
 mhk
-mhk
-csp
-qZB
-uaa
-qCR
-ram
-ryp
-qZB
-xYD
-xRZ
+taQ
+vtr
+wfI
+nhT
+cVp
+nMr
+fbq
+fGt
+aBt
+hME
 wBm
 wXk
 jte
-uoh
+biz
 yea
 vmt
 dzi
@@ -87337,23 +88299,23 @@ mLk
 nsL
 kVn
 srn
-uSM
-rYv
-srn
-sMi
-pMu
-qaA
-qkv
-qCi
-raC
-dty
-vzW
-syv
-wlF
-wzk
-tDJ
-blq
-cNu
+mBG
+pmm
+mhk
+xoY
+rJI
+nhT
+mhO
+rNm
+fZn
+nMr
+fGt
+jQe
+hIw
+wBm
+wXk
+hvO
+uMD
 yea
 vmH
 yea
@@ -87595,22 +88557,22 @@ dVW
 qSS
 mhk
 tKf
-rYD
+uAQ
 mhk
-jrZ
-xYD
-jEU
-uXN
-qCR
-raX
-vkz
-agF
-syG
-pHN
+wwv
+aZH
+cwh
+ttk
+whE
+cwh
+ttk
+fGt
+dHc
+dZL
 wAW
-wXk
+kgy
 xiF
-uoM
+cXc
 yea
 vne
 wMA
@@ -87852,22 +88814,22 @@ mhk
 mhk
 mhk
 xmI
-pbu
+ldU
 mhk
-mYS
+oPZ
+oNn
+uPL
+vyN
+cVp
+wDt
+kSF
+cwY
 xYD
-yaG
-qOp
-qCR
-uSC
-vkz
-vAA
-szy
-xRZ
-wAW
-iLK
+sAj
+wBm
+wXk
 glM
-khE
+sem
 yea
 vmX
 vij
@@ -88109,22 +89071,22 @@ mhk
 nFY
 mhk
 mhk
-xLO
-mhk
-ptZ
-sYF
-yaG
-qkw
-qCR
-raX
-rzu
-agF
-xYD
-wlQ
+gfc
+pPx
+mdA
+cAq
+tfe
+cwh
+xoO
+ttk
+bNF
+eLb
+oIm
+ijA
 wBm
 wXk
 glM
-xFO
+neV
 rQC
 vne
 vHV
@@ -88366,28 +89328,28 @@ mhk
 xYJ
 xYJ
 tYL
-pbu
+wMs
 mhk
-mhk
-oqE
-qbr
-hNT
-qCR
-rba
-rAb
-vAR
-vSE
-woB
-ntw
+pma
+klv
+aZH
+cwh
+xoO
+ttk
+qPm
+kjA
+auu
+iuT
+wBm
 vuR
 xgA
-wNR
-qnu
-vnn
-vIg
-wdV
-wyY
-eqP
+hlQ
+gLL
+vkP
+vkP
+hom
+uAi
+aPO
 uAi
 fEC
 rui
@@ -88403,7 +89365,7 @@ sNr
 syk
 vYD
 lox
-dXo
+rYE
 vTV
 iWj
 lRV
@@ -88594,7 +89556,7 @@ dDB
 dDB
 dDB
 slY
-rhm
+hRw
 cis
 slY
 slY
@@ -88623,28 +89585,28 @@ mhk
 xZd
 mhk
 sNW
-xLO
-xLO
+gfc
 mhk
-sYK
-sYF
-uao
-vzP
-vzP
-vkG
-bOl
-xYD
-xRZ
-wAZ
-wXk
-xgN
-rsQ
-kar
+pkl
+xBL
+fET
+uQT
+hOO
+ttk
+fGt
+nXW
+lfh
+sdB
+wAW
+mVw
+qFe
+hEj
+leT
 vnr
-vIh
-wfb
+tqO
+hom
 alg
-xfU
+nsf
 xjU
 fEC
 kJJ
@@ -88660,7 +89622,7 @@ xkt
 ujA
 cDH
 fFH
-fYX
+gkx
 vTV
 vTV
 xxO
@@ -88880,28 +89842,28 @@ mhk
 qTJ
 mhk
 rGN
-xYJ
-pbu
+gfc
 mhk
-mhk
-xpT
-xYD
-xYD
-xYD
-xPR
-xYD
-vSX
-tdg
+iyZ
+ivh
+fGt
+uQT
+xoO
+ttk
+fGt
+fGt
+fGt
+fGt
 wBm
 wXk
-bVv
+fny
 xOS
 rQC
 von
-vne
-wgj
+qyA
+jsq
 wzS
-kzd
+wzS
 tAu
 fEC
 rui
@@ -88911,17 +89873,17 @@ qVP
 llW
 llW
 xkt
-nNb
-ejc
+nOk
+sLC
 dah
 urw
 urw
-rzG
-rIH
+yah
+fhV
 cFg
 hWJ
-htV
-ild
+neW
+bHx
 voJ
 qxv
 apk
@@ -89137,28 +90099,28 @@ mhk
 mhk
 mhk
 mhk
-sqz
-xLO
-xLO
+gfc
 mhk
-tCk
-uaE
-uty
-rbh
-tTG
-sdg
-tEU
-hpP
-wAW
-mdU
-xhe
+lRY
+uoS
+xPV
+uQT
+xoO
+jnj
+cVp
+cHo
+cVp
+aMB
+kiP
+wXk
+glM
 oMF
 yea
 vrf
 von
 wgn
 pRe
-xhj
+wgn
 aHq
 xMg
 rui
@@ -89390,32 +90352,32 @@ lIf
 lXn
 srn
 ntJ
-jCA
 nGu
+xYJ
 ina
 mhk
+dvN
 mhk
-mhk
-sMG
-mhk
-mhk
-mhk
-mhk
-mhk
-mhk
-sdQ
-mhk
-mhk
+sCx
+xdm
+fGt
+uQT
+xoO
+xoO
+xoO
+xoO
+xoO
+wvp
 wAW
-wDJ
-xhH
-rje
+jpH
+dlR
+kbU
 yea
 yea
 vJn
 wgA
 guY
-xhA
+rhx
 guY
 fEC
 fEC
@@ -89647,32 +90609,32 @@ lIn
 lXY
 mhk
 ina
-tYL
-nGJ
-ntJ
+tZb
+ina
+xYJ
+xYJ
+hmY
 srn
-oSh
-ntJ
-pug
-mhk
-lJY
-bmM
-uSM
-uSM
-vmz
-rYv
-pug
-mhk
-fju
-wWT
-glM
-iwZ
-uIt
+sqW
+rVK
+fGt
+uQT
+xoO
+jBk
+akb
+akb
+akb
+keX
+meT
+wXk
+qeX
+qdX
+kju
 yea
 vJA
 vKa
 guY
-xiA
+gmz
 iQU
 pIw
 pIw
@@ -89901,36 +90863,36 @@ yjc
 vLP
 oyZ
 lIq
-lYt
+oRq
 mhk
 xYJ
-qAE
+tpe
 tYL
 mhk
 mhk
-tYL
+scm
 mhk
-xen
-lJY
-oSS
-mhk
-mhk
-oDK
-mhk
-mhk
-qSv
-sNv
-wDV
-tET
-glM
-xFO
+nji
+fDm
+fGt
+wQf
+xoO
+ttk
+fGt
+fGt
+cwY
+vNG
+wBm
+kBx
+vIK
+hTU
 dyq
 yea
 vKa
 wgM
 guY
-xdD
-hkJ
+bSV
+pwN
 liJ
 pwN
 pTq
@@ -90122,7 +91084,7 @@ lER
 hRO
 knv
 rKZ
-mGn
+eho
 lvK
 jiC
 vdw
@@ -90161,33 +91123,33 @@ lIw
 lYw
 mhk
 qjn
-xYJ
+mnH
 ina
 mhk
 ozt
-oSP
-uIW
-puj
-pNy
-mhk
-mhk
-uwU
-lVm
-rAn
-mhk
-mhk
-mhk
+rJO
+luP
+qkR
+wsY
+fbq
+uQT
+xoO
+ttk
+fGt
+fGt
+cPK
+aZH
 wAW
-wXk
-jte
-xFO
+fSV
+eCS
+xOS
 yeF
 xle
 xle
 xle
 xle
 xle
-xKx
+gnZ
 kte
 cVh
 fEC
@@ -90418,33 +91380,33 @@ lJV
 cYT
 mhk
 mhk
-sfL
+lLU
 mhk
 mhk
 sNW
-wht
+vsT
 mhk
-xIl
-mhk
-mhk
-nwS
-ozo
-lVm
-ebB
-yfC
-hAd
-enD
-thv
-tEW
-blq
-uoW
+eWZ
+tfo
+hRg
+nrP
+xoO
+ttk
+fbq
+dow
+auX
+aQE
+wBm
+kqH
+rhA
+jen
 xle
 xle
 slZ
 nGd
 wAj
 xle
-qvQ
+fVP
 guY
 yaW
 fEC
@@ -90674,38 +91636,38 @@ slY
 mhk
 mhk
 mhk
-xYJ
-xYJ
+sKR
+jZb
 xYJ
 nZW
 xYJ
-wht
+vsT
 mhk
-sZj
-pOb
-mhk
-gzj
-uye
-sVl
-qGA
-puv
-xVo
-sPt
-mKY
-wWT
-xiF
-xOS
+vBc
+eiW
+hME
+nrP
+xoO
+ttk
+fGt
+cwY
+rMu
+cEE
+wBm
+kqH
+ykc
+uoh
 xle
 vrt
 swu
 iDA
 wAS
 xle
-xxE
+hKg
 tuZ
 fEC
 fEC
-xpo
+mYx
 lGd
 dAn
 cjR
@@ -90931,26 +91893,26 @@ slY
 rXw
 lYT
 mhk
-xYJ
+mnH
 mhk
 mhk
 mhk
 mhk
-rZK
+fLB
 mhk
-sNW
-xIl
-mhk
-ubB
-ozo
-rcr
-rBx
-yfC
-szz
-efL
-mJW
-wWT
-glM
+kkv
+aXb
+mKA
+nrP
+xoO
+ttk
+fGt
+fGt
+pDW
+qyd
+wBm
+kqH
+qeX
 xOS
 yeS
 vrz
@@ -90958,11 +91920,11 @@ dxG
 wiC
 dOT
 xle
-pIg
-xNI
-uMI
+wjV
+fGP
+mQJ
 rOG
-dPI
+oVI
 fEq
 rpV
 qVP
@@ -91185,29 +92147,29 @@ kso
 kYG
 kYG
 pep
-lJY
-uSM
-naE
-rYv
-rYv
-rYv
-rYv
-rYv
-oSS
+pto
+nho
+xXd
+kkI
+nBJ
+mBG
+xiX
+xiX
+ozF
 mhk
-mhk
-pOj
-mhk
-yfC
-yfC
-rdo
-rBG
-yfC
-cpc
-iwa
-yfC
-wWT
-jjS
+uKm
+uKI
+aZH
+nrP
+xoO
+ttk
+cwY
+qKB
+bGC
+gcE
+wAW
+kqH
+cdR
 xZg
 lBN
 hKU
@@ -91215,8 +92177,8 @@ ixl
 qyx
 vXr
 jTh
-tWE
-xNZ
+aiN
+cfl
 qVP
 qVP
 qVP
@@ -91228,7 +92190,7 @@ xfN
 daq
 xFe
 lgh
-dYc
+raz
 nlf
 yjd
 xFe
@@ -91442,29 +92404,29 @@ uxd
 xaZ
 dZm
 slY
-lKt
+aOF
 tYL
 mhk
-mhk
+vhW
 mhk
 mhk
 oaa
 mhk
 oTH
 mhk
-xHB
-pOK
-qoi
-iEX
-yfC
-aws
-fMD
-sdT
-vTN
-aws
-yfC
-lzv
-glM
+ifo
+bGC
+aZH
+nrP
+xoO
+ttk
+gsE
+syL
+dXY
+hME
+wBm
+kqH
+qeX
 qHH
 xle
 dnK
@@ -91472,8 +92434,8 @@ vKV
 wjG
 wPh
 xle
-bOg
-xOP
+ssE
+kgP
 hDN
 dcc
 vRC
@@ -91699,29 +92661,29 @@ ksx
 mEB
 slY
 ueX
-wht
+vsT
 sNW
 mhk
-mSi
-qBj
-uVb
-rkR
+koB
+wVf
+tEq
+ius
 mhk
 mhk
 mhk
-vgJ
-uAV
-tDT
-fDp
-yfC
-hwe
-rBN
-aws
-vTN
-oMC
-yfC
-pTc
-rgT
+eWZ
+xOX
+iYJ
+nrP
+xoO
+ttk
+qve
+axx
+tfo
+sic
+wBm
+bdt
+oqB
 upg
 xle
 xle
@@ -91729,8 +92691,8 @@ xle
 xle
 xle
 xle
-keZ
-reT
+rgB
+hwA
 ybj
 uab
 rjN
@@ -91956,29 +92918,29 @@ ksA
 oJR
 oiw
 mhk
-wht
+vsT
 sqz
 mhk
 mTd
 qBz
 qTR
-rlz
+rzc
 rHD
 qVR
 wCR
-rHL
-tDP
-qbC
-lsJ
-yfC
-jKh
-fMD
-vBm
-vTN
-sQU
-mKY
-wWT
-glM
+kkv
+sza
+fGt
+iFt
+xoO
+ttk
+sdY
+kkv
+wkH
+hME
+wBm
+kqH
+qeX
 xOS
 kWJ
 tJz
@@ -91986,8 +92948,8 @@ tIa
 mvv
 jsS
 ocz
-wId
-uZb
+aTH
+aVh
 hDN
 xyx
 xjg
@@ -92168,7 +93130,7 @@ gKL
 upG
 daC
 jBo
-oEt
+vSq
 gpI
 lhq
 cBw
@@ -92213,29 +93175,29 @@ khZ
 nSY
 nYQ
 mhk
-oUO
+wZz
 mhk
 mhk
 wCR
 wCR
 qUs
-cxT
+mNp
 qmz
-oTO
+mfk
 wCR
-uej
-wms
-qbK
-jza
-yfC
-hwe
-fMD
-aws
-vTN
-vST
-yfC
-ijm
-jte
+fbS
+cWd
+fGt
+nrP
+xoO
+sWi
+fGt
+pIQ
+jri
+dZt
+wAW
+tfd
+eCS
 xOS
 par
 tJz
@@ -92243,8 +93205,8 @@ kql
 kql
 rAR
 ezM
-wId
-dtj
+aTH
+svY
 hDN
 vcl
 tPf
@@ -92470,29 +93432,29 @@ ktM
 sOP
 otG
 mhk
-xen
-ptk
+scT
+iAr
 mhk
 mTN
 wTO
 qVR
-rlz
+rzc
 rHH
 oUJ
 wCR
-pup
-tbq
-qcl
-uej
-yfC
-aws
-rBQ
-aws
-vTN
-say
-yfC
-rjH
-glM
+dGY
+fGt
+fGt
+nrP
+hBH
+ttk
+fGt
+wtd
+oin
+cEE
+wBm
+kqH
+qeX
 xOS
 uJD
 tJz
@@ -92500,8 +93462,8 @@ uZk
 gOw
 jsS
 iAM
-wId
-puY
+aTH
+kII
 vEP
 qVV
 qVV
@@ -92727,29 +93689,29 @@ kua
 lEm
 oiL
 mhk
-lKu
-cXm
+lAF
+pvy
 mhk
 wCR
 wCR
 qVZ
-rlB
+nFd
 rJo
 sas
 wCR
-rYd
-tbq
-qdm
-aeq
-qEp
-bCX
-bCX
-sei
-qDp
-sQY
-mKY
-wWT
-glM
+taQ
+fGt
+fGt
+eGU
+aWl
+ttk
+fGt
+shd
+ujX
+wfI
+wBm
+kqH
+qeX
 xOS
 uKA
 uBc
@@ -92757,8 +93719,8 @@ tuZ
 tuZ
 uBc
 xjX
-wId
-dtj
+aTH
+svY
 vEP
 gxg
 djg
@@ -92778,7 +93740,7 @@ xur
 xur
 iYY
 xur
-leB
+ltW
 dYj
 wuc
 aTn
@@ -92985,37 +93947,37 @@ kIO
 wnd
 mhk
 mhk
-wht
+dJA
 mhk
 mUt
 wTO
 uSI
-rlN
+jQF
 rJo
 bHU
 wCR
-roV
-tbq
-tSh
-aeq
-qFB
-rdK
-rDf
-sel
-rDy
-uWB
-yeu
-eTt
-tXT
-wHE
-qnz
-vtc
-vLf
-wZd
-sWJ
-xkg
-sxL
-jKm
+hsx
+iSR
+fGt
+eGU
+xoO
+ttk
+qst
+uoV
+wfI
+fGt
+wBm
+fVE
+lnN
+oIs
+qpM
+dzQ
+rRp
+lnw
+dQs
+tUU
+jgs
+miy
 vEP
 wXC
 crJ
@@ -93242,36 +94204,36 @@ msq
 laD
 gSX
 mhk
-wht
+vsT
 mhk
 wCR
 wCR
 wCR
-rmG
+uIu
 ozO
-nuX
+clB
 wCR
-uMg
-tcB
-uMg
-uej
-uzd
-uUI
-bUf
-fVV
-szG
-wow
-pxl
-wXO
-xjh
-alh
+fGt
+bIP
+ybV
+xLG
+akb
+cMj
+bCN
+fGt
+fGt
+fGt
+wAW
+wXk
+dJk
+aRm
 slM
 tJz
 vLC
 rRq
 jsS
 ezM
-xye
+jFE
 oZi
 vEP
 uQu
@@ -93481,7 +94443,7 @@ hCX
 vwZ
 gEM
 iCw
-jDP
+nlm
 lBz
 mJe
 iDO
@@ -93499,36 +94461,36 @@ kJb
 laL
 loj
 mhk
-scz
+sCr
 mhk
 mVM
 aSI
 xRV
-oaV
+xZI
 xZS
 xZS
 xRV
-bUt
-tcP
-bUt
+xZS
 xRV
 xRV
+esR
 xRV
+sGr
 xRV
+xZS
+xZS
 xRV
-szH
-sRv
-xRV
-saZ
-sxw
-upj
-mTq
-wfP
-mJB
-mJB
-gvn
-toY
-eAX
+jeo
+eiz
+jVT
+sCG
+tdR
+ava
+abu
+abu
+fZq
+uhx
+iPa
 lbO
 ybJ
 fbe
@@ -93705,7 +94667,7 @@ sHM
 iqB
 fdy
 hnS
-sKD
+lFo
 hxY
 vpZ
 oRj
@@ -93740,45 +94702,45 @@ wbi
 wbi
 wbi
 hnO
-tgR
-wbi
-oDs
-rrC
-iqN
-mDq
-snc
-snc
-lVL
-snc
-nys
-snc
-nTj
-snc
-snc
-mAo
-lYU
-mmp
+kpB
+aJg
+mze
+pfw
+chG
+ppa
+frI
+frI
+uIv
+frI
+klA
+eZO
 mZg
 frI
-uQi
-sfK
 frI
-frI
-pfw
-frI
-pPT
-xJR
-ofo
-mLi
-vsl
-ewi
-uny
-xJR
-frI
-ldZ
-wXk
-sxw
-xOS
+bOU
+hMx
+ayy
+wUs
+vhQ
+lFP
+uxM
+vhQ
+vhQ
+qOL
+vhQ
+uGi
+jai
+cOv
+ybH
+vhQ
+noL
+vhQ
+vhQ
+aFr
+lYc
+iDg
+iBN
+cDg
 nsO
 uBc
 tJz
@@ -93962,7 +94924,7 @@ qjx
 iqB
 phY
 jmZ
-oJl
+lel
 bDh
 fPY
 xkX
@@ -94013,29 +94975,29 @@ pWM
 foe
 jpu
 lKA
-jpu
+gjl
 jpu
 qdS
 jpu
-qWm
+nnH
 xmu
 jpu
 jpu
 jpu
 foe
-xmu
+jpu
 lKA
+gjl
 jpu
 jpu
-fMj
 fXJ
 jpu
 aRJ
 wRg
-gNU
-tFY
-tYb
-xOS
+bJy
+xQC
+mTp
+neV
 ftX
 udA
 mJB
@@ -94268,31 +95230,31 @@ kfw
 yeD
 kJj
 yjZ
+asr
 yjZ
+gdY
 yjZ
-lZD
-yjZ
-nau
-yjZ
-nHB
-obm
-oAk
-oWb
-pfO
-siC
-siC
-siC
-siC
-siC
-qio
-siC
-siC
-siC
-rCd
-wXZ
-tIc
-xGc
-xOS
+plc
+wnS
+krP
+eYS
+asr
+iBT
+lAL
+asr
+asr
+asr
+asr
+asr
+asr
+asr
+asr
+vfh
+obp
+hdJ
+jap
+tFq
+neV
 ftX
 fnP
 gvV
@@ -94465,7 +95427,7 @@ rrG
 gDq
 qqJ
 yjE
-rco
+qeA
 yjE
 dGV
 fDO
@@ -94524,32 +95486,32 @@ xRV
 vIJ
 kux
 wGz
-lbh
-oAF
-riu
+yaL
+faH
+faH
+yaL
+prF
+eLR
+vsP
+jVM
 xeO
 wMg
-qej
+xeO
+xeO
+xeO
+xeO
+uIM
+kyX
+xeO
 wMg
-jVM
-jVM
-ceE
-jVM
-jVM
-vkh
-vkh
-efC
-efC
-vpN
-oTo
-dHi
-vpN
-vkh
-vkh
-wBm
-tIc
-sxw
-xIy
+wMg
+wMg
+xeO
+xeO
+prs
+jap
+qeX
+leo
 isK
 uBc
 uBc
@@ -94779,36 +95741,36 @@ lEa
 lWk
 xRV
 owR
-nAx
-tmQ
-xeO
-xeO
-xeO
-xeO
-mnn
-naO
-yfH
+alN
+bXB
+xro
+eOg
+xUo
+yaL
+yaL
 jVM
-wzj
-uPd
-row
+mdi
 jVM
-puD
-pQe
-qdp
-qme
-ycS
-hWQ
-ycS
-ycS
-vUq
-uNW
-mku
-tIc
-sxw
-xuU
+umK
+kGE
+jiS
+xeO
+pHX
+hzz
+lql
+lql
+tmw
+wKr
+dqb
+qWs
+nVT
+gZB
+xeO
+jap
+qeX
+dYl
 fvh
-ogX
+hSM
 tCF
 ncD
 blb
@@ -95037,39 +95999,39 @@ jLI
 xZS
 vrn
 nzK
-lkZ
-xeO
-lpa
+wQB
+yaL
+oXq
+aaB
+slA
+cOy
+jVM
+uIE
+jVM
+qgO
+azq
 iTv
-xeO
-izB
-jFY
-xyY
-jVM
-paV
-wLJ
-ojl
-jVM
-vwg
-ycS
-tEI
-ycS
-uAF
-ree
-rFQ
-ycS
-ucV
-vkh
-oBm
-tIc
-bxA
-gYK
-wAW
-vtv
-kev
-qtl
-qtl
-qtl
+wMg
+wKr
+tTU
+kcU
+dhj
+vfP
+oDV
+mdc
+skL
+skL
+skL
+qWK
+jnD
+gOA
+dqo
+ovu
+ovu
+dDB
+dDB
+dDB
+dDB
 dDB
 dDB
 dDB
@@ -95294,39 +96256,39 @@ gBw
 xZS
 vrn
 ncL
-qwz
-xeO
-wKr
-lql
-xeO
-wJV
-nbu
-xyY
+wQB
+bOx
+kcP
+cYO
+xAu
+pAq
+yay
+cHE
 jVM
-uPd
-jVM
-sbm
-jVM
-vkh
-paL
-ycS
-uAX
-uAX
-reW
-uAX
-vEq
-szM
-vkh
-qOt
-wYr
-tYd
-hgE
-jqQ
-uNn
-vOh
-qTM
-qTM
-qtl
+ify
+vwD
+lzR
+dpG
+ntS
+wYm
+wYm
+gGO
+gxQ
+jHl
+akH
+rfc
+qcG
+ggV
+wMg
+glW
+ooL
+aQn
+tYX
+dDB
+dDB
+dDB
+dDB
+dDB
 dDB
 dDB
 dDB
@@ -95549,41 +96511,41 @@ qCJ
 xQw
 jLI
 jYU
-vrn
-ncL
-wQB
+hOD
+usW
+dhk
+uhW
+iwt
+pgS
+eju
+qAL
+jVM
+rpg
+jVM
+kJd
+ofM
+rtU
 wMg
-wKr
-eUW
-xeO
-eGl
-nbZ
-ntY
-jVM
-uPd
-jVM
-lxK
-rnw
-sON
-vkh
-tFG
-qmx
-uBn
-iZI
-vpU
-bKP
-vkh
-vkh
-uGp
-wYr
-tYH
-mVa
-uLn
-aTr
-hyl
-wlf
-qTM
-qtl
+uzg
+wvH
+glG
+ayH
+ufe
+jYy
+uxu
+uvb
+ggV
+ggV
+uQH
+xxu
+ooL
+aQn
+tYX
+dDB
+dDB
+dDB
+dDB
+dDB
 dDB
 dDB
 dDB
@@ -95806,41 +96768,41 @@ eHk
 xQw
 gtr
 xZS
-vrn
+sgk
 ncL
-wQB
-dNw
-lql
-azq
-lql
-lql
-wav
-qGU
+qwz
 jVM
-ydu
-qEa
-lTZ
-tOS
-crX
-gYg
-qdC
-qmI
-uCh
-vRE
-vpY
-sfh
-dks
-vkh
-tjb
-xAP
-wAW
-urh
-wAW
-vtv
-iho
-wlL
-wDZ
-iho
+jVM
+jVM
+jVM
+jVM
+jVM
+mec
+jVM
+jJO
+pxI
+sIl
+xeO
+vDO
+ozX
+rET
+oEp
+afi
+gxG
+cNd
+jLs
+jLs
+lLT
+xeO
+bPu
+ooL
+aQn
+tYX
+dDB
+dDB
+dDB
+dDB
+dDB
 dDB
 dDB
 dDB
@@ -96063,41 +97025,41 @@ iWW
 uVT
 uVT
 uVT
-vrn
+sgk
 nAy
 uIv
-okp
-wuw
-wuw
-jxy
-pNa
-wuw
-dfW
 jVM
-uPd
 jVM
-geC
-okK
-pvR
-vkh
-vzM
-qmO
-rZN
-rfI
-rHd
-vpY
-bfI
-vkh
-tkp
-cbT
-xli
-urv
-yeh
-blb
-kev
-fUj
-nnR
-iho
+oyz
+uxp
+ksM
+ksM
+mJN
+jVM
+oNP
+xeO
+xeO
+xeO
+jvJ
+vmf
+oEp
+tdk
+ozX
+qDf
+wKr
+wKr
+cjv
+hJn
+wMg
+fLG
+ooL
+aQn
+tYX
+dDB
+dDB
+dDB
+dDB
+dDB
 dDB
 dDB
 dDB
@@ -96320,42 +97282,42 @@ qJq
 oIP
 azm
 xQw
-vrn
+sgk
 ncL
 wQB
-wMg
-lqF
-lLJ
-maa
-wKr
-qgr
-ttC
-nIS
-rnY
+wTe
 jVM
-wlu
-gZR
-gVq
-vkh
-orH
-cOm
-eZJ
-vRE
-tZR
-cOm
-szS
-efC
-wEp
-qYu
+mec
+jVM
+jVM
+jVM
+jVM
+jVM
+mrM
+jVM
+tph
+yfC
+yfC
+yfC
+wqU
+aFy
+dKx
+yfC
+yfC
+yfC
+yfC
+yfC
 xli
-dDB
-dDB
-dDB
-qtl
-qTM
-qTM
-uMC
-dDB
+qOF
+cPm
+nRi
+ovu
+tYX
+tYX
+ovu
+tYX
+tYX
+ovu
 dDB
 dDB
 dDB
@@ -96577,42 +97539,42 @@ iLC
 jts
 wzK
 eAc
-wYD
+fpx
 kuE
 wQB
-xeO
-guR
-wiU
-mad
-wKr
-qgA
-beH
+gni
 jVM
 rpg
 jVM
+rEG
+bsa
+mqz
 jVM
-pfU
-sON
-vkh
-glb
-vpY
-sZQ
-fzf
-rHm
-sgS
-szZ
-vkh
-wEp
-wZo
-tYX
-dDB
-dDB
-dDB
-qtl
-qTM
-qTM
-uMC
-dDB
+rMB
+dxE
+lRp
+poH
+yfC
+lyZ
+opC
+vLp
+vLp
+vLp
+qLg
+oPK
+vLp
+mKY
+hfw
+iiq
+wmF
+nVz
+pkk
+wbn
+wbn
+sAU
+qDe
+bcz
+htR
 dDB
 dDB
 dDB
@@ -96834,42 +97796,42 @@ eku
 uVT
 uVT
 uVT
-lAS
+nwc
 kvl
 wQB
-xeO
-lti
-kGE
-mam
-wKr
-pZi
-iHL
-jVM
+aKu
+rNk
 rpg
-ipt
 jVM
-qqh
-hMz
-tGq
-tGq
-qnA
-xmt
-xmt
-wqs
-wqs
-wqs
-xmt
-eJY
-wZo
+oES
+veX
+pSI
+jVM
+rMB
+jVM
+bnf
+lEM
+yfC
+wTE
+elB
+uUR
+opQ
+hnF
+hnF
+wEv
+rYM
+opR
+czn
+bif
+nEo
+nVz
+wbn
+wbn
+wbn
+sLN
+nVz
+aQn
 tYX
-blb
-blb
-blb
-qtl
-qTM
-qTM
-uMC
-blb
 blb
 blb
 blb
@@ -97080,7 +98042,7 @@ xMk
 xsh
 hcc
 xGJ
-bBN
+mOZ
 jwi
 qtd
 hOg
@@ -97091,46 +98053,46 @@ ghD
 gaf
 xQw
 mvT
-vrn
+sgk
 kvT
-nVD
-xeO
-skI
-hzY
-sLc
-joy
-qgH
-wKr
+wQB
+xJQ
 jVM
-qhp
-rLw
-rsV
-pgW
-mwP
-pRP
-tGq
-xUG
-bgK
-qIP
-rHQ
-shw
-kQA
-xmt
-tmc
-wZo
+cHE
+jVM
+wCF
+cSi
+dha
+jVM
+mrM
+jVM
+mYN
+mXu
+bNz
+tEP
+fZX
+hzO
+dyk
+dyk
+nen
+pNs
+rYM
+mPb
+bWv
+rbQ
+upY
+ovu
+tYX
+tYX
+tYX
+ovu
+wxt
+eGe
+ovu
 tYX
 dDB
 dDB
-dDB
-kev
-wmY
-uPO
-iho
-dDB
-dDB
-dDB
-dDB
-dDB
+blb
 dDB
 dDB
 dDB
@@ -97348,46 +98310,46 @@ hMh
 juS
 uVT
 mvT
-vrn
+sgk
 kyO
-smf
-xeO
-lty
-xeO
-xeO
-wMg
-dCm
-wMg
+wQB
+pNR
 jVM
+mec
 jVM
-rMV
+lMH
+vWW
+tgB
+wRY
+mrM
 jVM
-swL
-sOW
-tfa
-tHh
-qnL
-xiL
-rgc
-rgc
-shU
-dvl
-luU
-tmV
-wZo
+jGF
+wpE
+yfC
+oXY
+oHm
+jQK
+jQK
+eUT
+dGv
+oKK
+rYM
+mkL
+bWv
+rbQ
+sif
+tYX
+blb
+blb
+dDB
+tYX
+wbn
+wbn
+wbn
 tYX
 dDB
 dDB
-dDB
-kev
-uPO
-mjB
-iho
-dDB
-dDB
-dDB
-dDB
-dDB
+blb
 dDB
 dDB
 dDB
@@ -97605,46 +98567,46 @@ cpT
 xQv
 xQw
 mvT
-vrn
+sgk
 ncL
-uUE
-xeO
-oCc
-xeO
-ctc
-joy
-qgN
-jVg
-qbi
+wQB
+suf
 jVM
-rMY
+oFn
 jVM
-sPE
-pvS
-tGq
-tGq
-poh
-ono
-rgx
-rIg
-prQ
-uXb
-sSr
-kcs
-wYV
-xli
+jVM
+jVM
+jVM
+jVM
+aMo
+jVM
+wfl
+hdw
+yfC
+qBw
+rYM
+vLp
+vLp
+vHA
+rYM
+rYM
+iyx
+mKY
+bWv
+wfo
+sif
+tYX
+dDB
 blb
+dDB
+tYX
+iWt
+wbn
+wbn
+tYX
+dDB
+dDB
 blb
-blb
-qtl
-wlf
-qTM
-uMC
-dDB
-dDB
-dDB
-dDB
-dDB
 dDB
 dDB
 dDB
@@ -97862,46 +98824,46 @@ xYO
 xYO
 xYO
 xYO
-qlV
-oGJ
+lXd
+gVm
 wQB
-xeO
-oCc
-xeO
-kTd
-mnu
-iZc
-omA
-vzI
 jVM
-vXW
 jVM
-siz
-sPT
-lej
-tGq
-voF
-qGw
-uVE
-rgx
-prQ
-chP
-xmt
-qqq
-tIA
-xli
+pXU
+ksM
+uxp
+ksM
+hil
+eCl
+isJ
+jVM
+jVM
+hrG
+yfC
+yfC
+tWZ
+ihe
+qEf
+yfC
+mtM
+xMt
+yfC
+yfC
+jLT
+rbQ
+gCh
+ovu
+blb
+blb
+blb
+ovu
+ovu
+lbt
+lbt
+ovu
+tYX
 dDB
-dDB
-kev
-kev
-oxS
-usl
-iho
-iho
-dDB
-dDB
-dDB
-dDB
+blb
 dDB
 dDB
 dDB
@@ -98119,51 +99081,51 @@ oXK
 uAY
 uAY
 xRU
-vrn
-oGJ
-wVZ
-xeO
-oBV
-xeO
-mjs
-mpC
-qhm
-xBK
-iuL
+sgk
+gVm
+wQB
 jVM
-vXW
 jVM
-fjF
-pww
-pRU
-tGq
-qon
-uXb
-uXw
-rgx
-prQ
-sBp
-xmt
-wEp
-tIL
+jVM
+jVM
+jVM
+jVM
+jVM
+jVM
+sAO
+dGk
+rok
+oKi
+lRX
+czI
+wHe
+lJk
+rZg
+xyg
+kLd
+kLd
+atw
+fGC
+ovC
+dcN
+vTZ
 tYX
 dDB
 dDB
-qtl
-suq
-wnB
-uth
-uMW
-uMC
-dDB
-dDB
-uXY
-uXY
-uXY
-uXY
-uXY
 blb
 dDB
+tYX
+mMX
+nVz
+rYz
+tYX
+blb
+blb
+uXY
+uXY
+uXY
+uXY
+uXY
 dDB
 dDB
 blb
@@ -98376,53 +99338,53 @@ iYh
 lZt
 lZt
 xYO
-hBK
-dTS
+dgN
+pzM
 sbU
-xeO
-oCc
-xeO
-maz
-mqc
-xfw
-fcM
+xZS
+rCz
+hVQ
+hgx
+fyr
+xzw
 jVM
+eHH
+dAD
+fUs
 jVM
-nKk
-rgf
-kWF
-pxO
-gHt
-tGq
-scC
-qGY
-uXb
-rIS
-prQ
-oYu
-sSt
-tqq
-wYF
+iAO
+taw
+kOn
+lCu
+evn
+ghd
+qZi
+fFz
+vmW
+oEG
+uMg
+eIN
+nom
+sif
+tYX
+blb
+blb
+blb
+blb
+tYX
+mMX
+wbn
+url
 tYX
 dDB
 dDB
-qtl
-jSK
-qpg
-uuv
-uMX
-uMC
-blb
-blb
 uXY
 dvo
 hkW
 rLN
 uXY
 uXY
-dDB
-dDB
-dDB
+blb
 blb
 dDB
 dDB
@@ -98633,52 +99595,52 @@ xYO
 xYO
 xYO
 xYO
-mZh
-rbU
-uIv
-voa
-uZY
-xeO
-xeO
-xeO
+sDi
+ryd
+kAm
+fnQ
+jGa
+jgP
+nUJ
+aOc
+mBz
 jVM
+jOm
+rxW
 jVM
-jVM
-obU
-ggq
-jVM
-jVM
-jVM
-jVM
-jVM
-voL
-uXb
-uXb
-rJh
-vEI
-sxd
+tGq
+tGq
 xmt
-wEp
-tIL
+xmt
+jOA
+xmt
+xmt
+xmt
+rdi
+xmt
+xmt
 xli
+pJS
+mqN
+sif
+tYX
+blb
+vDo
+ppE
 dDB
-dDB
-kev
-bjV
-qBy
-uwl
-kdl
-vPC
-qtl
-qtl
+tYX
+fwt
+wbn
+nyK
+ovu
+gQN
+gQN
 uXY
 iTn
 nBw
 nId
 mpk
 uXY
-dDB
-dDB
 dDB
 blb
 dDB
@@ -98890,52 +99852,52 @@ iYj
 sDp
 gZy
 kke
-kgz
+dEr
 oGJ
 wQB
-xeO
-lus
-uZY
-wvn
-uZY
-ndq
-nuv
-nKm
-aoJ
-aBy
-mAn
-wzj
-atM
-cNF
+xZS
+qAw
+gYy
+jwg
+brF
+lfu
 jVM
-qpX
-qHm
-aes
-rJl
-hBr
-vUG
+jOm
+jVM
+tGq
+qft
+tGq
+otE
+cEO
+jEF
+hPv
+mkm
+iSY
+ePl
+pxk
 xmt
-ffX
-tJG
-xli
+sCP
+wbT
+nKo
+sFW
+ovu
+dDB
+dxs
+iRv
 blb
-blb
-qtl
-qTM
-vHL
-ozd
-fYp
-xbP
-hYm
-rUB
-uvh
+ovu
+niY
+wbn
+qjL
+msb
+vWo
+oms
+xJa
 xcv
 nBw
 ghQ
 nId
 uXY
-dDB
-dDB
 dDB
 blb
 blb
@@ -99147,52 +100109,52 @@ opn
 jwa
 opn
 jYY
-aEl
+tUX
 oGJ
 wQB
-xeO
-xeO
-xeO
-puw
-xeO
+xZS
+cSB
+nns
+bDm
+ygc
+sCX
 jVM
-uPd
-wzj
+mrM
 jVM
-jVM
-ceE
-jVM
-jVM
-jVM
-jVM
-efj
-xKa
-xKa
-rJv
-tax
-vUZ
-qKE
-wEp
-tJD
-xli
+mPs
+anL
+tGq
+wMS
+cEO
+tmj
+sUs
+jQZ
+nKP
+dvB
+oIk
+xmt
+vec
+idI
+ovl
+mbd
+tYX
 dDB
-dDB
-kev
-kst
-qSU
-uwx
-agC
-kqo
-qtl
-qtl
+cOc
+aXC
+blb
+tYX
+lzq
+wbn
+rhq
+ovu
+gQN
+gQN
 uXY
 hzb
 erK
 iPj
 bob
 uXY
-nnk
-dDB
 dDB
 blb
 dDB
@@ -99404,53 +100366,53 @@ iYD
 jLR
 jLR
 xMY
-tSe
-oGJ
-wQB
-wix
-xeO
-hee
-mbK
-mqz
-jVM
-uPd
+kdR
+xeF
+fIv
+nZj
 jVM
 jVM
-mRp
-aeN
-lSw
-hym
-fhC
-mKH
-qrw
-xCu
-rij
-xCu
-xCu
-xCu
-asN
-wEI
-tIL
+jVM
+oAC
+jVM
+jVM
+dRo
+jVM
+bQq
+vhV
+pzk
+hMX
+cEO
+pmo
+aoU
+txm
+ajQ
+cEO
+cEO
+mbJ
+wlK
+acQ
+gIU
+sif
+tYX
+blb
+blb
+dDB
+dDB
+tYX
+mMX
+wbn
+eHb
 tYX
 dDB
 dDB
-qtl
-jSK
-rjz
-uxi
-uMX
-vnb
-blb
-blb
 uXY
 cHX
 qYh
 qXG
 uXY
 uXY
-dDB
-dDB
-dDB
+blb
 blb
 dDB
 dDB
@@ -99661,51 +100623,51 @@ qTD
 azv
 jNe
 psc
-tSe
+kdR
 oGJ
 wQB
 xAV
-xeO
-lMy
-iJN
-pSI
+eyf
+bzj
 jVM
-qhp
-rpy
+rNy
+eyS
 jVM
-gTV
-oXt
-xCu
-xCu
-xCu
-xCu
-xCu
-uCv
-ril
-vVw
-vFv
-vVw
-lJc
-wEp
-tIL
+yfV
+flO
+qIY
+kGJ
+tGq
+gav
+cEO
+vzH
+mNa
+luB
+cYz
+cEO
+cEO
+mbJ
+mXO
+vuD
+oCn
+sif
 tYX
 dDB
-dDB
-qtl
-rOy
-rrx
-uyg
-uOh
-vnb
-dDB
-dDB
-uXY
-uXY
-uXY
-uXY
-uXY
 blb
-dDB
+blb
+blb
+tYX
+mMX
+mcL
+eHb
+tYX
+blb
+blb
+uXY
+uXY
+uXY
+uXY
+uXY
 dDB
 dDB
 blb
@@ -99906,7 +100868,7 @@ ycC
 ycC
 noq
 ueC
-tJF
+fPN
 qoD
 jnZ
 jEx
@@ -99917,45 +100879,45 @@ xMY
 xMY
 xMY
 xMY
-xMY
-tUK
+mgh
+fUz
 oGJ
 wQB
 vpT
-xeO
-lMz
-vXo
-pSK
+bVB
+pnA
+jVM
+rNy
 jVM
 jVM
-nKL
+jOm
 jVM
-oAp
-iBg
-sze
-pya
-tgS
-sze
-wkk
-vVw
-vVw
-oAp
-vFE
-tPd
-sTp
-jFf
-tKm
-xli
+jQd
+haK
+tGq
+cLp
+cEO
+oyA
+cEO
+cEO
+cEO
+oyA
+fOH
+xmt
+itg
+wxt
+syE
+gCh
+ovu
+blb
+blb
 dDB
-dDB
-kev
-kev
-oxS
-uLu
-mVY
-mVY
-dDB
-dDB
+ovu
+ovu
+nRi
+nRi
+kml
+tYX
 dDB
 dDB
 dDB
@@ -100175,53 +101137,53 @@ hHF
 lGo
 jNO
 geE
-tWL
+qoT
 oGJ
 wQB
-ycx
-xeO
-lMH
-cnu
+cJu
+pCW
+gIi
 jVM
+dJs
+tHB
+tHB
+poY
 jVM
-xCz
-rpg
-jVM
-dNI
-vLO
-piZ
-pyS
-gal
-vgc
-wkk
-qJa
-vVw
-rJT
-sih
-oup
-sTp
-wEp
-tIA
+tGq
+tGq
+tGq
+xmt
+kdy
+frq
+wZx
+sHt
+sCU
+aIM
+xmt
+xmt
 xli
+lMQ
+syE
+sif
+tYX
+dDB
 blb
+dDB
+tYX
+spd
+wbn
+wbn
+rNR
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
 blb
-blb
-qtl
-qTM
-qTM
-vnb
-blb
-blb
-blb
-blb
-blb
-blb
-blb
-blb
-blb
-blb
-blb
-blb
+dDB
+dDB
+dDB
 blb
 dDB
 dDB
@@ -100432,50 +101394,50 @@ oUd
 lun
 wNv
 mzM
-tWL
+qoT
 kyZ
 kJR
+nBj
 jVM
 jVM
 jVM
+crm
 jVM
-jVM
-xhQ
-nLN
-cyh
-jVM
-jVM
-jVM
-jVM
-jVM
-jVM
-jVM
-qrI
-qKE
-riM
-qKE
-qKE
-qKE
-sTp
-vQA
-tIL
+sON
+gqa
+vkh
+vkh
+vkh
+ijC
+yir
+cMT
+cMT
+efQ
+efQ
+efQ
+efQ
+pov
+gwB
+vkh
+czD
+rbQ
+sif
 tYX
 dDB
+blb
 dDB
-dDB
-kev
-uPO
-mjB
-mVY
-dDB
-dDB
-dDB
+tYX
+wbn
+wbn
+wbn
+rNR
 dDB
 dDB
 dDB
 dDB
 dDB
 dDB
+blb
 dDB
 dDB
 dDB
@@ -100689,53 +101651,53 @@ soO
 gfs
 ivl
 mzM
-tWL
+qoT
 uFG
-vpI
+gdf
 jVM
-vML
-atM
-mdj
+vWZ
+diN
+wzj
+xvN
 jVM
-uPd
-jVM
-nKX
-jVM
-fSq
-hwN
-kXO
-pyY
-pSm
-jVM
-qrN
-ttA
-ttA
-ttA
-ttA
-sBz
-xvW
-tqz
-tIL
+vGh
+teO
+vkh
+jYQ
+vkh
+tvy
+jge
+gHg
+vJf
+slF
+uUU
+uUU
+uUU
+szR
+kzm
+vkh
+wxt
+rbQ
+reP
+ovu
 tYX
-dDB
-dDB
-dDB
-kev
-wmY
-uPO
-mVY
-dDB
-dDB
-dDB
-dDB
-dDB
-dDB
-dDB
-dDB
-dDB
-dDB
-dDB
-dDB
+tYX
+tYX
+ovu
+mMX
+qWf
+kml
+rNR
+blb
+blb
+blb
+blb
+blb
+blb
+blb
+blb
+blb
+blb
 blb
 dDB
 dDB
@@ -100946,42 +101908,42 @@ xSx
 jxC
 ufb
 xCl
-tYQ
+gvZ
 kzu
 wiF
 jVM
 jVM
-lMK
 jVM
 jVM
-xjq
-jVM
-tII
-oeF
-kGS
-kGS
-kGS
-kSV
-pSr
-jVM
-qsA
-uCJ
-rjb
-rKL
-siv
-sED
-rNq
-tmV
-tIL
-tYX
-blb
-blb
-blb
-qtl
-qTM
-qTM
-vnb
-dDB
+qQJ
+yhG
+iHu
+wlq
+oDN
+qPD
+vkh
+uxH
+xbb
+rre
+onH
+ycS
+jTw
+iRj
+sxf
+ycS
+cYa
+vkh
+wxt
+rbQ
+yhc
+qWf
+wbn
+wbn
+jSq
+uPC
+nVz
+iYL
+rNR
 dDB
 dDB
 dDB
@@ -101208,37 +102170,37 @@ dIN
 mwN
 jVM
 vMV
-jbL
-xkS
-pTC
-wLJ
+eZy
+eZy
+cRb
 jVM
-ygd
-jVM
-mBy
-wzj
-kGS
-qCC
-jVM
-jVM
-cmH
-qKN
-wLA
-rNA
-siP
-qTL
-jme
-tqK
-tIL
+lsS
+wdx
+vkh
+oEg
+kUn
+epN
+cpk
+sBO
+qTO
+dYT
+tXM
+moL
+nHL
+lLy
+aqJ
+fKQ
+wxt
+rbQ
+yhc
+jtA
+dci
+wbn
+wbn
+aQn
+aQn
+vxL
 tYX
-dDB
-dDB
-dDB
-qtl
-qTM
-qTM
-vnb
-dDB
 dDB
 dDB
 dDB
@@ -101461,41 +102423,41 @@ quU
 quU
 tsF
 ubK
-uFG
-gih
-lca
-oEN
-lMN
+rnm
+lzs
+ibg
+pAD
+eMp
 jVM
-hcB
-mAn
+mYV
 jVM
-jVM
-jVM
-jVM
-wzj
-omU
-uAH
-jVM
-wnK
-clc
-asn
-rkb
-rOm
-skY
-sED
-sXk
-wEp
-tKC
-xli
-dDB
-dDB
-dDB
-qtl
-qTM
-qTM
-vnb
-dDB
+aiW
+qNY
+vkh
+xkk
+hSF
+nez
+iSQ
+sBO
+qTO
+qML
+eGj
+hZR
+itJ
+ycS
+aqJ
+edt
+wxt
+rbQ
+qsH
+tLv
+kml
+rNR
+rNR
+kml
+rNR
+rNR
+ovu
 dDB
 dDB
 dDB
@@ -101725,34 +102687,34 @@ jVM
 jVM
 jVM
 jVM
-qhp
-sfX
-nLN
-rpy
 jVM
-jVM
-jVM
-jVM
-jVM
-nAi
-uio
-xOB
-xOB
-xOB
-xOB
-sFJ
-xvW
-tkp
-tMi
-xli
-urv
-yeh
-blb
-kev
-fUj
-uPO
-mVY
-blb
+sON
+sON
+vkh
+vZR
+kFl
+piJ
+khh
+sBO
+eGM
+dYT
+tfk
+vpX
+aec
+ycS
+iwD
+vkh
+wxt
+rbQ
+tAZ
+gTh
+ovu
+dDB
+dDB
+dDB
+dDB
+dDB
+dDB
 blb
 qIf
 qIf
@@ -101981,34 +102943,34 @@ tgl
 iSi
 fLn
 mLU
-jVM
-jVM
-jVM
-jVM
-pXU
-mAn
-jVM
-waS
-pzn
-xvW
-xvW
-qtW
-rRn
-rRn
-rRn
-rRn
-sIh
-xvW
-gXD
-tMj
-yeh
-uyp
-yeh
-urv
-mVY
-sDT
-wHX
-mVY
+tgl
+tgl
+tgl
+vkh
+hhK
+lXS
+dsK
+lTW
+iSQ
+sBO
+bfx
+dYT
+lPv
+ovF
+vbF
+ycS
+aqJ
+vkh
+iCO
+rbQ
+pTP
+kab
+tYX
+dDB
+dDB
+dDB
+dDB
+dDB
 dDB
 dDB
 qIf
@@ -102240,32 +103202,32 @@ pbd
 wtv
 hxp
 qhs
-qIg
-jVM
-jVM
-uPd
-jVM
-vsq
-pbZ
-pTl
-xvW
-qtW
-xzp
-rOx
-rOx
-rOx
-sIh
-xvW
-lWb
-mpO
-lmo
-vcP
-uPs
-fHb
-npY
-qTM
-qTM
-qtl
+hMR
+vkh
+lNK
+lJP
+mjI
+kGM
+lcA
+sBO
+qTO
+jvG
+edq
+eXU
+kQq
+tcS
+aqJ
+gcW
+wxt
+rbQ
+pqu
+mxh
+tYX
+dDB
+dDB
+dDB
+dDB
+dDB
 dDB
 dDB
 qIf
@@ -102495,34 +103457,34 @@ tgl
 lvA
 nyy
 diK
-rTt
-xkW
-nAO
-yiv
-ofk
-cyh
-jVM
-naI
-ogu
-xrz
-xvW
-qui
-vqp
-rkF
-rQt
-uEg
-tNc
-xvW
-hlo
-tMy
-tZG
-aiE
-waw
-uNn
-vOh
-qTM
-qTM
-qtl
+onJ
+scS
+hRc
+vkh
+xEp
+eSs
+reu
+iSQ
+iSQ
+sBO
+qTO
+jvG
+nOY
+dbI
+dlb
+ycS
+xZl
+gcW
+wxt
+ioE
+tAZ
+flH
+tYX
+dDB
+dDB
+dDB
+dDB
+dDB
 dDB
 dDB
 qIf
@@ -102752,34 +103714,34 @@ tgl
 wHO
 pbG
 wvv
-rTt
+onJ
 vGe
-crV
-jVM
-rUS
-rOb
-htI
-awN
-sQA
-xrz
-xvW
-quo
-uEg
-pCX
-vqp
-slv
-bOV
-xvW
-twf
-tMR
-tZV
-xtZ
-yeh
-urv
-kev
-qtl
-qtl
-qtl
+rkJ
+vkh
+vkh
+akz
+vkh
+nUn
+nUn
+eYv
+fFk
+jvG
+uwz
+uwz
+aAP
+ycS
+qlB
+gcW
+wxt
+klQ
+txG
+rqO
+tYX
+dDB
+dDB
+dDB
+dDB
+dDB
 dDB
 dDB
 qIf
@@ -103009,29 +103971,29 @@ tgl
 tgl
 tgl
 tgl
-wRD
-hRc
-hoU
-jVM
-rOb
-rhD
-jVM
-sZn
-pzX
-vII
-ygB
-xNL
-eQv
-qmf
-vrv
-pFr
-uCS
-xvW
-twj
-mpO
-ubf
-oEr
-yeh
+wVc
+cPn
+xNl
+vkh
+ppn
+jhD
+hVd
+dON
+dON
+iIz
+dno
+vhw
+hSR
+dON
+dON
+hbh
+wnH
+vkh
+dOx
+klQ
+biJ
+tpw
+xli
 blb
 blb
 blb
@@ -103263,32 +104225,32 @@ vrn
 uFG
 smf
 aCO
-lwa
+yda
 pcK
 tgl
-mtV
+ohB
 xHD
 xHD
-jVM
-jiN
-jVM
-jVM
-xvW
-xvW
-xvW
-xvW
-xvW
-xvW
-xvW
-xvW
-xvW
-xvW
-sXo
-twl
-mpO
-amI
-uAb
-yeh
+vkh
+fat
+vkh
+vkh
+vkh
+efC
+vkh
+fyQ
+dAe
+vkh
+nqZ
+nqZ
+nqZ
+vkh
+vkh
+lbt
+wJl
+ivH
+sak
+xli
 qir
 qir
 qir
@@ -103519,13 +104481,13 @@ tsF
 kiO
 nDV
 wNW
+swY
+oqy
+oqy
+rKw
+faa
 vpI
-vpI
-vpI
-pwO
-sfK
-vpI
-vpI
+hcI
 nMW
 tEL
 rQN
@@ -103534,18 +104496,18 @@ rZq
 vpI
 pBu
 vpI
-vpI
-oXZ
-rQN
-vpI
-pwO
-sIG
-vpI
-xDs
-mpO
-ucr
-xIK
-uQC
+edw
+vQS
+tMW
+tMW
+tMW
+aKu
+tRX
+nVz
+wGO
+wnP
+xRe
+dCW
 jeW
 pvY
 xry
@@ -103553,7 +104515,7 @@ ppu
 wSF
 qir
 kIS
-wfU
+oJX
 csw
 tlX
 rVH
@@ -103776,41 +104738,41 @@ tsF
 kjg
 oXV
 kJX
-xIw
+fMT
 vrH
 xIw
 xIw
-fqL
-dRh
+vfX
+sfc
 sDZ
-vnK
+cgi
 uVo
 oBA
 mut
 pjA
 mut
-iEE
+jWQ
 xIw
-xIw
+lRw
 xIw
 rlh
 vrH
 xIw
-vYt
-xyJ
-wFl
-sFH
-vuL
-xIK
-ygu
-mHb
-ona
-xEC
-ona
-uXB
+kJV
+feB
+aHy
+pgT
+unN
+xzK
+rcO
+gtp
+vCO
+qjU
+vCO
+lpH
 wMZ
 vnN
-ybL
+yfW
 pOm
 lwk
 gUn
@@ -104030,10 +104992,10 @@ gcz
 jyM
 uoB
 jZn
-mxN
+dnG
 rji
 vAw
-nvE
+spb
 nvE
 nvE
 nvE
@@ -104043,31 +105005,31 @@ vCZ
 uQi
 nvE
 oCx
-nvE
+hwj
 rFn
 nvE
-eWA
+ptw
 kfM
-fKO
-hvM
-hvM
-hvM
-hvM
-hvM
-hvM
-ouf
-wZE
-ucH
-xIM
-yfj
+cLH
+oEL
+oEL
+oEL
+oEL
+pRY
+oMQ
+unI
+hNz
+abf
+ybc
+wDx
 bcv
 kov
 viy
 efB
-kov
+sgM
 xyh
 xRI
-ycZ
+sgM
 hVh
 elM
 pYr
@@ -104288,9 +105250,9 @@ jzo
 uoB
 uoB
 wSZ
-dRf
-xqC
-bOp
+fpN
+mgV
+mZi
 dyF
 lNp
 xRA
@@ -104303,27 +105265,27 @@ qUt
 qUt
 qUt
 qUt
-tZd
+vDG
 qUt
 qUt
 xJB
 vYy
 vrO
 vYy
-vYy
+xJB
 xJB
 xJB
 wZO
 xpU
-uAw
-yga
-rbo
-vCO
-wnO
-jpK
-vCO
-lhg
-xSp
+uBY
+ygu
+mHb
+ona
+kEU
+jUV
+dMo
+pcV
+jTn
 dUC
 qTK
 vnF
@@ -104560,8 +105522,8 @@ qUt
 uZK
 ptl
 ptl
-dSK
-gZo
+ctS
+cxm
 qUt
 rnc
 ugH
@@ -104818,8 +105780,8 @@ qUt
 aIb
 qUt
 qUt
-aGH
-uiW
+nnZ
+woh
 qLt
 vrY
 vrY
@@ -105328,7 +106290,7 @@ bmz
 mSa
 tPW
 qUt
-bxk
+eFH
 rex
 axz
 qUt
@@ -105826,7 +106788,7 @@ xRH
 gcz
 wSZ
 jdp
-gRG
+iVf
 wSZ
 nNj
 ujq
@@ -106351,7 +107313,7 @@ oyn
 fSU
 fRV
 skd
-skd
+hzv
 rrp
 wqj
 aTb
@@ -107131,7 +108093,7 @@ knO
 adh
 hbz
 vIC
-gfJ
+roJ
 wua
 wua
 wua
@@ -107378,7 +108340,7 @@ fuD
 xVV
 eWP
 lNN
-lWp
+beQ
 xhD
 heN
 vjI
@@ -107388,7 +108350,7 @@ wqj
 qUt
 qUt
 qUt
-gfJ
+roJ
 qUt
 dWW
 tnb
@@ -107644,8 +108606,8 @@ gmf
 qva
 nqf
 qUt
-tnb
-tnb
+tNs
+tNs
 qUt
 uEP
 gfJ
@@ -107901,7 +108863,7 @@ cPp
 wqj
 wrx
 qUt
-gfJ
+roJ
 qUt
 qUt
 qUt
@@ -108158,7 +109120,7 @@ eeJ
 eeJ
 eeJ
 qUt
-gfJ
+roJ
 tnb
 tnb
 tnb
@@ -108415,7 +109377,7 @@ gMq
 duT
 gtk
 qUt
-gfJ
+roJ
 tnb
 qUt
 tkq
@@ -108672,12 +109634,12 @@ rsZ
 jQB
 kAJ
 qUt
-umM
 tNs
-umM
-qNz
-umM
-rSj
+tnb
+tnb
+tnb
+tnb
+jRH
 spP
 bRt
 wsb
@@ -109186,12 +110148,12 @@ opN
 eeJ
 eeJ
 qUt
-uiW
+pNB
 qUt
-htt
-wvP
-jQg
-vuo
+ntD
+pMv
+jto
+wua
 sqA
 sJi
 wty
@@ -109441,14 +110403,14 @@ ohr
 rqD
 opN
 xEM
-yaL
-xeY
-iLq
-pxg
-tZU
-jNJ
-aoy
-vuo
+qUt
+rzm
+ioi
+eaO
+qpA
+sRJ
+lnX
+wua
 wWX
 blf
 unf
@@ -109698,14 +110660,14 @@ fvj
 uDz
 jXB
 nYs
-yaL
-gYX
-gYX
-jRI
-qhi
-tFg
-lRD
-vuo
+qUt
+fhJ
+ioi
+eBE
+sRc
+eZX
+vPN
+wua
 wtX
 wtX
 wtX
@@ -109955,14 +110917,14 @@ fcU
 rem
 xvM
 uDE
-yaL
-oQD
-oWp
-dEV
-rrV
-rMM
-jLh
-yaL
+qUt
+uQW
+tba
+qAW
+axl
+bbW
+uEi
+qUt
 sqY
 ata
 taZ
@@ -110212,14 +111174,14 @@ pzd
 iIs
 axw
 shD
-yaL
-mzc
-mzc
-tNS
-yaL
-qTP
-yaL
-yaL
+qUt
+vGb
+vGb
+hUt
+qUt
+glm
+qUt
+qUt
 srA
 lrH
 aaH
@@ -111032,7 +111994,7 @@ ldq
 qdR
 naN
 vOr
-mdG
+iIm
 uLj
 oig
 oig
@@ -113536,7 +114498,7 @@ aBL
 rqw
 jsE
 rqw
-agp
+sLX
 vpP
 pzd
 bqy
@@ -114054,15 +115016,15 @@ fcW
 jVY
 cvk
 nFW
-pQO
-hDm
-jpp
-trc
-rBK
-jpp
-wsX
-cij
-pzd
+sdX
+trx
+kIX
+cFP
+sAV
+kIX
+axa
+iwB
+ffY
 gMz
 rem
 rQA
@@ -114311,15 +115273,15 @@ xUy
 rEd
 aWb
 nFW
-beR
-rvH
-ucw
-dzq
-jpp
-nsH
-cIC
-cij
-pzd
+qZR
+mOn
+sdJ
+rrB
+kIX
+ter
+xOe
+iwB
+ffY
 ycQ
 rem
 nvB
@@ -114568,13 +115530,13 @@ eav
 eav
 nFW
 nFW
-pzd
-pzd
-bED
-vjc
-ncs
-mKs
-pzd
+ffY
+ffY
+wNp
+itq
+ukr
+qQZ
+ffY
 xQJ
 xQJ
 xQJ
@@ -114826,12 +115788,12 @@ tLj
 wOp
 fsq
 iRl
-pzd
-pzd
-eYT
-pzd
-pzd
-pzd
+ffY
+ffY
+wsK
+ffY
+ffY
+ffY
 xqs
 xMO
 xQJ
@@ -115338,7 +116300,7 @@ ogE
 jhm
 qJH
 wQc
-pot
+lJl
 rUq
 lyq
 wOp
@@ -121044,7 +122006,7 @@ wos
 sXw
 vVX
 sTK
-tUD
+xqj
 vbQ
 iVE
 ksg
@@ -121815,7 +122777,7 @@ wos
 udv
 tSq
 mvo
-izw
+xqj
 bFw
 ulK
 cdn
@@ -123333,7 +124295,7 @@ blb
 dDB
 xaN
 dNG
-gJQ
+gwW
 vlq
 vFn
 qNO
@@ -130313,7 +131275,7 @@ xqq
 xLY
 ylD
 lye
-lNF
+hug
 ylD
 ylD
 ylD

--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -163,6 +163,9 @@
 	AddElement(/datum/element/diggable, /obj/item/stack/ore/glass, 2, worm_chance = 50, \
 		action_text = "uproot", action_text_third_person = "uproots")
 
+/turf/open/floor/grass/Airless
+	initial_gas_mix = AIRLESS_ATMOS
+
 /turf/open/floor/grass/proc/spawniconchange()
 	icon_state = "grass[rand(0,3)]"
 


### PR DESCRIPTION
## About The Pull Request

Revitalizing birdshot by extensively changing up most of the service departments.

## Why It's Good For The Game
Birdshot is in need of some changes. I was hoping that these changes would help improve it in the eyes of players.

This birdshot update features essentially an entirely moved/renovated service departments, along with an addition to an arcade and a commissary, along with a much improved public chapel. Moved the service lathe to a new service hall found between the kitchen and hydroponics. You can see the new layout below.


![image](https://github.com/tgstation/tgstation/assets/168238458/c281bd94-ba2a-4140-b7d4-e7ee58cc3a76)

## Changelog

:cl:Viralmilk22
add: Shifted up the service departments on Birdshot.
add: Added an arcade.
/:cl:
