### PR TITLE
Adds polling to Obsessed and promotes its frequency weight rank

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -860,10 +860,10 @@
 			|| candidate.stat == DEAD \
 			|| !(ROLE_OBSESSED in candidate.client?.prefs?.be_special) \
 			|| !candidate.mind.assigned_role \
-			//NOVA EDIT ADDITION
+			//NOVA EDIT ADDITION START
 			|| (candidate in rejected_traitor) \
 			|| (candidate in current_polling) \
-			//NOVA EDIT END
+			//NOVA EDIT ADDITION END
 		)
 			candidates -= candidate
 

--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -274,7 +274,7 @@
 		//NOVA EDIT ADDITION
 		else if(player in rejected_traitor)
 			candidates -= player
-		else if(player in sleeper_current_polling)
+		else if(player in current_polling)
 			candidates -= player
 		//NOVA EDIT END
 
@@ -860,11 +860,15 @@
 			|| candidate.stat == DEAD \
 			|| !(ROLE_OBSESSED in candidate.client?.prefs?.be_special) \
 			|| !candidate.mind.assigned_role \
+			//NOVA EDIT ADDITION
+			|| (candidate in rejected_traitor) \
+			|| (candidate in current_polling) \
+			//NOVA EDIT END
 		)
 			candidates -= candidate
 
 /datum/dynamic_ruleset/midround/from_living/obsessed/execute()
-	var/mob/living/carbon/human/obsessed = pick_n_take(candidates)
+	var/mob/living/carbon/human/obsessed = pick_n_take(poll_candidates_for_one(candidates)) // NOVA EDIT CHANGE - ORIGINAL: var/mob/living/carbon/human/obsessed = pick_n_take(candidates)
 	obsessed.gain_trauma(/datum/brain_trauma/special/obsessed)
 	message_admins("[ADMIN_LOOKUPFLW(obsessed)] has been made Obsessed by the midround ruleset.")
 	log_game("[key_name(obsessed)] was made Obsessed by the midround ruleset.")

--- a/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
+++ b/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
@@ -8,10 +8,8 @@
  */
 /datum/dynamic_ruleset/midround/from_living/proc/poll_candidates_for_one(candidates)
 	message_admins("Attempting to poll [length(candidates)] people individually to become [name].")
-	var/list/potential_candidates = candidates
 	var/list/yes_candidate = list()
-	for(var/mob/living/candidate in potential_candidates)
-		potential_candidates -= candidate
+	for(var/mob/living/candidate in candidates)
 		current_polling += candidate
 		yes_candidate += SSpolling.poll_candidates(
 		question = "Do you want to play as [name]? If you ignore this, you will be considered to have declined and will be inelegible for all future rolls this round.",

--- a/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
+++ b/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
@@ -1,42 +1,42 @@
-/datum/dynamic_ruleset/midround/from_living/autotraitor
-	var/static/list/sleeper_current_polling = list()
+/datum/dynamic_ruleset/midround/from_living
+	var/static/list/current_polling = list()
 	var/static/list/rejected_traitor = list()
 /**
  * Polls a group of candidates to see if they want to be a sleeper agent.
  *
  * @param candidates a list containing a candidate mobs
  */
-/datum/dynamic_ruleset/midround/from_living/autotraitor/proc/poll_candidates_for_one(candidates)
-	message_admins("Attempting to poll [length(candidates)] people individually to become a Sleeper Agent...first one to say yes gets chosen.")
-	var/list/potential_candidates = shuffle(candidates)
+/datum/dynamic_ruleset/midround/from_living/proc/poll_candidates_for_one(candidates)
+	message_admins("Attempting to poll [length(candidates)] people individually to become [name].")
+	var/list/potential_candidates = candidates
 	var/list/yes_candidate = list()
 	for(var/mob/living/candidate in potential_candidates)
 		potential_candidates -= candidate
-		sleeper_current_polling += candidate
+		current_polling += candidate
 		yes_candidate += SSpolling.poll_candidates(
-		question = "Do you want to be a syndicate sleeper agent? If you ignore this, you will be considered to have declined and will be inelegible for all future rolls this round.",
+		question = "Do you want to play as [name]? If you ignore this, you will be considered to have declined and will be inelegible for all future rolls this round.",
 		group = list(candidate),
 		poll_time = 15 SECONDS,
 		flash_window = TRUE,
 		start_signed_up = FALSE,
 		announce_chosen = FALSE,
-		role_name_text = "Sleeper Agent",
+		role_name_text = "[name]",
 		alert_pic = /obj/structure/sign/poster/contraband/gorlex_recruitment,
 		custom_response_messages = list(
-			POLL_RESPONSE_SIGNUP = "You have signed up to be a traitor!",
-			POLL_RESPONSE_ALREADY_SIGNED = "You are already signed up to be a traitor.",
-			POLL_RESPONSE_NOT_SIGNED = "You aren't signed up to be a traitor.",
-			POLL_RESPONSE_TOO_LATE_TO_UNREGISTER = "It's too late to decide against being a traitor.",
-			POLL_RESPONSE_UNREGISTERED = "You decide against being a traitor.",
+			POLL_RESPONSE_SIGNUP = "You have signed up to be an antagonist!",
+			POLL_RESPONSE_ALREADY_SIGNED = "You are already signed up to be an antagonist.",
+			POLL_RESPONSE_NOT_SIGNED = "You aren't signed up to be an antagonist.",
+			POLL_RESPONSE_TOO_LATE_TO_UNREGISTER = "It's too late to decide against being antagonist.",
+			POLL_RESPONSE_UNREGISTERED = "You decide against being an antagonist.",
 		),
 		chat_text_border_icon = /obj/structure/sign/poster/contraband/gorlex_recruitment,
 	)
 		if(length(yes_candidate))
-			sleeper_current_polling -= candidate
+			current_polling -= candidate
 			break
 		else
-			message_admins("Candidate [candidate] has declined to be a sleeper agent.")
+			message_admins("Candidate [candidate] has declined to be [name].")
 			rejected_traitor += candidate
-			sleeper_current_polling -= candidate
+			current_polling -= candidate
 
 	return yes_candidate

--- a/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
+++ b/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
@@ -8,10 +8,10 @@
  */
 /datum/dynamic_ruleset/midround/from_living/proc/poll_candidates_for_one(candidates)
 	message_admins("Attempting to poll [length(candidates)] people individually to become [name].")
-	var/list/yes_candidate = list()
+	var/list/yes_candidates = list()
 	for(var/mob/living/candidate in candidates)
 		current_polling += candidate
-		yes_candidate += SSpolling.poll_candidates(
+		yes_candidates += SSpolling.poll_candidates(
 		question = "Do you want to play as [name]? If you ignore this, you will be considered to have declined and will be inelegible for all future rolls this round.",
 		group = list(candidate),
 		poll_time = 15 SECONDS,
@@ -29,7 +29,7 @@
 		),
 		chat_text_border_icon = /obj/structure/sign/poster/contraband/gorlex_recruitment,
 	)
-		if(length(yes_candidate))
+		if(length(yes_candidates))
 			current_polling -= candidate
 			break
 		else
@@ -37,4 +37,4 @@
 			rejected_traitor += candidate
 			current_polling -= candidate
 
-	return yes_candidate
+	return yes_candidates

--- a/modular_nova/modules/ices_events/code/ICES_event_config.dm
+++ b/modular_nova/modules/ices_events/code/ICES_event_config.dm
@@ -196,7 +196,7 @@
  */
 /datum/round_event_control/obsessed
 	max_occurrences = 1
-	weight = VERY_LOW_EVENT_FREQ
+	weight = LOW_EVENT_FREQ
 
 /**
  * Medical


### PR DESCRIPTION
## About The Pull Request

Elevates the subtype level of the polling proc so other midrounds can make use of it, like obsessed.
Changes obsessed's frequency weight flag from very low to low.

## How This Contributes To The Nova Sector Roleplay Experience

This antag rules, actually. They don't get any syndie shitter gear, the antag just roleplays it out with what they have gotten from the job they signed up with. People already seem to enjoy roleplaying their character being in an altered mental state or brainwashed when they become evil for a round, obsessed supports that idea well!
I've seen some really _really_ creative stuff from obsessed antags, its just unfortunate for it to roll so infrequently.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  

https://github.com/user-attachments/assets/db5b7901-534a-493d-959a-930e48312de5


</details>

## Changelog
:cl:
qol: Obsessed traitor now polls for willing candidates like Sleeper
code: Obsessed traitor rolls slightly more frequently
/:cl: