### PR TITLE
[MODULAR] Bodypart Layering Tweaks

### DIFF
--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/genitals.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/genitals.dm
@@ -65,7 +65,7 @@
 	center = TRUE
 	special_x_dimension = TRUE
 	//default_color = DEFAULT_SKIN_OR_PRIMARY //This is the price we're paying for sheaths
-	relevent_layers = list(BODY_BEHIND_LAYER, BODY_FRONT_LAYER)
+	relevent_layers = list(BODY_BEHIND_LAYER, BODY_FRONT_UNDER_CLOTHES)
 	genetic = TRUE
 	var/can_have_sheath = TRUE
 
@@ -183,7 +183,7 @@
 	key = ORGAN_SLOT_VAGINA
 	always_color_customizable = TRUE
 	default_color = "#FFCCCC"
-	relevent_layers = list(BODY_FRONT_LAYER)
+	relevent_layers = list(BODY_FRONT_UNDER_CLOTHES)
 	genetic = TRUE
 	var/alt_aroused = TRUE
 
@@ -269,7 +269,7 @@
 	key = ORGAN_SLOT_BREASTS
 	always_color_customizable = TRUE
 	default_color = DEFAULT_SKIN_OR_PRIMARY
-	relevent_layers = list(BODY_BEHIND_LAYER, BODY_FRONT_LAYER)
+	relevent_layers = list(BODY_BEHIND_LAYER, BODY_FRONT_UNDER_CLOTHES)
 	has_skintone_shading = TRUE
 	genital_location = CHEST
 	genetic = TRUE

--- a/modular_nova/modules/customization/modules/surgery/organs/genitals.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/genitals.dm
@@ -97,7 +97,7 @@
 
 
 /datum/bodypart_overlay/mutant/genital
-	layers = EXTERNAL_FRONT
+	layers = EXTERNAL_FRONT_UNDER_CLOTHES
 	color_source = ORGAN_COLOR_OVERRIDE
 	/// The suffix appended to the feature_key for the overlays.
 	var/sprite_suffix
@@ -133,6 +133,12 @@
 
 	return sprite_datum.color_layer_names
 
+/datum/bodypart_overlay/mutant/genital/mutant_bodyparts_layertext(layer)
+	if(layer == -BODY_FRONT_UNDER_CLOTHES)
+		return "FRONT"
+	else
+		return ..()
+
 
 /obj/item/organ/external/genital/penis
 	name = "penis"
@@ -150,7 +156,7 @@
 
 /datum/bodypart_overlay/mutant/genital/penis
 	feature_key = ORGAN_SLOT_PENIS
-	layers = EXTERNAL_FRONT | EXTERNAL_BEHIND
+	layers = EXTERNAL_FRONT_UNDER_CLOTHES | EXTERNAL_BEHIND
 
 
 /obj/item/organ/external/genital/penis/get_description_string(datum/sprite_accessory/genital/gas)
@@ -322,7 +328,7 @@
 
 /datum/bodypart_overlay/mutant/genital/vagina
 	feature_key = ORGAN_SLOT_VAGINA
-	layers = EXTERNAL_FRONT
+	layers = EXTERNAL_FRONT_UNDER_CLOTHES
 
 /obj/item/organ/external/genital/vagina/get_description_string(datum/sprite_accessory/genital/gas)
 	var/returned_string = "You see a [LOWER_TEXT(genital_name)] vagina."
@@ -425,7 +431,7 @@
 
 /datum/bodypart_overlay/mutant/genital/breasts
 	feature_key = ORGAN_SLOT_BREASTS
-	layers = EXTERNAL_FRONT | EXTERNAL_BEHIND
+	layers = EXTERNAL_FRONT_UNDER_CLOTHES | EXTERNAL_BEHIND
 
 /obj/item/organ/external/genital/breasts/get_description_string(datum/sprite_accessory/genital/gas)
 	var/returned_string = "You see a [LOWER_TEXT(genital_name)] of breasts."


### PR DESCRIPTION
## About The Pull Request

Re-orders enterprise resource planning bodypart rendering to actually fit in underneath clothing and accessories as was likely originally intended.  I am open to trying to modify this code further to make layer an explicit toggle with a verb but it's gonna be Complicated(tm) to get right.

## How This Contributes To The Nova Sector Roleplay Experience

We literally have a whole set of special accessory layers and all of them are invisible due to their associated bodyparts rendering on top of everything.  :sob:

## Proof of Testing

Still compiles, accessory sprites are actually visible, new options combo well with certain suit slot items.  Nothing user-facing that's fit for Github Assets.

## Changelog

:cl:
fix: some bodypart rendering is properly below clothes & bespoke accessories now
/:cl:
