### PR TITLE
[MODULAR] Fixes Service Guards not being able to use their batons in the Bar Lounge or the Delta Service Promenade.

### DIFF
--- a/modular_nova/modules/goofsec/code/department_guards.dm
+++ b/modular_nova/modules/goofsec/code/department_guards.dm
@@ -790,7 +790,7 @@
 	name = "service stun baton"
 	desc = "A stun baton that doesn't operate outside of the Service department, based off the station's blueprint layout. Can be used outside of Service up to three times before needing to return!"
 	icon_state = "service_baton"
-	valid_areas = list(/area/station/service, /area/station/maintenance/department/chapel, /area/station/maintenance/department/crew_quarters, /area/shuttle/escape)
+	valid_areas = list(/area/station/service, /area/station/hallway/primary/fore, /area/station/commons/lounge, /area/station/maintenance/department/chapel, /area/station/maintenance/department/crew_quarters, /area/shuttle/escape)
 
 /obj/item/melee/baton/security/loaded/departmental/prison
 	name = "prison stun baton"


### PR DESCRIPTION
## About The Pull Request

Fixes Service Guards not being able to use their batons in the Bar Lounge or the Delta Service Promenade.

## How This Contributes To The Nova Sector Roleplay Experience

For some reason, the actual front of bar area got repathed to /commons instead of /service, and as a result Bouncers/Service Guards couldn't do their jobs there. This fixes that. This also enables them to hit the Fore Primary Hallway due to the Delta service promenade; ideally this should get typepathed to its own area so it's not just borrowing a stock hallway so that this can be fixed further.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl:
fix: Fixes Service Guards not being able to use their batons in the Bar Lounge or the Delta Service Promenade.
/:cl: