### PR TITLE
SC-1 and SC-2 are `normal` w_class

### DIFF
--- a/modular_nova/modules/modular_weapons/code/overrides/energy.dm
+++ b/modular_nova/modules/modular_weapons/code/overrides/energy.dm
@@ -11,6 +11,3 @@
 	name = "\improper Allstar SC-2 energy carbine"
 	desc = "A basic hybrid energy carbine with two settings: disable and kill."
 	w_class = WEIGHT_CLASS_NORMAL
-
-/obj/item/gun/energy/xray
-	w_class = WEIGHT_CLASS_BULKY


### PR DESCRIPTION
## About The Pull Request

Revival of https://github.com/NovaSector/NovaSector/pull/450.

## How This Contributes To The Nova Sector Roleplay Experience

Puts these guns on the map, and honestly deserve another buff like cell capacity.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
 Maybe if I actually tweak them significantly.
</details>

## Changelog
:cl:
balance: Allstar SC-1, Allstar SC-2, Adv E-gun, Laser carbine, Laser musket, Retro laser, Laser shotgun are now `normal` weight-class.
/:cl:
