### PR TITLE
Fixes prescription hud glasses

### DIFF
--- a/modular_nova/modules/huds/code/glasses/HUD_Glasses.dm
+++ b/modular_nova/modules/huds/code/glasses/HUD_Glasses.dm
@@ -20,7 +20,7 @@
 	icon = 'modular_nova/modules/huds/icons/huds.dmi'
 	icon_state = "glasses_securityhud"
 	worn_icon = 'modular_nova/modules/huds/icons/hudeyes.dmi'
-	clothing_traits = list(TRAIT_SEC_HUD, TRAIT_NEARSIGHTED_CORRECTED)
+	clothing_traits = list(TRAIT_SECURITY_HUD, TRAIT_NEARSIGHTED_CORRECTED)
 
 /obj/item/clothing/glasses/hud/science/prescription
 	name = "prescription science glasses"

--- a/modular_nova/modules/huds/code/glasses/HUD_Glasses.dm
+++ b/modular_nova/modules/huds/code/glasses/HUD_Glasses.dm
@@ -4,7 +4,7 @@
 	icon = 'modular_nova/modules/huds/icons/huds.dmi'
 	icon_state = "glasses_healthhud"
 	worn_icon = 'modular_nova/modules/huds/icons/hudeyes.dmi'
-	clothing_traits = list(TRAIT_NEARSIGHTED_CORRECTED)
+	clothing_traits = list(TRAIT_MEDICAL_HUD, TRAIT_NEARSIGHTED_CORRECTED)
 
 /obj/item/clothing/glasses/hud/diagnostic/prescription
 	name = "prescription diagnostic HUD"
@@ -12,7 +12,7 @@
 	icon = 'modular_nova/modules/huds/icons/huds.dmi'
 	icon_state = "glasses_diagnostichud"
 	worn_icon = 'modular_nova/modules/huds/icons/hudeyes.dmi'
-	clothing_traits = list(TRAIT_NEARSIGHTED_CORRECTED)
+	clothing_traits = list(TRAIT_DIAGNOSTIC_HUD, TRAIT_NEARSIGHTED_CORRECTED)
 
 /obj/item/clothing/glasses/hud/security/prescription
 	name = "prescription security HUD"
@@ -20,7 +20,7 @@
 	icon = 'modular_nova/modules/huds/icons/huds.dmi'
 	icon_state = "glasses_securityhud"
 	worn_icon = 'modular_nova/modules/huds/icons/hudeyes.dmi'
-	clothing_traits = list(TRAIT_NEARSIGHTED_CORRECTED)
+	clothing_traits = list(TRAIT_SEC_HUD, TRAIT_NEARSIGHTED_CORRECTED)
 
 /obj/item/clothing/glasses/hud/science/prescription
 	name = "prescription science glasses"
@@ -51,4 +51,4 @@
 /obj/item/clothing/glasses/meson/engine/tray/prescription
 	name = "prescription optical t-ray scanner"
 	desc = "Goggles used by engineers. The Meson Scanner mode lets you see basic structural and terrain layouts through walls, the T-ray Scanner mode lets you see underfloor objects such as cables and pipes, and the Radiation Scanner mode let's you see objects contaminated by radiation. This one has a lens that help correct eye sight."
-	clothing_traits = list(TRAIT_NEARSIGHTED_CORRECTED)
+	clothing_traits = list(TRAIT_MADNESS_IMMUNE, TRAIT_NEARSIGHTED_CORRECTED)

--- a/modular_nova/modules/modular_items/code/modular_glasses.dm
+++ b/modular_nova/modules/modular_items/code/modular_glasses.dm
@@ -211,7 +211,7 @@
 /obj/item/clothing/glasses/hud/ar/aviator/security/prescription
 	name = "prescription security HUD aviators"
 	desc = "A heads-up display that scans the humanoids in view and provides accurate data about their ID status and security records. This HUD has been fitted inside of a pair of sunglasses with toggleable electrochromatic tinting which. Has lenses that help correct eye sight."
-	clothing_traits = list(TRAIT_SEC_HUD, TRAIT_NEARSIGHTED_CORRECTED)
+	clothing_traits = list(TRAIT_SECURITY_HUD, TRAIT_NEARSIGHTED_CORRECTED)
 
 /obj/item/clothing/glasses/hud/ar/aviator/health/prescription
 	name = "prescription medical HUD aviators"

--- a/modular_nova/modules/modular_items/code/modular_glasses.dm
+++ b/modular_nova/modules/modular_items/code/modular_glasses.dm
@@ -211,12 +211,12 @@
 /obj/item/clothing/glasses/hud/ar/aviator/security/prescription
 	name = "prescription security HUD aviators"
 	desc = "A heads-up display that scans the humanoids in view and provides accurate data about their ID status and security records. This HUD has been fitted inside of a pair of sunglasses with toggleable electrochromatic tinting which. Has lenses that help correct eye sight."
-	clothing_traits = list(TRAIT_NEARSIGHTED_CORRECTED)
+	clothing_traits = list(TRAIT_SEC_HUD, TRAIT_NEARSIGHTED_CORRECTED)
 
 /obj/item/clothing/glasses/hud/ar/aviator/health/prescription
 	name = "prescription medical HUD aviators"
 	desc = "A heads-up display that scans the humanoids in view and provides accurate data about their health status. This HUD has been fitted inside of a pair of sunglasses which has lenses that help correct eye sight."
-	clothing_traits = list(TRAIT_NEARSIGHTED_CORRECTED)
+	clothing_traits = list(TRAIT_MEDICAL_HUD, TRAIT_NEARSIGHTED_CORRECTED)
 
 /obj/item/clothing/glasses/hud/ar/aviator/meson/prescription
 	name = "prescription meson HUD aviators"
@@ -226,7 +226,7 @@
 /obj/item/clothing/glasses/hud/ar/aviator/diagnostic/prescription
 	name = "prescription diagnostic HUD aviators"
 	desc = "A heads-up display capable of analyzing the integrity and status of robotics and exosuits. This HUD has been fitted inside of a pair of sunglasses which has lenses that help correct eye sight."
-	clothing_traits = list(TRAIT_NEARSIGHTED_CORRECTED)
+	clothing_traits = list(TRAIT_DIAGNOSTIC_HUD, TRAIT_NEARSIGHTED_CORRECTED)
 
 /obj/item/clothing/glasses/hud/ar/aviator/science/prescription
 	name = "prescription science aviators"


### PR DESCRIPTION

## About The Pull Request
fixes #3992
Huds were updated to use clothing traits, but prescription subtypes overwrite clothing traits to make them do prescription things.
(my bad)
## How This Contributes To The Nova Sector Roleplay Experience
i can't see without my glasses
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/e3fe2678-72bd-4e4e-a675-fb3adcaadd4f)
(I just tested on live by VVing some glasses)
</details>

## Changelog
:cl:
fix: prescription huds work
/:cl:
