### PR TITLE
[AutoMapper] Tweaks Birdshots NTC Office and Barbershop Templates

### DIFF
--- a/_maps/nova/automapper/automapper_config.toml
+++ b/_maps/nova/automapper/automapper_config.toml
@@ -284,15 +284,15 @@ trait_name = "Station"
 map_files = ["birdshot_barber.dmm"]
 directory = "_maps/nova/automapper/templates/birdshot/"
 required_map = "birdshot.dmm"
-coordinates = [129, 127, 1]
+coordinates = [118, 145, 1]
 trait_name = "Station"
 
-# Birdshot NTR Office
+# Birdshot NTC Office
 [templates.birdshot_ntrep_office]
 map_files = ["birdshot_ntrep_office.dmm"]
 directory = "_maps/nova/automapper/templates/birdshot/"
 required_map = "birdshot.dmm"
-coordinates = [111, 157, 1]
+coordinates = [91, 143, 1]
 trait_name = "Station"
 
 # Birdshot ERT Bay

--- a/_maps/nova/automapper/templates/birdshot/birdshot_barber.dmm
+++ b/_maps/nova/automapper/templates/birdshot/birdshot_barber.dmm
@@ -83,6 +83,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood/large,
 /area/station/service/barber/spa)
 "yz" = (

--- a/_maps/nova/automapper/templates/birdshot/birdshot_barber.dmm
+++ b/_maps/nova/automapper/templates/birdshot/birdshot_barber.dmm
@@ -20,7 +20,6 @@
 /area/station/service/barber/spa)
 "eJ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/service/barber/spa)

--- a/_maps/nova/automapper/templates/birdshot/birdshot_barber.dmm
+++ b/_maps/nova/automapper/templates/birdshot/birdshot_barber.dmm
@@ -1,141 +1,66 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"aJ" = (
-/obj/effect/spawner/random/engineering/atmospherics_portable,
-/turf/open/floor/plating,
-/area/station/maintenance/central/lesser)
-"bI" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/item/radio/intercom/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/commons/vacant_room/commissary)
 "cT" = (
-/obj/structure/chair/office/light{
-	dir = 4
+/obj/structure/mirror/directional/east,
+/obj/structure/table/glass,
+/obj/item/hairbrush/comb{
+	pixel_y = -1;
+	pixel_x = -3
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/small,
 /area/station/service/barber/spa)
 "ds" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/structure/mirror/directional/east,
+/obj/structure/table/glass,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/item/reagent_containers/spray/quantum_hair_dye{
+	pixel_x = 9;
+	pixel_y = 16
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/item/lipstick/random,
-/obj/structure/table/wood,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/small,
 /area/station/service/barber/spa)
 "eJ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/vending/barbervend,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
 /area/station/service/barber/spa)
 "fn" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
 /area/station/service/barber/spa)
-"fq" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/mirror/directional/east,
-/obj/item/reagent_containers/dropper,
-/obj/item/hairbrush/comb{
-	pixel_y = 10
-	},
-/turf/open/floor/iron,
-/area/station/service/barber/spa)
-"ga" = (
+"lK" = (
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/commons/vacant_room/commissary)
-"gL" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/structure/chair/comfy/barber_chair{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/landmark/start/barber,
+/turf/open/floor/iron/dark/small,
+/area/station/service/barber/spa)
+"na" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/button/curtain{
+	id = "barbershopcurtains";
+	pixel_y = 26;
+	dir = 8
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/wood/large,
+/area/station/service/barber/spa)
+"ri" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/service/barber/spa)
-"lK" = (
-/turf/closed/wall/r_wall,
-/area/station/service/barber/spa)
-"na" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Maintenance"
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron,
+/turf/open/floor/wood/large,
 /area/station/service/barber/spa)
-"nj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/service/barber/spa)
-"ol" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plating,
-/area/station/commons/vacant_room/commissary)
-"qn" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/dryer{
-	pixel_y = 29
-	},
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron,
-/area/station/service/barber/spa)
-"ri" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron,
-/area/station/service/barber/spa)
-"rv" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
-/area/station/service/barber/spa)
-"vY" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/station/maintenance/central/lesser)
 "wI" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/curtain/cloth/fancy/mechanical{
@@ -144,333 +69,111 @@
 /turf/open/floor/plating,
 /area/station/service/barber/spa)
 "wL" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/closed/wall,
+/area/station/commons/fitness/locker_room)
+"xN" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/effect/landmark/start/barber,
+/turf/open/floor/wood/large,
+/area/station/service/barber/spa)
+"yf" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
 	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood/large,
+/area/station/service/barber/spa)
+"yz" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood/large,
+/area/station/service/barber/spa)
+"EO" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/chair/sofa/bench/left{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plating,
+/area/station/service/barber/spa)
+"He" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Barbershop"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/door/firedoor/solid,
-/turf/open/floor/iron,
-/area/station/service/barber/spa)
-"xL" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron,
-/area/station/service/barber/spa)
-"xN" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/chair/comfy/barber_chair{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/service/barber/spa)
-"yf" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/obj/machinery/door/firedoor/solid,
-/turf/open/floor/iron,
-/area/station/service/barber/spa)
-"yz" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron,
-/area/station/service/barber/spa)
-"zo" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
-/area/station/service/barber/spa)
-"zN" = (
-/obj/structure/table,
-/turf/open/floor/plating,
-/area/station/commons/vacant_room/commissary)
-"BV" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/effect/landmark/navigate_destination{
+	location = "Barbershop"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/light_switch/directional/north,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron,
-/area/station/service/barber/spa)
-"DC" = (
-/turf/closed/wall,
-/area/station/commons/vacant_room/commissary)
-"EO" = (
-/obj/machinery/light/warm/directional/north,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/chair/comfy/barber_chair{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/service/barber/spa)
-"FQ" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Salon"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/chair/sofa/bench/right,
-/turf/open/floor/iron,
-/area/station/service/barber/spa)
-"He" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/table/wood,
-/obj/machinery/camera/directional/south,
-/obj/item/stack/cable_coil/five,
-/turf/open/floor/plating,
-/area/station/commons/vacant_room/commissary)
-"Hh" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron,
-/area/station/service/barber/spa)
-"JG" = (
-/obj/structure/table/glass,
-/obj/item/hairbrush,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/item/lipstick/random,
-/obj/machinery/camera/directional/east{
-	c_tag = "Salon - Massage Parlour"
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/textured_half,
 /area/station/service/barber/spa)
 "KQ" = (
+/obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/landmark/start/barber,
-/turf/open/floor/iron,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/wood/large,
 /area/station/service/barber/spa)
-"Lq" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/commons/vacant_room/commissary)
 "Me" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron,
+/obj/machinery/vending/barbervend,
+/turf/open/floor/iron/dark/small,
 /area/station/service/barber/spa)
-"MM" = (
-/obj/structure/sink/directional/south,
-/obj/structure/mirror/directional/north{
-	pixel_y = 38
-	},
-/turf/open/floor/iron,
-/area/station/service/barber/spa)
-"NX" = (
-/obj/effect/spawner/random/structure/crate,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/central/lesser)
-"Od" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/closet/secure_closet/barber,
-/obj/machinery/camera/directional/west,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
-/area/station/service/barber/spa)
-"PA" = (
-/turf/closed/wall,
-/area/station/maintenance/central/lesser)
 "QF" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/service/barber/spa)
-"Ro" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/light/small/broken/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/tile,
-/area/station/commons/vacant_room/commissary)
-"Su" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/table/wood,
-/obj/machinery/light/small/built/directional/north,
-/obj/item/stack/sheet/iron/ten,
-/turf/open/floor/wood/tile,
-/area/station/commons/vacant_room/commissary)
-"SO" = (
-/obj/structure/bed/pod,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/service/barber/spa)
-"Tt" = (
-/obj/machinery/door/airlock{
-	name = "Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/obj/machinery/door/firedoor/solid,
-/turf/open/floor/plating,
-/area/station/service/barber/spa)
-"TH" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/mirror/directional/east,
-/obj/item/reagent_containers/spray/barbers_aid{
-	pixel_x = 6
-	},
-/obj/item/razor{
-	pixel_x = -6
-	},
-/turf/open/floor/iron,
-/area/station/service/barber/spa)
-"TL" = (
-/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/broken_flooring/corner/directional/south,
-/obj/effect/landmark/start/barber,
-/turf/open/floor/plating,
-/area/station/service/barber/spa)
-"WI" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/item/lipstick/random,
-/obj/item/reagent_containers/spray/quantum_hair_dye{
-	pixel_x = 6
-	},
-/obj/machinery/button/curtain{
-	id = "barbershopcurtains";
-	pixel_y = 2;
-	pixel_x = 26;
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/wood/large,
 /area/station/service/barber/spa)
 "XS" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/warm/directional/south,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/landmark/start/barber,
+/turf/open/floor/iron/dark/small,
 /area/station/service/barber/spa)
 "XV" = (
-/turf/closed/wall,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/closet/secure_closet/barber,
+/turf/open/floor/plating,
 /area/station/service/barber/spa)
-"YF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood/tile,
-/area/station/commons/vacant_room/commissary)
 "Zx" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/structure/chair/comfy/barber_chair{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/item/book/manual/fish_catalog,
-/obj/structure/table/wood,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/small,
 /area/station/service/barber/spa)
 "ZD" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/machinery/camera/autoname/directional/east,
+/obj/structure/table/glass,
+/obj/machinery/airalarm/directional/east,
+/obj/item/razor{
+	pixel_x = 6;
+	pixel_y = 12
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/chair/sofa/bench/left,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
+/obj/item/reagent_containers/spray/barbers_aid{
+	pixel_x = 1;
+	pixel_y = 4
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark/small,
 /area/station/service/barber/spa)
 
 (1,1,1) = {"
-PA
-vY
-NX
-aJ
 XV
-XV
-XV
+KQ
+EO
 yf
-XV
+wL
 "}
 (2,1,1) = {"
-XV
-XV
-XV
-XV
-XV
+xN
 eJ
-Od
 QF
-wI
+QF
+He
 "}
 (3,1,1) = {"
-XV
-qn
-rv
-TL
 na
 fn
 ri
@@ -478,68 +181,16 @@ yz
 wI
 "}
 (4,1,1) = {"
-XV
-MM
-nj
-cT
-XV
-FQ
+lK
+XS
 Zx
 XS
-XV
+wI
 "}
 (5,1,1) = {"
-Tt
-KQ
-xL
-SO
-XV
+cT
 ZD
 ds
 Me
 wL
-"}
-(6,1,1) = {"
-XV
-XV
-XV
-JG
-XV
-BV
-Hh
-zo
-XV
-"}
-(7,1,1) = {"
-DC
-Su
-DC
-DC
-XV
-EO
-gL
-xN
-wI
-"}
-(8,1,1) = {"
-Ro
-ga
-Lq
-He
-XV
-fq
-WI
-TH
-wI
-"}
-(9,1,1) = {"
-zN
-ol
-YF
-bI
-lK
-lK
-lK
-lK
-lK
 "}

--- a/_maps/nova/automapper/templates/birdshot/birdshot_barber.dmm
+++ b/_maps/nova/automapper/templates/birdshot/birdshot_barber.dmm
@@ -7,7 +7,7 @@
 	pixel_x = -3
 	},
 /turf/open/floor/iron/dark/small,
-/area/station/service/barber/spa)
+/area/station/service/barber)
 "ds" = (
 /obj/structure/mirror/directional/east,
 /obj/structure/table/glass,
@@ -17,12 +17,12 @@
 	pixel_y = 16
 	},
 /turf/open/floor/iron/dark/small,
-/area/station/service/barber/spa)
+/area/station/service/barber)
 "eJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/service/barber/spa)
+/area/station/service/barber)
 "fn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -31,14 +31,14 @@
 	dir = 4
 	},
 /turf/open/floor/wood/large,
-/area/station/service/barber/spa)
+/area/station/service/barber)
 "lK" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/chair/comfy/barber_chair{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/small,
-/area/station/service/barber/spa)
+/area/station/service/barber)
 "na" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -50,7 +50,7 @@
 	},
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood/large,
-/area/station/service/barber/spa)
+/area/station/service/barber)
 "ri" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -59,14 +59,14 @@
 	dir = 4
 	},
 /turf/open/floor/wood/large,
-/area/station/service/barber/spa)
+/area/station/service/barber)
 "wI" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/curtain/cloth/fancy/mechanical{
 	id = "barbershopcurtains"
 	},
 /turf/open/floor/plating,
-/area/station/service/barber/spa)
+/area/station/service/barber)
 "wL" = (
 /turf/closed/wall,
 /area/station/commons/fitness/locker_room)
@@ -75,7 +75,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/start/barber,
 /turf/open/floor/wood/large,
-/area/station/service/barber/spa)
+/area/station/service/barber)
 "yf" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/structure/chair/sofa/bench/right{
@@ -84,14 +84,14 @@
 /obj/effect/landmark/start/assistant,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood/large,
-/area/station/service/barber/spa)
+/area/station/service/barber)
 "yz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood/large,
-/area/station/service/barber/spa)
+/area/station/service/barber)
 "EO" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/chair/sofa/bench/left{
@@ -99,7 +99,7 @@
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plating,
-/area/station/service/barber/spa)
+/area/station/service/barber)
 "He" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Barbershop"
@@ -111,38 +111,38 @@
 	location = "Barbershop"
 	},
 /turf/open/floor/iron/textured_half,
-/area/station/service/barber/spa)
+/area/station/service/barber)
 "KQ" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/landmark/start/barber,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/wood/large,
-/area/station/service/barber/spa)
+/area/station/service/barber)
 "Me" = (
 /obj/machinery/vending/barbervend,
 /turf/open/floor/iron/dark/small,
-/area/station/service/barber/spa)
+/area/station/service/barber)
 "QF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
-/area/station/service/barber/spa)
+/area/station/service/barber)
 "XS" = (
 /obj/effect/landmark/start/barber,
 /turf/open/floor/iron/dark/small,
-/area/station/service/barber/spa)
+/area/station/service/barber)
 "XV" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/closet/secure_closet/barber,
 /turf/open/floor/plating,
-/area/station/service/barber/spa)
+/area/station/service/barber)
 "Zx" = (
 /obj/structure/chair/comfy/barber_chair{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/small,
-/area/station/service/barber/spa)
+/area/station/service/barber)
 "ZD" = (
 /obj/machinery/camera/autoname/directional/east,
 /obj/structure/table/glass,
@@ -157,7 +157,7 @@
 	},
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark/small,
-/area/station/service/barber/spa)
+/area/station/service/barber)
 
 (1,1,1) = {"
 XV

--- a/_maps/nova/automapper/templates/birdshot/birdshot_ntrep_office.dmm
+++ b/_maps/nova/automapper/templates/birdshot/birdshot_ntrep_office.dmm
@@ -1,161 +1,143 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ae" = (
-/obj/machinery/airalarm/directional/north,
-/turf/template_noop,
-/area/template_noop)
-"au" = (
 /obj/structure/table/wood,
-/obj/machinery/fax{
-	fax_name = "Nanotrasen Consultant's Office";
-	name = "Nanotrasen Consultant's Fax Machine"
-	},
-/turf/open/floor/carpet/executive,
-/area/station/command/heads_quarters/nt_rep)
-"aU" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/carpet/executive,
-/area/station/command/heads_quarters/nt_rep)
-"bD" = (
-/obj/structure/closet/secure_closet/nanotrasen_consultant,
-/turf/open/floor/carpet/executive,
-/area/station/command/heads_quarters/nt_rep)
-"ca" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/turf/open/floor/carpet/executive,
-/area/station/command/heads_quarters/nt_rep)
-"cP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/light/directional/south,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/nt_rep)
-"eD" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/rust,
-/area/station/maintenance/fore/lesser)
-"gh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron,
-/area/station/maintenance/hallway/abandoned_command)
-"ii" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock{
-	name = "Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
-"ix" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/nt_rep)
-"iC" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/hallway/abandoned_command)
-"iD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/spawner/random/trash,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
-"iS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
-"jh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/nt_rep)
-"lJ" = (
-/obj/machinery/power/apc/auto_name/directional/north,
+"gh" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/nt_rep)
+"iS" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "nt_rep_priv";
+	name = "Privacy Shutter"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/area/station/command/heads_quarters/nt_rep)
 "nh" = (
-/obj/machinery/button/door/directional/west{
-	id = "nt_rep_priv";
-	name = "Privacy Shutters Control"
-	},
-/obj/structure/sign/calendar/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/nanotrasen_consultant,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/nt_rep)
 "nw" = (
-/turf/template_noop,
-/area/template_noop)
-"nM" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/wood,
+/obj/item/clipboard{
+	pixel_x = -7;
+	pixel_y = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
-"pV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/item/stamp/centcom{
+	pixel_y = 8;
+	pixel_x = -7
 	},
-/turf/open/floor/carpet/executive,
-/area/station/command/heads_quarters/nt_rep)
-"rA" = (
-/obj/machinery/modular_computer/preset/command,
+/obj/item/stamp{
+	pixel_x = 12;
+	pixel_y = 11
+	},
+/obj/item/stamp/denied{
+	pixel_x = 10;
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/nt_rep)
 "sZ" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/nt_rep)
 "ti" = (
-/obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/nt_rep)
-"vK" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/camera/autoname/directional/east,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/landmark/start/nanotrasen_consultant,
-/turf/open/floor/wood,
+/obj/machinery/photocopier,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/nt_rep)
 "wx" = (
+/obj/item/kirbyplants/organic/plant22,
+/obj/machinery/light/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/nt_rep)
+"Dp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/landmark/start/nanotrasen_consultant,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/nt_rep)
+"Ds" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/nt_rep)
+"Et" = (
+/obj/effect/mapping_helpers/airlock/access/all/cent_com/rep_door,
+/obj/machinery/door/airlock{
+	name = "Maintenance"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/nt_rep)
+"EK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
-"xH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/executive,
+/area/station/command/heads_quarters/nt_rep)
+"FF" = (
+/obj/structure/table/wood,
+/obj/machinery/fax{
+	fax_name = "Nanotrasen Consultant's Office";
+	name = "Nanotrasen Consultant's Fax Machine"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/west{
+	id = "nt_rep_priv";
+	name = "Privacy Shutters Control"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/executive,
+/area/station/command/heads_quarters/nt_rep)
+"FO" = (
+/obj/structure/sign/calendar/directional/south,
+/obj/effect/landmark/start/nanotrasen_consultant,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/executive,
+/area/station/command/heads_quarters/nt_rep)
+"Ht" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ants,
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/nt_rep)
+"HH" = (
+/obj/item/radio/intercom/directional/west,
 /obj/structure/table/wood,
 /obj/item/paper_bin/carbon{
 	pixel_y = 4;
@@ -165,291 +147,128 @@
 	pixel_x = -4;
 	pixel_y = 6
 	},
-/obj/item/stamp{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/stamp/denied{
-	pixel_x = 8
-	},
-/obj/machinery/button/door/directional/west{
-	id = "nt_rep_priv";
-	name = "Privacy Shutters Control"
-	},
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/nt_rep)
-"xL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/nt_rep)
-"yC" = (
-/turf/open/floor/carpet/executive,
-/area/station/command/heads_quarters/nt_rep)
-"Ab" = (
-/turf/closed/wall,
-/area/station/maintenance/hallway/abandoned_command)
-"Bv" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "nt_rep_priv";
-	name = "Privacy Shutter"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/maintenance/hallway/abandoned_command)
-"Bw" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/hallway/abandoned_command)
-"Dp" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
-"Ds" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/command/captain,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
-"Et" = (
-/obj/machinery/door/airlock/corporate{
-	name = "NT Consultant's Office"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/cent_com/rep_door,
-/turf/open/floor/iron,
-/area/station/maintenance/hallway/abandoned_command)
-"EK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/nt_rep)
-"FF" = (
-/obj/structure/cable,
-/turf/template_noop,
-/area/station/command/heads_quarters/captain/private)
-"FO" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/hallway/abandoned_command)
-"Ht" = (
-/obj/effect/spawner/random/maintenance,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating/rust,
-/area/station/maintenance/fore/lesser)
-"HH" = (
-/obj/structure/cable,
-/obj/structure/displaycase/captain{
-	pixel_y = 5
-	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/iron/dark/small,
-/area/station/command/heads_quarters/captain/private)
-"HS" = (
-/obj/structure/table/wood,
-/obj/item/camera{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/obj/item/camera_film{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/camera_film{
-	pixel_x = -4;
-	pixel_y = 7
-	},
-/turf/open/floor/carpet/executive,
-/area/station/command/heads_quarters/nt_rep)
-"Ll" = (
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/carpet/executive,
-/area/station/command/heads_quarters/nt_rep)
-"Nt" = (
-/turf/open/floor/iron,
-/area/station/maintenance/hallway/abandoned_command)
 "OS" = (
-/obj/structure/filingcabinet/employment,
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/nanotrasen_consultant,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/nt_rep)
 "Pd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/hallway/abandoned_command)
-"Pf" = (
-/turf/closed/wall/r_wall,
-/area/station/maintenance/hallway/abandoned_command)
-"QJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair/office,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
-"Rb" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/large,
 /area/station/command/heads_quarters/nt_rep)
-"Rk" = (
-/turf/closed/wall,
+"QJ" = (
+/obj/machinery/door/airlock/corporate{
+	name = "NT Consultant's Office"
+	},
+/obj/effect/turf_decal/siding/thinplating,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/cent_com/rep_door,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/textured_half,
 /area/station/command/heads_quarters/nt_rep)
 "TT" = (
-/obj/machinery/photocopier,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/sign/clock/directional/south,
+/obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/nt_rep)
 "VM" = (
-/obj/structure/table/wood,
-/obj/item/stamp/centcom{
-	pixel_y = 13;
-	pixel_x = -7
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/nt_rep)
 "Yp" = (
-/turf/closed/wall/r_wall,
-/area/station/maintenance/fore/lesser)
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair/office,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/nt_rep)
 "Zf" = (
-/obj/structure/hedge,
-/obj/machinery/camera/autoname/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/small,
-/area/station/command/heads_quarters/captain/private)
+/obj/structure/filingcabinet/employment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/executive,
+/area/station/command/heads_quarters/nt_rep)
 "ZQ" = (
-/obj/effect/spawner/random/structure/crate_abandoned,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/obj/item/kirbyplants/organic/plant22,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/light_switch/directional/east,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/nt_rep)
 
 (1,1,1) = {"
+sZ
+sZ
+sZ
+sZ
+sZ
+sZ
+sZ
+"}
+(2,1,1) = {"
 iS
 wx
 Ds
 HH
 FF
-nw
+ti
+sZ
 "}
-(2,1,1) = {"
-QJ
+(3,1,1) = {"
+iS
 Ht
 Yp
 nw
-FF
-nw
-"}
-(3,1,1) = {"
-QJ
-Dp
-Yp
-ae
-FF
-FF
+OS
+FO
+sZ
 "}
 (4,1,1) = {"
-eD
-ZQ
-Yp
-nw
-nw
-Zf
+QJ
+Dp
+Pd
+ae
+EK
+TT
+sZ
 "}
 (5,1,1) = {"
-QJ
-sZ
-sZ
-sZ
-sZ
+iS
+ZQ
+gh
+VM
+nh
+Zf
 sZ
 "}
 (6,1,1) = {"
-QJ
-Rk
-xH
-nh
-aU
-bD
-"}
-(7,1,1) = {"
-lJ
-Rk
-rA
-ca
-yC
-au
-"}
-(8,1,1) = {"
-nM
-Rk
-HS
-VM
-yC
-OS
-"}
-(9,1,1) = {"
-iD
-Rk
-Ll
-jh
-pV
-TT
-"}
-(10,1,1) = {"
-QJ
-Rk
-Rb
-xL
-vK
 sZ
-"}
-(11,1,1) = {"
-nM
-Rk
-EK
-cP
 sZ
-nw
-"}
-(12,1,1) = {"
-eD
-Rk
-ti
-ix
 sZ
-nw
-"}
-(13,1,1) = {"
-ii
-Ab
-Bv
+sZ
 Et
-Pf
-Pf
-"}
-(14,1,1) = {"
-iC
-Bw
-Pd
-FO
-Nt
-gh
+sZ
+sZ
 "}

--- a/_maps/nova/automapper/templates/birdshot/birdshot_ntrep_office.dmm
+++ b/_maps/nova/automapper/templates/birdshot/birdshot_ntrep_office.dmm
@@ -71,6 +71,7 @@
 /obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/nt_rep)
 "Dp" = (
@@ -193,6 +194,7 @@
 "VM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/nt_rep)
 "Yp" = (

--- a/_maps/nova/automapper/templates/birdshot/birdshot_ntrep_office.dmm
+++ b/_maps/nova/automapper/templates/birdshot/birdshot_ntrep_office.dmm
@@ -97,7 +97,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/nt_rep)
 "EK" = (


### PR DESCRIPTION
## About The Pull Request

Title.

## How This Contributes To The Nova Sector Roleplay Experience
Birdshot already had a barbershop, so I moved it there.
As for the NTC office, I didn't like where it was, so I slid it over.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

NTC Office
![image](https://github.com/NovaSector/NovaSector/assets/70232195/396efb79-427b-41b8-8082-01e8e37537e8)

Barbershop
![image](https://github.com/NovaSector/NovaSector/assets/70232195/71370a53-4206-471c-82f8-ae3122e7f739)


</details>

## Changelog

:cl: Jolly
fix: [Birdshot] There are no longer two barbershops on Birdshot.
del: [Birdshot] The NTC office is no longer next to the Captain's office, instead, its near the HoPs office!
/:cl:
