### PR TITLE
Seed Mesh Tweak - Gatfruit and Evil Seedlings

### DIFF
--- a/modular_nova/modules/ashwalkers/code/items/ash_seedmesh.dm
+++ b/modular_nova/modules/ashwalkers/code/items/ash_seedmesh.dm
@@ -5,6 +5,8 @@
 	icon_state = "mesh"
 	var/list/static/seeds_blacklist = list(
 		/obj/item/seeds/lavaland,
+		/obj/item/seeds/gatfruit,
+		/obj/item/seeds/seedling/evil,
 	)
 
 /obj/item/seed_mesh/attackby(obj/item/attacking_item, mob/user, params)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds gatfruit and evil seedlings to the list of things that a seedmesh cannot randomly generate.

Gatfruit should be explanitory. Evil seedlings are a botanist traitor item that will straight up murder you if you pull one and don't know it's coming. There's no way to tell the difference between the friendly and the evil seeds ingame.

## How This Contributes To The Nova Sector Roleplay Experience

Gatfruit is around a 1/160 chance to pull from a seedmesh. In comparison, it's somewhere around 1/1200 via xenobio.

Not randomly dying to a seedling is also good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: seed meshes no longer spawn evil seedlings or gatfruit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
