### PR TITLE
(Early Mirror) Fix inventory item interactions sometimes being blocked due to not counting as adjacent when not on a turf

### DIFF
--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -68,6 +68,8 @@
 /atom/movable/Adjacent(atom/neighbor, atom/target, atom/movable/mover)
 	if(neighbor == loc)
 		return TRUE
+	if(neighbor?.loc == src)
+		return TRUE
 	var/turf/T = loc
 	if(!istype(T))
 		return FALSE
@@ -78,6 +80,8 @@
 // This is necessary for storage items not on your person.
 /obj/item/Adjacent(atom/neighbor, atom/target, atom/movable/mover, recurse = 1)
 	if(neighbor == loc)
+		return TRUE
+	if(neighbor?.loc == src)
 		return TRUE
 	if(isitem(loc))
 		if(recurse > 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
 
Makes an Early mirror of : https://github.com/tgstation/tgstation/pull/85478

00-Steven explanation is as follows:

```
So it seems that currently can_perform_action(target, ...) being called for an inventory item while you're inside of another object, say a closet or a pAI card, blocks with the message "You are too far away!".
Looking into this, it seemed to be due to CanReach(target) failing, which seemed to be due to Adjacent(target) not actually recognizing these as being adjacent when not on a turf.
This seemed to be because it only really passes when either on a turf or if the object we're checking adjacency with is the loc of the object we're checking adjacency from.

After talking about it in the code channel, we decided to go for adding a simple inverse check to make it symmetric.
Being, we add a second neighbor?.loc == src check parallel to our existing neighbor == loc check.
This seems to fix the issue.
```


## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

It lets you use your pda while hiding in a locker, or lets PAI's use their pda while in pocket form, which is quite important for us given how those aid to our communications. Plus, it makes sense, if there is one thing you should be able to use in a locker is a pda.

00-Steven explanation:

```
Kinda weird if being in a closet means somehow your inventory is no longer adjacent to you for interactions, saying you're too far away.
Especially for pAIs, whom are always in this situation when not in holoform (pAI in card, PDA in pAI).
```

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  Test before the change on the live server:
    
![image](https://github.com/user-attachments/assets/acbadc42-94d2-4d4e-8669-4a182778fa98)

Test on local, on the same closet, with the changes:

![image](https://github.com/user-attachments/assets/50e19541-42db-4e7c-a40a-e01205d46636)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes getting a "You are too far away!" interaction block on inventory items when inside of another object. This includes accessing storage or using your PDA from a closet, or as pAI using your digital messenger while inside of your card.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
