### PR TITLE
Exploit Patch + Forge changes

### DIFF
--- a/modular_nova/modules/reagent_forging/code/crafting_bench.dm
+++ b/modular_nova/modules/reagent_forging/code/crafting_bench.dm
@@ -12,6 +12,8 @@
 
 	anchored = TRUE
 	density = TRUE
+	///whether the crafting is being hammered
+	var/in_use = FALSE
 
 	/// What the currently picked recipe is
 	var/datum/crafting_bench_recipe/selected_recipe
@@ -108,6 +110,10 @@
 
 /obj/structure/reagent_crafting_bench/attack_hand(mob/living/user, list/modifiers)
 	. = ..()
+	if(in_use)
+		balloon_alert(user, "already in use")
+		return
+
 	update_appearance()
 
 	if(length(contents))
@@ -141,6 +147,10 @@
 	current_hits_to_completion = 0
 
 /obj/structure/reagent_crafting_bench/attackby(obj/item/attacking_item, mob/user, params)
+	if(in_use)
+		balloon_alert(user, "already in use")
+		return
+
 	if(istype(attacking_item, /obj/item/forging/complete))
 		if(length(contents))
 			balloon_alert(user, "already full")
@@ -154,6 +164,10 @@
 	return ..()
 
 /obj/structure/reagent_crafting_bench/wrench_act(mob/living/user, obj/item/tool)
+	if(in_use)
+		balloon_alert(user, "it's currently in use!")
+		return
+
 	user.balloon_alert_to_viewers("disassembling...")
 	if(!tool.use_tool(src, user, 2 SECONDS, volume = 100))
 		return
@@ -165,7 +179,10 @@
 	new /obj/item/stack/sheet/mineral/wood(drop_location(), 5)
 
 /obj/structure/reagent_crafting_bench/hammer_act(mob/living/user, obj/item/tool)
-	playsound(src, 'modular_nova/modules/reagent_forging/sound/forge.ogg', 50, TRUE)
+	if(in_use)
+		balloon_alert(user, "already in use")
+		return ITEM_INTERACT_SUCCESS
+
 	if(length(contents))
 		if(!istype(contents[1], /obj/item/forging/complete))
 			balloon_alert(user, "invalid item")
@@ -192,6 +209,8 @@
 			message_admins("[src] just tried to finish a weapon but somehow created nothing! This is not working as intended!")
 			return ITEM_INTERACT_SUCCESS
 
+		playsound(src, 'modular_nova/modules/reagent_forging/sound/forge.ogg', 50, TRUE)
+
 		balloon_alert_to_viewers("[thing_just_made] created")
 		update_appearance()
 		return ITEM_INTERACT_SUCCESS
@@ -204,30 +223,27 @@
 		balloon_alert(user, "missing ingredients")
 		return ITEM_INTERACT_SUCCESS
 
-	var/skill_modifier = user.mind.get_skill_modifier(selected_recipe.relevant_skill, SKILL_SPEED_MODIFIER) * 1 SECONDS
+	in_use = TRUE
+	while(current_hits_to_completion < selected_recipe.required_good_hits)
+		var/skill_modifier = user.mind.get_skill_modifier(selected_recipe.relevant_skill, SKILL_SPEED_MODIFIER) * 1 SECONDS
 
-	if(!COOLDOWN_FINISHED(src, hit_cooldown)) // If you hit it before the cooldown is done, you get a bad hit, setting you back three good hits
-		current_hits_to_completion -= BAD_HIT_PENALTY
-
-		if(current_hits_to_completion <= -(selected_recipe.required_good_hits))
-			balloon_alert_to_viewers("recipe failed")
-			clear_recipe()
+		if(!do_after(user, skill_modifier, src))
+			balloon_alert(user, "stopped hammering")
+			in_use = FALSE
 			return ITEM_INTERACT_SUCCESS
 
-		balloon_alert(user, "bad hit")
-		return ITEM_INTERACT_SUCCESS
+		if(!can_we_craft_this(selected_recipe.recipe_requirements))
+			balloon_alert(user, "missing ingredients")
+			in_use = FALSE
+			return ITEM_INTERACT_SUCCESS
 
-	COOLDOWN_START(src, hit_cooldown, skill_modifier)
+		playsound(src, 'modular_nova/modules/reagent_forging/sound/forge.ogg', 50, TRUE)
+		current_hits_to_completion++
+		user.mind.adjust_experience(selected_recipe.relevant_skill, selected_recipe.relevant_skill_reward / 15)
 
-	if((current_hits_to_completion >= selected_recipe.required_good_hits) && !length(contents))
-		var/list/things_to_use = can_we_craft_this(selected_recipe.recipe_requirements, TRUE)
-
-		create_thing_from_requirements(things_to_use, selected_recipe, user, selected_recipe.relevant_skill, selected_recipe.relevant_skill_reward)
-		return ITEM_INTERACT_SUCCESS
-
-	current_hits_to_completion++
-	balloon_alert(user, "good hit")
-	user.mind.adjust_experience(selected_recipe.relevant_skill, selected_recipe.relevant_skill_reward / 15) // Good hits towards the current item grants experience in that skill
+	in_use = FALSE
+	var/list/things_to_use = can_we_craft_this(selected_recipe.recipe_requirements, TRUE)
+	create_thing_from_requirements(things_to_use, selected_recipe, user, selected_recipe.relevant_skill, selected_recipe.relevant_skill_reward)
 	return ITEM_INTERACT_SUCCESS
 
 /// Takes the given list of item requirements and checks the surroundings for them, returns TRUE unless return_ingredients_list is set, in which case a list of all the items to use is returned

--- a/modular_nova/modules/reagent_forging/code/forge.dm
+++ b/modular_nova/modules/reagent_forging/code/forge.dm
@@ -837,6 +837,11 @@
 	// Here we check the item used on us (tongs) for an incomplete forge item of some kind to heat
 	var/obj/item/forging/incomplete/search_incomplete = locate(/obj/item/forging/incomplete) in forge_item.contents
 	if(search_incomplete)
+		if(!COOLDOWN_FINISHED(search_incomplete, heating_remainder))
+			fail_message(user, "metal doesn't need heating")
+			forge_item.in_use = FALSE
+			return ITEM_INTERACT_SUCCESS
+
 		balloon_alert_to_viewers("heating [search_incomplete]")
 
 		if(!do_after(user, skill_modifier * forge_item.toolspeed, target = src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I finally decided to fix an exploit that people were abusing to quickly get to legendary smith levels. But doing so, I discovered the reason why people were even resorting to this risk behavior was due to extreme frustration with the smiting system of clicking consistently at a rhythm the selected object, especially when one lives in areas with high ms such as Europe, Latin America, etc.

This pr swaps the hit system to an automatic one, similar to how repairing smith weapons/armor works, that scales on speed the more skilled you are in forging.

The time it takes for each item to forge wasn't touched up,  the already existing delay values were used.

Resolves: https://github.com/NovaSector/NovaSector/issues/4180

## How This Contributes To The Nova Sector Roleplay Experience

People won't be so desperate to avoid the hits system in smiting they'll resort to exploit use, reduces your chances of getting carpal tunnel drastically, and of slowly losing your mind after an hour smiting non-stop because your tribe people keep coming to you with requests to smith them a full set of equipment and- 

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
Novice level

https://github.com/user-attachments/assets/f04aa294-1483-4e46-bc9d-2e9fc7c3ce5c

https://github.com/user-attachments/assets/eb0f5440-bd1c-4105-95b9-287d2d8e21e3

Legendary smith level 

https://github.com/user-attachments/assets/7642178f-0c3f-45bf-8189-d3e21f5cb3f1

https://github.com/user-attachments/assets/e805895f-dae4-42b5-8f50-7943eb0dbd43

Exploit fixed 

![Screenshot 2024-08-02 223325](https://github.com/user-attachments/assets/7eb24154-0592-409a-a1cc-6a2a04212658)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: MortoSasye & Kaostico
qol: Swapped the hit-system for smiting with an automatic one, to avoid people going insane/getting carpal tunnel due to bad ping.
fix: Patched up an exploit re: to forging, where heating up an object repeatedly would quickly give you enough xp to reach legendary smith, in less than fifteen minutes in-game.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
