### PR TITLE
various mapping fixes for Serenity station

### DIFF
--- a/_maps/map_files/SerenityStation/SerenityStation.dmm
+++ b/_maps/map_files/SerenityStation/SerenityStation.dmm
@@ -4331,12 +4331,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/science/xenobiology)
-"blU" = (
-/obj/effect/turf_decal/trimline/purple/filled/warning{
-	dir = 10
-	},
-/turf/closed/wall,
-/area/station/science/robotics/mechbay)
 "blY" = (
 /obj/structure/lattice,
 /obj/docking_port/stationary/random{
@@ -5543,6 +5537,9 @@
 	space_dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
 /turf/open/floor/iron/smooth_large,
@@ -10343,7 +10340,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/portable_atmospherics/scrubber/huge,
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cWy" = (
@@ -11693,6 +11690,7 @@
 /obj/structure/desk_bell{
 	pixel_x = 7
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "dqx" = (
@@ -12792,6 +12790,9 @@
 	space_dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
 /turf/open/floor/iron/smooth_large,
@@ -15101,6 +15102,7 @@
 "esE" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/oven/range,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/service/kitchen)
 "esJ" = (
@@ -23232,6 +23234,7 @@
 	id = "kitchen_counter";
 	name = "Kitchen Counter Shutters"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "gGZ" = (
@@ -42238,6 +42241,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/south,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/central/lesser)
 "mcX" = (
@@ -49135,7 +49139,6 @@
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/supermatter/room)
 "ohL" = (
-/obj/machinery/light/small/directional/north,
 /obj/machinery/shower/directional/east,
 /obj/structure/drain,
 /obj/machinery/button/door/directional/north{
@@ -51635,11 +51638,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
 /area/station/service/theater)
-"oXG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/maintenance/central/lesser)
 "oXP" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/cable,
@@ -176488,7 +176486,7 @@ eMM
 eMM
 aDp
 eMM
-blU
+frt
 frt
 frt
 frt
@@ -176745,7 +176743,7 @@ ntz
 ntz
 ntz
 sBI
-blU
+frt
 nqe
 qsv
 hHe
@@ -180107,7 +180105,7 @@ oRQ
 cNN
 vWE
 oti
-oXG
+yaa
 dDQ
 gtT
 gNC


### PR DESCRIPTION

## About The Pull Request
Closes https://github.com/NovaSector/NovaSector/issues/3675
Closes https://github.com/NovaSector/NovaSector/issues/3920

Not sure how to go about the raptor skin issue since this map has both an icebox-like mining area and a lavaland (?)

Check changelog for more details
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl: grungussuss
fix: Serenity station kitchen now has all fire safety-equipment
fix: Serenity station robotics stray decals have been removed
fix: Serenity station Arrivals Transport Airlocks now have correct unrestricted access
fix: Serenity station bridge maintenance has more redundancy
fix: Serenity station extra lightbulb in a bathroom stall has been removed
/:cl:
