### PR TITLE
Adds missing air alarms on Blueshift engineering

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -72714,8 +72714,8 @@
 /area/station/commons/storage/primary)
 "nZg" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/status_display/evac/directional/north,
 /obj/machinery/recharge_station,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "nZh" = (
@@ -98538,6 +98538,7 @@
 /area/station/security/checkpoint/escape)
 "sTh" = (
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/transit_tube)
 "sTk" = (


### PR DESCRIPTION

## About The Pull Request
Adds some missing air alarms on the engineering room with the shutters to the secure storage and transit tube.

Before

![StrongDMM_3gDKzzpuSO](https://github.com/user-attachments/assets/2bd640a9-b235-4c50-a7fa-846ba1a2e09a)

After

![StrongDMM_68VMRHRnvI](https://github.com/user-attachments/assets/944c7f20-84e8-4d35-b7ea-b192d4b6ad6d)


Transit tube

Before
![StrongDMM_VqxYAEu2oy](https://github.com/user-attachments/assets/78b873e0-b91e-4db9-8278-7f78b15ca077)

After
![StrongDMM_2qYYNed303](https://github.com/user-attachments/assets/82256a08-9df0-4af6-a2bc-ea49a3e32f92)


## How This Contributes To The Nova Sector Roleplay Experience
Fixes some mapping oversights

## Proof of Testing
Should be working fine
</details>

## Changelog
:cl: Hardly
fix: Adds missing air alarms in Blueshift's Engineering Room and Transit Tube
/:cl:
