### PR TITLE
Heavy duty medical crate updates [NO GBP]

### DIFF
--- a/modular_nova/modules/company_imports/code/armament_datums/deforest_medical.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/deforest_medical.dm
@@ -33,15 +33,15 @@
 
 /datum/armament_entry/company_import/deforest/first_aid_kit/first_responder
 	item_type = /obj/item/storage/backpack/duffelbag/deforest_surgical/stocked
-	cost = PAYCHECK_COMMAND * 10
+	cost = PAYCHECK_COMMAND * 10.5
 
 /datum/armament_entry/company_import/deforest/first_aid_kit/orange_satchel
 	item_type = /obj/item/storage/backpack/duffelbag/deforest_medkit/stocked
-	cost = PAYCHECK_COMMAND * 10
+	cost = PAYCHECK_COMMAND * 9.5
 
 /datum/armament_entry/company_import/deforest/first_aid_kit/technician_satchel
 	item_type = /obj/item/storage/backpack/duffelbag/deforest_paramedic/stocked
-	cost = PAYCHECK_COMMAND * 7
+	cost = PAYCHECK_COMMAND * 11.75
 
 // Basic first aid supplies like gauze, sutures, mesh, so on
 

--- a/modular_nova/modules/deforest_medical_items/code/cargo_packs.dm
+++ b/modular_nova/modules/deforest_medical_items/code/cargo_packs.dm
@@ -29,36 +29,33 @@
 		/obj/item/storage/medkit/combat_surgeon/stocked = 3,
 	)
 
-/datum/supply_pack/medical/kit_medical_surgical
-	name = "Heavy Duty Medical Kit Crate - Medical/Surgical"
-	crate_name = "heavy duty medical kit crate"
-	desc = "Contains a large satchel medical kit, and a first responder surgical kit."
+/datum/supply_pack/medical/kit_technician
+	name = "Heavy Duty Medical Kit Crate - Technician"
+	crate_name = "technician kit crate"
+	desc = "Contains a pink medical technician kit."
 	access = ACCESS_MEDICAL
-	cost = CARGO_CRATE_VALUE * 10
+	cost = CARGO_CRATE_VALUE * 5.5
 	contains = list(
-		/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked,
+		/obj/item/storage/backpack/duffelbag/deforest_paramedic/stocked,
+	)
+
+/datum/supply_pack/medical/kit_surgical
+	name = "Heavy Duty Medical Kit Crate - Surgical"
+	crate_name = "surgical kit crate"
+	desc = "Contains a grey first responder surgical kit."
+	access = ACCESS_MEDICAL
+	cost = CARGO_CRATE_VALUE * 5
+	contains = list(
 		/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked,
 	)
 
-/datum/supply_pack/medical/kit_surgical_technician
-	name = "Heavy Duty Medical Kit Crate - Surgical/Technician"
-	crate_name = "heavy duty medical kit crate"
-	desc = "Contains a first responder surgical kit, and a medical technician kit."
+/datum/supply_pack/medical/kit_medical
+	name = "Heavy Duty Medical Kit Crate - Medical"
+	crate_name = "medical kit crate"
+	desc = "Contains an orange satchel medical kit."
 	access = ACCESS_MEDICAL
-	cost = CARGO_CRATE_VALUE * 10
+	cost = CARGO_CRATE_VALUE * 4.5
 	contains = list(
-		/obj/item/storage/backpack/duffelbag/deforest_paramedic/stocked,
-		/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked,
-	)
-
-/datum/supply_pack/medical/kit_medical_technician
-	name = "Heavy Duty Medical Kit Crate - Medical/Technician"
-	crate_name = "heavy duty medical kit crate"
-	desc = "Contains a large satchel medical kit, and a medical technician kit."
-	access = ACCESS_MEDICAL
-	cost = CARGO_CRATE_VALUE * 10
-	contains = list(
-		/obj/item/storage/backpack/duffelbag/deforest_paramedic/stocked,
 		/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked,
 	)
 


### PR DESCRIPTION
## About The Pull Request

Updates the DeForest heavy duty medical crates. The technician satchel was priced too low, as I'd missed a PR that had raised the overall prices of the kits.

Balances the three kits, and adjusts so that you can order them in singular quantities through department order.

## How This Contributes To The Nova Sector Roleplay Experience

Fixes pricing, crew using department orders aren't required to order two when they only require one.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
 
![image](https://github.com/user-attachments/assets/d41dd3b4-1699-49b4-8932-47b47b724133)

</details>

## Changelog

:cl: LT3
balance: Price adjustments to DeForest heavy duty medical kits
balance: DeForest heavy duty medical crates via department order includes one pre-stocked kit instead of two
/:cl: