### PR TITLE
Fix NIF persistence

### DIFF
--- a/modular_nova/modules/modular_persistence/code/modular_persistence.dm
+++ b/modular_nova/modules/modular_persistence/code/modular_persistence.dm
@@ -15,7 +15,7 @@ GLOBAL_LIST_INIT(modular_persistence_ignored_vars, list(
 	"tag",
 	"type",
 	"parent_type",
-	"owner",
+	"owner_brain",
 	"vars",
 	"stored_character_slot_index",
 ))
@@ -67,6 +67,9 @@ GLOBAL_LIST_INIT(modular_persistence_ignored_vars, list(
 		return
 
 	for(var/var_name in vars)
+		if(var_name in GLOB.modular_persistence_ignored_vars)
+			continue
+
 		var/var_entry = persistence_data[var_name]
 
 		if(var_entry)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Soooooo a recent pr changed `/datum/modular_persistence` to use a weakref to the brain:
https://github.com/NovaSector/NovaSector/blob/fe19d1745fecd3196e60731f4cc9b068e2675d92/modular_nova/modules/modular_persistence/code/modular_persistence.dm#L47-L50
However! This pr also renamed this variable from `owner` to `owner_brain`, without updating the `modular_persistence_ignored_vars` list (see line 18):
https://github.com/NovaSector/NovaSector/blob/fe19d1745fecd3196e60731f4cc9b068e2675d92/modular_nova/modules/modular_persistence/code/modular_persistence.dm#L1-L21

This meant it was trying to save `owner_brain`, leading to jsons like this:
```json
{"2":{"harddel_deets_dumped":0,"nif_soulcatcher_rooms":"","owner_brain":"/datum/weakref"}}
```

Because we only check `modular_persistence_ignored_vars` on SAVING but not LOADING, this would set `owner_brain` to `"/datum/weakref"` on every load beyond the first, and thus block saving from that point on.

So we simply change `owner` to `owner_brain` in `modular_persistence_ignored_vars`, and then making loading ignore any explicitly not desired saved values.
This fixes it, and removes the faulty data from the json upon next saving.

Making it ignore any vars in `modular_persistence_ignored_vars` on loading avoids needing to manually fix the data now or the next time this happens.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Fixes #4182.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

Loading from a broken json with `owner_brain`:
```json
{"2":{"harddel_deets_dumped":0,"nif_soulcatcher_rooms":"","owner_brain":"/datum/weakref"}}
```
![image](https://github.com/user-attachments/assets/80d6ccc7-e1f7-45cb-8d92-696f83997231)


Installing a new NIF:
![image](https://github.com/user-attachments/assets/a6856046-11e4-4cb4-9375-d2c92bafe6be)
![image](https://github.com/user-attachments/assets/02986574-276c-41ae-bff8-dfdfa7e38357)

Updated json file after calibration/round end:
```json
{"2":{"harddel_deets_dumped":0,"nif_examine_text":"There's a certain spark to their eyes.","nif_path":"/obj/item/organ/internal/cyberimp/brain/nif/standard","nif_durability":100,"nif_theme":"default","nif_is_calibrated":1,"stored_rewards_points":0,"persistent_nifsofts":"","nif_soulcatcher_rooms":""}}
```

Loading in the next round, NIF saved:
![image](https://github.com/user-attachments/assets/f4658cb4-4022-48da-ab4c-00654eddd115)

Updated json file after adding a soulcatcher and round ending:
```json
{"2":{"harddel_deets_dumped":0,"nif_examine_text":"There's a certain spark to their eyes.","nif_path":"/obj/item/organ/internal/cyberimp/brain/nif/standard","nif_durability":100,"nif_theme":"default","nif_is_calibrated":1,"stored_rewards_points":75,"persistent_nifsofts":"&/datum/nifsoft/soulcatcher","soul_poem_nifsoft_name":"Chrysanthemum Gardener","soul_poem_nifsoft_message":"Hello, I am Chrysanthemum Gardener, it's nice to meet you!","nif_soulcatcher_rooms":"Gay+Room=A+rainbow+platform+suspended+in+space+orbited+by+reflective+cubes+of+various+sizes.+There+really+isn%26%2339%3bt+much+here+at+the+moment."}}
```

Loading in the next round, NIF saved:
![image](https://github.com/user-attachments/assets/6fd4dbfe-5517-4189-bc2c-25631dab3b4a)
Soulcatcher saved:
![image](https://github.com/user-attachments/assets/3336f27b-c93a-470e-b487-f72eaf7b972f)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: (Nova) Fixed NIF persistence.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
