### PR TITLE
Adds the pipe scrubber to our maps

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -17700,7 +17700,7 @@
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "dsy" = (
-/obj/machinery/space_heater,
+/obj/machinery/portable_atmospherics/pipe_scrubber,
 /obj/effect/turf_decal/stripes{
 	dir = 5
 	},
@@ -55840,7 +55840,7 @@
 /area/station/medical/medbay/lobby)
 "kHp" = (
 /obj/effect/turf_decal/bot_white,
-/obj/machinery/portable_atmospherics/scrubber/huge,
+/obj/machinery/portable_atmospherics/pipe_scrubber,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)

--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -36536,7 +36536,7 @@
 "kBL" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/portable_atmospherics/pipe_scrubber,
 /obj/machinery/power/apc/auto_name/directional/east{
 	areastring = "/area/station/science/ordnance/burnchamber"
 	},
@@ -52736,7 +52736,7 @@
 /area/station/hallway/primary/central/aft)
 "pnh" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/portable_atmospherics/pipe_scrubber,
 /obj/machinery/light/warm/directional/south,
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible/layer4{

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -19143,11 +19143,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/box/red,
-/obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/trimline/dark_red/filled/line{
 	dir = 10
 	},
 /obj/machinery/status_display/evac/directional/south,
+/obj/machinery/portable_atmospherics/pipe_scrubber,
 /turf/open/floor/iron/smooth,
 /area/station/science/ordnance)
 "fAP" = (
@@ -77980,7 +77980,7 @@
 /area/station/cargo/warehouse)
 "vHh" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/portable_atmospherics/pipe_scrubber,
 /obj/effect/turf_decal/box,
 /obj/structure/sign/poster/official/moth_piping/directional/north,
 /obj/effect/turf_decal/stripes/line,


### PR DESCRIPTION
## About The Pull Request
Title.

## How This Contributes To The Nova Sector Roleplay Experience

I didn't get a chance to add these to our maps in #3521.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/NovaSector/NovaSector/assets/70232195/e99cbc58-9df5-4d1e-9cd8-aea759a080c5)


</details>

## Changelog

:cl: Jolly
fix: Our maps (Ouroboros, Blueshift, Voidraptor) now have pipe scrubbers in atmos and ordnance!
/:cl:

