### PR TITLE
Expands the ckey whitelist of the feathered serenity cloak to SomeNetwork

### DIFF
--- a/modular_nova/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
+++ b/modular_nova/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
@@ -26,7 +26,7 @@
 /datum/loadout_item/neck/padded
 	name = "Feathered Serenity Cloak"
 	item_path = /obj/item/clothing/neck/padded
-	ckeywhitelist = list("thedragmeme")
+	ckeywhitelist = list("thedragmeme", "SomeNetwork")
 
 /datum/loadout_item/neck/padded/alt
 	name = "Feathered Serenity Cloak"


### PR DESCRIPTION
## About The Pull Request

The tin. My coding prowess is amazing I assure you. The feathered serenity cloak is my item and SomeNetwork has permission to have it as well.

## How This Contributes To The Nova Sector Roleplay Experience

People having cool shit with the items owners permission is neat

## Proof of Testing

I sure did add the one name in the one line of code good. 

## Changelog

:cl:
qol: Expands the ckey whitelist of the feathered serenity cloak
/:cl:
