### PR TITLE
Fixes Ashwalker factions and Lavaland Tendril Factions

### DIFF
--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/mob/simple/lavaland/nest.dmi'
 	icon_state = "tendril"
 
-	faction = list(FACTION_MINING, FACTION_ASHWALKER)
+	faction = list(FACTION_MINING, FACTION_MINING_FAUNA) // NOVA EDIT CHANGE - ORIGINAL: faction = list(FACTION_MINING, FACTION_ASHWALKER)
 	max_mobs = 3
 	max_integrity = 250
 	mob_types = list(/mob/living/basic/mining/watcher)

--- a/modular_nova/modules/ashwalkers/code/species/Ashwalkers.dm
+++ b/modular_nova/modules/ashwalkers/code/species/Ashwalkers.dm
@@ -14,13 +14,13 @@
 	ADD_TRAIT(carbon_target, TRAIT_ASHSTORM_IMMUNE, SPECIES_TRAIT)
 	RegisterSignal(carbon_target, COMSIG_MOB_ITEM_ATTACK, PROC_REF(mob_attack))
 	carbon_target.AddComponent(/datum/component/ash_age)
-	carbon_target.faction |= FACTION_ASHWALKER
+	carbon_target.faction |= list(FACTION_ASHWALKER,FACTION_NEUTRAL)
 
 /datum/species/lizard/ashwalker/on_species_loss(mob/living/carbon/carbon_target)
 	. = ..()
 	REMOVE_TRAIT(carbon_target, TRAIT_ASHSTORM_IMMUNE, SPECIES_TRAIT)
 	UnregisterSignal(carbon_target, COMSIG_MOB_ITEM_ATTACK)
-	carbon_target.faction &= FACTION_ASHWALKER
+	carbon_target.faction &= list(FACTION_ASHWALKER,FACTION_NEUTRAL)
 
 /datum/species/lizard/ashwalker/proc/mob_attack(datum/source, mob/mob_target, mob/user)
 	SIGNAL_HANDLER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

https://github.com/NovaSector/NovaSector/pull/3447

When i did my initial testing i only ran to pre-spawned guys in the wastes and then admin spawned the others, which gave them their default faction.

For some damn reason, Tendrils apply a faction when spawning a creature as well and i didnt know that so i assumed incorrectly.

## How This Contributes To The Nova Sector Roleplay Experience

Ashwalker play is now where it was meaning to be a few days ago

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
  
![image](https://github.com/NovaSector/NovaSector/assets/22140677/fc321056-26e8-4b56-aaa2-b75209962174)

  
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Ashwalker Factions now apply properly
fix: Lavaland Tendril factions now apply the Mining Fauna Faction properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
