### PR TITLE
Snowglobe service guard kiosk windoor access fix

### DIFF
--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -40189,7 +40189,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
 "kMM" = (
-/obj/machinery/door/window/brigdoor,
+/obj/machinery/door/window/brigdoor{
+	req_access = list("security")
+	},
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark/side,
 /area/station/security/checkpoint/service)


### PR DESCRIPTION

## About The Pull Request
Adds security as required access to open the windoor to the service guard kiosk on Snowglobe.

## How This Contributes To The Nova Sector Roleplay Experience

stay out of my little guard room!!!!!!!!!!

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  😇
</details>

## Changelog
:cl:
fix: Snowglobe's service guard kiosk its windoor now requires security access to open
/:cl:
