### PR TITLE
Fixes lingering issue with immovable rod reality tears

### DIFF
--- a/modular_nova/modules/rod-stopper/code/immovable_nova.dm
+++ b/modular_nova/modules/rod-stopper/code/immovable_nova.dm
@@ -7,5 +7,6 @@
 		visible_message(span_boldwarning("The rod tears into the rodstopper with a reality-rending screech!"))
 		playsound(src.loc,'sound/effects/supermatter.ogg', 200, TRUE)
 		visible_message(span_boldwarning("You have five seconds to move away before the localized reality-collapse!"))
-		new/obj/reality_tear(src.loc)
+		var/obj/reality_tear/tear = new(src.loc)
+		tear.start_disaster()
 		qdel(src)


### PR DESCRIPTION
## About The Pull Request

In the literal sense. These will no longer linger forever and should disappear after a time.

## How This Contributes To The Nova Sector Roleplay Experience

Bugfix

## Proof of Testing

<details>
<summary>Goes away now</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/13398309/572d2ef8-b229-4509-b767-7a129159e30c)


</details>

## Changelog

:cl:
fix: fixes rodstoppers leaving a permanent (inert) bag of holding tear effect
/:cl:
