### PR TITLE
Adds missing secret documents and vault content to Snowglobe Station

### DIFF
--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -63588,6 +63588,24 @@
 /area/station/commons/dorms/room3)
 "rmW" = (
 /obj/structure/safe/vault,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/book{
+	desc = "An undeniably handy book.";
+	icon_state = "bookknock";
+	name = "\improper A Simpleton's Guide to Safe-cracking with Stethoscopes"
+	},
+/obj/item/stack/sheet/mineral/diamond,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c500,
+/obj/item/stack/spacecash/c500,
+/obj/item/stack/spacecash/c500,
+/obj/item/stack/spacecash/c500,
+/obj/item/stack/spacecash/c500,
+/obj/item/gun/ballistic/rifle/boltaction/prime,
 /turf/open/floor/iron/dark/corner,
 /area/station/ai_monitored/command/nuke_storage)
 "rmY" = (
@@ -83453,6 +83471,8 @@
 "wCK" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/status_display/evac/directional/north,
+/obj/structure/filingcabinet,
+/obj/item/folder/documents,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/command/nuke_storage)
 "wCP" = (


### PR DESCRIPTION

## About The Pull Request

Adds missing stuff in the vault such as the secret documents and some content into the vault, including 7500 credits, a diamond, a stethoscope, a safecracking book and a fully loaded Sakhno sporting rifle.


![StrongDMM_E7hkMnQIzt](https://github.com/user-attachments/assets/49cd307d-8bad-4739-b94c-1d69ce31296d)


Fixes https://github.com/NovaSector/NovaSector/issues/4283
## How This Contributes To The Nova Sector Roleplay Experience
Fixes a map oversight while allowing traitors to do their objectives properly.
As for the safe; Consistency, every map has unique rewards for the vault's safe, such as a Desert Eagle for Delta, lethal shotguns for Wawa and so on.

## Proof of Testing
it's linting

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl: Hardly
fix: Fixed Snowglobe Station not having secret documents
tweak: Added items to Snowglobe station's safe located inside the vault
/:cl:
