### PR TITLE
Fix elevation component jank (fix bed elevation jank, gut old code)

### DIFF
--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_helpers/misc.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_helpers/misc.dm
@@ -22,35 +22,6 @@
 /datum/looping_sound/lewd/vibrator/high
 	volume = 100
 
-/*
-*	Dancing pole code.
-*/
-
-/atom
-	var/pseudo_z_axis
-
-/atom/proc/get_fake_z()
-	return pseudo_z_axis
-
-/obj/structure/table
-	pseudo_z_axis = 8
-
-/turf/open/get_fake_z()
-	var/objschecked
-	for(var/obj/structure/structurestocheck in contents)
-		objschecked++
-		if(structurestocheck.pseudo_z_axis)
-			return structurestocheck.pseudo_z_axis
-		if(objschecked >= 25)
-			break
-	return pseudo_z_axis
-
-/mob/living/Move(atom/newloc, direct)
-	. = ..()
-	if(.)
-		pseudo_z_axis = newloc.get_fake_z()
-		pixel_z = pseudo_z_axis
-
 /// Used to add a cum decal to the floor while transferring viruses and DNA to it
 /mob/living/proc/add_cum_splatter_floor(turf/the_turf, female = FALSE)
 	if(!the_turf)

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_structures/dancing_pole.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_structures/dancing_pole.dm
@@ -109,7 +109,6 @@
 	dance_animate(user)
 	pole_in_use = FALSE
 	user.pixel_y = 0
-	//user.pixel_z = pseudo_z_axis //incase we are off it when we jump on!
 	dancer = null
 
 /// The proc used to make the user 'dance' on the pole. Basically just consists of pixel shifting them around a bunch and sleeping. Could probably be improved a lot.

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_structures/dancing_pole.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_structures/dancing_pole.dm
@@ -8,7 +8,6 @@
 	anchored = TRUE
 	max_integrity = 75
 	layer = BELOW_MOB_LAYER
-	pseudo_z_axis = 9 //stepping onto the pole makes you raise upwards!
 	density = 0 //easy to step up on
 	light_system = COMPLEX_LIGHT
 	light_range = 3
@@ -81,6 +80,7 @@
 	if(!length(pole_designs))
 		populate_pole_designs()
 
+	AddElement(/datum/element/elevation, pixel_shift = 9)
 
 /obj/structure/stripper_pole/update_icon_state()
 	. = ..()
@@ -109,7 +109,7 @@
 	dance_animate(user)
 	pole_in_use = FALSE
 	user.pixel_y = 0
-	user.pixel_z = pseudo_z_axis //incase we are off it when we jump on!
+	//user.pixel_z = pseudo_z_axis //incase we are off it when we jump on!
 	dancer = null
 
 /// The proc used to make the user 'dance' on the pole. Basically just consists of pixel shifting them around a bunch and sleeping. Could probably be improved a lot.
@@ -149,7 +149,6 @@
 		dancer.SetStun(0)
 		dancer.pixel_y = 0
 		dancer.pixel_x = 0
-		dancer.pixel_z = pseudo_z_axis
 		dancer.layer = layer
 		dancer.forceMove(get_turf(src))
 		dancer = null

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_structures/pillow.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_structures/pillow.dm
@@ -162,6 +162,7 @@
 	icon = 'modular_nova/modules/modular_items/lewd_items/icons/obj/lewd_structures/pillows.dmi'
 	icon_state = "pillow_pink_round"
 	base_icon_state = "pillow"
+	elevation = 0
 	var/current_color = "pink"
 	var/current_form = "round"
 
@@ -202,13 +203,13 @@
 	. = ..()
 	density = TRUE
 	//Push them up from the normal lying position
-	affected_mob.pixel_y = affected_mob.base_pixel_y + 2
+	affected_mob.pixel_y += 6
 
 /obj/structure/bed/pillow_tiny/post_unbuckle_mob(mob/living/affected_mob)
 	. = ..()
 	density = FALSE
 	//Set them back down to the normal lying position
-	affected_mob.pixel_y = affected_mob.base_pixel_y
+	affected_mob.pixel_y -= 6
 
 //"Upgrading" pillow
 /obj/structure/bed/pillow_tiny/attackby(obj/item/used_item, mob/living/user, params)
@@ -249,7 +250,6 @@
 	icon = 'modular_nova/modules/modular_items/lewd_items/icons/obj/lewd_structures/pillows.dmi'
 	icon_state = "pillowpile_small_pink"
 	base_icon_state = "pillowpile_small"
-	pseudo_z_axis = 4
 	var/current_color = "pink"
 	var/mutable_appearance/armrest
 
@@ -270,7 +270,8 @@
 
 /obj/structure/chair/pillow_small/Initialize(mapload)
 	update_icon()
-	return ..()
+	. = ..()
+	AddElement(/datum/element/elevation, pixel_shift = 4)
 
 /obj/structure/chair/pillow_small/proc/GetArmrest()
 	if(current_color == "pink")
@@ -286,8 +287,8 @@
 	. = ..()
 	update_icon()
 	density = TRUE
-	//Push them up from the normal lying position
-	affected_mob.pixel_y = affected_mob.base_pixel_y + 2
+	//Push them up from the normal sitting position
+	affected_mob.pixel_y += 2
 
 /obj/structure/chair/pillow_small/update_overlays()
 	. = ..()
@@ -297,8 +298,8 @@
 /obj/structure/chair/pillow_small/post_unbuckle_mob(mob/living/affected_mob)
 	. = ..()
 	density = FALSE
-	//Set them back down to the normal lying position
-	affected_mob.pixel_y = affected_mob.base_pixel_y
+	//Set them back down to the normal sitting position
+	affected_mob.pixel_y -= 2
 
 /obj/structure/chair/pillow_small/update_icon_state()
 	. = ..()
@@ -376,7 +377,7 @@
 	icon = 'modular_nova/modules/modular_items/lewd_items/icons/obj/lewd_structures/pillows.dmi'
 	icon_state = "pillowpile_large_pink"
 	base_icon_state = "pillowpile_large"
-	pseudo_z_axis = 4
+	elevation = 4
 	var/current_color = "pink"
 	var/mutable_appearance/armrest
 	//Containing pillows that we have here
@@ -417,7 +418,7 @@
 	update_icon()
 	density = TRUE
 	//Push them up from the normal lying position
-	affected_mob.pixel_y = affected_mob.base_pixel_y + 0.5
+	affected_mob.pixel_y += 1
 
 /obj/structure/bed/pillow_large/update_overlays()
 	. = ..()
@@ -428,7 +429,7 @@
 	. = ..()
 	density = FALSE
 	//Set them back down to the normal lying position
-	affected_mob.pixel_y = affected_mob.base_pixel_y
+	affected_mob.pixel_y -= 1
 
 /obj/structure/bed/pillow_large/update_icon_state()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Yeah so for whatever reason the code for the dancing pole lifting you up worked by every move checking your location for things that have an offset set and then changing your `pixel_z` regardless, which kinda just broke the elevation component.
As in, whenever you'd move onto the tile, the elevation component would increase your `pixel_z`, but then this code would reset your `pixel_z`.

Anyhow, because we now have the elevation component, this pr just entirely guts that piece of code and makes anything that used it (dancing poles, pillow piles) use the elevation component instead.
This fixes our issue, but also makes things _much_ cleaner. It animates the movement, it has better checks, et cetera.

As a side-bit, because this touches pillow pile offsets, this makes the pillow piles stop making their post-(un)buckle procs set things relative to `base_pixel_y` and instead just uses `pixel_y +=` and `pixel_y -=` with fitting values parallel to how things like the plastic chair do it.
This makes it stop giving you weird offsets, as the previous behaviour would make it so buckling and unbuckling would give you a different `pixel_y` from when you started (as resting already offsets your `pixel_y`).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Fixes the elevation component on beds, crates, etc just not working.
Pillow piles feel nicer.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Some generic elevation tests</summary>

![image](https://github.com/user-attachments/assets/59ce1b19-3e47-4751-ba54-8ab282a8734a)
![image](https://github.com/user-attachments/assets/0410d87b-166b-4d18-9a2f-8e0455cba3b1)
![image](https://github.com/user-attachments/assets/35409979-2b47-4f45-b440-b979d8b30479)

And buckled:
![image](https://github.com/user-attachments/assets/007b71ad-f8f5-48fb-83e1-2d3340b7aefa)
![image](https://github.com/user-attachments/assets/4fb86716-b761-43e3-ab17-dbad47cd52da)

</details>

<details>
<summary>Dancing pole and pillow piles</summary>

Dancing pole:
![image](https://github.com/user-attachments/assets/d1f89056-a157-4ddc-ab93-e3b9986bd150)

Pillow piles (order for easier comparison between buckled and unbuckled):

Tiny pile (Standing, Lying, Buckled):
![image](https://github.com/user-attachments/assets/51ed97b5-14dd-477d-8023-25a47e3a3229)
![image](https://github.com/user-attachments/assets/9911dc59-b106-4cf6-8dcb-cfa7c8c27ff8)
![image](https://github.com/user-attachments/assets/fce2dd89-ecdf-4212-95df-27b3f909e309)

Small pile (Lying, Standing, Buckled):
![image](https://github.com/user-attachments/assets/e5110fe8-ebfb-4513-8841-18b66fc98693)
![image](https://github.com/user-attachments/assets/4106ac17-a89e-4f92-a113-f358cb40a0a0)
![image](https://github.com/user-attachments/assets/e334b3d8-3606-402a-b73a-56372ba9b04f)

Large pile (Standing, Lying, Buckled):
![image](https://github.com/user-attachments/assets/7a823958-02ce-4ebd-a1a6-9f6f0f40635c)
![image](https://github.com/user-attachments/assets/ed7939d8-7c9c-40ae-9457-2bc3a35d00f7)
![image](https://github.com/user-attachments/assets/3f8160c3-543c-4413-9b25-c44a7762786b)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: (Nova) Fixes a host of things that are supposed to elevate you (like beds, crates, somesuch) not actually elevating you.
qol: (Nova) Changes the offsets for being on or being buckled to pillow piles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
