### PR TITLE
Returns xenohybrid resin heal

### DIFF
--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/xeno.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/xeno.dm
@@ -90,6 +90,7 @@
 	stored_plasma = 55
 	max_plasma = 55
 	plasma_rate = 2
+	heal_rate = 1.5
 	actions_types = list(
 		/datum/action/cooldown/alien/make_structure/plant_weeds/roundstart,
 		/datum/action/cooldown/alien/transfer,


### PR DESCRIPTION
## About The Pull Request

Heals a xenohybrid 0.3 of each dmg per tick when resting in weeds.
(1.5 * 0.2 = 0.3)
![image](https://github.com/user-attachments/assets/e42c732b-71b0-4eee-b965-6ccf8ac9780a)

## How This Contributes To The Nova Sector Roleplay Experience

They like the goop. :)
Its good when species have real advantages and disadvantages that are applicable frequently.
![image](https://github.com/user-attachments/assets/c2f62b80-c7c9-45e6-a709-53f3ee99c7a7)


## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
 Tell me if it needs this.
</details>

## Changelog
:cl:
balance: Xenohybrids inherit the initial heal factor of xenomorph resin weeds, instead of 0
/:cl:
