### PR TITLE
[MODULAR] Digitigrade Augs+ Limb Support

### DIFF
--- a/modular_nova/modules/customization/modules/client/augment/limbs.dm
+++ b/modular_nova/modules/customization/modules/client/augment/limbs.dm
@@ -5,6 +5,8 @@
 	var/uses_robotic_styles = TRUE
 	///Should we draw these greyscale?
 	var/uses_greyscale = FALSE
+	///Used for legs - if it has a digitigrade sprite variant, set to TRUE.
+	var/supports_digitigrade = FALSE
 
 /datum/augment_item/limb/apply(mob/living/carbon/human/augmented, character_setup = FALSE, datum/preferences/prefs)
 	if(character_setup)
@@ -13,8 +15,9 @@
 		var/body_zone = initial(new_limb.body_zone)
 		var/obj/item/bodypart/old_limb = augmented.get_bodypart(body_zone)
 
-		old_limb.limb_id = initial(new_limb.limb_id)
-		old_limb.base_limb_id = initial(new_limb.limb_id)
+		if(old_limb.limb_id != BODYPART_ID_DIGITIGRADE || supports_digitigrade == FALSE) //Retain digitigrade status
+			old_limb.limb_id = initial(new_limb.limb_id)
+			old_limb.base_limb_id = initial(new_limb.limb_id)
 		old_limb.is_dimorphic = initial(new_limb.is_dimorphic)
 
 		if(uses_robotic_styles && prefs.augment_limb_styles[slot])
@@ -36,6 +39,9 @@
 			var/chosen_style = GLOB.robotic_styles_list[prefs.augment_limb_styles[slot]]
 			new_limb.set_icon_static(chosen_style)
 			new_limb.current_style = prefs.augment_limb_styles[slot]
+		if(supports_digitigrade == TRUE && old_limb.limb_id == BODYPART_ID_DIGITIGRADE)
+			new_limb.limb_id = BODYPART_ID_DIGITIGRADE
+			new_limb.base_limb_id = BODYPART_ID_DIGITIGRADE
 		new_limb.replace_limb(augmented, special = TRUE)
 		qdel(old_limb)
 

--- a/modular_nova/modules/customization/modules/client/augment/species_limbs.dm
+++ b/modular_nova/modules/customization/modules/client/augment/species_limbs.dm
@@ -1,45 +1,63 @@
 //Subtype for most custom species that use GAGS.  Also provides Anthromorphs.
 /datum/augment_item/limb/head/species
+	cost = 0
+	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
+
+/datum/augment_item/limb/head/species/mutant
 	name = "anthromorph head"
 	path = /obj/item/bodypart/head/mutant
-	cost = 0
-	uses_robotic_styles = FALSE
-	uses_greyscale = TRUE
+	supports_digitigrade = TRUE
 
 /datum/augment_item/limb/chest/species
+	cost = 0
+	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
+
+/datum/augment_item/limb/chest/species/mutant
 	name = "anthromorph chest"
 	path = /obj/item/bodypart/chest/mutant
-	cost = 0
-	uses_robotic_styles = FALSE
-	uses_greyscale = TRUE
+	supports_digitigrade = TRUE
 
 /datum/augment_item/limb/l_arm/species
+	cost = 0
+	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
+
+/datum/augment_item/limb/l_arm/species/mutant
 	name = "anthromorph left arm"
 	path = /obj/item/bodypart/arm/left/mutant
-	cost = 0
-	uses_robotic_styles = FALSE
-	uses_greyscale = TRUE
+	supports_digitigrade = TRUE
 
 /datum/augment_item/limb/r_arm/species
+	cost = 0
+	uses_robotic_styles = FALSE
+	uses_greyscale = TRUE
+
+/datum/augment_item/limb/r_arm/species/mutant
 	name = "anthromorph right arm"
 	path = /obj/item/bodypart/arm/right/mutant
-	cost = 0
-	uses_robotic_styles = FALSE
-	uses_greyscale = TRUE
+	supports_digitigrade = TRUE
 
 /datum/augment_item/limb/l_leg/species
-	name = "anthromorph left leg"
-	path = /obj/item/bodypart/leg/left/mutant
 	cost = 0
 	uses_robotic_styles = FALSE
 	uses_greyscale = TRUE
 
+/datum/augment_item/limb/l_leg/species/mutant
+	name = "anthromorph left leg"
+	path = /obj/item/bodypart/leg/left/mutant
+	supports_digitigrade = TRUE
+
 /datum/augment_item/limb/r_leg/species
-	name = "anthromorph right leg"
-	path = /obj/item/bodypart/leg/right/mutant
 	cost = 0
 	uses_robotic_styles = FALSE
 	uses_greyscale = TRUE
+
+/datum/augment_item/limb/r_leg/species/mutant
+	name = "anthromorph right leg"
+	path = /obj/item/bodypart/leg/right/mutant
+	supports_digitigrade = TRUE
 
 
 
@@ -70,27 +88,27 @@
 	path = /obj/item/bodypart/leg/right/mutant/akula
 
 //Aquatic
-/datum/augment_item/limb/head/species/aquatic
+/datum/augment_item/limb/head/species/mutant/aquatic
 	name = "aquatic head"
 	path = /obj/item/bodypart/head/mutant/aquatic
 
-/datum/augment_item/limb/chest/species/aquatic
+/datum/augment_item/limb/chest/species/mutant/aquatic
 	name = "aquatic chest"
 	path = /obj/item/bodypart/chest/mutant/aquatic
 
-/datum/augment_item/limb/l_arm/species/aquatic
+/datum/augment_item/limb/l_arm/species/mutant/aquatic
 	name = "aquatic left arm"
 	path = /obj/item/bodypart/arm/left/mutant/aquatic
 
-/datum/augment_item/limb/r_arm/species/aquatic
+/datum/augment_item/limb/r_arm/species/mutant/aquatic
 	name = "aquatic right arm"
 	path = /obj/item/bodypart/arm/right/mutant/aquatic
 
-/datum/augment_item/limb/l_leg/species/aquatic
+/datum/augment_item/limb/l_leg/species/mutant/aquatic
 	name = "aquatic left leg"
 	path = /obj/item/bodypart/leg/left/mutant/aquatic
 
-/datum/augment_item/limb/r_leg/species/aquatic
+/datum/augment_item/limb/r_leg/species/mutant/aquatic
 	name = "aquatic right leg"
 	path = /obj/item/bodypart/leg/right/mutant/aquatic
 
@@ -120,27 +138,27 @@
 	path = /obj/item/bodypart/leg/right/mutant/insect
 
 //Lizard
-/datum/augment_item/limb/head/species/lizard
+/datum/augment_item/limb/head/species/mutant/lizard
 	name = "lizard head"
 	path = /obj/item/bodypart/head/lizard
 
-/datum/augment_item/limb/chest/species/lizard
+/datum/augment_item/limb/chest/species/mutant/lizard
 	name = "lizard chest"
 	path = /obj/item/bodypart/chest/lizard
 
-/datum/augment_item/limb/l_arm/species/lizard
+/datum/augment_item/limb/l_arm/species/mutant/lizard
 	name = "lizard left arm"
 	path = /obj/item/bodypart/arm/left/lizard
 
-/datum/augment_item/limb/r_arm/species/lizard
+/datum/augment_item/limb/r_arm/species/mutant/lizard
 	name = "lizard right arm"
 	path = /obj/item/bodypart/arm/right/lizard
 
-/datum/augment_item/limb/l_leg/species/lizard
+/datum/augment_item/limb/l_leg/species/mutant/lizard
 	name = "lizard left leg"
 	path = /obj/item/bodypart/leg/left/lizard
 
-/datum/augment_item/limb/r_leg/species/lizard
+/datum/augment_item/limb/r_leg/species/mutant/lizard
 	name = "lizard right leg"
 	path = /obj/item/bodypart/leg/right/lizard
 
@@ -219,27 +237,27 @@
 	uses_robotic_styles = FALSE
 
 //Slimes
-/datum/augment_item/limb/head/species/slime
+/datum/augment_item/limb/head/species/mutant/slime
 	name = "slime head"
 	path = /obj/item/bodypart/head/jelly/slime/roundstart
 
-/datum/augment_item/limb/chest/species/slime
+/datum/augment_item/limb/chest/species/mutant/slime
 	name = "slime chest"
 	path = /obj/item/bodypart/chest/jelly/slime/roundstart
 
-/datum/augment_item/limb/l_arm/species/slime
+/datum/augment_item/limb/l_arm/species/mutant/slime
 	name = "slime left arm"
 	path = /obj/item/bodypart/arm/left/jelly/slime/roundstart
 
-/datum/augment_item/limb/r_arm/species/slime
+/datum/augment_item/limb/r_arm/species/mutant/slime
 	name = "slime right arm"
 	path = /obj/item/bodypart/arm/right/jelly/slime/roundstart
 
-/datum/augment_item/limb/l_leg/species/slime
+/datum/augment_item/limb/l_leg/species/mutant/slime
 	name = "slime left leg"
 	path = /obj/item/bodypart/leg/left/jelly/slime/roundstart
 
-/datum/augment_item/limb/r_leg/species/slime
+/datum/augment_item/limb/r_leg/species/mutant/slime
 	name = "slime right leg"
 	path = /obj/item/bodypart/leg/right/jelly/slime/roundstart
 
@@ -394,52 +412,52 @@
 	path = /obj/item/bodypart/leg/right/mutant/skrell
 
 //Standard Vox
-/datum/augment_item/limb/head/species/vox
+/datum/augment_item/limb/head/species/mutant/vox
 	name = "vox head"
 	path = /obj/item/bodypart/head/mutant/vox
 
-/datum/augment_item/limb/chest/species/vox
+/datum/augment_item/limb/chest/species/mutant/vox
 	name = "vox chest"
 	path = /obj/item/bodypart/chest/mutant/vox
 
-/datum/augment_item/limb/l_arm/species/vox
+/datum/augment_item/limb/l_arm/species/mutant/vox
 	name = "vox left arm"
 	path = /obj/item/bodypart/arm/left/mutant/vox
 
-/datum/augment_item/limb/r_arm/species/vox
+/datum/augment_item/limb/r_arm/species/mutant/vox
 	name = "vox right arm"
 	path = /obj/item/bodypart/arm/right/mutant/vox
 
-/datum/augment_item/limb/l_leg/species/vox
+/datum/augment_item/limb/l_leg/species/mutant/vox
 	name = "vox left leg"
 	path = /obj/item/bodypart/leg/left/mutant/vox
 
-/datum/augment_item/limb/r_leg/species/vox
+/datum/augment_item/limb/r_leg/species/mutant/vox
 	name = "vox right leg"
 	path = /obj/item/bodypart/leg/right/mutant/vox
 
 //Xenomorph Hybrids
-/datum/augment_item/limb/head/species/xenohybrid
+/datum/augment_item/limb/head/species/mutant/xenohybrid
 	name = "xenohybrid head"
 	path = /obj/item/bodypart/head/mutant/xenohybrid
 
-/datum/augment_item/limb/chest/species/xenohybrid
+/datum/augment_item/limb/chest/species/mutant/xenohybrid
 	name = "xenohybrid chest"
 	path = /obj/item/bodypart/chest/mutant/xenohybrid
 
-/datum/augment_item/limb/l_arm/species/xenohybrid
+/datum/augment_item/limb/l_arm/species/mutant/xenohybrid
 	name = "xenohybrid left arm"
 	path = /obj/item/bodypart/arm/left/mutant/xenohybrid
 
-/datum/augment_item/limb/r_arm/species/xenohybrid
+/datum/augment_item/limb/r_arm/species/mutant/xenohybrid
 	name = "xenohybrid right arm"
 	path = /obj/item/bodypart/arm/right/mutant/xenohybrid
 
-/datum/augment_item/limb/l_leg/species/xenohybrid
+/datum/augment_item/limb/l_leg/species/mutant/xenohybrid
 	name = "xenohybrid left leg"
 	path = /obj/item/bodypart/leg/left/digitigrade/xenohybrid
 
-/datum/augment_item/limb/r_leg/species/xenohybrid
+/datum/augment_item/limb/r_leg/species/mutant/xenohybrid
 	name = "xenohybrid right leg"
 	path = /obj/item/bodypart/leg/right/digitigrade/xenohybrid
 


### PR DESCRIPTION
## About The Pull Request

Small bugfix to #3738 - I realized too late that digitigrade prefs weren't being respected & so capable limbs would get forced back to plantigrade when applied through the menu.  This should now be fixed, albiet with a limited selection (anthromorph, aquatic, lizard, slime, vox, and xenohybrid) since the other limb types don't support digitigrade variants.

## How This Contributes To The Nova Sector Roleplay Experience

Final prerequisite before I can work on #1587 again since it was strongly requested that no new additional species be added.

## Proof of Testing

![image](https://github.com/user-attachments/assets/a889b855-a4b5-4c13-bdfa-7576b64ed0bf)

## Changelog

:cl:
fix: digitigrade-capable species limbs in Augs+ now respect your digitigrade preference
/:cl:

