### PR TITLE
Removes most placements / availability of the old energy guns, in favor of the hoshi carbines.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -21,7 +21,7 @@
 	new /obj/item/card/id/departmental_budget(src) //NOVA EDIT ADDITION
 
 /obj/structure/closet/secure_closet/captains/populate_contents_immediate()
-	new /obj/item/gun/energy/e_gun(src)
+	new /obj/item/gun/energy/modular_laser_rifle/carbine(src) // NOVA EDIT - Replacement
 	new /obj/item/storage/belt/sabre(src)
 
 /obj/structure/closet/secure_closet/hop
@@ -49,7 +49,7 @@
 	new /obj/item/card/id/departmental_budget/srv(src) //NOVA EDIT ADDITION
 
 /obj/structure/closet/secure_closet/hop/populate_contents_immediate()
-	new /obj/item/gun/energy/e_gun(src)
+	new /obj/item/gun/energy/modular_laser_rifle/carbine(src) // NOVA EDIT - Replacement
 
 /obj/structure/closet/secure_closet/hos
 	name = "head of security's locker"

--- a/modular_nova/master_files/code/modules/jobs/job_types/head_of_security.dm
+++ b/modular_nova/master_files/code/modules/jobs/job_types/head_of_security.dm
@@ -1,2 +1,3 @@
 /datum/outfit/job/hos
+	suit_store = /obj/item/gun/energy/modular_laser_rifle/carbine
 	messenger = /obj/item/storage/backpack/messenger/sec

--- a/modular_nova/modules/company_imports/code/armament_datums/microstar_energy.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/microstar_energy.dm
@@ -26,17 +26,9 @@
 /datum/armament_entry/company_import/microstar/basic_energy_long_weapons
 	subcategory = "Basic Energy Longarms"
 
-/datum/armament_entry/company_import/microstar/basic_energy_long_weapons/laser
-	item_type = /obj/item/gun/energy/laser
-	cost = PAYCHECK_CREW * 5
-
 /datum/armament_entry/company_import/microstar/basic_energy_long_weapons/laser_carbine
 	item_type = /obj/item/gun/energy/laser/carbine
 	cost = PAYCHECK_CREW * 7 // slightly more expensive due to ease of use/full auto
-
-/datum/armament_entry/company_import/microstar/basic_energy_long_weapons/egun
-	item_type = /obj/item/gun/energy/e_gun
-	cost = PAYCHECK_COMMAND * 4
 
 /datum/armament_entry/company_import/microstar/basic_energy_long_weapons/mod_laser_small
 	item_type = /obj/item/gun/energy/modular_laser_rifle/carbine

--- a/modular_nova/modules/modular_weapons/code/overrides/energy.dm
+++ b/modular_nova/modules/modular_weapons/code/overrides/energy.dm
@@ -1,11 +1,11 @@
 /obj/item/gun/energy/laser
 	name = "\improper Allstar SC-1 laser carbine"
-	desc = "A basic energy-based laser carbine that fires concentrated beams of light which pass through glass and thin metal."
+	desc = "An early version of more standardized "laser" based energy weapons made internally by Nanotrasen, originally sent along on their early stations, they're little more then surplus in the current year."
 
 /obj/item/gun/energy/laser/carbine
 	name = "\improper Allstar SC-1A laser auto-carbine"
-	desc = "An basic energy-based laser auto-carbine that rapidly fires weakened, concentrated beams of light which pass through glass and thin metal."
+	desc = "A basic energy-based laser auto-carbine that rapidly fires weakened, concentrated beams of light which pass through glass and thin metal."
 
 /obj/item/gun/energy/e_gun
 	name = "\improper Allstar SC-2 energy carbine"
-	desc = "A basic hybrid energy carbine with two settings: disable and kill."
+	desc = "A heavily outdated antique of a dual mode energy weapon, possessing both a "kill" and "disable" mode, sometimes ends up as overstock on Nanotrasen stations, it has faint freezer burn marks on it."

--- a/modular_nova/modules/modular_weapons/code/overrides/energy.dm
+++ b/modular_nova/modules/modular_weapons/code/overrides/energy.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/energy/laser
 	name = "\improper Allstar SC-1 laser carbine"
-	desc = "An early version of more standardized "laser" based energy weapons made internally by Nanotrasen, originally sent along on their early stations, they're little more then surplus in the current year."
+	desc = "An early version of more standardized 'laser' based energy weapons made internally by Nanotrasen, originally sent along on their early stations, they're little more then surplus in the current year."
 
 /obj/item/gun/energy/laser/carbine
 	name = "\improper Allstar SC-1A laser auto-carbine"
@@ -8,4 +8,4 @@
 
 /obj/item/gun/energy/e_gun
 	name = "\improper Allstar SC-2 energy carbine"
-	desc = "A heavily outdated antique of a dual mode energy weapon, possessing both a "kill" and "disable" mode, sometimes ends up as overstock on Nanotrasen stations, it has faint freezer burn marks on it."
+	desc = "A heavily outdated antique of a dual mode energy weapon, possessing both a 'kill' and 'disable' mode, sometimes ends up as overstock on Nanotrasen stations, it has faint freezer burn marks on it."


### PR DESCRIPTION
## About The Pull Request

Presently, energy guns / laser guns are a downgrade in almost every aspect outside of a couple shot gain in capacity, this replaces most of their default spawns with the hoshi, which is just all around better and more applicable for the roles that would elsewise have energy guns.

It also removes their presence in energy star, because they're already goodies, but additionally because they're kind of traps for people who don't know better.

## How This Contributes To The Nova Sector Roleplay Experience

The default 'gun' a job gets, shouldn't be something meant to be immediately replaced by it's better, especially if the better is extremely readily available, this just skips the early round hustle of swapping out the roundstart egun for the hoshi.

complimentary lore change approved by des, for both removed (from company imports, and default spawns) weapons being old-as-hell

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/172772ae-e545-46b8-a6af-bca8ba46b725)
here is your hero john mitchell spawning with his brandnew hoshi
</details>

## Changelog



:cl:
balance: Removed energy guns from company imports(they're still in normal cargo, for crafting recipes), swapped their default spawns for the HoS, Captain, and HoP for the hoshi carbine.
/:cl:
