### PR TITLE
Polish the robotic voicebox silicon emotes refactor port

### DIFF
--- a/modular_nova/modules/emotes/code/synth_emotes.dm
+++ b/modular_nova/modules/emotes/code/synth_emotes.dm
@@ -1,14 +1,12 @@
 /datum/emote/silicon
 	cooldown = 2 SECONDS
 
-/datum/emote/living/human/dwoop
-    key = "dwoop"
-    key_third_person = "dwoops"
-    message = "chirps happily!"
-    vary = TRUE
-    sound = 'modular_nova/modules/emotes/sound/emotes/dwoop.ogg'
-    allowed_species = list(/datum/species/synthetic)
-    cooldown = 2 SECONDS
+/datum/emote/silicon/dwoop
+	key = "dwoop"
+	key_third_person = "dwoops"
+	message = "chirps happily!"
+	vary = TRUE
+	sound = 'modular_nova/modules/emotes/sound/emotes/dwoop.ogg'
 
 
 /datum/emote/silicon/yes

--- a/modular_nova/modules/organs/code/tongue.dm
+++ b/modular_nova/modules/organs/code/tongue.dm
@@ -78,6 +78,7 @@
 	taste_sensitivity = 25 // not as good as an organic tongue
 	liked_foodtypes = NONE
 	disliked_foodtypes = NONE
+	organ_traits = list(TRAIT_SILICON_EMOTES_ALLOWED)
 	voice_filter = "alimiter=0.9,acompressor=threshold=0.2:ratio=20:attack=10:release=50:makeup=2,highpass=f=1000"
 
 /obj/item/organ/internal/tongue/lizard/robot/can_speak_language(language)


### PR DESCRIPTION

## About The Pull Request

This pr applies some more polishing to the port of my pr, #3802, continuing from #3924.

### Robotic Lizard Voicebox
First off, in the original pr we added `organ_traits = list(TRAIT_SILICON_EMOTES_ALLOWED)` to the robotic voicebox to allow users to use silicon emotes. The port, however, didn't account for our codebase _here_ having another robotic voicebox, the lizard robotic voicebox, that while functionally similar does not inherit this behaviour.
We simply add `organ_traits = list(TRAIT_SILICON_EMOTES_ALLOWED)` to this voicebox too, fixing that.

### Dwoop
Then, we have the dwoop emote.
Before the port, our synth emotes here were actually inheritors of `/datum/emote/living/human`, with a typecache set to allow only humans and silicons, and then on each emote specifically checking for the synth species if it were a human.
```dm
/datum/emote/living/human
	mob_type_allowed_typecache = list(/mob/living/carbon/human, /mob/living/silicon)
```
This effectively limited these emotes to synths and silicons.

Now, as per the port, most of these emotes were updated to the new system, instead inheriting `/datum/emote/silicon` and working off of the trait. As that parent and its typechecks are no longer needed, those two lines were removed.
However! The emote `/datum/emote/living/human/dwoop` was left on the old system!
Without the now removed typechecks, but still present species checks, this actually allowed every single living entity except non-synth humans to use dwoop.
![image](https://github.com/user-attachments/assets/40096ff6-d60f-441f-9740-bc4245d6d777)

Though I know keeping dwoop synth/silicon-limited was intentional, the current implementation is broken.
So we have to do _something_ to fix it.
I acknowledge we _could_ reimplement the part of the old system that made this work, which would also fix it.
However, this would reintroduce the annoying easy to break specialcases that the original ported pr was intended to resolve.
Additionally, this would require introducing _more_ specialcases _just_ for that emote for things like the emote tabs.
So from a purely technical standpoint, I believe finishing porting it to the new system is still the correct choice.

As such, that is what this pr does.

### Sidenotes

Somehow the indentation for dwoop was swapped from tabs to spaces during the port, as opposed to the indentation in the rest of the file. This has been also been fixed.
## How This Contributes To The Nova Sector Roleplay Experience

### Robotic Lizard Voicebox
Robotic voiceboxes now allow silicon emote usage, but the robotic _lizard_ voicebox hadn't been updated for this yet.
This fixes that.

### Dwoop

i was gonna write out this whole argument against the exclusion of it, but like
man i just think it'd be cool
if like, if we would let people's characters that intentionally get an implant to sound more synth/silicon-like like, actually use all the synth/silicon sounds
there's a sense of small wonder in those kinds of interactions y'know?

and that the exclusion of it from other synthesized voices, whether voiceboxes or bots, is unintuitive at best and boring at worst
when in the original pr we already decided that that's the base logic, that it can already synthesize those kinds of sounds and, hell, even weirder ones like slowclap and honking
to block it is equally arbitrary of a choice, but it goes against the already made choice for no seeming roleplay benefit

so i just think this'd be more fun really, aside from keeping the code jank at bay
## Proof of Testing
<details>
<summary>Robotic Lizard Voicebox</summary>

![image](https://github.com/user-attachments/assets/5103da98-a131-449d-83d5-60fb8c5364ae)

</details>

<details>
<summary>Dwoop</summary>
  
![image](https://github.com/user-attachments/assets/e82181b5-939e-473d-babb-50414188f8c6)
![image](https://github.com/user-attachments/assets/d1170ec4-9245-472a-b4f9-ba43600601e7)
![image](https://github.com/user-attachments/assets/4fc64b66-6081-4876-8d89-6e9ada14aac1)

![image](https://github.com/user-attachments/assets/b26f5669-1067-4f37-8d66-315ad74faa86)
![image](https://github.com/user-attachments/assets/cc01d02d-0f5d-4b8b-b3f7-003899846cb1)
![image](https://github.com/user-attachments/assets/9c1ccc61-2a00-4695-a44c-b3037121d0f8)
![image](https://github.com/user-attachments/assets/5d410ba6-b4ed-4bb1-a3f4-fdeb1f0c8e0f)
![image](https://github.com/user-attachments/assets/1516d61a-b102-4b35-a493-30b8e3d9c172)

For good measure:
![image](https://github.com/user-attachments/assets/4f5facf4-1e16-4298-95ab-9ad0433b07dd)

</details>

## Changelog
:cl:
fix: Fixes a half-port accidentally causing the Dwoop emote to be usable by not just synths and silicons, but every single living entity except non-synth humans. It is now fully ported to the new silicon emotes system, allowing it to be used by everything that can use silicon emotes.
fix: Robotic lizard voicebox allows silicon emotes parallel to the stock robotic voicebox.
/:cl:
