### PR TITLE
adds the autopsy scanner to the big deforest medical kit (dufflebag?)_

### DIFF
--- a/modular_nova/modules/deforest_medical_items/code/storage_items.dm
+++ b/modular_nova/modules/deforest_medical_items/code/storage_items.dm
@@ -334,6 +334,7 @@
 	. = ..()
 
 	can_hold = typecacheof(list(
+		/obj/item/autopsy_scanner,
 		/obj/item/blood_filter,
 		/obj/item/bonesetter,
 		/obj/item/cautery,


### PR DESCRIPTION


## About The Pull Request

What it says on the tin
## How This Contributes To The Nova Sector Roleplay Experience

Lets you carry more medical stuff, in the medical kit, idk
https://discord.com/channels/1171566433923239977/1269706234483834983/1269706234483834983
## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  its like, test-free capable because it's just a storage addition
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Let's the coroner store their autopsy scanner in the big-evil-medical-bag, if they have it for some reason.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
