### PR TITLE
Tweaks code owners + adds myself as a code owner to the maplints lint folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@
 /icons/ @GoldenAlpharex
 
 # Jolly-66
-/modular_nova/modules/mapping @Jolly-66 @Zergspower
+/tools/maplint/lints @Jolly-66
 /tools/UpdatePaths @Jolly-66
 
 # Zergspower
@@ -28,6 +28,7 @@
 
 # Maptainers
 /_maps/ @Jolly-66 @Zergspower
+/modular_nova/modules/mapping @Jolly-66 @Zergspower
 
 # Expensive files that touching basically always cause performance problems
 ## Init times


### PR DESCRIPTION
I do a lot of work with map lints upstream, and I would like to keep an eye on them down here if I can.

Map lints impact maps but sometimes they can be a bit too restrictive, we want to avoid that, since being a downstream we have 0 way to satisfy issues on /tg/ maps.