### PR TITLE
Globally reduces the sound of announcements (including BSA and SM sounds), reduces the sound of the shuttles taking off and landing

### DIFF
--- a/modular_nova/master_files/code/modules/shuttle/shuttle.dm
+++ b/modular_nova/master_files/code/modules/shuttle/shuttle.dm
@@ -6,7 +6,7 @@
 	/// The landing sound to be played
 	var/landing_sound = sound('modular_nova/modules/advanced_shuttles/sound/engine_landing.ogg')
 	/// The sound range coeff for the landing and take off sound effect
-	var/sound_range = 20
+	var/sound_range = 11
 
 /obj/docking_port/mobile/proc/bolt_all_doors() // Expensive procs :(
 	var/list/turfs = return_ordered_turfs(x, y, z, dir)
@@ -30,7 +30,7 @@
 		for(var/mob/hearing_mob in range(sound_range, distant_source))
 			if(hearing_mob?.client)
 				var/dist = get_dist(hearing_mob.loc, distant_source.loc)
-				var/vol = clamp(40 - ((dist - 3) * 5), 5, 40) // Every tile decreases sound volume by 5
+				var/vol = clamp(40 - ((dist - 3) * 5), 0, 40) // Every tile decreases sound volume by 5
 				if(takeoff)
 					if(hearing_mob.client?.prefs?.read_preference(/datum/preference/toggle/sound_ship_ambience))
 						hearing_mob.playsound_local(distant_source, takeoff_sound, vol)

--- a/modular_nova/master_files/code/modules/shuttle/shuttle.dm
+++ b/modular_nova/master_files/code/modules/shuttle/shuttle.dm
@@ -30,7 +30,7 @@
 		for(var/mob/hearing_mob in range(sound_range, distant_source))
 			if(hearing_mob?.client)
 				var/dist = get_dist(hearing_mob.loc, distant_source.loc)
-				var/vol = clamp(50 - ((dist - 7) * 5), 10, 50) // Every tile decreases sound volume by 5
+				var/vol = clamp(40 - ((dist - 3) * 5), 5, 40) // Every tile decreases sound volume by 5
 				if(takeoff)
 					if(hearing_mob.client?.prefs?.read_preference(/datum/preference/toggle/sound_ship_ambience))
 						hearing_mob.playsound_local(distant_source, takeoff_sound, vol)


### PR DESCRIPTION
## About The Pull Request
They were far too loud, so I lowered them across the board to 50 instead of 70/80 (override_volume doesn't have sounds play even LOUDER either). The shuttles taking off and landing were also obnoxiously loud, so I made them falloff quicker.

## How This Contributes To The Nova Sector Roleplay Experience
Announcements have always been an ear-rape, now they're a little quieter. It's not perfect, and someone should probably go in those sound files and equalize them so they're not obnoxiously louder than they should be, but I figured I'd do something quick to make them better while I was still thinking about it.

Shuttles being so obnoxiously loud are what got me to turn off ship ambience in my prefs when they were introduced, I got them to lower to much more reasonable levels much faster so that it's not pure ear-rape anymore.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  I tested it, I didn't want to record my screen for sounds because I'm again still on my laptop.
</details>

## Changelog

:cl: GoldenAlpharex
sound: Announcements should now be a little quieter across the board, ESPECIALLY for sounds such as the BSA that were forcing a much higher volume for some reason.
code: Improved the code for alert_sound_to_playing(). Single-letter variables begone.
/:cl: