### PR TITLE
Revert "Fixes bedsheets laid incorrectly onto beds (#85837)"

### DIFF
--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -44,7 +44,7 @@
 /obj/item/toy/plush/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/squeak, squeak_override)
-	AddElement(/datum/element/bed_tuckable, mapload, 6, 7, 90)
+	AddElement(/datum/element/bed_tuckable, mapload, 6, -5, 90)
 	AddElement(/datum/element/toy_talk)
 
 	//have we decided if Pinocchio goes in the blue or pink aisle yet?

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -38,7 +38,7 @@ LINEN BINS
 /obj/item/bedsheet/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/surgery_initiator)
-	AddElement(/datum/element/bed_tuckable, mapload, 0, 12, 0)
+	AddElement(/datum/element/bed_tuckable, mapload, 0, 0, 0)
 	if(bedsheet_type == BEDSHEET_DOUBLE)
 		stack_amount *= 2
 		dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET

--- a/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -26,7 +26,7 @@
 
 /obj/item/disk/nuclear/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/bed_tuckable, mapload, 6, 6, 0)
+	AddElement(/datum/element/bed_tuckable, mapload, 6, -6, 0)
 	AddComponent(/datum/component/stationloving, !fake)
 
 	if(!fake)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/4302

This was a wallening PR that got merged with the batch on accident.

## Changelog

:cl:
fix: bedsheet pixel offsets should be fixed
/:cl: