### PR TITLE
Fixes a glassblowing runtime

### DIFF
--- a/modular_nova/modules/primitive_production/code/glassblowing.dm
+++ b/modular_nova/modules/primitive_production/code/glassblowing.dm
@@ -76,7 +76,9 @@
 
 /obj/item/glassblowing/molten_glass/examine(mob/user)
 	. = ..()
-	. += get_examine_message(src)
+	var/message = get_examine_message(src)
+	if(message)
+		. += message
 
 /obj/item/glassblowing/molten_glass/pickup(mob/living/user)
 	if(!istype(user))
@@ -116,7 +118,9 @@
 	var/obj/item/glassblowing/molten_glass/glass = glass_ref.resolve()
 	if(!glass)
 		return
-	. += get_examine_message(glass)
+	var/message = get_examine_message(glass)
+	if(message)
+		. += message
 
 
 /**
@@ -132,6 +136,8 @@
 /obj/item/glassblowing/proc/get_examine_message(obj/item/glassblowing/molten_glass/glass)
 	if(COOLDOWN_FINISHED(glass, remaining_heat))
 		. += span_warning("The glass has cooled down and will require reheating to modify! ")
+	if(!length(glass.steps_remaining))
+		return
 	if(glass.steps_remaining[STEP_BLOW])
 		. += "The glass requires [glass.steps_remaining[STEP_BLOW]] more blowing actions! "
 	if(glass.steps_remaining[STEP_SPIN])


### PR DESCRIPTION
## About The Pull Request

Tin, saw this in the logs and it bugged me. It does not change anything functionally, but it is better to not have the logs being polluted by garbage.

## How This Contributes To The Nova Sector Roleplay Experience

Less runtime log pollution with useless runtimes.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/f5c171ee-1233-42d2-bbab-4d1f473ee09d)

</details>

## Changelog

Nothing really player-facing