### PR TITLE
[NO GBP] Fixes a stray extra item left by my donor PR and fixes the name of the feathered serenity dress in the loadout menu

### DIFF
--- a/modular_nova/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
+++ b/modular_nova/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
@@ -19,7 +19,7 @@
 	ckeywhitelist = list("thedragmeme")
 
 /datum/loadout_item/under/jumpsuit/paddedunder/alt
-	name = "Feathered Serenity Suit"
+	name = "Feathered Serenity Dress"
 	item_path = /obj/item/clothing/under/padded/alt
 	ckeywhitelist = list("snailomi")
 
@@ -32,12 +32,6 @@
 	name = "Feathered Serenity Cloak"
 	item_path = /obj/item/clothing/neck/padded/alt
 	ckeywhitelist = list("snailomi")
-
-/datum/loadout_item/neck/padded/alt
-	name = "Feathered Serenity Cloak"
-	item_path = /obj/item/clothing/neck/padded/alt
-	ckeywhitelist = list("thedragmeme")
-
 
 /datum/loadout_item/gloves/padded
 	name = "Serenity Gloves"


### PR DESCRIPTION
## About The Pull Request

In #3887 there was an unintentional duplicate /obj/item/clothing/neck/padded/alt in the loadout menu, oops

## How This Contributes To The Nova Sector Roleplay Experience

Things not being broken = good

## Proof of Testing

Game compiles and works good

## Changelog

:cl: Thedragmeme
fix: Fixes a duplicate item left by my donor PR and fixes a typo
/:cl:

