### PR TITLE
Mood Buff while on special dorms

### DIFF
--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -418,6 +418,10 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	has_gravity = TRUE
 	area_flags = NOTELEPORT | HIDDEN_AREA
 	static_lighting = TRUE
+	// NOVA EDIT ADDITION - GHOST HOTEL UPDATE
+	mood_bonus = 25
+	mood_message = "I am taking a well deserved rest!"
+	// NOVA EDIT END
 	/* 	NOVA EDIT REMOVAL - GHOST HOTEL UPDATE
 	ambientsounds = list('sound/ambience/servicebell.ogg')
 	NOVA EDIT END */

--- a/modular_nova/modules/mapping/code/areas/centcom.dm
+++ b/modular_nova/modules/mapping/code/areas/centcom.dm
@@ -6,6 +6,8 @@
 
 /area/centcom/holding
 	name = "Holding Facility"
+	mood_bonus = 25
+	mood_message = "I am taking a well deserved rest!"
 
 /area/centcom/holding/cafe
 	name = "Ghost Cafe"
@@ -24,3 +26,5 @@
 
 /area/centcom/interlink/dorm_rooms
 	name = "Interlink Dorm Rooms"
+	mood_bonus = 25
+	mood_message = "I am taking a well deserved rest!"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Gives a 25 mood bonus to the Cafe areas, the Hillbert hotel rooms, and the interlink dorms.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

It allows for the long RP focused moments people tend to have in the hotel without having the maluses or issues that arise from a bad mood, often time needing to plan for a round's worth of food and interruption for such. 

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  Cafe and Hotel:
  
![image](https://github.com/user-attachments/assets/331e18a4-7f42-4459-8c4a-19b0698f27a1)

Interlink Dorm:

![image](https://github.com/user-attachments/assets/1606fabc-c39c-43d8-ad33-b1dbfb794f80)

Proof it doesnt carry outside the dorm:

![image](https://github.com/user-attachments/assets/b4da53bc-61f1-47c8-bd5d-430f13961d11)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: The Cafe areas and the Interlink Dorms now properly account for how one would feel being off the clock, making you happy enough to counter most work related worries while inside. (You get a mood buff inside those areas)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
