### PR TITLE
Change Shibari Rope size to Small

### DIFF
--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_items/shibari.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_items/shibari.dm
@@ -6,6 +6,7 @@
 /obj/item/stack/shibari_rope
 	name = "shibari ropes"
 	desc = "Coil of bondage ropes."
+	full_w_class = WEIGHT_CLASS_SMALL
 	icon = 'modular_nova/modules/modular_items/lewd_items/icons/obj/lewd_items/lewd_items.dmi'
 	icon_state = "shibari_rope"
 	amount = 1
@@ -39,6 +40,7 @@
 /obj/item/stack/shibari_rope/glow
 	name = "glowy shibari ropes"
 	singular_name = "glowy rope"
+	full_w_class = WEIGHT_CLASS_SMALL
 	merge_type = /obj/item/stack/shibari_rope/glow
 	icon_state = "shibari_rope_glow"
 	light_system = OVERLAY_LIGHT


### PR DESCRIPTION

## About The Pull Request
This Pull Request I have bestowed upon All Of Us changes the size of Shibari Rope Stacks To S M A L L .
## How This Contributes To The Nova Sector Roleplay Experience
It can now fit in boxes. The shibari rope can fit in box. Box can have shibari rope in it. Shibari Rope is now easier to carry.
Rope is Shibari, Shibari in box, Rope is in box. The Shibari Rope is in Box. Box can Fit The Shibari Rope, which is a Rope.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/a9b861c7-860a-4973-b662-8a873f213378)
![image](https://github.com/user-attachments/assets/ebc9e1df-5959-4116-aef7-8f0f9e316f1a)

</details>

## Changelog
:cl:
qol: Shibari Rope stacks now fit in boxes.
/:cl:
