### PR TITLE
Removes unusable sustenance machine from NT Rep's maintenance in Icebox

### DIFF
--- a/_maps/nova/automapper/templates/icebox/icebox_ntrep_office.dmm
+++ b/_maps/nova/automapper/templates/icebox/icebox_ntrep_office.dmm
@@ -390,11 +390,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
-"CN" = (
-/obj/machinery/vending/sustenance,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/central/greater)
 "DJ" = (
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
@@ -1206,7 +1201,7 @@ uy
 uy
 uy
 uK
-CN
+Jj
 Jj
 Jj
 uK


### PR DESCRIPTION

## About The Pull Request
There is a sustenance vending machine in NT Rep's maintenance that currently does nothing without a valid prisoner ID, this PR gets rid of it.

Before
![StrongDMM_XRKblP5hXr](https://github.com/user-attachments/assets/ce4107b5-f6c9-4a93-9da2-4740c6239921)

After
![StrongDMM_vcWckcTMUJ](https://github.com/user-attachments/assets/be50ba86-716e-4ca5-90f3-372794994490)


Fixes https://github.com/NovaSector/NovaSector/issues/4091

## How This Contributes To The Nova Sector Roleplay Experience
Removes what seems to be an oversight, considering that crew or prisoners can't really make use of that if you consider that it's several tiles away from the prison.

I opted against making an all-access version since it seems to be a bit too much work for an empty room for a map and would probably be better off done upstream.

## Proof of Testing
Works, it's a pretty simple change.
## Changelog
:cl: Hardly
fix: Removes unusable sustenance machine in NT Rep's maintenance in Icebox Station
/:cl:
