### PR TITLE
Fix: Hearthkin Armor now inherits from the forged armor

### DIFF
--- a/modular_nova/modules/icemoon_additions/code/icecat_recipes.dm
+++ b/modular_nova/modules/icemoon_additions/code/icecat_recipes.dm
@@ -64,20 +64,13 @@
 
 	result = /obj/item/anointing_oil
 
-/obj/item/clothing/suit/armor/handcrafted_hearthkin_armor
+/obj/item/clothing/suit/armor/forging_plate_armor/hearthkin
 	name = "handcrafted hearthkin armor"
 	desc = "An armor obviously crafted by the expertise of a hearthkin. It has leather shoulder pads and a chain mail underneath."
 	icon_state = "chained_leather_armor"
 	icon = 'modular_nova/modules/primitive_catgirls/icons/objects.dmi'
 	worn_icon = 'modular_nova/modules/primitive_catgirls/icons/clothing_greyscale.dmi'
-	resistance_flags = FIRE_PROOF
 	body_parts_covered = GROIN|CHEST
-	obj_flags_nova = ANVIL_REPAIR
-	armor_type = /datum/armor/armor_forging_plate_armor
-
-/obj/item/clothing/suit/armor/handcrafted_hearthkin_armor/Initialize(mapload)
-    . = ..()
-    allowed += /obj/item/forging/reagent_weapon
 
 /datum/crafting_recipe/handcrafted_hearthkin_armor
 	name = "Handcrafted Hearthkin Armor"
@@ -91,7 +84,7 @@
 		/obj/item/stack/sheet/leather = 2,
 	)
 
-	result = /obj/item/clothing/suit/armor/handcrafted_hearthkin_armor
+	result = /obj/item/clothing/suit/armor/forging_plate_armor/hearthkin
 
 // Hearthkin Exclusive Beds
 /obj/structure/bed/double/pelt


### PR DESCRIPTION

## About The Pull Request

I was convinced I made the hearthkin armor inherit from the forged armor. Turns out it didn't. Woops!

## How This Contributes To The Nova Sector Roleplay Experience

Now the hearthkin can finally upgrade or imbue their armor. 

## Proof of Testing
<details>

![Screenshot 2024-07-26 151132](https://github.com/user-attachments/assets/ea14deff-928f-4fb9-b69b-f8d32a126aec)

![Screenshot 2024-07-26 151120](https://github.com/user-attachments/assets/a71ebc1e-1d26-47af-8fa5-3b97389cf8ea)

![Screenshot 2024-07-26 151040](https://github.com/user-attachments/assets/66338786-eb1e-4744-9a43-2c0ce8d0cbab)

![Screenshot 2024-07-26 151012](https://github.com/user-attachments/assets/a81a26ce-91d0-43df-9db8-04ff86162b22)

![Screenshot 2024-07-26 150948](https://github.com/user-attachments/assets/f38c895c-3d27-4f7e-b938-abd9334676f8)

![Screenshot 2024-07-26 150836](https://github.com/user-attachments/assets/5ac9247a-6c49-4164-9aa2-b1d5089dd059)

</details>

## Changelog
:cl: MortoSasye
fix: The Hearthkin's armor now inherits from the forged variety.
/:cl:
