### PR TITLE
[MDB Ignore] Pixel_X, Pixel_Y & Dir - A Tragic Sanity Pass

### DIFF
--- a/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1.dmm
+++ b/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1.dmm
@@ -282,7 +282,6 @@
 "aZ" = (
 /obj/structure/closet/secure_closet/personal/wall{
 	pixel_y = 30;
-	pixel_w = 0;
 	icon_door = "locker_wall"
 	},
 /turf/open/floor/iron/smooth_edge,
@@ -572,9 +571,7 @@
 /area/ruin/interdyne_planetary_base/cargo)
 "bK" = (
 /obj/structure/table/glass,
-/obj/item/reagent_containers/dropper{
-	pixel_y = 0
-	},
+/obj/item/reagent_containers/dropper,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/mapping_helpers/apc/syndicate_access,
 /obj/structure/cable,
@@ -904,9 +901,7 @@
 /obj/effect/turf_decal/siding/brown{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/south{
-	dir = 1
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/interdyne_planetary_base/cargo)
 "cC" = (
@@ -943,9 +938,7 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/cargo)
 "cG" = (
-/obj/machinery/firealarm/directional/south{
-	dir = 1
-	},
+/obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/siding/brown{
 	dir = 9
 	},
@@ -1351,18 +1344,14 @@
 /turf/open/floor/iron/smooth_large,
 /area/ruin/interdyne_planetary_base/cargo/obs)
 "dE" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 2
-	},
+/obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/interdyne_planetary_base/cargo/obs)
 "dF" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 2
-	},
+/obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -1370,12 +1359,9 @@
 /turf/open/floor/iron/smooth_large,
 /area/ruin/interdyne_planetary_base/cargo/obs)
 "dG" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 2
-	},
+/obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/button/door/directional/north{
 	name = "window security button";
-	pixel_x = 0;
 	id = "interdyneobservation"
 	},
 /turf/open/floor/iron/smooth_large,
@@ -1428,9 +1414,7 @@
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/interdyne_planetary_base/med/viro)
 "dO" = (
-/obj/machinery/firealarm/directional/south{
-	dir = 1
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/interdyne_planetary_base/med/viro)
 "dP" = (
@@ -1440,9 +1424,7 @@
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/interdyne_planetary_base/med/viro)
 "dQ" = (
-/obj/structure/weightmachine{
-	dir = 2
-	},
+/obj/structure/weightmachine,
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
@@ -2188,9 +2170,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/south{
-	dir = 1
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/main)
 "fV" = (
@@ -2281,9 +2261,7 @@
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/interdyne_planetary_base/med)
 "gh" = (
-/obj/machinery/firealarm/directional/north{
-	dir = 1
-	},
+/obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -2301,9 +2279,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/north{
-	dir = 1
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/main)
 "gk" = (
@@ -2536,9 +2512,7 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/main)
 "gM" = (
-/obj/machinery/firealarm/directional/east{
-	dir = 8
-	},
+/obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2571,9 +2545,7 @@
 	},
 /area/ruin/interdyne_planetary_base/main)
 "gR" = (
-/obj/machinery/firealarm/directional/west{
-	dir = 4
-	},
+/obj/machinery/firealarm/directional/west,
 /obj/machinery/vending/medical/syndicate_access{
 	onstation = 0;
 	contraband = list(/obj/item/storage/box/gum/happiness=3, /obj/item/storage/box/hug/medical=3, /obj/item/mmi/syndie/interdyne=3);
@@ -2966,7 +2938,6 @@
 /obj/machinery/button/door/directional/south{
 	name = "window security button";
 	pixel_x = -24;
-	pixel_w = 0;
 	id = "interdynesciencehall";
 	req_access = list("syndicate")
 	},
@@ -3033,9 +3004,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/west{
-	dir = 4
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/main)
 "ie" = (
@@ -3048,9 +3017,7 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/science)
 "if" = (
-/obj/machinery/firealarm/directional/east{
-	dir = 8
-	},
+/obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured_large,
@@ -3229,9 +3196,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/firealarm/directional/north{
-	dir = 1
-	},
+/obj/machinery/firealarm/directional/north,
 /obj/machinery/light/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -3455,9 +3420,7 @@
 /area/ruin/interdyne_planetary_base/med/morgue)
 "jj" = (
 /obj/structure/table/glass,
-/obj/machinery/firealarm/directional/west{
-	dir = 4
-	},
+/obj/machinery/firealarm/directional/west,
 /obj/item/storage/box/beakers/bluespace{
 	pixel_x = -5;
 	pixel_y = 3
@@ -4072,7 +4035,6 @@
 /obj/machinery/button/door/directional/south{
 	name = "window security button";
 	pixel_x = 24;
-	pixel_w = 0;
 	id = "interdynesciencehall";
 	req_access = list("syndicate")
 	},
@@ -4723,7 +4685,6 @@
 	pixel_x = 30
 	},
 /obj/machinery/button/door/directional/north{
-	pixel_x = 0;
 	id = "interdynecabin6";
 	name = "door bolt control";
 	specialfunctions = 4;
@@ -4805,9 +4766,7 @@
 	dir = 4
 	},
 /obj/machinery/duct,
-/obj/machinery/firealarm/directional/south{
-	dir = 1
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/serv)
 "ms" = (
@@ -5014,7 +4973,6 @@
 "mS" = (
 /obj/machinery/camera/autoname/directional/east{
 	pixel_x = -32;
-	pixel_y = 0;
 	network = list("intd13")
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -5049,9 +5007,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/west{
-	dir = 4
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plating/reinforced,
 /area/ruin/interdyne_planetary_base/eng)
 "mZ" = (
@@ -5121,9 +5077,7 @@
 /area/ruin/interdyne_planetary_base/eng)
 "ni" = (
 /obj/effect/turf_decal/stripes/white/line,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/eng)
 "nj" = (
@@ -5556,9 +5510,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/west{
-	dir = 4
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/ruin/interdyne_planetary_base/serv/bar)
 "ok" = (
@@ -5907,8 +5859,7 @@
 /area/ruin/interdyne_planetary_base/main/dorms)
 "oU" = (
 /obj/machinery/vending/dorms{
-	onstation = 0;
-	extended_inventory = 0
+	onstation = 0
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/main/dorms)
@@ -6169,7 +6120,6 @@
 "pE" = (
 /obj/machinery/camera/autoname/directional/east{
 	pixel_x = -32;
-	pixel_y = 0;
 	network = list("intd13")
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -6186,9 +6136,7 @@
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 4
 	},
-/obj/machinery/firealarm/directional/south{
-	dir = 1
-	},
+/obj/machinery/firealarm/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
@@ -6227,7 +6175,6 @@
 "pL" = (
 /obj/machinery/camera/autoname/directional/west{
 	pixel_x = 32;
-	pixel_y = 0;
 	network = list("intd13")
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -6243,7 +6190,6 @@
 "pN" = (
 /obj/machinery/camera/autoname/directional/east{
 	pixel_x = -32;
-	pixel_y = 0;
 	network = list("intd13")
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -6266,7 +6212,6 @@
 "pP" = (
 /obj/machinery/camera/autoname/directional/west{
 	pixel_x = 32;
-	pixel_y = 0;
 	network = list("intd13")
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -6488,9 +6433,7 @@
 /turf/open/floor/iron/diagonal,
 /area/ruin/interdyne_planetary_base/cargo/obs)
 "qx" = (
-/obj/machinery/processor{
-	pixel_z = 0
-	},
+/obj/machinery/processor,
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/serv/kitchen)
@@ -6760,7 +6703,6 @@
 "rh" = (
 /obj/machinery/camera/autoname/directional/west{
 	pixel_x = 32;
-	pixel_y = 0;
 	network = list("intd13")
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -7085,7 +7027,6 @@
 	pixel_x = 30
 	},
 /obj/machinery/button/door/directional/north{
-	pixel_x = 0;
 	id = "interdynecabin5";
 	name = "door bolt control";
 	specialfunctions = 4;
@@ -7467,7 +7408,6 @@
 	pixel_x = 30
 	},
 /obj/machinery/button/door/directional/north{
-	pixel_x = 0;
 	id = "interdynecabin8";
 	name = "door bolt control";
 	specialfunctions = 4;
@@ -7508,7 +7448,6 @@
 	pixel_x = 30
 	},
 /obj/machinery/button/door/directional/north{
-	pixel_x = 0;
 	id = "interdynecabin7";
 	name = "door bolt control";
 	specialfunctions = 4;

--- a/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
@@ -1994,8 +1994,6 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/nova/des_two/security)
 "iK" = (
@@ -7281,8 +7279,7 @@
 /area/ruin/space/has_grav/nova/des_two/security/prison)
 "GQ" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/structure/table/wood,
 /turf/open/floor/wood/tile,

--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -1895,15 +1895,13 @@
 /obj/structure/chair/comfy/teal{
 	dir = 8
 	},
-/obj/machinery/button/door/directional/south{
-	id = "cmoshutter3";
-	name = "CMO Quarters Shutters";
-	pixel_x = 25;
-	pixel_y = 0;
-	req_access = list("cmo")
-	},
 /obj/machinery/light/directional/east,
 /obj/effect/landmark/start/chief_medical_officer,
+/obj/machinery/button/door/directional/east{
+	id = "cmoshutter3";
+	name = "CMO Quarters Shutters";
+	req_access = list("cmo")
+	},
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
 "att" = (
@@ -13516,9 +13514,7 @@
 /area/station/security/detectives_office/private_investigators_office)
 "cDI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
@@ -15847,9 +15843,7 @@
 /area/station/maintenance/abandon_art_studio)
 "cZw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -17457,9 +17451,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -19567,9 +19559,7 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "dKC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 4
 	},
@@ -22948,11 +22938,9 @@
 	id = "Portbowmaints";
 	name = "Port Bow Maintenance"
 	},
-/obj/machinery/button/door/directional/north{
+/obj/machinery/button/door/directional/east{
 	id = "Portbowmaints";
 	name = "Shutter control";
-	pixel_x = 24;
-	pixel_y = 0;
 	req_access = list("engineering","atmospherics")
 	},
 /turf/open/floor/iron/stairs/right,
@@ -35527,12 +35515,7 @@
 /obj/machinery/computer/apc_control{
 	dir = 4
 	},
-/obj/machinery/requests_console/directional/north{
-	department = "Chief Engineer's Desk";
-	name = "Chief Engineer's Requests Console";
-	pixel_x = -29;
-	pixel_y = 0
-	},
+/obj/machinery/requests_console/auto_name/directional/west,
 /obj/effect/mapping_helpers/requests_console/announcement,
 /obj/effect/mapping_helpers/requests_console/information,
 /turf/open/floor/iron/dark/textured_large,
@@ -43096,12 +43079,10 @@
 /obj/structure/chair/sofa/left/brown,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
-/obj/machinery/button/door/directional/west{
+/obj/machinery/button/door/directional/north{
 	id = "Dorm2";
 	name = "Dormitory Door Lock";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
-	pixel_y = 25;
 	specialfunctions = 4
 	},
 /turf/open/floor/wood,
@@ -47816,7 +47797,6 @@
 /area/station/medical/virology/isolation)
 "jkz" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
 	name = "Mix to Engine"
 	},
 /turf/open/floor/iron,
@@ -48147,12 +48127,10 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/freezer/fridge/open,
-/obj/machinery/button/door/directional/west{
+/obj/machinery/button/door/directional/south{
 	id = "Dorm4";
 	name = "Dormitory Door Lock";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
-	pixel_y = -25;
 	specialfunctions = 4
 	},
 /turf/open/floor/wood,
@@ -49419,11 +49397,9 @@
 	icon_state = "dirt-flat-1"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/button/door/directional/north{
+/obj/machinery/button/door/directional/west{
 	id = "Portbowmaints";
 	name = "Shutter control";
-	pixel_x = -24;
-	pixel_y = 0;
 	req_access = list("command")
 	},
 /obj/machinery/door/poddoor/shutters{
@@ -58972,9 +58948,7 @@
 /area/space/nearstation)
 "loM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
@@ -61176,12 +61150,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
-/obj/machinery/requests_console/directional/north{
-	department = "Virology";
-	name = "Virology Requests Console";
-	pixel_x = -30;
-	pixel_y = 0
-	},
+/obj/machinery/requests_console/auto_name/directional/west,
 /obj/effect/mapping_helpers/requests_console/ore_update,
 /obj/machinery/camera/autoname/directional/west{
 	network = list("ss13","medbay")
@@ -61255,7 +61224,6 @@
 /area/station/security/prison/mess)
 "lMn" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
 	name = "Pure to Fuel Pipe"
 	},
 /turf/open/floor/iron,
@@ -61627,10 +61595,7 @@
 /turf/open/floor/iron/white,
 /area/station/science)
 "lQa" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/machinery/firealarm/directional/south,
 /obj/machinery/light/small/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -66515,9 +66480,7 @@
 /area/station/security/brig)
 "mMT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
@@ -71784,7 +71747,6 @@
 /area/station/command/secure_bunker)
 "nPP" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
 	name = "Mix Outlet Pump"
 	},
 /obj/effect/turf_decal/tile/brown/fourcorners,
@@ -76062,9 +76024,7 @@
 /area/station/service/cafeteria)
 "oDp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -83325,9 +83285,7 @@
 "pYU" = (
 /obj/machinery/power/energy_accumulator/tesla_coil,
 /obj/effect/turf_decal/bot/left,
-/turf/open/floor/iron/dark/side{
-	dir = 2
-	},
+/turf/open/floor/iron/dark/side,
 /area/station/engineering/storage)
 "pYX" = (
 /turf/closed/wall,
@@ -88464,11 +88422,9 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/obj/machinery/button/door/directional/south{
+/obj/machinery/button/door/directional/east{
 	id = "councilblast";
-	name = "Council Blast Doors";
-	pixel_x = 26;
-	pixel_y = 0
+	name = "Council Blast Doors"
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/meeting_room/council)
@@ -92127,11 +92083,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/workout)
 "rFT" = (
-/obj/machinery/button/door/directional/north{
+/obj/machinery/button/door/directional/east{
 	id = "evashutters";
 	name = "E.V.A. Shutters";
-	pixel_x = 24;
-	pixel_y = 0;
 	req_access = list("command")
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -93643,12 +93597,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
 	},
-/obj/machinery/requests_console/directional/south{
-	department = "Genetics";
-	name = "Genetics Requests console";
-	pixel_x = -30;
-	pixel_y = 0
-	},
+/obj/machinery/requests_console/auto_name/directional/west,
 /obj/item/bouquet/rose,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
@@ -94568,7 +94517,6 @@
 	dir = 1
 	},
 /obj/item/flatpack{
-	pixel_x = 0;
 	pixel_y = 13
 	},
 /turf/open/floor/iron/white,
@@ -101503,12 +101451,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 2
 	},
-/obj/machinery/requests_console/directional/north{
-	department = "Head of Security's Desk";
-	name = "Head of Security's Requests Console";
-	pixel_x = -31;
-	pixel_y = 0
-	},
+/obj/machinery/requests_console/auto_name/directional/west,
 /obj/effect/mapping_helpers/requests_console/announcement,
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/assistance,
@@ -104601,9 +104544,7 @@
 /area/station/ai_monitored/command/storage/eva/upper)
 "tZB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
@@ -107174,12 +107115,7 @@
 "uxK" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/requests_console/directional/south{
-	department = "Pharmacy";
-	name = "Pharmacy Requests Console";
-	pixel_x = -32;
-	pixel_y = 0
-	},
+/obj/machinery/requests_console/auto_name/directional/west,
 /obj/effect/mapping_helpers/requests_console/ore_update,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -107700,12 +107636,10 @@
 /area/station/maintenance/abandon_exam/cat)
 "uCu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/button/door/directional/west{
+/obj/machinery/button/door/directional/north{
 	id = "Dorm8";
 	name = "Dormitory Door Lock";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
-	pixel_y = 25;
 	specialfunctions = 4
 	},
 /obj/structure/chair/comfy/brown{
@@ -109015,12 +108949,10 @@
 /obj/structure/chair/wood{
 	dir = 4
 	},
-/obj/machinery/button/door/directional/west{
+/obj/machinery/button/door/directional/south{
 	id = "Dorm6";
 	name = "Dormitory Door Lock";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
-	pixel_y = -25;
 	specialfunctions = 4
 	},
 /turf/open/floor/wood,
@@ -113067,12 +112999,7 @@
 /obj/structure/table,
 /obj/item/clipboard,
 /obj/item/toy/figure/botanist,
-/obj/machinery/requests_console/directional/east{
-	department = "Hydroponics";
-	name = "Hydroponics Requests Console";
-	pixel_x = 0;
-	pixel_y = -33
-	},
+/obj/machinery/requests_console/auto_name/directional/south,
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
@@ -113661,11 +113588,9 @@
 /turf/open/floor/iron/goonplaque,
 /area/station/hallway/primary/central/aft)
 "vIA" = (
-/obj/machinery/button/door/directional/north{
+/obj/machinery/button/door/directional/west{
 	id = "evashutters";
 	name = "E.V.A. Shutters";
-	pixel_x = -24;
-	pixel_y = 0;
 	req_access = list("command")
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -115060,11 +114985,9 @@
 	id = "Starboardbowmaints";
 	name = "Starboard Bow Maintenance"
 	},
-/obj/machinery/button/door/directional/north{
+/obj/machinery/button/door/directional/east{
 	id = "Starboardbowmaints";
 	name = "Shutter control";
-	pixel_x = 24;
-	pixel_y = 0;
 	req_access = list("engineering","atmospherics")
 	},
 /turf/open/floor/plating,
@@ -115358,9 +115281,7 @@
 "wao" = (
 /obj/machinery/power/shieldwallgen,
 /obj/effect/turf_decal/bot/right,
-/turf/open/floor/iron/dark/side{
-	dir = 2
-	},
+/turf/open/floor/iron/dark/side,
 /area/station/engineering/storage)
 "war" = (
 /mob/living/basic/garden_gnome,
@@ -115999,11 +115920,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
-/obj/machinery/button/door/directional/north{
+/obj/machinery/button/door/directional/east{
 	id = "Starboardbowmaints";
 	name = "Shutter control";
-	pixel_x = 24;
-	pixel_y = 0;
 	req_access = list("engineering","atmospherics")
 	},
 /obj/machinery/door/poddoor/shutters{
@@ -119801,12 +119720,7 @@
 	name = "medbay camera";
 	network = list("ss13","medbay")
 	},
-/obj/machinery/requests_console/directional/north{
-	department = "Medbay";
-	name = "Medbay Requests Console";
-	pixel_x = 27;
-	pixel_y = 0
-	},
+/obj/machinery/requests_console/auto_name/directional/east,
 /obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
@@ -123655,9 +123569,7 @@
 	name = "library camera"
 	},
 /obj/machinery/light/directional/east,
-/obj/machinery/light_switch/directional/east{
-	pixel_x = 34
-	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/wood,
 /area/station/service/library)
 "xEi" = (
@@ -124842,9 +124754,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
@@ -125974,15 +125884,13 @@
 	name = "Door Lock";
 	normaldoorcontrol = 1;
 	pixel_x = -7;
-	pixel_y = 25;
 	req_access = list("cmo");
 	specialfunctions = 4
 	},
-/obj/machinery/button/door/directional/south{
+/obj/machinery/button/door/directional/north{
 	id = "cmoshutter";
 	name = "CMO Office Shutters";
 	pixel_x = 7;
-	pixel_y = 25;
 	req_access = list("cmo")
 	},
 /turf/open/floor/iron/dark,

--- a/_maps/nova/automapper/templates/mining/lavaland_ashwalker_fortress.dmm
+++ b/_maps/nova/automapper/templates/mining/lavaland_ashwalker_fortress.dmm
@@ -2,12 +2,10 @@
 "ac" = (
 /obj/structure/table/wood,
 /obj/structure/stone_tile/block/cracked{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/stone_tile/block/cracked{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
@@ -35,7 +33,6 @@
 	},
 /obj/structure/stone_tile/burnt{
 	dir = 8;
-	pixel_y = 0;
 	pixel_x = 3
 	},
 /obj/effect/mapping_helpers/no_lava,
@@ -202,9 +199,7 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "cF" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 2
-	},
+/obj/effect/turf_decal/siding/wood,
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
@@ -325,9 +320,7 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "ei" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 2
-	},
+/obj/effect/turf_decal/siding/wood,
 /obj/structure/closet/crate/wooden/storage_barrel,
 /obj/effect/mapping_helpers/no_lava,
 /obj/item/stack/sheet/mineral/gold{
@@ -495,25 +488,19 @@
 /area/ruin/unpowered/ash_walkers)
 "gx" = (
 /obj/structure/rack/wooden,
-/obj/item/hatchet/wooden{
-	pixel_y = 0
-	},
+/obj/item/hatchet/wooden,
 /obj/item/shovel,
 /obj/item/hatchet/wooden{
-	pixel_y = 0;
 	pixel_x = -5
 	},
 /obj/item/hatchet/wooden{
-	pixel_y = 0;
 	pixel_x = 5
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "gC" = (
-/obj/structure/stone_tile/surrounding/cracked{
-	dir = 2
-	},
+/obj/structure/stone_tile/surrounding/cracked,
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
@@ -633,14 +620,6 @@
 /area/ruin/unpowered/ash_walkers)
 "iN" = (
 /obj/structure/water_source/puddle,
-/obj/effect/mapping_helpers/no_lava,
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
-"iO" = (
-/obj/structure/stone_tile/block/cracked{
-	dir = 1;
-	pixel_y = 0
-	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
@@ -822,7 +801,6 @@
 	},
 /obj/structure/stone_tile/surrounding_tile/burnt{
 	dir = 8;
-	pixel_y = 0;
 	pixel_x = -16
 	},
 /obj/structure/stone_tile/block/cracked{
@@ -1105,9 +1083,7 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "qb" = (
-/obj/structure/chair/pew/right{
-	dir = 2
-	},
+/obj/structure/chair/pew/right,
 /obj/structure/wall_torch/spawns_lit/directional/east,
 /obj/structure/stone_tile/surrounding/cracked{
 	dir = 8
@@ -1144,8 +1120,7 @@
 /obj/structure/bed/maint,
 /obj/structure/curtain/bounty,
 /obj/structure/stone_tile/block/cracked{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
@@ -1214,9 +1189,7 @@
 /turf/open/floor/grass/lavaland,
 /area/ruin/unpowered/ash_walkers)
 "rt" = (
-/obj/structure/chair/pew/left{
-	dir = 2
-	},
+/obj/structure/chair/pew/left,
 /obj/structure/stone_tile/block,
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
@@ -1236,9 +1209,7 @@
 /obj/item/chair/wood{
 	dir = 8
 	},
-/obj/structure/stone_tile/surrounding/cracked{
-	dir = 2
-	},
+/obj/structure/stone_tile/surrounding/cracked,
 /obj/structure/stone_tile/center/burnt,
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
@@ -1255,9 +1226,7 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "rW" = (
-/obj/structure/chair/pew/right{
-	dir = 2
-	},
+/obj/structure/chair/pew/right,
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
@@ -1850,9 +1819,7 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "ze" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 2
-	},
+/obj/effect/turf_decal/siding/wood,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/wood/lavaland,
@@ -2143,15 +2110,12 @@
 /area/ruin/unpowered/ash_walkers)
 "DD" = (
 /obj/structure/wall_torch/spawns_lit/directional/east,
-/obj/structure/stone_tile/surrounding/cracked{
-	dir = 2
-	},
+/obj/structure/stone_tile/surrounding/cracked,
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "DI" = (
 /obj/structure/stone_tile/block/burnt{
-	pixel_y = 0;
 	pixel_x = 15
 	},
 /obj/structure/stone_tile/block/cracked{
@@ -2225,8 +2189,7 @@
 /area/ruin/unpowered/ash_walkers)
 "EI" = (
 /obj/structure/stone_tile/surrounding_tile/burnt{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
@@ -2398,8 +2361,7 @@
 "Ic" = (
 /obj/structure/wall_torch/spawns_lit/directional/north,
 /obj/structure/stone_tile/surrounding_tile/burnt{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
@@ -2447,7 +2409,6 @@
 	pixel_x = 5
 	},
 /obj/item/food/grown/aloe{
-	pixel_y = 0;
 	pixel_x = 10
 	},
 /obj/effect/mapping_helpers/no_lava,
@@ -2478,8 +2439,7 @@
 /area/ruin/unpowered/ash_walkers)
 "Jn" = (
 /obj/structure/stone_tile/surrounding_tile/burnt{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
@@ -2529,9 +2489,7 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "Ks" = (
-/obj/structure/chair/pew/left{
-	dir = 2
-	},
+/obj/structure/chair/pew/left,
 /obj/structure/wall_torch/spawns_lit/directional/west,
 /obj/structure/stone_tile/surrounding/cracked{
 	dir = 1
@@ -2564,16 +2522,12 @@
 /turf/open/floor/grass/lavaland,
 /area/ruin/unpowered/ash_walkers)
 "KC" = (
-/obj/item/flashlight/lantern{
-	pixel_y = 0
-	},
+/obj/item/flashlight/lantern,
 /obj/structure/closet/crate/wooden,
 /obj/item/flashlight/lantern{
-	pixel_y = 0;
 	pixel_x = -5
 	},
 /obj/item/flashlight/lantern{
-	pixel_y = 0;
 	pixel_x = 5
 	},
 /obj/structure/stone_tile/block{
@@ -2590,7 +2544,6 @@
 "KZ" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4;
-	pixel_y = 0;
 	pixel_x = -15
 	},
 /obj/effect/mapping_helpers/no_lava,
@@ -2873,7 +2826,6 @@
 /area/ruin/unpowered/ash_walkers)
 "Pa" = (
 /obj/structure/stone_tile/block/burnt{
-	pixel_y = 0;
 	pixel_x = 7
 	},
 /obj/effect/mapping_helpers/no_lava,
@@ -2911,7 +2863,6 @@
 "PZ" = (
 /obj/structure/table/wood,
 /obj/item/plate/ceramic{
-	pixel_y = 0;
 	pixel_x = 3
 	},
 /obj/item/reagent_containers/cup/glass/trophy{
@@ -2941,9 +2892,7 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "QA" = (
-/obj/structure/chair/pew/right{
-	dir = 2
-	},
+/obj/structure/chair/pew/right,
 /obj/structure/stone_tile,
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
@@ -2968,7 +2917,6 @@
 	},
 /obj/structure/stone_tile/burnt{
 	dir = 8;
-	pixel_y = 0;
 	pixel_x = 2
 	},
 /obj/effect/mapping_helpers/no_lava,
@@ -3255,7 +3203,6 @@
 	pixel_y = 4
 	},
 /obj/item/flashlight/flare/candle/infinite{
-	pixel_y = 0;
 	pixel_x = -6
 	},
 /obj/effect/mapping_helpers/no_lava,
@@ -3676,14 +3623,6 @@
 /area/ruin/unpowered/ash_walkers)
 "Zo" = (
 /obj/structure/flora/ash/leaf_shroom,
-/obj/effect/mapping_helpers/no_lava,
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
-"Zr" = (
-/obj/structure/stone_tile/block/cracked{
-	dir = 2;
-	pixel_y = 0
-	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
@@ -4211,7 +4150,7 @@ sQ
 fB
 CV
 CV
-iO
+ED
 qg
 El
 Jn
@@ -4280,7 +4219,7 @@ CV
 CV
 ed
 xk
-Zr
+Ea
 CV
 Hv
 JC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Kills off a bunch of dirty varedits on a few maps; from Blueshift to DS-2 to the Ashie fortress all the way to my unkillable bastard child in Icedyne, A few directional variants being used improperly; etc. CI probably should've caught these.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Futureproofing (the ever-illusive wallening); less map-loaded variables.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshot Wall</summary>

Icedyne's fire alarms:
 
![image](https://github.com/user-attachments/assets/8d34d82b-fb58-4f64-8a1c-73382ff984fa)

CMO's buttons; requests console:
![image](https://github.com/user-attachments/assets/2159df11-475f-46b4-ae95-499718b85322)

EVA Buttons:
![image](https://github.com/user-attachments/assets/5abe660e-5af5-4351-b43b-50e4ef317456)

Virology RC:
![image](https://github.com/user-attachments/assets/eccfb920-8254-4159-8474-9e3f360d2740)

Wooden Hatchets in the Ashie Bunker:
![image](https://github.com/user-attachments/assets/ca5048a3-7e94-4664-a19d-03316c805768)

DS-2 Drinks Machine:
![image](https://github.com/user-attachments/assets/a2679aef-1b24-44d0-aba3-4673a39eb6ce)

DS-2 Pipes:
![image](https://github.com/user-attachments/assets/4d56c3fa-e887-4721-b80d-2fd42a245668)

 
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Icedyne's fire alarms are now rotated the right way around.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
