### PR TITLE
Fixes Akula lung oversight

### DIFF
--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/akula.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/akula.dm
@@ -204,12 +204,12 @@
 	. = ..()
 	REMOVE_TRAIT(src, TRAIT_SPACEBREATHING, REF(src))
 
-/obj/item/organ/internal/lungs/carp/akula/check_breath(datum/gas_mixture/breath, mob/living/carbon/human/breather)
-	if(breath && !breather.has_status_effect(/datum/status_effect/fire_handler/wet_stacks))
-		for(var/datum/gas/gas as anything in breath.gases)
-			breath.gases[gas][MOLES] = 0 //cant filter gas out of the air unless wet
+/obj/item/organ/internal/lungs/check_breath(datum/gas_mixture/breath, mob/living/carbon/human/breather)
+	if(is_species(breather, /datum/species/akula))
+		if(breath && !breather.has_status_effect(/datum/status_effect/fire_handler/wet_stacks))
+			for(var/datum/gas/gas as anything in breath.gases)
+				breath.gases[gas][MOLES] = 0 //cant filter gas out of the air unless wet
 	return ..()
-
 
 // Wet_stacks handling
 // more about grab_resists in `code\modules\mob\living\living.dm` at li 1119


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Puts the necessity of being wet to breathe on the highest lungs subtype. This handicap should only be able to get null'd by work, like a virologist's virus.

## How This Contributes To The Nova Sector Roleplay Experience

You can't have 3/4th of all the Akula race benefits for free.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
https://github.com/user-attachments/assets/4a66e2fc-2188-4fa9-8bff-2d8bf4e7f253

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed an oversight on akula lungs which let them avoid the race its gills gimmick
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
