### PR TITLE
Fix synth/silicon emotes being missing from the emote panels for synths, bots, robotic voicebox users

### DIFF
--- a/modular_nova/modules/emote_panel/code/emote_panel.dm
+++ b/modular_nova/modules/emote_panel/code/emote_panel.dm
@@ -228,14 +228,14 @@
 			available_emotes += nova_living_emotes
 			available_emotes += nova_living_emotes_overlay
 			available_emotes += /mob/living/proc/emote_mark_turf
+			// Checking if should apply Synth emotes
+			if(HAS_TRAIT(src, TRAIT_SILICON_EMOTES_ALLOWED))
+				available_emotes += synth_emotes
 		if(iscarbon(src))
 			available_emotes += carbon_emotes
 		if(ishuman(src))
 			available_emotes += human_emotes
-			// Checking if should apply Synth emotes
 			var/mob/living/carbon/human/current_mob = src
-			if(!HAS_TRAIT(current_mob, TRAIT_SILICON_EMOTES_ALLOWED))
-				available_emotes += synth_emotes
 			// Checking if can wag tail
 			var/obj/item/organ/external/tail/tail = current_mob.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAIL)
 			if(!(tail?.wag_flags & WAG_ABLE))
@@ -245,8 +245,6 @@
 				available_emotes -= /mob/living/carbon/human/proc/emote_wing
 		if(isalien(src))
 			available_emotes += alien_emotes
-		if(issilicon(src))
-			available_emotes += synth_emotes
 
 	// Applying emote panel if preferences allow
 	for(var/emote in available_emotes)


### PR DESCRIPTION

## About The Pull Request

https://github.com/NovaSector/NovaSector/blob/25887ec78016fe28095b0236379e1c02715ed81f/modular_nova/modules/emote_panel/code/emote_panel.dm#L235-L238
so yeah someone inverted a check when this was ported over

anyhow this should also be on the living checklist instead of the human checklist cause like, it applies to borgs and bots too and whatever.
## How This Contributes To The Nova Sector Roleplay Experience

Fixes #3923.
## Proof of Testing
<details>
<summary>Human (No Robotic Voicebox)</summary>
  
![image](https://github.com/user-attachments/assets/3db01d89-bbcd-444b-97ef-b17dd04a0373)

</details>

<details>
<summary>Human (Yes Robotic Voicebox)</summary>
  
![image](https://github.com/user-attachments/assets/e4e68475-1c77-492e-a664-c2b70b86ed77)

</details>

<details>
<summary>Synth</summary>
  
![image](https://github.com/user-attachments/assets/19325204-58a9-48a6-a5f0-b6f7f9d59b2c)


</details>

<details>
<summary>Borg</summary>
  
![image](https://github.com/user-attachments/assets/ee61a527-1d7e-4e2c-9b59-b755e8ae4ac4)


</details>

<details>
<summary>AI</summary>
  
![image](https://github.com/user-attachments/assets/4bbe40d0-20db-45c7-b52d-bc80c4cee522)

</details>

<details>
<summary>Basic Bot</summary>
  
![image](https://github.com/user-attachments/assets/02f8b20b-9a6e-46bc-b446-e96553b52220)


</details>

<details>
<summary>Simple Bot</summary>
  
![image](https://github.com/user-attachments/assets/ac0ca891-0309-4979-b481-5eb1584ced61)


</details>


<details>
<summary>Lisa the Corgi (For good measure)</summary>
  
![image](https://github.com/user-attachments/assets/7b1adefc-082e-4811-974d-c9d1813722eb)


</details>

## Changelog
:cl:
fix: Fixes silicon/synth emotes not showing up in the emote panels for synths, bots, or robotic voicebox users.
fix: Fixes silicon/synth emotes showing up in the emote panels for every human that CAN'T use them.
/:cl:
