### PR TITLE
removes/replaces diagonal airlocks on Serenity station

### DIFF
--- a/_maps/map_files/SerenityStation/SerenityStation.dmm
+++ b/_maps/map_files/SerenityStation/SerenityStation.dmm
@@ -1885,12 +1885,9 @@
 /turf/open/floor/plating,
 /area/station/command/bridge)
 "aDl" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/area/station/cargo/lobby)
 "aDp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2216,7 +2213,7 @@
 	location = "hall18"
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "aHv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm/directional/west,
@@ -2961,7 +2958,7 @@
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "aRe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4840,6 +4837,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "btV" = (
@@ -5564,7 +5566,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "bCY" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/structure/sign/nanotrasen{
@@ -7577,7 +7579,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "cgK" = (
 /turf/open/openspace,
 /area/station/cargo/storage)
@@ -8299,7 +8301,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "csU" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck,
@@ -9173,7 +9175,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "cEX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/south,
@@ -9588,7 +9590,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "cKQ" = (
 /obj/structure/table/wood,
 /obj/item/storage/dice,
@@ -10894,11 +10896,10 @@
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms/room7)
 "dez" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/bush/flowers_pp,
+/turf/open/floor/grass,
+/area/station/cargo/lobby)
 "deE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -11072,7 +11073,7 @@
 /obj/machinery/light/directional/north,
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "dia" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/structure/closet/secure_closet/freezer/meat,
@@ -11254,7 +11255,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "dkj" = (
 /obj/machinery/light/floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11831,7 +11832,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "dsy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -13271,7 +13272,7 @@
 /obj/effect/landmark/start/paramedic,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "dOs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -14786,7 +14787,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "emW" = (
 /obj/machinery/power/smes/engineering,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -15315,7 +15316,7 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "ewR" = (
 /obj/structure/railing{
 	dir = 1
@@ -16812,7 +16813,7 @@
 /obj/structure/flora/bush/grassy,
 /obj/structure/flora/tree/jungle/style_2,
 /turf/open/floor/grass,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "eRx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19676,6 +19677,11 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "fHl" = (
@@ -20478,17 +20484,9 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "fTq" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/area/station/cargo/lobby)
 "fTL" = (
 /obj/structure/lattice,
 /turf/open/misc/dirt/forest,
@@ -20791,7 +20789,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "fYs" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/sofa/bench/left{
@@ -21219,8 +21217,8 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "gei" = (
@@ -21644,7 +21642,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "gkW" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -23378,7 +23376,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "gID" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access"
@@ -23992,6 +23990,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "gSr" = (
@@ -24974,7 +24973,7 @@
 	dir = 8
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/hallway/primary/central/fore)
+/area/station/maintenance/port/upper)
 "hhI" = (
 /obj/structure/chair/sofa/corp/right,
 /turf/open/floor/iron,
@@ -25188,7 +25187,7 @@
 	},
 /obj/machinery/medical_kiosk,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "hkF" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -25464,7 +25463,7 @@
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "hoC" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -26415,7 +26414,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "hBW" = (
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/plating,
@@ -27056,7 +27055,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "hKl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -27253,7 +27252,7 @@
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "hNG" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -27914,7 +27913,7 @@
 /area/station/maintenance/department/security/prison_upper)
 "hXP" = (
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "hYb" = (
 /obj/structure/chair/sofa/corp/left,
 /obj/item/radio/intercom/directional/north,
@@ -29363,7 +29362,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "iqK" = (
 /obj/structure/table/wood,
 /obj/item/food/baguette,
@@ -29751,6 +29750,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/vg_decals/department/cargo,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "iwe" = (
@@ -29823,7 +29825,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "ixi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -33037,14 +33039,10 @@
 /area/station/security/office)
 "juN" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "juP" = (
@@ -34582,7 +34580,7 @@
 "jRs" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "jRu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/structure/cable,
@@ -39856,11 +39854,6 @@
 /turf/open/misc/dirt/forest,
 /area/station/service/chapel/funeral)
 "lvM" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
 	},
@@ -40721,7 +40714,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "lHG" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -40825,7 +40818,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "lJh" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line,
@@ -42078,7 +42071,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "maO" = (
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/iron/dark/textured_large,
@@ -42812,7 +42805,6 @@
 /area/station/medical/medbay/central)
 "mlv" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "mlC" = (
@@ -43237,6 +43229,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/dorms/room8)
+"msf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/cargo/lobby)
 "msk" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -44283,12 +44281,11 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "mIj" = (
-/obj/structure/chair/sofa/bench/right{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "mIq" = (
@@ -44386,15 +44383,10 @@
 /turf/open/misc/asteroid/forest,
 /area/forestplanet/outdoors/nospawn)
 "mKh" = (
-/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/corner{
 	dir = 8
@@ -44476,7 +44468,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "mLB" = (
 /obj/machinery/vending/autodrobe/all_access,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -45779,11 +45771,6 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/crew_quarters/dorms)
 "ngv" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "ngX" = (
@@ -47069,7 +47056,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "nDf" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 1
@@ -47320,12 +47307,14 @@
 /turf/open/floor/wood/large,
 /area/station/maintenance/department/crew_quarters/dorms)
 "nIl" = (
-/obj/structure/chair/sofa/bench/left{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "nIm" = (
@@ -48780,7 +48769,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "oed" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -49370,7 +49359,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "olC" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/window/reinforced/fulltile,
@@ -49876,7 +49865,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "otR" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/door/airlock/bathroom{
@@ -50429,7 +50418,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "oDd" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -50480,8 +50469,12 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/camera/autoname/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "oDO" = (
@@ -50680,9 +50673,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "oHl" = (
@@ -51926,7 +51917,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "pbP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -53758,7 +53749,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "pEa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -54103,7 +54094,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "pIW" = (
 /obj/structure/reflector/box/anchored{
 	dir = 4
@@ -54277,7 +54268,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "pMS" = (
 /obj/structure/cable,
 /obj/structure/punching_bag,
@@ -54553,7 +54544,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "pRN" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/closet/crate/freezer,
@@ -54595,13 +54586,8 @@
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "pSi" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
@@ -57144,8 +57130,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "qEO" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -57712,7 +57699,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "qMH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
@@ -57902,16 +57889,16 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/station/tcommsat/server)
 "qPz" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/area/station/hallway/primary/central/fore)
 "qPG" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/railing{
@@ -58688,7 +58675,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "rbA" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
@@ -60873,7 +60860,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "rLZ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -61552,6 +61539,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "rWw" = (
@@ -62970,7 +62958,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "sqQ" = (
 /obj/machinery/photocopier,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -63123,7 +63111,7 @@
 	location = "hall16"
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "stk" = (
 /turf/closed/wall,
 /area/station/service/bar)
@@ -63141,13 +63129,8 @@
 /turf/open/floor/iron/dark/small,
 /area/station/hallway/secondary/exit/departure_lounge)
 "stt" = (
-/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -63268,7 +63251,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "svm" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
@@ -64829,11 +64812,14 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/structure/chair,
 /obj/item/radio/intercom/directional/west,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/assistant,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
 "sSD" = (
@@ -65471,7 +65457,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "tcA" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66436,11 +66422,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "trT" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner{
@@ -68796,7 +68777,7 @@
 	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "tVQ" = (
 /turf/open/floor/iron,
 /area/station/science/ordnance)
@@ -69463,7 +69444,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "ugY" = (
 /obj/structure/table,
 /obj/item/kirbyplants/fern{
@@ -69940,11 +69921,6 @@
 /turf/open/floor/iron/stairs/medium,
 /area/station/science/xenobiology)
 "upe" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -70167,7 +70143,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "usS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -72096,7 +72072,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "uUX" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
@@ -73200,14 +73176,14 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "vlo" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /obj/structure/railing/below_trees,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "vlr" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
@@ -73974,7 +73950,7 @@
 /obj/structure/flora/grass/jungle,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/grass,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "vxR" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -74449,7 +74425,7 @@
 /obj/machinery/light/directional/south,
 /obj/structure/sign/departments/chemistry/pharmacy/directional/south,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "vER" = (
 /obj/structure/flora/grass/jungle/a/style_3,
 /obj/effect/turf_decal/weather/dirt{
@@ -74735,11 +74711,15 @@
 /area/station/service/bar)
 "vIB" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/hangover,
 /obj/machinery/status_display/ai/directional/west,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "vIC" = (
@@ -75001,7 +74981,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "vMf" = (
 /obj/structure/toilet/greyscale,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
@@ -75085,7 +75065,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "vOd" = (
 /obj/structure/table/reinforced,
 /obj/item/surgery_tray/full,
@@ -75304,7 +75284,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "vSd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -77860,12 +77840,7 @@
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/science/robotics/lab)
 "wDb" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
@@ -78299,7 +78274,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -78319,7 +78293,7 @@
 /obj/structure/flora/bush/flowers_pp,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/grass,
-/area/station/hallway/primary/central/fore)
+/area/station/cargo/lobby)
 "wJj" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -78878,7 +78852,7 @@
 /obj/effect/turf_decal/tile/dark,
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "wSp" = (
 /obj/machinery/computer/security/labor{
 	dir = 8
@@ -80134,7 +80108,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "xmv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -81793,7 +81767,7 @@
 	pixel_y = -2
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/hallway/primary/central/aft)
 "xOg" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -83353,6 +83327,11 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "ylX" = (
@@ -175761,7 +175740,7 @@ lxS
 jxf
 iWA
 wFy
-fTq
+wFy
 nOx
 jtg
 qsV
@@ -176004,8 +175983,8 @@ kAG
 geh
 ivN
 pSi
-dez
-dez
+pSi
+pSi
 aHp
 cKM
 vSl
@@ -176018,7 +175997,7 @@ qMR
 dAO
 cRo
 jxf
-juN
+jxf
 fEo
 oQw
 aEe
@@ -176260,11 +176239,11 @@ wBn
 iOq
 aWz
 ngv
-mDY
-mDY
-mDY
+ngv
+ngv
+ngv
 oec
-dKx
+fTq
 eja
 tOo
 tOo
@@ -176275,11 +176254,11 @@ tOo
 gNd
 tOo
 tOo
-qPz
+tOo
 fGs
 wlq
 tKx
-tKx
+juN
 tKx
 drA
 tKx
@@ -176517,9 +176496,9 @@ wBn
 eSK
 lvM
 ste
-mDY
-mDY
-mDY
+ngv
+ngv
+ngv
 emU
 hoB
 rgn
@@ -176534,10 +176513,10 @@ qUU
 qUU
 qUU
 wIP
-aDl
+tOo
 mIj
 nIl
-aDl
+tOo
 tOo
 tOo
 tOo
@@ -176778,7 +176757,7 @@ qMC
 hKj
 cEW
 oec
-miF
+aDl
 vQW
 fdI
 dzq
@@ -177035,7 +177014,7 @@ pME
 vxN
 maL
 vNV
-miF
+aDl
 qUU
 qUU
 fFA
@@ -177285,14 +177264,14 @@ gMe
 vty
 rtk
 sSZ
-hFj
+qPz
 lHB
 cgI
 vxN
 wJb
 dsx
-qzT
-miF
+msf
+aDl
 jyR
 dqB
 jAJ
@@ -177544,7 +177523,7 @@ wPu
 lZl
 ylS
 vlo
-rDS
+dez
 eRv
 ePE
 tDA

--- a/_maps/map_files/SerenityStation/SerenityStation.dmm
+++ b/_maps/map_files/SerenityStation/SerenityStation.dmm
@@ -65118,7 +65118,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/disposal/bin,
-/obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},

--- a/_maps/map_files/SerenityStation/SerenityStation.dmm
+++ b/_maps/map_files/SerenityStation/SerenityStation.dmm
@@ -1194,6 +1194,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "ass" = (
@@ -2263,7 +2264,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "aHZ" = (
@@ -5130,6 +5133,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "bxG" = (
@@ -6599,6 +6603,7 @@
 	name = "medbay camera";
 	network = list("ss13","medbay")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "bSJ" = (
@@ -12688,15 +12693,13 @@
 /turf/open/floor/glass/reinforced,
 /area/station/science/lab)
 "dEu" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/station/cargo/sorting)
+/area/station/cargo/storage)
 "dET" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -13948,7 +13951,7 @@
 /turf/open/floor/wood,
 /area/station/service/theater)
 "dZJ" = (
-/obj/structure/cable,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "dZR" = (
@@ -15313,8 +15316,6 @@
 	dir = 6
 	},
 /obj/item/kirbyplants/random,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/central/aft)
 "ewR" = (
@@ -19748,6 +19749,8 @@
 	pixel_x = -4;
 	pixel_y = 8
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "fIi" = (
@@ -24219,17 +24222,13 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/central/greater)
 "gVu" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
-/area/station/cargo/sorting)
+/area/station/cargo/storage)
 "gVK" = (
 /obj/structure/chair/sofa/corp/left{
 	desc = "Looks like someone threw it out. Covered in donut crumbs.";
@@ -26296,19 +26295,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "hAc" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/cargo/sorting)
+/area/station/cargo/storage)
 "hAl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/hangover,
@@ -27207,6 +27201,7 @@
 "hMr" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/modular_computer/preset/cargochat/cargo,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "hMT" = (
@@ -29300,6 +29295,7 @@
 "ipL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "ipS" = (
@@ -30873,8 +30869,6 @@
 /area/station/security/checkpoint/escape)
 "iOq" = (
 /obj/machinery/computer/piratepad_control/civilian,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera/directional/north{
 	c_tag = "Supply - Cargo Lobby"
@@ -34111,6 +34105,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/gateway)
+"jKg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "jKp" = (
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
@@ -34316,6 +34322,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "jNa" = (
@@ -36341,15 +36348,7 @@
 	pixel_x = 31;
 	pixel_y = -5
 	},
-/obj/machinery/light/directional/east,
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/east{
-	pixel_y = 8
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/closed/wall,
 /area/station/cargo/storage)
 "krl" = (
 /obj/machinery/newscaster/directional/north,
@@ -36954,7 +36953,6 @@
 /area/station/medical/virology)
 "kAG" = (
 /obj/structure/chair,
-/obj/structure/cable,
 /obj/effect/landmark/start/cargo_technician,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
@@ -47605,6 +47603,7 @@
 	},
 /obj/effect/landmark/start/orderly,
 /obj/machinery/status_display/ai/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "nNj" = (
@@ -47850,8 +47849,12 @@
 /turf/open/floor/carpet,
 /area/station/maintenance/department/science/lower)
 "nQR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -49862,10 +49865,12 @@
 /turf/open/indestructible/hotelwood,
 /area/station/commons/dorms/room8)
 "otQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/hallway/primary/central/aft)
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "otR" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/door/airlock/bathroom{
@@ -50611,12 +50616,18 @@
 	},
 /area/station/medical/treatment_center)
 "oFR" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/cargo/sorting)
+/area/station/cargo/storage)
 "oGh" = (
 /obj/structure/flora/bush/large,
 /turf/open/floor/grass,
@@ -51600,14 +51611,14 @@
 /turf/open/floor/plating/forest,
 /area/station/science/ordnance/bomb)
 "oWv" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/cargo/sorting)
+/area/station/cargo/storage)
 "oWE" = (
 /obj/structure/flora/grass/jungle/b/style_4,
 /turf/open/floor/grass,
@@ -58194,7 +58205,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "qTv" = (
@@ -58707,6 +58717,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/paramedic,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "rbX" = (
@@ -65116,6 +65127,8 @@
 	network = list("ss13","prison")
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/light/directional/south,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "sXX" = (
@@ -71229,9 +71242,8 @@
 "uIi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "uIk" = (
@@ -72067,7 +72079,6 @@
 	dir = 5
 	},
 /obj/machinery/disposal/bin,
-/obj/structure/cable,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -73133,6 +73144,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "vks" = (
@@ -75897,8 +75909,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "wae" = (
-/obj/effect/turf_decal/bot_white,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "waf" = (
@@ -80556,9 +80577,10 @@
 /turf/open/floor/wood,
 /area/station/maintenance/department/security/prison_lower)
 "xtc" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "xti" = (
@@ -81741,6 +81763,7 @@
 	name = "Markus's bed"
 	},
 /mob/living/basic/pet/dog/markus,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "xNU" = (
@@ -173657,12 +173680,12 @@ mCK
 ehJ
 mCK
 xKi
-nQR
-wae
-oxQ
-xtc
+mCK
+ehJ
+bQW
+bQW
 qTq
-hAc
+oPT
 aHS
 gII
 xNO
@@ -173914,13 +173937,13 @@ mCK
 qqa
 jVF
 xKi
-bQW
+mCK
 ehJ
 hef
+oxQ
 eWP
 oWv
-hul
-hul
+otQ
 rpL
 hul
 wuA
@@ -174172,12 +174195,12 @@ bCQ
 bSY
 ihd
 uIi
-sNa
-sNa
+gVu
+xtc
 dEu
-ipL
-ipL
-ipL
+hAc
+wae
+jKg
 ipL
 moR
 moR
@@ -174430,10 +174453,10 @@ rSj
 bnc
 mVG
 krk
-gVu
+oPT
 oFR
-dZJ
-dZJ
+nQR
+oFb
 dZJ
 qDr
 exF
@@ -176527,7 +176550,7 @@ cVq
 trT
 csM
 pDY
-otQ
+jRs
 gvZ
 iLL
 hUs


### PR DESCRIPTION

## About The Pull Request
With the current framework we have - diagonally placed firelocks just don't look very good. 
Changes:
- Cargo lobby diagonal firelocks removed, areas updated to match the new layout additional firelocks placed in hallways, removed APC that isn't needed there anymore
- Cargo office diagonal firelocks replaced with a more box-y layout, moved fire alarms around to accommodate the new layout, areas adjusted.
- Medbay lobby diagonal firelocks removed, APC moved into the paramedic dispatch/medbay desk area, areas adjusted for the new layout, fire alarms moved around, moved around firelocks in hallways.

Additionally fixed this: 
![image](https://github.com/user-attachments/assets/3d4eeed3-3094-4ab1-8093-e1c679bf8b6e)
and moved the apc to accomodate for the new layout
## How This Contributes To The Nova Sector Roleplay Experience
With the current framework we have for firelocks - diagonally placed firelocks are an eyesore and just don't look very good, I provide an alternative here but the author of the map is welcome to make their own and I'll close this one.
## Proof of Testing
the map linters are linting
## Changelog
:cl: grungussuss
add: Removed/replaced instances of diagonally placed firelocks on serenity station
fix: added missing firelocks in serenity station "cafe" area
/:cl:
