### PR TITLE
Fix clothing that shows anthro ears hiding belt items

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -111,15 +111,15 @@ DEFINE_BITFIELD(no_equip_flags, list(
 
 //NOVA EDIT ADDITION: CUSTOM EAR TOGGLE FOR ANTHRO/ETC EAR SHOWING -
 /// Manually set this on items you want anthro ears to show on!
-#define SHOWSPRITEEARS (1<<14)
+#define SHOWSPRITEEARS (1<<15)
 /// Does this sprite hide the tail?
-#define HIDETAIL (1<<15)
+#define HIDETAIL (1<<16)
 /// Does this sprite also hide the spine on tails? Realistically only useful for the clothes that have a special tail overlay, like MODsuits
-#define HIDESPINE (1<<16)
+#define HIDESPINE (1<<17)
 /// Does this sprite hide devious devices?
-#define HIDESEXTOY (1<<17)
+#define HIDESEXTOY (1<<18)
 /// If this has our taur variant, do we hide our taur part?
-#define HIDETAUR (1<<18)
+#define HIDETAUR (1<<19)
 //NOVA EDIT ADDITION END
 
 //bitflags for clothing coverage - also used for limbs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Basically, a recent upstream mirror added the `HIDEBELT` bitflag, but this caused it to overlap with our `SHOWSPRITEEARS` bitflag:
https://github.com/NovaSector/NovaSector/blob/fe19d1745fecd3196e60731f4cc9b068e2675d92/code/__DEFINES/inventory.dm#L109-L114

Because these are defines, we should be able to just increment the assigned bitflags for `SHOWSPRITEEARS` and all of the following defines in that cluster.

We do so, and this fixes it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Fixes belts inexplicably not showing on certain hats.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
  
![image](https://github.com/user-attachments/assets/8a7df681-fa46-459a-a72d-ce00f3ffd06e)

  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Clothing that shows anthro ears no longer also hides belt items. This would usually be hats.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
