### PR TITLE
Hemophage Balance Pass - Hemophages Suck Less Edition

### DIFF
--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/_hemophage_defines.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/_hemophage_defines.dm
@@ -11,7 +11,7 @@
 /// Minimum amount of blood that you can reach via blood regeneration, regeneration will stop below this.
 #define MINIMUM_VOLUME_FOR_REGEN (BLOOD_VOLUME_BAD + 1) // We do this to avoid any jankiness, and because we want to ensure that they don't fall into a state where they're constantly passing out in a locker.
 /// Vomit flags for hemophages who eat food
-#define HEMOPHAGE_VOMIT_FLAGS (MOB_VOMIT_MESSAGE | MOB_VOMIT_HARM | MOB_VOMIT_FORCE)
+#define HEMOPHAGE_VOMIT_FLAGS (MOB_VOMIT_MESSAGE | MOB_VOMIT_FORCE)
 /// The ratio of reagents that get purged while a Hemophage vomits from trying to eat/drink something that their tumor doesn't like.
 #define HEMOPHAGE_VOMIT_PURGE_RATIO 0.95
 /// How much disgust we're at after eating/drinking something the tumor doesn't like.

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/corrupted_tongue.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/corrupted_tongue.dm
@@ -106,14 +106,14 @@
 	if(ismonkey(victim))
 		is_target_human_with_client = FALSE // Sorry, not going to get the status effect from monkeys, even if they have a client in them.
 		hemophage.add_mood_event("gross_food", /datum/mood_event/disgust/hemophage_feed_monkey) // drinking from a monkey is inherently gross, like, REALLY gross
-		hemophage.adjust_disgust(DISGUST_LEVEL_GROSS + 15, DISGUST_LEVEL_MAXEDOUT)
+		hemophage.adjust_disgust(TUMOR_DISLIKED_FOOD_DISGUST, TUMOR_DISLIKED_FOOD_DISGUST)
 		blood_volume_difference = BLOOD_VOLUME_NORMAL - hemophage.blood_volume
 		horrible_feeding = TRUE
 
 	if(istype(victim, /mob/living/carbon/human/species/monkey))
 		is_target_human_with_client = FALSE // yep you're still not getting the status effect from humonkeys either. your tumour knows.
 		hemophage.add_mood_event("gross_food", /datum/mood_event/disgust/hemophage_feed_humonkey)
-		hemophage.adjust_disgust(DISGUST_LEVEL_GROSS / 4, DISGUST_LEVEL_GROSS) // it's still gross but nowhere near as bad, though.
+		hemophage.adjust_disgust(DISGUST_LEVEL_GROSS / 4, TUMOR_DISLIKED_FOOD_DISGUST) // it's still gross but nowhere near as bad, though.
 		horrible_feeding = TRUE
 
 	StartCooldown()

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_actions.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_actions.dm
@@ -18,8 +18,8 @@
 
 /datum/action/cooldown/hemophage/toggle_dormant_state
 	name = "Enter Dormant State"
-	desc = "Causes the tumor inside of you to enter a dormant state, causing it to need just a minimum amount of blood to survive. However, as the tumor living in your body is the only thing keeping you still alive, rendering it latent cuts both it and you to just the essential functions to keep standing. It will no longer mend your body even in the darkness, and the lack of blood pumping through you will have you the weakest you've ever felt; and leave you hardly able to run. It is not on a switch, and it will take some time for it to awaken."
-	cooldown_time = 3 MINUTES
+	desc = "Causes the tumor inside of you to enter a dormant state, causing it to need just a minimum amount of blood to survive. However, as the tumor living in your body is the only thing keeping you still alive, rendering it latent cuts both it and you to just the essential functions to keep standing. It will no longer mend your body even in the darkness nor allow you to taste anything, and the lack of blood pumping through you will have you the weakest you've ever felt; and leave you hardly able to run. It is not on a switch, and it will take some time for it to awaken."
+	cooldown_time = 2 MINUTES
 
 
 /datum/action/cooldown/hemophage/toggle_dormant_state/Activate(atom/action_target)

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_actions.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_actions.dm
@@ -45,10 +45,12 @@
 
 	if(tumor.is_dormant)
 		name = "Exit Dormant State"
-		desc =  "Causes the pitch-black mass living inside of you to awaken, allowing your circulation to return and blood to pump freely once again. It fills your legs to let you run again, and longs for the darkness as it did before. You start to feel strength rather than the weakness you felt before. However, the tumor giving you life is not on a switch, and it will take some time to subdue it again."
+		desc = "Causes the pitch-black mass living inside of you to awaken, allowing your circulation to return and blood to pump freely once again. It fills your legs to let you run again, and longs for the darkness as it did before. You start to feel strength rather than the weakness you felt before. However, the tumor giving you life is not on a switch, and it will take some time to subdue it again."
 	else
 		name = initial(name)
 		desc = initial(desc)
+
+	build_all_button_icons(UPDATE_BUTTON_NAME)
 
 
 #undef DORMANT_STATE_START_MESSAGE

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_moods.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_moods.dm
@@ -12,8 +12,3 @@
 	description = "Somehow I know deep down that humonkey blood is no substitute for the real thing..."
 	mood_change = -1
 	timeout = 5 MINUTES
-
-/datum/mood_event/disgust/hemophage_feed_synthesized_blood
-	description = "My last blood meal was artificial and tasted... wrong."
-	mood_change = -2
-	timeout = 5 MINUTES

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_organs.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_organs.dm
@@ -85,10 +85,6 @@
 	var/datum/reagent/blood/blood = reagents.has_reagent(/datum/reagent/blood)
 	if(blood)
 		blood.metabolization_rate = BLOOD_METABOLIZATION_RATE
-		var/blood_DNA = blood.data["blood_DNA"]
-		if (!blood_DNA) //does the blood we're digesting have any DNA? if it doesn't, it's artificial, and that's gross.
-			src.owner.adjust_disgust(DISGUST_LEVEL_GROSS / 16, DISGUST_LEVEL_VERYGROSS)
-			src.owner.add_mood_event("gross_food", /datum/mood_event/disgust/hemophage_feed_synthesized_blood)
 
 	return ..()
 

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_status_effects.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_status_effects.dm
@@ -140,8 +140,8 @@
 
 /datum/movespeed_modifier/hemophage_dormant_state
 	id = "hemophage_dormant_state"
-	multiplicative_slowdown = 3 // Yeah, they'll be quite significantly slower when in their dormant state.
-	blacklisted_movetypes = FLOATING
+	multiplicative_slowdown = 2 // Yeah, they'll be quite significantly slower when in their dormant state.
+	blacklisted_movetypes = FLOATING|FLYING
 
 
 /atom/movable/screen/alert/status_effect/blood_thirst_satiated

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_status_effects.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_status_effects.dm
@@ -50,7 +50,7 @@
 	processing_speed = STATUS_EFFECT_NORMAL_PROCESS
 	alert_type = /atom/movable/screen/alert/status_effect/blood_regen_active
 	/// Current multiplier for how much blood they spend healing themselves for every point of damage healed.
-	var/blood_to_health_multiplier = 1
+	var/blood_to_health_multiplier = 0.25
 
 
 /datum/status_effect/blood_regen_active/on_apply()

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_tumor.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_tumor.dm
@@ -1,5 +1,5 @@
 /// Minimum amount of light for Hemophages to be considered in pure darkness, and therefore be allowed to heal just like in a closet.
-#define MINIMUM_LIGHT_THRESHOLD_FOR_REGEN 0.2
+#define MINIMUM_LIGHT_THRESHOLD_FOR_REGEN 0.1
 
 /// How high should the damage multiplier to the Hemophage be when they're in a dormant state?
 #define DORMANT_DAMAGE_MULTIPLIER 3

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_tumor.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_tumor.dm
@@ -11,6 +11,9 @@
 /// Just a conversion factor that ensures there's no weird floating point errors when blood is draining.
 #define FLOATING_POINT_ERROR_AVOIDING_FACTOR 1000
 
+/// Trait gained from the pulsating tumor.
+#define TRAIT_TUMOR "tumor"
+
 
 /obj/item/organ/internal/heart/hemophage
 	name = "pulsating tumor"
@@ -95,9 +98,11 @@
 
 	if(is_dormant)
 		owner.add_movespeed_modifier(/datum/movespeed_modifier/hemophage_dormant_state)
+		ADD_TRAIT(owner, TRAIT_AGEUSIA, TRAIT_TUMOR)
 
 	else
 		owner.remove_movespeed_modifier(/datum/movespeed_modifier/hemophage_dormant_state)
+		REMOVE_TRAIT(owner, TRAIT_AGEUSIA, TRAIT_TUMOR)
 
 
 /// Simple helper proc that returns whether or not the given hemophage is in a closet subtype (but not in any bodybag subtype).
@@ -149,3 +154,5 @@
 #undef DORMANT_DAMAGE_MULTIPLIER
 #undef DORMANT_BLOODLOSS_MULTIPLIER
 #undef NORMAL_BLOOD_DRAIN
+
+#undef TRAIT_TUMOR

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_tumor.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_tumor.dm
@@ -1,12 +1,12 @@
 /// Minimum amount of light for Hemophages to be considered in pure darkness, and therefore be allowed to heal just like in a closet.
-#define MINIMUM_LIGHT_THRESHOLD_FOR_REGEN 0
+#define MINIMUM_LIGHT_THRESHOLD_FOR_REGEN 0.2
 
 /// How high should the damage multiplier to the Hemophage be when they're in a dormant state?
 #define DORMANT_DAMAGE_MULTIPLIER 3
 /// By how much the blood drain will be divided when the tumor is in a dormant state.
 #define DORMANT_BLOODLOSS_MULTIPLIER 10
 /// How much blood do Hemophages normally lose per second (visible effect is every two seconds, so twice this value).
-#define NORMAL_BLOOD_DRAIN 0.125
+#define NORMAL_BLOOD_DRAIN 0.05
 
 /// Just a conversion factor that ensures there's no weird floating point errors when blood is draining.
 #define FLOATING_POINT_ERROR_AVOIDING_FACTOR 1000


### PR DESCRIPTION
## About The Pull Request
Tweaked down a lot of numbers on Hemophages, being:

- Passive tumor blood drain: 0.125 u/s -> 0.05 u/s
- Tumor dormancy toggle cooldown: 3 minutes -> 2 minutes
- Dormant tumor speed multiplier: 3 -> 2 (they're moving faster when their tumor is dormant now).
- Blood consumed per 1 damage healed by the tumor: 1 u -> 0.25 u
- Maximum luminosity for healing: 0 -> 0.1 (they can regen with a little more light than before, it doesn't need to be PITCH BLACK anymore)

On top of that, Hemophages no longer get disgust or mood debuff from consuming synthetic blood, and their disgust from drinking from both Monkeys and Humonkeys are capped just like the disgust from eating regular food without Taste Suppressor.

On the topic of Taste Suppressor, you now get `TRAIT_AGEUSIA` when your tumor is dormant, allowing you to eat food without throwing up anymore.

Speaking of throwing up, Hemophages no longer get hurt from throwing up, I'm not sure when that was introduced but I don't think it was intentional, I don't remember wanting them to get hurt when throwing up like that.

Finally, I also fixed the action button displaying the wrong text because it wasn't being updated at the right time after you toggled it once.

## How This Contributes To The Nova Sector Roleplay Experience
A lot of people have been complaining about Hemophages just being too annoying to play, so I've made a good amount of balance changes for some quality of life improvements, so it's not as incredibly harder to play it than any other species.

The change of not tasting food when their tumor is dormant makes it so Hemophages can hide their hemophagia a little easier, without needing to rely on chemicals all the time in order to do so.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/95adf70b-7714-4964-a78f-807f94d2ad3d)

I didn't feel like recording a video of all of the value changes, but I tested everything already.
</details>

## Changelog

:cl: GoldenAlpharex
qol: Hemophages no longer taste food when their tumor is dormant, reducing the reliance on Taste Suppressor in order to let them eat food.
fix: Hemophages no longer get hurt from vomiting when eating something rejected by their tumor.
balance: Hemophages passive blood drain lowered from 0.125 u/s to 0.05 u/s.
balance: Tumor dormancy toggle cooldown lowered from 3 minutes to 2 minutes.
balance: Dormant tumor slowdown lowered from 3 to 2 (making them move a little faster than before when their tumor is dormant).
balance: Blood consumed per 1 damage healed by tumor regen lowered from 1u to 0.25u.
balance: Slightly increased the minimum luminosity required for healing using the tumor regen (0 -> 0.1).
fix: The Toggle Dormant State action button should now update its name and description at the right moment, instead of being reversed on accident.
/:cl: