### PR TITLE
Fixes medical records not being viewable to observers

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -345,8 +345,10 @@
 			var/datum/record/crew/target_record = find_record(examined_name)
 			to_chat(usr, "<b>Exploitable information:</b> [target_record.exploitable_information]")
 	if(href_list["medrecords"])
+		var/examined_name = get_face_name(get_id_name("")) //Named as such because this is the name we see when we examine
+		var/datum/record/crew/target_record = find_record(examined_name)
 		to_chat(usr, "<b>Medical Record:</b> [target_record.past_medical_records]")
-	//NOVA EDIT END
+	//NOVA EDIT ADDITION END
 
 	..() //end of this massive fucking chain. TODO: make the hud chain not spooky. - Yeah, great job doing that.
 


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/4279

Due to an `ishuman()` check in TG's code we are just gonna stick this at the end here so it is reachable by observers.

## How This Contributes To The Nova Sector Roleplay Experience

Features working as intended

## Proof of Testing

<details>
<summary>Working</summary>

![image](https://github.com/user-attachments/assets/a5ee3982-fec6-41d9-a23f-b7a2a6ea6bfd)

</details>

## Changelog

:cl:
fix: fixes medical record link not being viewable to observers when examining a mob
/:cl:
