### PR TITLE
Balance reagent weapons

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -300,6 +300,8 @@ GLOBAL_LIST_INIT(mining_suit_allowed, list(
 	/obj/item/pickaxe,
 	/obj/item/resonator,
 	/obj/item/spear,
+	/obj/item/forging/reagent_weapon, // NOVA EDIT ADDITION
+	/obj/item/gun/ballistic/bow, // NOVA EDIT ADDITION
 ))
 
 /// String for items placed into the left pocket.

--- a/code/__DEFINES/~nova_defines/colony_fabricator_misc.dm
+++ b/code/__DEFINES/~nova_defines/colony_fabricator_misc.dm
@@ -40,4 +40,5 @@ GLOBAL_LIST_INIT(colonist_suit_allowed, list(
 	/obj/item/analyzer,
 	/obj/item/storage/medkit,
 	/obj/item/fireaxe/metal_h2_axe,
+	/obj/item/forging/reagent_weapon,
 ))

--- a/code/datums/storage/subtypes/pockets.dm
+++ b/code/datums/storage/subtypes/pockets.dm
@@ -140,6 +140,7 @@
 			/obj/item/holochip,
 			/obj/item/implanter,
 			/obj/item/knife,
+			/obj/item/forging/reagent_weapon/dagger, // NOVA EDIT ADDITION
 			/obj/item/lighter,
 			/obj/item/lipstick,
 			/obj/item/match,

--- a/modular_nova/modules/reagent_forging/code/forge_weapons.dm
+++ b/modular_nova/modules/reagent_forging/code/forge_weapons.dm
@@ -1,94 +1,100 @@
+#define FAUNA_MULTIPLIER 1
+#define MEGAFAUNA_MULTIPLIER 1
+
 /obj/item/forging/reagent_weapon
 	icon = 'modular_nova/modules/reagent_forging/icons/obj/forge_items.dmi'
 	lefthand_file = 'modular_nova/modules/reagent_forging/icons/mob/forge_weapon_l.dmi'
 	righthand_file = 'modular_nova/modules/reagent_forging/icons/mob/forge_weapon_r.dmi'
 	worn_icon = 'modular_nova/modules/reagent_forging/icons/mob/forge_weapon_worn.dmi'
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_GREYSCALE | MATERIAL_COLOR
-	obj_flags = UNIQUE_RENAME
+	obj_flags = UNIQUE_RENAME | CONDUCTS_ELECTRICITY
 	obj_flags_nova = ANVIL_REPAIR
-	toolspeed = 0.9 //Slightly better than avg. - A forged hammer or knife is probably better than a standard one
+	resistance_flags = FIRE_PROOF | LAVA_PROOF
+	toolspeed = 0.9
+	throwforce = 5
+	throw_speed = 3
+	throw_range = 7
+	var/static/list/nemesis = MOB_BEAST
 
 /obj/item/forging/reagent_weapon/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/reagent_weapon)
+	AddElement(/datum/element/bane, mob_biotypes = MOB_BEAST, damage_multiplier = FAUNA_MULTIPLIER, requires_combat_mode = FALSE)
+	AddElement(/datum/element/bane, target_type = /mob/living/simple_animal/hostile/megafauna, damage_multiplier = MEGAFAUNA_MULTIPLIER, requires_combat_mode = FALSE)
 
 /obj/item/forging/reagent_weapon/examine(mob/user)
 	. = ..()
 	. += span_notice("Using a hammer on [src] will repair its damage!")
 
-//vanilla sword with no quirks, at least it's good versus other melees :)
 /obj/item/forging/reagent_weapon/sword
 	name = "forged sword"
 	desc = "A sharp, one-handed sword most adept at blocking opposing melee strikes."
 	force = 20
-	armour_penetration = 10
+	armour_penetration = 20
+	demolition_mod = 1.2
 	icon_state = "sword"
 	inhand_icon_state = "sword"
 	worn_icon_state = "sword_back"
 	belt_icon_state = "sword_belt"
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	throwforce = 10
-	block_chance = 25
+	block_chance = 20
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_BULKY
-	resistance_flags = FIRE_PROOF
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	sharpness = SHARP_EDGED
 	max_integrity = 150
 
-//katana, one which shall cut through your puny armour
 /obj/item/forging/reagent_weapon/katana
 	name = "forged katana"
 	desc = "A katana sharp enough to penetrate body armor, but not quite million-times-folded sharp."
 	force = 20
-	armour_penetration = 25
+	armour_penetration = 40
 	icon_state = "katana"
 	inhand_icon_state = "katana"
 	worn_icon_state = "katana_back"
 	belt_icon_state = "katana_belt"
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	throwforce = 10
-	block_chance = 20
+	block_chance = 10
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_BULKY
-	resistance_flags = FIRE_PROOF
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	sharpness = SHARP_EDGED
 
-//quirky knife that lets you click fast
 /obj/item/forging/reagent_weapon/dagger
 	name = "forged dagger"
-	desc = "A lightweight dagger with an extremely quick swing!"
+	desc = "A lightweight dagger that seems ideal for butchering and surviving!"
 	force = 13
 	icon_state = "dagger"
 	inhand_icon_state = "dagger"
 	worn_icon_state = "dagger_back"
 	belt_icon_state = "dagger_belt"
 	hitsound = 'sound/weapons/bladeslice.ogg'
+	embed_type = /datum/embed_data/combat_knife/weak
+	throwforce = 17
 	throw_speed = 4
-	embed_type = /datum/embed_data/forged_dagger
-	throwforce = 15
+	demolition_mod = 0.75
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_SMALL
-	resistance_flags = FIRE_PROOF
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	sharpness = SHARP_EDGED
 	tool_behaviour = TOOL_KNIFE
 
+/obj/item/forging/reagent_weapon/axe/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/butchering, \
+	speed = 8 SECONDS, \
+	effectiveness = 100, \
+	bonus_modifier = force + 7, \
+	)
+
 /datum/embed_data/forged_dagger
 	embed_chance = 50
-	fall_chance = 1
+	fall_chance = 10
 	pain_mult = 2
 
-//what a cute gimmick
-/obj/item/forging/reagent_weapon/dagger/attack(mob/living/M, mob/living/user, params)
-	. = ..()
-	user.changeNext_move(CLICK_CD_RANGE)
-
-//this isnt a weapon...
 /obj/item/forging/reagent_weapon/staff
 	name = "forged staff"
 	desc = "A staff most notably capable of being imbued with reagents, especially useful alongside its otherwise harmless nature."
@@ -99,99 +105,81 @@
 	throwforce = 0
 	slot_flags = ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_NORMAL
-	resistance_flags = FIRE_PROOF
 	attack_verb_continuous = list("bonks", "bashes", "whacks", "pokes", "prods")
 	attack_verb_simple = list("bonk", "bash", "whack", "poke", "prod")
 
-//omg, two tile range! surely i wont lose a fight now...
 /obj/item/forging/reagent_weapon/spear
 	name = "forged spear"
 	desc = "A long spear that can be wielded in two hands to boost damage at the cost of single-handed versatility."
 	force = 13
 	armour_penetration = 15
+	demolition_mod = 0.75
 	icon_state = "spear"
 	inhand_icon_state = "spear"
 	worn_icon_state = "spear_back"
-	throwforce = 22
+	throwforce = 24
 	throw_speed = 4
-	embed_data = /datum/embed_data/forged_spear
+	embed_data = /datum/embed_data/spear
 	slot_flags = ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_BULKY
-	resistance_flags = FIRE_PROOF
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("attack", "poke", "jab", "tear", "lacerate", "gore")
 	wound_bonus = -15
 	bare_wound_bonus = 15
 	reach = 2
-	sharpness = SHARP_EDGED
+	sharpness = SHARP_POINTY
 
-/datum/embed_data/forged_spear
-	embed_chance = 75
-	fall_chance = 0
-	pain_mult = 6
-
-//this is 1:1 with the bonespear, lets use this as a 'balance anchor'. weapons that blatantly outclass this are powercrept.
 /obj/item/forging/reagent_weapon/spear/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/two_handed, force_unwielded = 13, force_wielded = 23)
 
-//throwing weapons, what a fun gimmick. lets make them actually worth using
 /obj/item/forging/reagent_weapon/axe
 	name = "forged axe"
-	desc = "An axe especially balanced for throwing and embedding into fleshy targets. Nonetheless useful as a traditional melee tool."
-	force = 13
+	desc = "An axe especially balanced for throwing. Nonetheless useful as a traditional melee tool."
+	force = 15
 	armour_penetration = 10
+	demolition_mod = 1.2
 	icon_state = "axe"
 	inhand_icon_state = "axe"
 	worn_icon_state = "axe_back"
-	throwforce = 18
+	throwforce = 25
 	throw_speed = 4
+	demolition_mod = 1.2
 	embed_type = /datum/embed_data/forged_axe
 	slot_flags = ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_NORMAL
-	resistance_flags = FIRE_PROOF
 	attack_verb_continuous = list("slashes", "bashes")
 	attack_verb_simple = list("slash", "bash")
 	sharpness = SHARP_EDGED
 
 /datum/embed_data/forged_axe
-	embed_chance = 65
+	embed_chance = 40
 	fall_chance = 10
-	pain_mult = 4
+	pain_mult = 2
 
-//Boring option for doing the most raw damage
 /obj/item/forging/reagent_weapon/hammer
 	name = "forged hammer"
 	desc = "A heavy, weighted hammer that packs an incredible punch but can prove to be unwieldy. Useful for forging!"
-	force = 24 //Requires wielding
+	force = 10
 	armour_penetration = 10
+	demolition_mod = 2
 	icon_state = "crush_hammer"
 	inhand_icon_state = "crush_hammer"
 	worn_icon_state = "hammer_back"
 	throwforce = 10
+	throw_speed = 2
+	throw_range = 5
 	slot_flags = ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_BULKY
-	resistance_flags = FIRE_PROOF
 	attack_verb_continuous = list("bashes", "whacks")
 	attack_verb_simple = list("bash", "whack")
 	tool_behaviour = TOOL_HAMMER
-	///the list of things that, if attacked, will set the attack speed to rapid
-	var/static/list/fast_attacks = list(
-		/obj/structure/reagent_anvil,
-		/obj/structure/reagent_crafting_bench
-	)
 
 /obj/item/forging/reagent_weapon/hammer/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded = 24, force_wielded = 24, require_twohands = TRUE)
+	AddComponent(/datum/component/two_handed, force_unwielded = 10, force_wielded = 25, require_twohands = TRUE)
 	AddElement(/datum/element/kneejerk)
-
-/obj/item/forging/reagent_weapon/hammer/attack_atom(atom/attacked_atom, mob/living/user, params)
-	. = ..()
-	if(!is_type_in_list(attacked_atom, fast_attacks))
-		return
-	user.changeNext_move(CLICK_CD_RAPID)
 
 /obj/item/shield/buckler/reagent_weapon
 	name = "forged buckler shield"
@@ -204,19 +192,21 @@
 	lefthand_file = 'modular_nova/modules/reagent_forging/icons/mob/forge_weapon_l.dmi'
 	righthand_file = 'modular_nova/modules/reagent_forging/icons/mob/forge_weapon_r.dmi'
 	custom_materials = list(/datum/material/iron=HALF_SHEET_MATERIAL_AMOUNT)
-	resistance_flags = FIRE_PROOF
 	block_chance = 30
 	transparent = FALSE
-	max_integrity = 150 //over double that of a wooden one
+	max_integrity = 150
 	w_class = WEIGHT_CLASS_NORMAL
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_GREYSCALE | MATERIAL_AFFECT_STATISTICS
 	obj_flags_nova = ANVIL_REPAIR
+	resistance_flags = FIRE_PROOF | LAVA_PROOF
 	shield_break_sound = 'sound/effects/bang.ogg'
 	shield_break_leftover = /obj/item/forging/complete/plate
 
 /obj/item/shield/buckler/reagent_weapon/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/reagent_weapon)
+	AddElement(/datum/element/bane, mob_biotypes = MOB_BEAST, damage_multiplier = FAUNA_MULTIPLIER, requires_combat_mode = FALSE)
+	AddElement(/datum/element/bane, target_type = /mob/living/simple_animal/hostile/megafauna, damage_multiplier = MEGAFAUNA_MULTIPLIER, requires_combat_mode = FALSE)
 
 /obj/item/shield/buckler/reagent_weapon/examine(mob/user)
 	. = ..()
@@ -233,40 +223,43 @@
 				return
 			var/fixing_amount = min(max_integrity - atom_integrity, 5)
 			atom_integrity += fixing_amount
-			user.mind.adjust_experience(/datum/skill/smithing, 5) //useful heating means you get some experience
+			user.mind.adjust_experience(/datum/skill/smithing, 5)
 			balloon_alert(user, "partially repaired!")
 		return
 	return ..()
 
-/obj/item/shield/buckler/reagent_weapon/pavise //similar to the adamantine shield. Huge, slow, lets you soak damage and packs a wallop.
+/obj/item/shield/buckler/reagent_weapon/pavise
 	name = "forged pavise shield"
 	desc = "An oblong shield used by ancient crossbowmen as cover while reloading. Probably just as useful with an actual gun."
 	icon_state = "pavise"
 	inhand_icon_state = "pavise"
 	worn_icon_state = "pavise_back"
-	block_chance = 75
+	block_chance = 50
+	force = 12
 	item_flags = SLOWS_WHILE_IN_HAND
 	w_class = WEIGHT_CLASS_HUGE
 	slot_flags = ITEM_SLOT_BACK
 	max_integrity = 300 //tanky
 
-/obj/item/shield/buckler/reagent_weapon/pavise/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/two_handed, require_twohands = TRUE, force_wielded = 15)
-
 /obj/item/pickaxe/reagent_weapon
 	name = "forged pickaxe"
+	toolspeed = 0.75
 
 /obj/item/pickaxe/reagent_weapon/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/reagent_weapon)
+	AddElement(/datum/element/bane, mob_biotypes = MOB_BEAST, damage_multiplier = FAUNA_MULTIPLIER, requires_combat_mode = FALSE)
+	AddElement(/datum/element/bane, target_type = /mob/living/simple_animal/hostile/megafauna, damage_multiplier = MEGAFAUNA_MULTIPLIER, requires_combat_mode = FALSE)
 
 /obj/item/shovel/reagent_weapon
 	name = "forged shovel"
+	toolspeed = 0.75
 
 /obj/item/shovel/reagent_weapon/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/reagent_weapon)
+	AddElement(/datum/element/bane, mob_biotypes = MOB_BEAST, damage_multiplier = FAUNA_MULTIPLIER, requires_combat_mode = FALSE)
+	AddElement(/datum/element/bane, target_type = /mob/living/simple_animal/hostile/megafauna, damage_multiplier = MEGAFAUNA_MULTIPLIER, requires_combat_mode = FALSE)
 
 /obj/item/ammo_casing/arrow/attackby(obj/item/attacking_item, mob/user, params)
 	var/spawned_item
@@ -292,28 +285,27 @@
 	user.put_in_hands(converted_arrow)
 	qdel(src)
 
-#define INCREASE_BLOCK_CHANCE 2
-
 /obj/item/forging/reagent_weapon/bokken
 	name = "bokken"
-	desc = "A bokken that is capable of blocking attacks when wielding in two hands, possibly including bullets should the user be brave enough."
+	desc = "A wooden sword that is capable of blocking attacks when wielding in two hands, possibly including bullets should the user be brave enough. It seems to be made to prevent permanent injuries."
 	force = 20
+	armour_penetration = 40
 	icon_state = "bokken"
 	inhand_icon_state = "bokken"
 	worn_icon_state = "bokken_back"
-	throwforce = 10
 	block_chance = 20
+	damtype = STAMINA
 	slot_flags = ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_BULKY
-	resistance_flags = FIRE_PROOF
+	resistance_flags = FLAMMABLE
 	attack_verb_continuous = list("bonks", "bashes", "whacks", "pokes", "prods")
 	attack_verb_simple = list("bonk", "bash", "whack", "poke", "prod")
-	///whether the bokken is being wielded or not
 	var/wielded = FALSE
+	var/wielded_block_chance = 40
 
 /obj/item/forging/reagent_weapon/bokken/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, final_block_chance, damage, attack_type)
 	if(wielded)
-		final_block_chance *= INCREASE_BLOCK_CHANCE
+		final_block_chance = wielded_block_chance
 	if(prob(final_block_chance))
 		if(attack_type == PROJECTILE_ATTACK)
 			owner.visible_message(span_danger("[owner] deflects [attack_text] with [src]!"))
@@ -326,13 +318,11 @@
 		return TRUE
 	return FALSE
 
-#undef INCREASE_BLOCK_CHANCE
-
 /obj/item/forging/reagent_weapon/bokken/Initialize(mapload)
 	. = ..()
 	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, PROC_REF(on_wield))
 	RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, PROC_REF(on_unwield))
-	AddComponent(/datum/component/two_handed, force_unwielded = 20, force_wielded = 10)
+	AddComponent(/datum/component/two_handed, force_unwielded = 20, force_wielded = 30)
 
 /obj/item/forging/reagent_weapon/bokken/proc/on_wield()
 	SIGNAL_HANDLER
@@ -341,3 +331,14 @@
 /obj/item/forging/reagent_weapon/bokken/proc/on_unwield()
 	SIGNAL_HANDLER
 	wielded = FALSE
+
+/obj/item/forging/reagent_weapon/bokken/attack(mob/living/carbon/target_mob, mob/living/user, params)
+	. = ..()
+	if(!iscarbon(target_mob))
+		user.visible_message(span_warning("The [src] seems to be ineffective against the [target_mob]!"))
+		playsound(src, 'sound/weapons/genhit.ogg', 75, TRUE)
+		return
+	playsound(src, pick('sound/weapons/genhit1.ogg', 'sound/weapons/genhit2.ogg', 'sound/weapons/genhit3.ogg'), 100, TRUE)
+
+#undef FAUNA_MULTIPLIER
+#undef MEGAFAUNA_MULTIPLIER

--- a/modular_nova/modules/reagent_forging/code/forge_weapons.dm
+++ b/modular_nova/modules/reagent_forging/code/forge_weapons.dm
@@ -144,7 +144,7 @@
 	icon_state = "axe"
 	inhand_icon_state = "axe"
 	worn_icon_state = "axe_back"
-	throwforce = 25
+	throwforce = 20
 	throw_speed = 4
 	embed_type = /datum/embed_data/forged_axe
 	slot_flags = ITEM_SLOT_BACK

--- a/modular_nova/modules/reagent_forging/code/forge_weapons.dm
+++ b/modular_nova/modules/reagent_forging/code/forge_weapons.dm
@@ -287,13 +287,14 @@
 
 /obj/item/forging/reagent_weapon/bokken
 	name = "bokken"
-	desc = "A wooden sword that is capable of blocking attacks when wielding in two hands, possibly including bullets should the user be brave enough. It seems to be made to prevent permanent injuries."
-	force = 20
+	desc = "A wooden sword that is capable of wielded in two hands. It seems to be made to prevent permanent injuries."
+	force = 15
 	armour_penetration = 40
 	icon_state = "bokken"
 	inhand_icon_state = "bokken"
 	worn_icon_state = "bokken_back"
 	block_chance = 20
+	block_sound = 'sound/weapons/parry.ogg'
 	damtype = STAMINA
 	slot_flags = ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_BULKY
@@ -301,36 +302,24 @@
 	attack_verb_continuous = list("bonks", "bashes", "whacks", "pokes", "prods")
 	attack_verb_simple = list("bonk", "bash", "whack", "poke", "prod")
 	var/wielded = FALSE
+	var/unwielded_block_chance = 20
 	var/wielded_block_chance = 40
-
-/obj/item/forging/reagent_weapon/bokken/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, final_block_chance, damage, attack_type)
-	if(wielded)
-		final_block_chance = wielded_block_chance
-	if(prob(final_block_chance))
-		if(attack_type == PROJECTILE_ATTACK)
-			owner.visible_message(span_danger("[owner] deflects [attack_text] with [src]!"))
-			playsound(src, pick('sound/weapons/effects/ric1.ogg', 'sound/weapons/effects/ric2.ogg', 'sound/weapons/effects/ric3.ogg', 'sound/weapons/effects/ric4.ogg', 'sound/weapons/effects/ric5.ogg'), 100, TRUE)
-		else
-			playsound(src, 'sound/weapons/parry.ogg', 75, TRUE)
-			owner.visible_message(span_danger("[owner] parries [attack_text] with [src]!"))
-		var/owner_turf = get_turf(owner)
-		new block_effect(owner_turf, COLOR_YELLOW)
-		return TRUE
-	return FALSE
 
 /obj/item/forging/reagent_weapon/bokken/Initialize(mapload)
 	. = ..()
 	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, PROC_REF(on_wield))
 	RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, PROC_REF(on_unwield))
-	AddComponent(/datum/component/two_handed, force_unwielded = 20, force_wielded = 30)
+	AddComponent(/datum/component/two_handed, force_unwielded = 15, force_wielded = 25)
 
 /obj/item/forging/reagent_weapon/bokken/proc/on_wield()
 	SIGNAL_HANDLER
 	wielded = TRUE
+	block_chance = wielded_block_chance
 
 /obj/item/forging/reagent_weapon/bokken/proc/on_unwield()
 	SIGNAL_HANDLER
 	wielded = FALSE
+	block_chance = unwielded_block_chance
 
 /obj/item/forging/reagent_weapon/bokken/attack(mob/living/carbon/target_mob, mob/living/user, params)
 	. = ..()

--- a/modular_nova/modules/reagent_forging/code/forge_weapons.dm
+++ b/modular_nova/modules/reagent_forging/code/forge_weapons.dm
@@ -71,7 +71,7 @@
 	worn_icon_state = "dagger_back"
 	belt_icon_state = "dagger_belt"
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	embed_type = /datum/embed_data/combat_knife/weak
+	embed_type = /datum/embed_data/forged_dagger
 	throwforce = 17
 	throw_speed = 4
 	demolition_mod = 0.75
@@ -93,7 +93,8 @@
 /datum/embed_data/forged_dagger
 	embed_chance = 50
 	fall_chance = 10
-	pain_mult = 2
+	pain_mult = 4
+	ignore_throwspeed_threshold = TRUE
 
 /obj/item/forging/reagent_weapon/staff
 	name = "forged staff"

--- a/modular_nova/modules/reagent_forging/code/forge_weapons.dm
+++ b/modular_nova/modules/reagent_forging/code/forge_weapons.dm
@@ -146,7 +146,6 @@
 	worn_icon_state = "axe_back"
 	throwforce = 25
 	throw_speed = 4
-	demolition_mod = 1.2
 	embed_type = /datum/embed_data/forged_axe
 	slot_flags = ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_NORMAL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Balance of reagent weapons proposal

Overall, it gives some QoL for reagent weapons users, the add of the bane element,  minor buffs and common sense traits, while removing the unbalanced aspects we had with thrown weapons due to not understanding the different equations involved.

To all weapons we make them Lava Proof as well as electriciticy conductive. We also add the bane element for beasts and megafauna, which basically makes them twice the damage in melee, and add their melee damage to their thrown damage. Additionally, all weapons, and bows, can now be fitted in the colonist and mining themed armors (so the drake armor can finally have the bow / forged spear on their exosuit slot)

Onto specifics:

Sword:
+10 ap, -5 block chance, 20% bonus damage against objects.

Katana:
+15 ap, -10 block chance

Dagger:
Removed the quick attack, throw force +2, pain mult +2, fall chance set to 10 instead of 1, added a bonus to butchering meat, added the ability to store in boots that have storage, -25% damage to objects. Normalized the Embeed stats.

Staff:
No changes

Spear:
-25% damage to objects, Embeeding works like regular spears, +2 throw force

Axe:
+2 force, +20% against objects, +2 to throw damage, embeed chance reduced by 15%, damage on embeed reduced by 6

Hammer:
+1 damage,+100% damage against objects, throw speed reduce by 1, throw range reduced by 2, removed redundant rapid click code that is no longer used.

buckler:
no extra changes

Pavise:
made one handed (still slows you down), reduced block chance to 50, reduced damage to 12

Shovel and Pickaxe:
Made it so they are 25% faster than the regular mass produced counterparts.

Bokken:
Changed the weapon damage to Stamina, made its block chance behave like any other weapon, since as discussed with JR, its too strong of an ability we need implants and this was giving it for free for 4 wood. Damage is 15 unwielded, 25 wielded,  and block chance is 20 and 40 respectively, it is flammable since its a wooden sword. It does not work on mobs.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

First and foremost, throwing a spear and killing even people in the most protective armor in the game with a very little investment is bad design if other weapons that are much more advanced require so much. So the old super ninja spears had to go.

The bokken being able to reflect _any_ kind of attach with no real reason attach to it had to do, not to mention that some players expressed their desire for a non lethal option for tribals.

Finally, I believe its bad design to not add things in return, and I saw that it was a good chance to make forged weapons more appealing by doing the same thing the weapon most used for surviving was doing, the bow, which was doing extra damage, thus, the idea to apply bane was born.

I tried to buff all weapons with this in mind, given them some more distinct niche while using the most used stuff in the station as a baseline too, so, things forged should be better than mass produced stuff in the station but not better than hard to get objects, an example is the shamshir blade, aka the cargo sabre (which you might notice its only slightly better, but it doesnt have the fauna bonus nor the 20% vs objects)

All in all, I want this PR to be something that is well received and leaves a good after taste even as the inevitable nerf for the first two points will come regardless of my paltry attempt to lessen the blow.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  It was tested, but I urge the staff to test it on the side and see if they are happy with the changes.
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Added additional storages for Forged Weapons and bows, colonist and mining types exosuits (this includes gear harness) now store them too. Shoe types with storage also store forged daggers.
qol: Forged weapons are now also lavaproof.
balance: Forged weapons ungodly throwing stats were balanced and brough to more normal levels, allow Cúchulainn to rest.
balance: All Forged weapons (plus shields and mining tools) gain the Bane element against Beasts and Megafauna, this means that they do a bonus damage equal to their melee damage against against them (so a sword does 40 when you hit with it, and 25 if you throw it). This affects more creatures than the ones in the mines, like carps or Ian.
balance: Forged Sword does 20 damage, with 20 AP, 20 block chance and has 20% more damage against objects. Bulky sized.
balance: Forged Katana does 20 damage, with 40 AP, and 10 block chance. Bulky sized.
balance: Forged Dagger does 13 damage, 25% less to objects, and 17 damage when thrown, it additionally has a bonus when used to butcher. Small sized.
balance: Forged Spear does 13 damage while unwielded, 23 while wielded, with 10 AP, 24 damage when thrown and reach of 2 tiles. Bulky sized.
balance: Forged Axe does 15 damage, armor penetration 10, throw force of 20 and 20% more damage against objects. Normal sized.
balance: Forged Hammer forces you to carry it two handed, does 25 damage, with 10 AP and does double damage against objects. Bulky sized.
balance: Forged Buckler does 10 damage, has 30 block chance and 150 integrity (a lot for a shield). Normal sized.
balance: Forged Pavise does 12 damage, has 50 block chance, requires only one hand but slows you down while in your hand, with 300 integrity. Huge sized.
balance: Forged Shovel and Pickaxe have a 25% speed bonus when used to mine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
