### PR TITLE
Colonial clothing/pouches/ration in the loadout

### DIFF
--- a/modular_nova/modules/food_replicator/code/storage.dm
+++ b/modular_nova/modules/food_replicator/code/storage.dm
@@ -30,6 +30,6 @@
 /obj/item/storage/pouch/cin_medkit/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
-	atom_storage.max_total_storage = 4
+	atom_storage.max_total_storage = 8
 	atom_storage.max_slots = 4
 	atom_storage.cant_hold = typecacheof(list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/stack/sheet))

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_heads.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_heads.dm
@@ -121,6 +121,10 @@
 	name = "Mothic Softcap"
 	item_path = /obj/item/clothing/head/mothcap
 
+/datum/loadout_item/head/colonialcap
+	name = "Colonial Cap"
+	item_path = /obj/item/clothing/head/hats/colonial
+
 /datum/loadout_item/head/frontiercap
 	name = "Frontier Cap"
 	item_path = /obj/item/clothing/head/soft/frontier_colonist

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_neck.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_neck.dm
@@ -287,6 +287,10 @@
 	name = "Maid Neck Cover"
 	item_path = /obj/item/clothing/neck/maid
 
+/datum/loadout_item/neck/colonial_cloak
+	name = "Colonial Cloak"
+	item_path = /obj/item/clothing/neck/cloak/colonial
+
 /datum/loadout_item/neck/imperial_police_cloak
 	name = "Imperial Police Cloak"
 	item_path = /obj/item/clothing/neck/cloak/colonial/nri_police

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_pocket.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_pocket.dm
@@ -211,6 +211,10 @@
 	name = "Mothic Rations Pack"
 	item_path = /obj/item/storage/box/mothic_rations
 
+/datum/loadout_item/pocket_items/colonial_mre
+	name = "Foreign Colonization Ration"
+	item_path = /obj/item/storage/box/colonial_rations
+
 /datum/loadout_item/pocket_items/cloth_ten
 	name = "Ten Cloth Sheets"
 	item_path = /obj/item/stack/sheet/cloth/ten
@@ -222,6 +226,14 @@
 /datum/loadout_item/pocket_items/medkit
 	name = "First-Aid Kit"
 	item_path = /obj/item/storage/medkit/regular
+
+/datum/loadout_item/pocket_items/medipen_pouch
+	name = "Empty Colonial Medipen Pouch"
+	item_path = /obj/item/storage/pouch/cin_medipens
+
+/datum/loadout_item/pocket_items/medkit_pouch
+	name = "Empty Colonial First Aid Pouch"
+	item_path = /obj/item/storage/pouch/cin_medkit
 
 /datum/loadout_item/pocket_items/deforest_cheesekit
 	name = "Civil Defense Medical Kit"

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_shoes.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_shoes.dm
@@ -44,6 +44,10 @@
 	name = "Recolorable Jackboots"
 	item_path = /obj/item/clothing/shoes/jackboots/recolorable
 
+/datum/loadout_item/shoes/colonial_boots
+	name = "Colonial Half-Boots"
+	item_path = /obj/item/clothing/shoes/jackboots/colonial
+
 /datum/loadout_item/shoes/jackboots/frontier
 	name = "Heavy Frontier Boots"
 	item_path = /obj/item/clothing/shoes/jackboots/frontier_colonist

--- a/modular_nova/modules/loadouts/loadout_items/under/loadout_datum_under.dm
+++ b/modular_nova/modules/loadouts/loadout_items/under/loadout_datum_under.dm
@@ -157,6 +157,10 @@
 	item_path = /obj/item/clothing/under/rank/security/peacekeeper
 	restricted_roles = list(JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_HEAD_OF_SECURITY)
 
+/datum/loadout_item/under/jumpsuit/colonial_uniform
+	name = "Colonial Uniform"
+	item_path = /obj/item/clothing/under/colonial
+
 /datum/loadout_item/under/jumpsuit/imperial_police_uniform
 	name = "Imperial Police Uniform"
 	item_path = /obj/item/clothing/under/colonial/nri_police


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the entirety of colonial apparel (cap-cloak-jumpsuit-boots) to the loadout, as well as the colonial ration and the [empty] medipen and first-aid pouches.
Worth mentioning that this PR also fixes the colonial first-aid pouch's storage capacity, *as I did intend it to have four small, not tiny, slots but screwed up and felt like this wasn't -that- important until now*.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Lets people LARP as Dick Mullens and wear cool cloaks that are otherwise locked behind an expensive biomass-hungry machine Cargo-and-people-in-general tend to rarely buy otherwise.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  In a moment.
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Stalkeros
add: Added the entirety of colonial apparel, as well as colonial rations and pouches to the loadout
fix: Colonial pouch now can hold four small items, instead of four tiny items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
