### PR TITLE
Xenohybrids can do some xenomorph emotes

### DIFF
--- a/modular_nova/modules/emotes/code/emotes.dm
+++ b/modular_nova/modules/emotes/code/emotes.dm
@@ -190,13 +190,18 @@
 	sound = 'modular_nova/modules/emotes/sound/emotes/meow.ogg'
 
 /datum/emote/living/hiss
-	key = "hiss1"
+	key = "hiss"
 	key_third_person = "hisses"
 	message = "hisses!"
 	emote_type = EMOTE_AUDIBLE
 	mob_type_allowed_typecache = list(/mob/living/carbon, /mob/living/silicon/pai)
 	vary = TRUE
-	sound = 'modular_nova/modules/emotes/sound/emotes/hiss.ogg'
+
+/datum/emote/living/hiss/get_sound(mob/living/user)
+	if(isxenohybrid(user))
+		return SFX_HISS
+	else
+		return 'modular_nova/modules/emotes/sound/emotes/hiss.ogg'
 
 /datum/emote/living/chitter
 	key = "chitter"
@@ -232,6 +237,10 @@
 
 /datum/emote/living/gasp/get_sound(mob/living/user)
 	if(iscarbon(user))
+		if(isxenohybrid(user))
+			return pick('sound/voice/lowHiss2.ogg',
+						'sound/voice/lowHiss3.ogg',
+						'sound/voice/lowHiss4.ogg')
 		if(user.gender == MALE)
 			return pick('modular_nova/modules/emotes/sound/emotes/male/gasp_m1.ogg',
 						'modular_nova/modules/emotes/sound/emotes/male/gasp_m2.ogg',


### PR DESCRIPTION
## About The Pull Request

Changes the hiss1 emote key to use hiss instead.
Lets xenohybrids use the xenomorph hiss, and changes their gasp to the xenomorph breathing sound effect.

## How This Contributes To The Nova Sector Roleplay Experience

Just a final touch sort-a thing for the xenohybrid species.

## Proof of Testing

https://github.com/user-attachments/assets/609965a3-cb1b-4754-8001-887a020f63c6

(idk why i spawned a human instead of a lizard)


## Changelog

:cl:
add: Changes the hiss1 emote to hiss and lets xenohybrids xenohiss
add: Xenohybrids now have a different gasp sound
/:cl:

