### PR TITLE
Primal Instincts brain trauma can no longer be randomly rolled

### DIFF
--- a/modular_nova/master_files/code/datums/brain_damage/special.dm
+++ b/modular_nova/master_files/code/datums/brain_damage/special.dm
@@ -1,0 +1,2 @@
+/datum/brain_trauma/special/primal_instincts
+	random_gain = FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6477,6 +6477,7 @@
 #include "modular_nova\master_files\code\datums\ai_laws\laws_ghost_role.dm"
 #include "modular_nova\master_files\code\datums\bodypart_overlays\bodypart_overlay.dm"
 #include "modular_nova\master_files\code\datums\bodypart_overlays\mutant_bodypart_overlay.dm"
+#include "modular_nova\master_files\code\datums\brain_damage\special.dm"
 #include "modular_nova\master_files\code\datums\components\crafting.dm"
 #include "modular_nova\master_files\code\datums\components\damage_tracker.dm"
 #include "modular_nova\master_files\code\datums\components\fullauto.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
tin. `random_gain` on the primal instincts brain trauma is now false
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Well, Primal Instincts is a brain trauma that takes control away from you and gives it to an angry monkey AI datum. This is funny as shit, but it's not really for our server because it literally makes you punch/shove people on sight with the only way to fix it being surgery. I feel like even if this could be fixed with simple use of chems, it'd still be *way* too much. So I'm opting to make it not random-gainable.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
Very small change that would be probably difficult to test since brain traumas are RNG

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: (Nova) You can no longer randomly roll the Primal Instincts brain trauma
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
