### PR TITLE
Clamp GMM resource values to minimize arbitrage

### DIFF
--- a/code/controllers/subsystem/stock_market.dm
+++ b/code/controllers/subsystem/stock_market.dm
@@ -1,5 +1,5 @@
-#define MINIMUM_VALUE_MULT 0.5 // NOVA EDIT: used in price_minimum declarations, /tg/ default is 0.5
-#define MAXIMUM_VALUE_MULT 3 // NOVA EDIT: used in prixe_maximum declarations, /tg/ default is 3
+#define MINIMUM_VALUE_MULT 0.95 // NOVA EDIT: used in price_minimum declarations, /tg/ default is 0.5
+#define MAXIMUM_VALUE_MULT 1.05 // NOVA EDIT: used in prixe_maximum declarations, /tg/ default is 3
 
 SUBSYSTEM_DEF(stock_market)
 	name = "Stock Market"


### PR DESCRIPTION
## About The Pull Request

Really quick PR based on feedback from Discord (https://discord.com/channels/1171566433923239977/1172988592658841680/1265961618315935764).

This clamps the values that the GMM subsystem can set a material's price to a much, much narrower band. Previously, you could buy materials at a minimum value of 0.5x their base price and sell them for 3x their base price. I've changed this to have the minimum price be 95% and the maximum be 105% for a total of 10% ROI in the absolute best possible circumstances.

All this effectively does is slow down the arbitrage cycle. If you're increasing your investment by 5-10% every time you iterate an investment, your profit compounds quite significantly.

## How This Contributes To The Nova Sector Roleplay Experience

Follows up on https://github.com/NovaSector/NovaSector/pull/2498 to encourage people to use supplementary income streams instead of just the GMM.

## Proof of Testing

It's just number tweaking.

## Changelog

:cl: yooriss
balance: The GMM's prices are now much narrower, making arbitrage harder and initial purchases a little more expensive.
/:cl:
