### PR TITLE
Buyable personalized bitrunner avatar disks (Feat. Evil Evil Hacks)

### DIFF
--- a/code/modules/bitrunning/server/obj_generation.dm
+++ b/code/modules/bitrunning/server/obj_generation.dm
@@ -141,7 +141,7 @@
 		to_chat(neo, span_warning("This domain forbids the use of [english_list(import_ban)], your disk [english_list(disk_ban)] will not be granted!"))
 
 	var/failed = FALSE
-	//NOVA EDIT ADDITION BEGIN - BITRUNNING_PREFS_DISKS - (Optional Reason/comment)
+	//NOVA EDIT ADDITION BEGIN - BITRUNNING_PREFS_DISKS - Track if we've used multiple avatar preference disks, for avoiding overrides and displaying the failure message.
 	var/duplicate_prefs = FALSE
 	//NOVA EDIT ADDITION END
 
@@ -173,7 +173,7 @@
 				continue
 
 			avatar.put_in_hands(new item_disk.granted_item())
-		//NOVA EDIT ADDITION BEGIN - BITRUNNING_PREFS_DISKS - (Optional Reason/comment)
+		//NOVA EDIT ADDITION BEGIN - BITRUNNING_PREFS_DISKS - Handles our avatar preference disks, if present.
 		if(istype(disk, /obj/item/bitrunning_disk/preferences))
 			var/obj/item/bitrunning_disk/preferences/prefs_disk = disk
 			var/datum/preferences/avatar_preference = prefs_disk.chosen_preference

--- a/code/modules/bitrunning/server/obj_generation.dm
+++ b/code/modules/bitrunning/server/obj_generation.dm
@@ -141,6 +141,9 @@
 		to_chat(neo, span_warning("This domain forbids the use of [english_list(import_ban)], your disk [english_list(disk_ban)] will not be granted!"))
 
 	var/failed = FALSE
+	//NOVA EDIT ADDITION BEGIN - BITRUNNING_PREFS_DISKS - (Optional Reason/comment)
+	var/duplicate_prefs = FALSE
+	//NOVA EDIT ADDITION END
 
 	// We don't need to bother going over the disks if neither of the types can be used.
 	if(domain_forbids_spells && domain_forbids_items)
@@ -170,6 +173,23 @@
 				continue
 
 			avatar.put_in_hands(new item_disk.granted_item())
+		//NOVA EDIT ADDITION BEGIN - BITRUNNING_PREFS_DISKS - (Optional Reason/comment)
+		if(istype(disk, /obj/item/bitrunning_disk/preferences))
+			var/obj/item/bitrunning_disk/preferences/prefs_disk = disk
+			var/datum/preferences/avatar_preference = prefs_disk.chosen_preference
+
+			if(isnull(avatar_preference) || duplicate_prefs)
+				failed = TRUE
+				continue
+
+			if(!domain_forbids_spells)
+				avatar_preference.safe_transfer_prefs_to(avatar)
+				SSquirks.AssignQuirks(avatar, prefs_disk.mock_client)
+			if(!domain_forbids_items && prefs_disk.include_loadout)
+				avatar.equip_outfit_and_loadout(/datum/outfit, avatar_preference)
+
+			duplicate_prefs = TRUE
+		//NOVA EDIT ADDITION END
 
 	if(failed)
 		to_chat(neo, span_warning("One of your disks failed to load. Check for duplicate or inactive disks."))

--- a/modular_nova/modules/bitrunning_prefs_disks/code/disks/prefs_disk.dm
+++ b/modular_nova/modules/bitrunning_prefs_disks/code/disks/prefs_disk.dm
@@ -1,0 +1,109 @@
+/**
+ * Bitrunning tech disks which let you load a custom character preference for your bit avatar.
+ * This uses a preference selected from your character list.
+ * Optionally, this may include the loadout as well.
+ *
+ * For the sake of domain restrictions:
+ * - ability blocks block the application of character prefs.
+ * - item blocks block the application of character loadout.
+ */
+/obj/item/bitrunning_disk/preferences
+	name = "bitrunning program: personalized avatar"
+	desc = "A disk containing source code. It can be used to override your bit avatar's standard appearance. Further avatar disks will be ignored."
+
+	/// Our chosen preference.
+	var/datum/preferences/chosen_preference
+	/// Whether we include the loadout as well.
+	var/include_loadout = FALSE
+	/// Mock client we use for forwarding to quirk assignment (beware, evil hacks).
+	var/datum/prefs_disk_client_interface/mock_client
+
+/obj/item/bitrunning_disk/preferences/Initialize(mapload)
+	. = ..()
+	register_context()
+
+/obj/item/bitrunning_disk/preferences/examine(mob/user)
+	. = ..()
+	if(isnull(chosen_preference))
+		return
+
+	. += span_info("Loadout application is currently [include_loadout ? "enabled" : "disabled"].")
+	. += span_notice("Ctrl-click to toggle loadout application.")
+
+/obj/item/bitrunning_disk/preferences/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	var/result = NONE
+	if(isnull(chosen_preference) && (held_item == src))
+		context[SCREENTIP_CONTEXT_LMB] = "Select avatar"
+		result = CONTEXTUAL_SCREENTIP_SET
+	if(!isturf(src.loc))
+		context[SCREENTIP_CONTEXT_CTRL_LMB] = "Toggle loadout"
+		result = CONTEXTUAL_SCREENTIP_SET
+
+	return result
+
+/obj/item/bitrunning_disk/preferences/Destroy()
+	QDEL_NULL(chosen_preference)
+	QDEL_NULL(mock_client)
+	return ..()
+
+/obj/item/bitrunning_disk/preferences/attack_self(mob/user, modifiers)
+	. = ..()
+
+	if(chosen_preference)
+		return
+
+	var/list/character_profiles = user.client.prefs?.create_character_profiles()
+	if(isnull(character_profiles) || !length(character_profiles))
+		return
+
+	var/choice = tgui_input_list(user, message = "Select a character",  title = "Bitrunning Avatar", items = character_profiles)
+	if(isnull(choice) || !user.is_holding(src))
+		return
+
+	choice_made = choice
+	chosen_preference = new(user.client)
+	chosen_preference.load_character(character_profiles.Find(choice))
+
+	// Perform our evil hacks
+	if(mock_client)
+		qdel(mock_client)
+	mock_client = new
+	mock_client.prefs = chosen_preference
+
+	balloon_alert(user, "avatar set!")
+
+/obj/item/bitrunning_disk/preferences/item_ctrl_click(mob/user)
+	if(isturf(src.loc)) // If on a turf, we skip to dragging
+		return NONE
+	if(isnull(chosen_preference))
+		balloon_alert(user, "set preference first!")
+		return CLICK_ACTION_BLOCKING
+	include_loadout = !include_loadout
+	balloon_alert(user, include_loadout ? "loadout enabled!" : "loadout disabled!")
+	return CLICK_ACTION_SUCCESS
+
+/**
+ * Allows for ordering of the prefs disk.
+ */
+/datum/orderable_item/bitrunning_tech/prefs_disk
+	cost_per_order = 1000
+	item_path = /obj/item/bitrunning_disk/preferences
+	desc = "This disk contains a program that lets you load in custom bit avatars."
+
+/**
+ * Evil hack that allows us to assign quirks without needing to forward a real client.
+ * Using this instead of the normal mock client allows us to include only what we need without editing the base,
+ * or interfering with things like `mock_client_uid`.
+ *
+ * Much the same, this should match the interface of /client wherever necessary.
+ */
+/datum/prefs_disk_client_interface
+	/// Player preferences datum for the client
+	var/datum/preferences/prefs
+
+	/// The mob the client controls
+	var/mob/mob
+
+/// We don't actually care about award status, but we don't want it to runtime due to not existing.
+/datum/prefs_disk_client_interface/proc/get_award_status(achievement_type, mob/user, value = 1)
+	return 0

--- a/modular_nova/modules/bitrunning_prefs_disks/code/disks/prefs_disk.dm
+++ b/modular_nova/modules/bitrunning_prefs_disks/code/disks/prefs_disk.dm
@@ -71,6 +71,7 @@
 	mock_client.prefs = chosen_preference
 
 	balloon_alert(user, "avatar set!")
+	playsound(user, 'sound/items/click.ogg', 50, TRUE)
 
 /obj/item/bitrunning_disk/preferences/item_ctrl_click(mob/user)
 	if(isturf(src.loc)) // If on a turf, we skip to dragging
@@ -80,6 +81,11 @@
 		return CLICK_ACTION_BLOCKING
 	include_loadout = !include_loadout
 	balloon_alert(user, include_loadout ? "loadout enabled!" : "loadout disabled!")
+
+	// High frequency range when enabled, low when disabled. More tactile.
+	var/toggle_frequency = include_loadout ? rand(45000, 55000) : rand(32000, 42000)
+	playsound(user, 'sound/items/click.ogg', 50, TRUE, frequency = toggle_frequency)
+
 	return CLICK_ACTION_SUCCESS
 
 /**

--- a/modular_nova/modules/bitrunning_prefs_disks/readme.md
+++ b/modular_nova/modules/bitrunning_prefs_disks/readme.md
@@ -1,0 +1,46 @@
+<!-- This should be copy-pasted into the root of your module folder as readme.md -->
+
+https://github.com/NovaSector/NovaSector/pull/<!--PR Number-->
+
+## Bitrunning Avatar Preference Disks <!--Title of your addition.-->
+
+Module ID: BITRUNNING_PREFS_DISKS <!-- Uppercase, UNDERSCORE_CONNECTED name of your module, that you use to mark files. This is so people can case-sensitive search for your edits, if any. -->
+
+### Description:
+
+Allows bitrunners to buy a personalized avatar disk, which lets them load in a given character preference, with all that entails.
+This includes even quirks through evil hacks, and optionally loadouts.
+The evil hacks this performs are using a barebones mock client to allow for quirk assignment without forwarding or affecting the real client.
+
+<!-- Here, try to describe what your PR does, what features it provides and any other directly useful information. -->
+
+### TG Proc/File Changes:
+
+- `code/modules/bitrunning/server/obj_generation.dm`: `proc/stock_gear`
+<!-- If you edited any core procs, you should list them here. You should specify the files and procs you changed.
+E.g: 
+- `code/modules/mob/living.dm`: `proc/overriden_proc`, `var/overriden_var`
+-->
+
+### Modular Overrides:
+
+- N/A
+<!-- If you added a new modular override (file or code-wise) for your module, you should list it here. Code files should specify what procs they changed, in case of multiple modules using the same file.
+E.g: 
+- `modular_nova/master_files/sound/my_cool_sound.ogg`
+- `modular_nova/master_files/code/my_modular_override.dm`: `proc/overriden_proc`, `var/overriden_var`
+-->
+
+### Defines:
+
+- N/A
+<!-- If you needed to add any defines, mention the files you added those defines in, along with the name of the defines. -->
+
+### Included files that are not contained in this module:
+
+- N/A
+<!-- Likewise, be it a non-modular file or a modular one that's not contained within the folder belonging to this specific module, it should be mentioned here. Good examples are icons or sounds that are used between multiple modules, or other such edge-cases. -->
+
+### Credits: 00-Steven, loosely based on Bubberstation.
+
+<!-- Here go the credits to you, dear coder, and in case of collaborative work or ports, credits to the original source of the code. -->

--- a/modular_nova/modules/bitrunning_prefs_disks/readme.md
+++ b/modular_nova/modules/bitrunning_prefs_disks/readme.md
@@ -10,6 +10,7 @@ Module ID: BITRUNNING_PREFS_DISKS <!-- Uppercase, UNDERSCORE_CONNECTED name of y
 
 Allows bitrunners to buy a personalized avatar disk, which lets them load in a given character preference, with all that entails.
 This includes even quirks through evil hacks, and optionally loadouts.
+Preference application and quirks are blocked if a domain blocks spells/abilities, loadouts are blocked if a domain blocks items.
 The evil hacks this performs are using a barebones mock client to allow for quirk assignment without forwarding or affecting the real client.
 
 <!-- Here, try to describe what your PR does, what features it provides and any other directly useful information. -->

--- a/modular_nova/modules/bitrunning_prefs_disks/readme.md
+++ b/modular_nova/modules/bitrunning_prefs_disks/readme.md
@@ -1,6 +1,6 @@
 <!-- This should be copy-pasted into the root of your module folder as readme.md -->
 
-https://github.com/NovaSector/NovaSector/pull/<!--PR Number-->
+https://github.com/NovaSector/NovaSector/pull/4221<!--PR Number-->
 
 ## Bitrunning Avatar Preference Disks <!--Title of your addition.-->
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7039,6 +7039,7 @@
 #include "modular_nova\modules\bitrunning\code\virtual_domains\ancient_milsim\outfit.dm"
 #include "modular_nova\modules\bitrunning\code\virtual_domains\ancient_milsim\turf.dm"
 #include "modular_nova\modules\bitrunning\code\virtual_domains\ancient_milsim\virtual_domain.dm"
+#include "modular_nova\modules\bitrunning_prefs_disks\code\disks\prefs_disk.dm"
 #include "modular_nova\modules\blastwave_outfits\code\cargo_packs.dm"
 #include "modular_nova\modules\blastwave_outfits\code\clothing\blastwave_head.dm"
 #include "modular_nova\modules\blastwave_outfits\code\clothing\blastwave_mask.dm"


### PR DESCRIPTION

## About The Pull Request

So a while back a few friends talked about wanting to be able to select a custom bit avatar, rather than always having a randomly generated one.
We talked a bit about this, possible ways to implement it, and another friend mentioned Bubberstation already had such and what it did.
This is essentially implemented from scratch, but I can't say it isn't based on it to some degree- loadouts being toggleable on ctrl-click, for one.

### What's it actually _do_

It simply just adds a disk you can buy like other bitrunning disks which allows you to select a character from your list of actual characters, and apply the prefs of those when you enter your virtual domain while holding the disk. One preference per disk, set forever, parallel to the other bitrunning disks.
This includes species, tails, augments, etc etc, somesuch, hell even quirks work! (...more on that later...)
Optionally, you can also toggle loadout application, respecting the character slot's loadout prefs.

There's screentips and examine hints for these applications, and the same duplicate/inactive disk warnings apply to them.

### Costs, alternative options

I'm on the fence about this being roundstart for bitrunners due to the sheer amount of cheese options quirks/augments/loadouts could allow, but then again even the mainline TG disks note balance is not a primary concern.
So it's currently bought for 1000 points at the bitrunner ordering machine, so it's _at least_ around the cost of a T1 disk.

But I could imagine allowing bitrunners one to start with, because the roleplay potential could offset balance concerns, and it only lets you select one preference per disk anyway.

### ✨EVIL EVIL HACKS✨

So! The implementation for allow quirks here is done via ✨EVIL EVIL HACKS✨.
Specifically, `SSquirks.AssignQuirks(...)` requires forwarding a _client_ as one of its parameters, and forwards these all the way to each individual quirk, which then takes the preferences from the client for configuration's sake.
Theoretically we could include a preferences parameter with a massive pile of core edits, or attempt to do this on mainline TG without real backing for it, but even then it's still lightly awkward due to especially the Paraplegic quirk calling a proc on the client and runtiming if it's not there.

Sooooooooooooo that's where the ✨EVIL EVIL HACKS✨come in!
We don't _want_ to forward our proper client, cause it'd get the wrong prefs, and we _especially_ don't want to have to affect the client and its loaded prefs such that it fetches the right prefs.

So, instead, we use mock clients. Or more so, mock mock clients.
The standard mock clients for unit testing have their own assumptions and effects we don't quite want, so we create our own mock client that has only and exactly only what we care about to avoid runtimes while still applying properly configured quirks.

This works! We can roll around in a wheelchair or play EVERY domain with echolocation.
And there's no need to edit every quirk file that gets preferences! Or mess with the real client!
It's still, however, ✨EVIL EVIL HACKS✨. The alternatives just, still, seem somehow less appealing.
## How This Contributes To The Nova Sector Roleplay Experience

I think it's cool to be able to select a customized avatar! Already just on its own, but _especially_ when you're running with others, broadcasting, or encountering anomalies.
Quirks also allow for challenge runs if you really feel like it.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

No disks, random bit avatar
![image](https://github.com/user-attachments/assets/3e982079-211b-4c31-a7f4-ecffef7dbefd)


Avatar disk (no loadout) + fireball disk, synth bit avatar, paraplegic/nearsighted/limb mounts
![image](https://github.com/user-attachments/assets/4242d787-8abb-4c20-9b48-683dd0f3adcf)


Avatar disk (no loadout) + armor vest disk, human avatar, assorted quirks, tail, augmented left arm
![image](https://github.com/user-attachments/assets/023e0b05-ae13-4cf0-9d03-c1f6e85047b8)


Avatar disk (yes loadout) + armor vest disk, human avatar, case loadout
![image](https://github.com/user-attachments/assets/6ad0957e-acde-4689-a36d-7312c5a43049)


Avatar disk (yes loadout) + armor vest disk, human avatar, job overriding loadout
![image](https://github.com/user-attachments/assets/d61f6633-b5d0-4e8d-9c3b-d394518657c2)



</details>

## Changelog
:cl:
add: Bitrunners are now able to buy personalized avatar disks, allowing them to apply a given character slot's preferences, including quirks and optionally loadouts.
/:cl:
