### PR TITLE
Fixes assistant loadout undersuit items being overridden by jumpsuits in the preview

### DIFF
--- a/modular_nova/master_files/code/modules/jobs/job_types/assistant/assistant.dm
+++ b/modular_nova/master_files/code/modules/jobs/job_types/assistant/assistant.dm
@@ -13,8 +13,9 @@
 	if(modified_outfit_slots & ITEM_SLOT_ICLOTHING)
 		uniform = original_uniform
 
-/datum/outfit/job/assistant/consistent/give_jumpsuit(mob/living/carbon/human/target)
+/datum/outfit/job/assistant/preview/give_jumpsuit(mob/living/carbon/human/target)
+	// This is so it doesn't force a jumpsuit on if there's already something in the jumpsuit slot from the loadout.
 	if(modified_outfit_slots & ITEM_SLOT_ICLOTHING)
 		return
 
-	uniform = /obj/item/clothing/under/color/grey
+	return ..()


### PR DESCRIPTION
## About The Pull Request
They added a new assistant outfit, and unfortunately this behavior wasn't carried over, so now it is, and as such it should be fixed!

## How This Contributes To The Nova Sector Roleplay Experience
Seeing what pants you picked is pretty good for roleplay, I'd say. Less bugs == more better.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
The pants are here! 

![image](https://github.com/user-attachments/assets/b80ddef7-a3cf-40ea-8fa6-905edaf74fd9)


</details>

## Changelog

:cl: GoldenAlpharex
fix: Assistant jumpsuits/jumpskirts no longer override the undersuit loadout item in the character preview.
/:cl: