### PR TITLE
Allows Ghost Roles To Avoid Being From Being Given Random Mutant Parts

### DIFF
--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -234,16 +234,6 @@
 	return FALSE
 
 /obj/effect/mob_spawn/ghost_role/human/ash_walker/special(mob/living/carbon/human/spawned_human)
-	// NOVA EDIT ADDITION BEGIN
-	/*
-	 * 2024/01/03 TODO:
-	 * MOVE THE MODULAR STUFF IN THIS PROC TO
-	 * /modular_nova/master_files/code/modules/mob_spawn/ghost_roles/mining_roles.dm
-	 * There's an ashwalker camp section ready for you to slot it into
-	 */
-	spawned_human.fully_replace_character_name(null, spawned_human.generate_random_mob_name(TRUE)) // NOVA EDIT MOVE - Moving before parent call prevents char name randomization
-	quirks_enabled = TRUE // ghost role quirks
-	// NOVA EDIT ADDITION END
 	. = ..()
 	spawned_human.fully_replace_character_name(null, spawned_human.generate_random_mob_name(TRUE))
 	to_chat(spawned_human, "<b>Drag the corpses of men and beasts to your nest. It will absorb them to create more of your kind. Invade the strange structure of the outsiders if you must. Do not cause unnecessary destruction, as littering the wastes with ugly wreckage is certain to not gain you favor. Glory to the Necropolis!</b>")

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -60,7 +60,8 @@
 		spawned_human.undershirt = "Nude"
 		spawned_human.socks = "Nude"
 		spawned_human.bra = "Nude" //NOVA EDIT ADDITION
-		randomize_human_normie(spawned_human)
+		if(random_appearance) //NOVA EDIT ADDITION
+			randomize_human_normie(spawned_human)
 		if(hairstyle)
 			spawned_human.set_hairstyle(hairstyle, update = FALSE)
 		if(facial_hairstyle)

--- a/modular_nova/master_files/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/modular_nova/master_files/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -29,6 +29,11 @@
 	restricted_species = list(/datum/species/lizard/ashwalker)
 	random_appearance = FALSE
 
+/obj/effect/mob_spawn/ghost_role/human/ash_walker/special(mob/living/carbon/human/spawned_human)
+	spawned_human.fully_replace_character_name(null, spawned_human.generate_random_mob_name(TRUE))
+	quirks_enabled = TRUE // ghost role quirks
+	. = ..()
+
 /// Listening Outpost
 
 /obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/comms/space

--- a/modular_nova/master_files/code/modules/mob_spawn/mob_spawn.dm
+++ b/modular_nova/master_files/code/modules/mob_spawn/mob_spawn.dm
@@ -1,9 +1,11 @@
+/obj/effect/mob_spawn
+	/// Do we use a random appearance for this role?
+	var/random_appearance = TRUE
+
 /obj/effect/mob_spawn/ghost_role
 	/// set this to make the spawner use the outfit.name instead of its name var for things like cryo announcements and ghost records
 	/// modifying the actual name during the game will cause issues with the GLOB.mob_spawners associative list
 	var/use_outfit_name
-	/// Do we use a random appearance for this ghost role?
-	var/random_appearance = TRUE
 	/// Can we use our loadout for this role?
 	var/loadout_enabled = FALSE
 	/// Can we use our quirks for this role?


### PR DESCRIPTION
## About The Pull Request
Making a small adjustment related to the randomizing of mob_spawn mobs introduced in https://github.com/NovaSector/NovaSector/pull/3490. This added a call to randomize_human_normie in the /special proc, which a few layers down was adding randomized mutant body parts if no option was previously selected for that mutant part. Also moved a nova edit block into the master_files to clear up a todo.

## How This Contributes To The Nova Sector Roleplay Experience

This has been a pain point for ashwalkers over the past couple weeks, who either have to set some horns/frills/spines or wear a helmet to cover up what random parts they are given. This would restore some character customization for ashwalkers as well as other ghost roles that may have been of effected.

I don't know if other ghost roles have also had troubles with this change would protect them from this issue to since several of them already have the random_appearance flag now being checked set to false. 

## Proof of Testing

- spawned in as an ashwalker with no frills, horns, or spines and verified random ones were not added to the character. Verified chosen mutant parts were still present.
- spawned as an ashwalker with frills, horns and spines and verified all were present as selected still.
- spawned as lizard person as another ghost role (interdyne scientist) and verified no random mutant body parts were added
- verified quirks were still added to egg spawned ashwalkers

<details>
<summary>Screenshots/Videos</summary>
<img width="157" alt="ashwalker_spawns_demo" src="https://github.com/user-attachments/assets/7d61a77c-a54d-4ca2-99f8-c338744d3575">
</details>

## Changelog

:cl:
fix: fixes ghost roles sometimes being given random mutant body parts if no selection for the part was made
/:cl:

