### PR TITLE
Adds colonist modsuit skin to Entombed quirk

### DIFF
--- a/modular_nova/master_files/code/modules/entombed_quirk/code/entombed.dm
+++ b/modular_nova/master_files/code/modules/entombed_quirk/code/entombed.dm
@@ -107,7 +107,7 @@
 	for(var/obj/item/part as anything in modsuit.get_parts())
 		part.name = "[modsuit.theme.name] [initial(part.name)]"
 		part.desc = "[initial(part.desc)] [modsuit.theme.desc]"
-		if(modsuit.skin == "colonist")
+		if(modsuit.skin == "colonist") // That special case again. If more Nova modsuit skins ever get added, we may want to refactor this quirk to use the mod_theme's variants list instead of hardcoded strings.
 			part.icon = 'modular_nova/modules/kahraman_equipment/icons/modsuits/mod.dmi'
 			part.worn_icon = 'modular_nova/modules/kahraman_equipment/icons/modsuits/mod_worn.dmi'
 


### PR DESCRIPTION
## About The Pull Request

Continuation of https://github.com/NovaSector/NovaSector/pull/3377 which was closed by the original author.

## How This Contributes To The Nova Sector Roleplay Experience

More customization options yay

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_g4UOFQf4AT](https://github.com/user-attachments/assets/253ebf9e-4cb1-46cf-ad2f-c0317d5e1683)

</details>

## Changelog

:cl:
add: Colonist modsuit skin can now be selected for the Entombed quirk
/:cl:
