### PR TITLE
Gives tarkon NT Frontier, + tiny qol/fixes

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/port_tarkon.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/port_tarkon.dmm
@@ -3396,6 +3396,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/starboardhall)
+"wR" = (
+/obj/machinery/icecream_vat,
+/turf/open/floor/iron/freezer,
+/area/ruin/space/has_grav/port_tarkon/kitchen)
 "wT" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/tile/blue/half{
@@ -4905,7 +4909,10 @@
 "HB" = (
 /obj/machinery/door/window/left/directional/west,
 /obj/machinery/door/window/right/directional/east,
-/obj/machinery/mineral/ore_redemption/offstation,
+/obj/machinery/mineral/ore_redemption/offstation{
+	input_dir = 4;
+	output_dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/mining)
 "HC" = (
@@ -5899,7 +5906,7 @@
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 1
 	},
-/obj/machinery/modular_computer,
+/obj/machinery/modular_computer/preset/research/away,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "NS" = (
@@ -7031,6 +7038,7 @@
 /obj/structure/noticeboard/directional/north,
 /obj/item/paper/fluff/ruins/oldstation/generator_manual,
 /obj/item/paper/fluff/ruins/tarkon,
+/obj/structure/tank_dispenser,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/atmos)
 "Vv" = (
@@ -7496,6 +7504,7 @@
 /obj/item/raw_anomaly_core/random,
 /obj/item/raw_anomaly_core/random,
 /obj/machinery/camera/autoname/tarkon/directional/north,
+/obj/item/computer_disk/ordnance,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
 "YT" = (
@@ -11278,7 +11287,7 @@ tT
 tT
 iG
 hG
-VZ
+wR
 VZ
 Ut
 hG

--- a/_maps/RandomRuins/SpaceRuins/nova/port_tarkon/dorm_party.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/port_tarkon/dorm_party.dmm
@@ -41,10 +41,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/template_noop)
 "o" = (
-/obj/machinery/airalarm/directional/south,
-/obj/effect/mapping_helpers/airalarm/all_access,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/south,
 /turf/open/floor/wood/large,
 /area/template_noop)
 "q" = (
@@ -67,6 +66,7 @@
 /obj/effect/spawner/random/entertainment/lighter,
 /obj/item/bong,
 /obj/item/reagent_containers/hash,
+/obj/item/flashlight/lamp,
 /turf/open/floor/carpet/royalblack,
 /area/template_noop)
 "t" = (
@@ -94,6 +94,7 @@
 /obj/item/cigarette/candy,
 /obj/item/cigarette,
 /obj/effect/spawner/random/entertainment/lighter,
+/obj/item/flashlight/lamp,
 /turf/open/floor/carpet/royalblue,
 /area/template_noop)
 "z" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Primarily, gives tarkon a computer pre-loaded with NT Frontier, as well as an ordnance data disk either as a backup or to use for storing the experiments. (in the spirit of #3457, where I would have done this if I realized they didn't already have access despite having an entire ordnance setup)

In addition:
- fixes the ORM being rotated the wrong way around
- fixes one of the dorm variants not having any lighting
- adds a tank dispenser in engineering to also assist with ordnance
- adds an ice cream vat 🍨 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Research is a big part of tarkon, and ordnance is a fairly big part of the new research. TG's charliestation has it, tarkon probably should as well. 
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/25628932/2548638d-4f9a-44b4-8a74-34eb85686de7)
![image](https://github.com/NovaSector/NovaSector/assets/25628932/0cfeeefe-9be0-4430-b3fe-18ff9bc7c426)
![image](https://github.com/NovaSector/NovaSector/assets/25628932/575e40c2-dab0-40ef-a876-53b4b945c7e3)
![image](https://github.com/NovaSector/NovaSector/assets/25628932/06712fa9-df24-46ef-b4b7-a7ff9cb76b5f)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: tarkon now has access to NT Frontier for advancing their tech tree, and a tank dispenser in engi
fix: tarkon ORM has been rotated the right way around
fix: one of tarkon's possible dorms has lights now
balance: tarkon has an ice cream vat, fear their power
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
