### PR TITLE
Adds the Shock Collar to EE AR PE remove item list.

### DIFF
--- a/modular_nova/modules/modular_items/lewd_items/code/clothing_pref_check.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/clothing_pref_check.dm
@@ -8,6 +8,7 @@ GLOBAL_LIST_INIT(pref_checked_clothes, list(
 	/obj/item/clothing/glasses/hypno,
 	/obj/item/clothing/neck/kink_collar,
 	/obj/item/clothing/neck/mind_collar,
+	/obj/item/electropack/shockcollar,
 	/obj/item/clothing/glasses/blindfold/kinky,
 	/obj/item/clothing/ears/kinky_headphones,
 	/obj/item/clothing/suit/straight_jacket/kinky_sleepbag,


### PR DESCRIPTION

## About The Pull Request
the title
## How This Contributes To The Nova Sector Roleplay Experience
a prefbreak waiting to happen
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/a29caa5b-cf7d-4589-8057-d7e150903708)
![image](https://github.com/user-attachments/assets/249839ab-cfd8-46af-a920-3d0b2a7446ef)
![image](https://github.com/user-attachments/assets/938e98db-1f7f-4fc9-be82-5a5a3d471799)

</details>

## Changelog
:cl:
fix: Shock Collar is now properly recognized as a lewd item, and thus can be removed using the Remove verb.
/:cl:
