### PR TITLE
Meowing faster, everything faster! | Reduces global emote CDs drastically.

### DIFF
--- a/modular_nova/modules/emotes/code/emotes.dm
+++ b/modular_nova/modules/emotes/code/emotes.dm
@@ -1,5 +1,5 @@
 
-#define EMOTE_DELAY (5 SECONDS) //To prevent spam emotes.
+#define EMOTE_DELAY (2 SECONDS) //To prevent spam emotes.
 
 /mob
 	var/nextsoundemote = 1 //Time at which the next emote can be played


### PR DESCRIPTION
## About The Pull Request
Greetings. On Thine Fine Evening, Thy Reckoning Shall Take Place.
All emote cooldowns have been pummelled thoroughly and reduced from 5s to 2s``TM``
Indeed. You can now flip back to back if you have Freerunning. You can meow faster to annoy your friends more efficiently, and you can even Scream Until Your Lungs Burst. This has everything a Space Station 13 would ever ever need. Please merge this fantastical PR.
## How This Contributes To The Nova Sector Roleplay Experience
Five seconds is just far too long. There's already a magical thing called ```audio_cooldown``` that handles audio emotes and doesn't allow you to Stack Them Like A Raging Maniac. Two seconds should be roughly enough for the most extreme of spamming (meowmeowmeowmeommeowmeowmeowmeowmeowmeowmeow) and so on. I find myself sometimes wanting to release a cacophony of beastial noises but then failing to the dissident factor that is Emote Cooldowns. This Pull Request Greatly enhances the Space Station 13``TM`` Roleplay experience.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  

https://github.com/user-attachments/assets/14b86d4f-eccc-4dad-b733-37a0b44114e1


</details>

## Changelog
:cl:
qol: Meow faster! Scream faster! Mrrp faster! Everything faster! (Global Emote cooldowns 5s -> 2s)
/:cl:
