### PR TITLE
Makes Loader and Civilian Modsuits Belt Based

### DIFF
--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -193,6 +193,8 @@
 	complexity_max = DEFAULT_MAX_COMPLEXITY - 3
 	slowdown_inactive = 0.5
 	slowdown_active = 0
+	slot_flags = ITEM_SLOT_BELT // NOVA EDIT
+	inbuilt_modules = list(/obj/item/mod/module/storage/civilian) // NOVA EDIT
 	variants = list(
 		"civilian" = list(
 			/obj/item/clothing/head/mod = list(
@@ -568,13 +570,14 @@
 	complexity_max = DEFAULT_MAX_COMPLEXITY - 5
 	slowdown_inactive = 0.5
 	slowdown_active = 0
+	slot_flags = ITEM_SLOT_BELT // NOVA EDIT
 	allowed_suit_storage = list(
 		/obj/item/mail,
 		/obj/item/delivery/small,
 		/obj/item/paper,
 		/obj/item/storage/bag/mail,
 	)
-	inbuilt_modules = list(/obj/item/mod/module/hydraulic, /obj/item/mod/module/clamp/loader, /obj/item/mod/module/magnet)
+	inbuilt_modules = list(/obj/item/mod/module/hydraulic, /obj/item/mod/module/clamp/loader, /obj/item/mod/module/magnet, /obj/item/mod/module/storage/civilian) // NOVA EDIT - original: list(/obj/item/mod/module/hydraulic, /obj/item/mod/module/clamp/loader, /obj/item/mod/module/magnet)
 	variants = list(
 		"loader" = list(
 			/obj/item/clothing/head/mod = list(

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -212,7 +212,7 @@
 	use_energy_cost = DEFAULT_CHARGE_DRAIN * 0.1
 	incompatible_modules = list(/obj/item/mod/module/status_readout)
 	tgui_id = "status_readout"
-	required_slots = list(ITEM_SLOT_BACK)
+	required_slots = list(ITEM_SLOT_BACK|ITEM_SLOT_BELT) // NOVA EDIT - original: list(ITEM_SLOT_BACK)
 	/// Does this show damage types, body temp, satiety
 	var/display_detailed_vitals = TRUE
 	/// Does this show DNA data

--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -35,7 +35,7 @@
 	cooldown_time = 0.5 SECONDS
 	overlay_state_inactive = "module_clamp"
 	overlay_state_active = "module_clamp_on"
-	required_slots = list(ITEM_SLOT_GLOVES, ITEM_SLOT_BACK)
+	required_slots = list(ITEM_SLOT_GLOVES, ITEM_SLOT_BACK|ITEM_SLOT_BELT) // NOVA EDIT - original: list(ITEM_SLOT_GLOVES, ITEM_SLOT_BACK)
 	/// Time it takes to load a crate.
 	var/load_time = 3 SECONDS
 	/// The max amount of crates you can carry.
@@ -108,7 +108,7 @@
 	load_time = 1 SECONDS
 	max_crates = 5
 	use_mod_colors = TRUE
-	required_slots = list(ITEM_SLOT_BACK)
+	required_slots = list(ITEM_SLOT_BACK|ITEM_SLOT_BELT) // NOVA EDIT - original: list(ITEM_SLOT_BACK)
 
 ///Drill - Lets you dig through rock and basalt.
 /obj/item/mod/module/drill
@@ -220,7 +220,7 @@
 	overlay_state_inactive = "module_hydraulic"
 	overlay_state_active = "module_hydraulic_active"
 	use_mod_colors = TRUE
-	required_slots = list(ITEM_SLOT_BACK)
+	required_slots = list(ITEM_SLOT_BACK|ITEM_SLOT_BELT) // NOVA EDIT - original: list(ITEM_SLOT_BACK)
 	/// Time it takes to launch
 	var/launch_time = 2 SECONDS
 	/// User overlay
@@ -309,7 +309,7 @@
 	cooldown_time = 1.5 SECONDS
 	overlay_state_active = "module_magnet"
 	use_mod_colors = TRUE
-	required_slots = list(ITEM_SLOT_BACK)
+	required_slots = list(ITEM_SLOT_BACK|ITEM_SLOT_BELT) // NOVA EDIT - original: list(ITEM_SLOT_BACK)
 
 /obj/item/mod/module/magnet/on_select_use(atom/target)
 	. = ..()

--- a/modular_nova/master_files/code/modules/mod/modules/modules_general.dm
+++ b/modular_nova/master_files/code/modules/mod/modules/modules_general.dm
@@ -1,0 +1,6 @@
+/obj/item/mod/module/storage/civilian
+	name = "MOD case civilian storage module"
+	complexity = 2
+	max_w_class = WEIGHT_CLASS_SMALL
+	required_slots = list(ITEM_SLOT_BELT)
+	removable = FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6801,6 +6801,7 @@
 #include "modular_nova\master_files\code\modules\mod\mod_types.dm"
 #include "modular_nova\master_files\code\modules\mod\modules\_module.dm"
 #include "modular_nova\master_files\code\modules\mod\modules\modules_antag.dm"
+#include "modular_nova\master_files\code\modules\mod\modules\modules_general.dm"
 #include "modular_nova\master_files\code\modules\mod\modules\modules_science.dm"
 #include "modular_nova\master_files\code\modules\mod\modules\modules_supply.dm"
 #include "modular_nova\master_files\code\modules\modular_computers\computers\item\laptop_presets.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Turns the Loader (cargo) and Civilian modsuits into belt based modsuits, this means they can only be equipped on the belt, have some mods they cannot use (jetpack, storage, etc), and have an unremovable special storage that can only hold seven small or less items, but has complexity 2 instead of 3 as the regular storages.

Also edits four mods so they are usable with either the back or the belt, this does buffs very lightly the infiltrator modsuit, as they can use clamps now. The Mods are the three cargo ones (Magnetic, Arms and Clamps), and the status readout one, because there might be the odd person that uses the civilian modsuit to have an alarm go loud the moment they die.

Fixes the request of JR himself: https://discord.com/channels/1171566433923239977/1172988592658841680/1265361493629730897

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Both the Loader and the Civilian modsuits are commercial grade modsuits not prepared for space, so its interesting  to see them onto the wild like this, and makes sense for them to have an easier version to use, given they actually have little to no cooldown once they are active, I think its gonna be interesting to see how people use them and its a nice change of pace to see non weapon objects be more accessible for the masses.
## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/73df55e7-0489-45b2-826d-7f1e43cddf8d)

![image](https://github.com/user-attachments/assets/68fb218d-421f-4727-b65a-a9abeb66c157)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Cargo and Civilian Modsuits Control units were miniaturized to belt versions, while they dont hold as much as their old counterparts, and some functionality like the use of jetpacks was lost, Users can now use their backpack of choice along these practical modsuits!
add: The following modparts were adapted to both regular and miniaturized modsuits: Hydraulic Clamps, Hydraulic Arms, Hydraulic Magnet and the Status Monitor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
