### PR TITLE
Removes emote ignores walls var on some emotes

### DIFF
--- a/modular_nova/modules/emotes/code/emotes.dm
+++ b/modular_nova/modules/emotes/code/emotes.dm
@@ -121,7 +121,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_nova/modules/emotes/sound/voice/awoo.ogg'
-	sound_wall_ignore = TRUE
 
 /datum/emote/living/nya
 	key = "nya"
@@ -170,7 +169,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_nova/modules/emotes/sound/voice/bark2.ogg'
-	sound_wall_ignore = TRUE
 
 /datum/emote/living/squish
 	key = "squish"
@@ -532,7 +530,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_nova/modules/emotes/sound/voice/goose_honk.ogg'
-	sound_wall_ignore = TRUE
 
 /datum/emote/living/mggaow
 	key = "mggaow"
@@ -541,7 +538,6 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_nova/modules/emotes/sound/voice/mggaow.ogg'
-	sound_wall_ignore = TRUE
 
 /datum/emote/living/mrrp
 	key = "mrrp"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The original design intention was to allow only very important emotes to act as audio cues for people to hear through walls, emotes that act as fluff to your character or to act out an RP situation shouldn't be passing through walls as this contributes to ear fatigue and makes emote spam even more unbearable.
Emotes that no longer ignore walls for playing the sound:
- *awoo
- *mggaow
- *bark
- *honk
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Lessens ear fatigue and emote spam fatigue, the whole reason emote sounds were made to not ignore walls.
Makes fluff emotes more meaningful as they will be heard less often and to the people they are directed at.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
super minor change, hopefully you don't need me to test this.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: grungussuss
sound: awoo, honk, mggaow and bark emote sounds no longer pierce through walls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
