### PR TITLE
Modernizes the SEVA allowed items

### DIFF
--- a/modular_nova/modules/SEVA_suit/code/seva_obj.dm
+++ b/modular_nova/modules/SEVA_suit/code/seva_obj.dm
@@ -17,7 +17,10 @@
 	armor_type = /datum/armor/hooded_seva
 	resistance_flags = FIRE_PROOF
 	transparent_protection = HIDEJUMPSUIT
-	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/gun/energy/recharge/kinetic_accelerator, /obj/item/pickaxe)
+
+/obj/item/clothing/suit/hooded/seva/Initialize(mapload)
+	. = ..()
+	allowed = GLOB.mining_suit_allowed
 
 /datum/armor/hooded_seva
 	melee = 20


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Like in #2795 , modernizes the SEVA allowed items to use the same global mining items all other mining related exosuits use.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Consistent and unified allowed objects allows for the SEVA to need less maintenance on the future as anything we do on that list will affect SEVA too, it makes sense in setting that the two base mining outfits can carry the same and are standarized, and allows those that preffer the seva protection to use it without giving up on an entire playstyle.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/b4208772-813a-4ae4-b29c-32abd2a4694d)
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: SEVA suits use the same global list of items allowed than the rest of mining (they can carry crushers now).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
