### PR TITLE
Ouroboros fixes and tweaks

### DIFF
--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -31755,6 +31755,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "jjv" = (
@@ -43073,6 +43074,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/corner,
 /area/station/commons/dorms)
 "mtK" = (
@@ -51697,7 +51699,9 @@
 /area/station/maintenance/disposal/incinerator)
 "oUZ" = (
 /obj/effect/turf_decal/box/red,
-/obj/item/banner/red,
+/obj/item/banner/red{
+	inspiration_available = 0
+	},
 /obj/effect/turf_decal/siding/white/corner,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/common/laser_tag)
@@ -60445,9 +60449,11 @@
 /area/station/ai_monitored/command/nuke_storage)
 "rCS" = (
 /obj/effect/turf_decal/box/blue,
-/obj/item/banner/blue,
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 1
+	},
+/obj/item/banner/blue{
+	inspiration_available = 0
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/common/laser_tag)

--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -17955,7 +17955,6 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/structure/cable,
-/obj/item/stack/rods/fifty,
 /turf/open/floor/iron,
 /area/station/maintenance/aft/greater)
 "fjL" = (

--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -145,6 +145,10 @@
 /obj/structure/chair/office,
 /obj/effect/landmark/start/engineering_guard,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "acy" = (
@@ -793,6 +797,8 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "ama" = (
@@ -1648,11 +1654,13 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central/aft)
 "aAk" = (
-/obj/machinery/holopad,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
 /obj/machinery/computer/security/telescreen/engine/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "aAm" = (
@@ -2206,7 +2214,6 @@
 /area/station/commons/storage/mining)
 "aIy" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -2626,9 +2633,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/machinery/light/small/directional/west,
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/dark,
@@ -2947,7 +2951,6 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/structure/chair/comfy/black,
 /obj/machinery/light/small/blacklight/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/room4)
 "aUE" = (
@@ -3438,11 +3441,8 @@
 /area/station/security/holding_cell)
 "bcz" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/machinery/light_switch/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms/room5)
@@ -5004,7 +5004,9 @@
 	pixel_y = 9;
 	specialfunctions = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -5401,7 +5403,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/common/cryopods)
+/area/station/commons/dorms)
 "bCk" = (
 /turf/closed/wall,
 /area/station/service/library/private)
@@ -5870,7 +5872,11 @@
 /area/station/maintenance/aft/greater)
 "bJq" = (
 /obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/wood,
 /area/station/commons/dorms/room1)
 "bJB" = (
@@ -8036,7 +8042,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/commons/dorms)
+/area/station/maintenance/port/aft)
 "crT" = (
 /obj/structure/bed/double,
 /obj/effect/spawner/random/bedsheet/double,
@@ -8078,11 +8084,8 @@
 /area/station/hallway/secondary/entry)
 "csF" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/machinery/light_switch/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/room4)
@@ -8760,7 +8763,9 @@
 	pixel_y = 9;
 	specialfunctions = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -12566,7 +12571,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/status_display/evac/directional/south,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/corner,
 /area/station/commons/dorms)
 "dKn" = (
@@ -12971,7 +12975,6 @@
 /obj/machinery/light/warm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "dQe" = (
@@ -13956,9 +13959,6 @@
 "ebZ" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/spawner/random/structure/closet_private,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/commons/dorms/room2)
 "ecl" = (
@@ -14651,8 +14651,10 @@
 	specialfunctions = 4;
 	pixel_y = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms/room2)
@@ -15235,8 +15237,9 @@
 	pixel_x = 4
 	},
 /obj/machinery/light/small/blacklight/directional/east,
-/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/dark/small,
 /area/station/commons/dorms/room4)
 "eug" = (
@@ -15780,9 +15783,6 @@
 "eCM" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/spawner/random/structure/closet_private,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/commons/dorms/room5)
 "eCN" = (
@@ -17955,6 +17955,7 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/structure/cable,
+/obj/item/stack/rods/fifty,
 /turf/open/floor/iron,
 /area/station/maintenance/aft/greater)
 "fjL" = (
@@ -19225,8 +19226,10 @@
 	specialfunctions = 4;
 	pixel_y = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms/room1)
@@ -20142,8 +20145,6 @@
 /obj/structure/chair/comfy{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/dorms/room5)
 "fTt" = (
@@ -20200,6 +20201,9 @@
 /obj/effect/landmark/start/engineering_guard,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
@@ -20269,8 +20273,10 @@
 	specialfunctions = 4;
 	pixel_y = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms/room3)
@@ -20383,11 +20389,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "fXd" = (
-/obj/item/stack/rods/fifty,
-/obj/structure/rack,
-/obj/item/stack/sheet/mineral/plasma/five,
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/station/maintenance/aft/greater)
 "fXg" = (
 /obj/effect/spawner/random/structure/crate,
@@ -22434,7 +22437,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/common/cryopods)
+/area/station/commons/dorms)
 "gCE" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/siding/dark_blue,
@@ -26992,7 +26995,6 @@
 /area/station/command/teleporter)
 "hTG" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -29419,11 +29421,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
-"iAW" = (
-/obj/structure/hedge,
-/obj/structure/window/fulltile,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/commons/dorms/room3)
 "iAX" = (
 /obj/effect/turf_decal/tile/dark_red{
 	dir = 8
@@ -31205,9 +31202,6 @@
 "jbB" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/spawner/random/structure/closet_private,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/commons/dorms/room3)
 "jbG" = (
@@ -31761,7 +31755,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/hangover,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "jjv" = (
@@ -32173,7 +32166,6 @@
 	pixel_y = 22;
 	pixel_x = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/dorms/room3)
 "jrg" = (
@@ -32845,7 +32837,6 @@
 /area/station/medical/medbay/central)
 "jAS" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/flatpacker,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "jAT" = (
@@ -33993,6 +33984,11 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/item/flatpack{
+	board = /obj/item/circuitboard/machine/flatpacker;
+	pixel_x = -6;
+	pixel_y = 5
+	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "jSO" = (
@@ -34763,6 +34759,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/atmos/upper)
 "kdD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/dorms/room1)
@@ -34857,9 +34854,6 @@
 /obj/machinery/computer/records/security,
 /obj/effect/turf_decal/box,
 /obj/machinery/digital_clock/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
@@ -36946,6 +36940,9 @@
 /turf/open/openspace,
 /area/station/engineering/transit_tube)
 "kHA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/station/commons/dorms/room5)
 "kHF" = (
@@ -41654,6 +41651,9 @@
 /area/station/service/salon)
 "lXd" = (
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "lXf" = (
@@ -41978,9 +41978,6 @@
 "mby" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/spawner/random/structure/closet_private,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/commons/dorms/room6)
 "mbC" = (
@@ -42831,7 +42828,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/corner,
 /area/station/commons/dorms)
 "mpS" = (
@@ -42993,6 +42989,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "msz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/station/commons/dorms/room2)
 "msA" = (
@@ -43074,7 +43073,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/corner,
 /area/station/commons/dorms)
 "mtK" = (
@@ -43096,6 +43094,9 @@
 "mtR" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/rack,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/sheet/mineral/plasma/five,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "mtT" = (
@@ -43113,8 +43114,10 @@
 	pixel_y = 9;
 	specialfunctions = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms/room6)
@@ -44332,13 +44335,6 @@
 	},
 /turf/open/floor/iron/checker,
 /area/station/service/kitchen/diner)
-"mKL" = (
-/obj/structure/bodycontainer/morgue,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/effect/turf_decal/bot_white,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/morgue)
 "mKO" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -45435,7 +45431,6 @@
 	pixel_y = 22;
 	pixel_x = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/dorms/room2)
 "mZD" = (
@@ -47749,7 +47744,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/common/cryopods)
+/area/station/commons/dorms)
 "nHQ" = (
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/engine/vacuum,
@@ -49417,8 +49412,6 @@
 /obj/structure/chair/comfy{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/dorms/room2)
 "ojT" = (
@@ -50043,6 +50036,7 @@
 "osk" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/wood,
 /area/station/commons/dorms/room6)
 "osl" = (
@@ -50111,6 +50105,9 @@
 /turf/open/floor/iron/checker,
 /area/station/service/kitchen/diner)
 "oto" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/dorms/room6)
@@ -50224,9 +50221,6 @@
 "ouH" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /obj/item/surgery_tray/full/morgue,
@@ -51466,7 +51460,6 @@
 /turf/open/floor/glass/reinforced,
 /area/station/science/xenobiology)
 "oQi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/coroner,
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_y = 14;
@@ -52862,7 +52855,9 @@
 /area/station/hallway/secondary/entry)
 "pnM" = (
 /obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/wood,
 /area/station/commons/dorms/room3)
 "pnQ" = (
@@ -57137,11 +57132,11 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/iron/edge{
 	dir = 8
@@ -59468,11 +59463,8 @@
 /area/station/science/robotics/lab)
 "rlC" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light_switch/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms/room2)
@@ -60234,7 +60226,6 @@
 	pixel_y = 22;
 	pixel_x = -4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/dorms/room5)
 "rya" = (
@@ -60687,6 +60678,8 @@
 /area/station/security/lockers)
 "rGm" = (
 /obj/machinery/light/small/blacklight/directional/north,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "rGn" = (
@@ -60989,11 +60982,11 @@
 "rMx" = (
 /obj/effect/turf_decal/tile/yellow/half,
 /obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/iron/edge,
 /area/station/engineering/main)
@@ -62569,7 +62562,9 @@
 /area/station/science/xenobiology)
 "shE" = (
 /obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/wood,
 /area/station/commons/dorms/room2)
 "shG" = (
@@ -63198,11 +63193,8 @@
 /area/station/engineering/atmos/office)
 "srF" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light_switch/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms/room3)
@@ -65079,8 +65071,6 @@
 /obj/structure/chair/comfy{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/dorms/room6)
 "sRf" = (
@@ -65197,11 +65187,6 @@
 	dir = 1
 	},
 /area/station/maintenance/port/greater)
-"sTA" = (
-/obj/structure/hedge,
-/obj/structure/window/fulltile,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/common/cryopods)
 "sTE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -66000,7 +65985,6 @@
 /obj/item/clothing/mask/whistle,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/north,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
 	},
@@ -66298,7 +66282,9 @@
 /area/station/science/explab)
 "tjh" = (
 /obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/wood,
 /area/station/commons/dorms/room5)
 "tjE" = (
@@ -68532,9 +68518,6 @@
 /obj/item/storage/box/strippole_kit,
 /obj/item/storage/backpack/satchel,
 /obj/item/clothing/glasses/nice_goggles,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/room4)
 "tUl" = (
@@ -69055,7 +69038,7 @@
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/primary/port)
 "ucK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "ucT" = (
@@ -69272,10 +69255,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
-/obj/machinery/door/window/left/directional/south{
-	name = "Engineering Desk";
-	req_access = list("engineering")
-	},
 /obj/item/paper_bin{
 	pixel_x = -5;
 	pixel_y = 4
@@ -69289,6 +69268,7 @@
 	name = "Engineering Blast Door"
 	},
 /obj/structure/cable,
+/obj/machinery/door/window/left/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "ugj" = (
@@ -75319,8 +75299,6 @@
 /obj/structure/chair/comfy{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/dorms/room1)
 "vOa" = (
@@ -77925,9 +77903,6 @@
 	pixel_x = 7;
 	pixel_y = 3
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
@@ -79526,9 +79501,6 @@
 "wVc" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/spawner/random/structure/closet_private,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/commons/dorms/room1)
 "wVg" = (
@@ -80868,8 +80840,6 @@
 /obj/structure/chair/comfy{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/dorms/room3)
 "xsO" = (
@@ -81096,6 +81066,9 @@
 /turf/open/floor/carpet/black,
 /area/station/command/heads_quarters/ce)
 "xxd" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/small,
 /area/station/commons/dorms/room4)
 "xxw" = (
@@ -81648,9 +81621,6 @@
 	pixel_y = 22;
 	pixel_x = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/dorms/room6)
@@ -82074,11 +82044,6 @@
 "xJI" = (
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/brig/entrance)
-"xJN" = (
-/obj/structure/hedge,
-/obj/structure/window/fulltile,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/commons/dorms/room4)
 "xJQ" = (
 /obj/structure/bed/double,
 /obj/item/bedsheet/centcom/double,
@@ -82631,6 +82596,9 @@
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/primary/central/aft)
 "xUv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/station/commons/dorms/room3)
 "xUy" = (
@@ -120901,7 +120869,7 @@ kpb
 ghZ
 mMb
 jEF
-mKL
+pit
 pit
 hQF
 uOJ
@@ -121684,7 +121652,7 @@ xOm
 xOm
 aUS
 twj
-ePd
+vIg
 ePd
 lzn
 hbh
@@ -177971,11 +177939,11 @@ tPF
 aAm
 wUS
 jNS
-jyy
-jyy
-jyy
-jyy
-jyy
+gfP
+gfP
+gfP
+gqd
+gqd
 sah
 qyI
 gqd
@@ -178227,12 +178195,12 @@ jUK
 aAm
 aAm
 crS
-jyy
-jyy
+gfP
+gfP
 vFy
 bJq
 vNQ
-jyy
+gqd
 pJn
 ndH
 gqd
@@ -178489,7 +178457,7 @@ fFk
 aIy
 kdD
 wPp
-jyy
+gqd
 wit
 gqd
 gqd
@@ -178746,7 +178714,7 @@ jyy
 wVc
 mCY
 xte
-jyy
+gqd
 gqd
 gqd
 jNS
@@ -178999,12 +178967,12 @@ aAm
 jiE
 syb
 vMj
-bfC
-bfC
-bfC
-bfC
-bfC
-bfC
+jyy
+jyy
+jyy
+jyy
+jyy
+gfP
 lqY
 nEJ
 gfP
@@ -179261,7 +179229,7 @@ emu
 rlC
 shE
 ojf
-bfC
+gfP
 bHM
 jNS
 uIV
@@ -179518,7 +179486,7 @@ bfC
 mZy
 msz
 bxo
-bfC
+gfP
 gfP
 gEQ
 gfP
@@ -179775,7 +179743,7 @@ bfC
 ebZ
 crT
 juQ
-bfC
+gfP
 wJm
 ygD
 koe
@@ -180028,12 +179996,12 @@ feC
 qLH
 uQp
 lyh
-eLT
-eLT
-eLT
-eLT
-eLT
-eLT
+bfC
+bfC
+bfC
+bfC
+gfP
+gfP
 new
 mDm
 rmw
@@ -180290,7 +180258,7 @@ fVB
 srF
 pnM
 xsG
-eLT
+gfP
 vZm
 nYH
 rmw
@@ -180547,7 +180515,7 @@ eLT
 jqN
 xUv
 nPA
-eLT
+gfP
 vZm
 viG
 rmw
@@ -180804,7 +180772,7 @@ eLT
 jbB
 anV
 igA
-eLT
+gfP
 vZm
 gfP
 gfP
@@ -181052,16 +181020,16 @@ hab
 hab
 hab
 hab
-sTA
+xpi
 nHH
 gCr
-sTA
-iAW
+xpi
+xpi
 eLT
 eLT
 eLT
 eLT
-eLT
+gfP
 gfP
 gfP
 bRn
@@ -183108,11 +183076,11 @@ hab
 hab
 hab
 hab
-sTA
+xpi
 bCf
 gCr
-sTA
-xJN
+xpi
+xpi
 hoa
 hoa
 hoa
@@ -185167,10 +185135,10 @@ npF
 vBA
 bzw
 fXE
-qdL
-qdL
-qdL
-qdL
+ptp
+ptp
+ptp
+ptp
 pHy
 pHy
 uTA

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -76,7 +76,6 @@ map blueshift
 endmap
 
 map ouroboros
-	default
 	maxplayers 80
 	votable
 endmap

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -76,6 +76,7 @@ map blueshift
 endmap
 
 map ouroboros
+	default
 	maxplayers 80
 	votable
 endmap


### PR DESCRIPTION
## About The Pull Request
Fixes and tweak stuff in Ouroboros to keep it consistent with other maps

-Laser tag banners no longer heal
-Flatpacker now starts as a flatpacking cube rather than pre-built, decal was kept intact as an indicator to build new machines on.
-Engineering lobby windoor rotated to north
-Adds a vent in engineering lobby
-Repipes the morgue, engineering guard post, dorms
-Changed the areas a bit in dorms
-Moved morgue APC from being on top of a morgue tray to somewhere else.
-Moved firelocks at engine room
-Moved a misplaced wall in maintenance
## How This Contributes To The Nova Sector Roleplay Experience
Makes Ouroboros better and more consistent with the other maps.

The reasoning for every change:
Banners are not meant to heal unless it's bussed by an admin.
Every other map starts with the flatpacker as a flatpack rather than pre-built.
Every other map (afaik) has the windoor facing into the lobby as well as making it easier to hand over stuff through it.
Every room is meant to have a scrubber and a vent, and the lobby was missing at least one vent.
Some places had vents and scrubbers obstructed, which can make engineering's job a bit hard.
Makes the areas marked around dorms a bit more consistent.
Morgue APC being on the top of a morgue tray is really awkward to work on.
The firelocks at engine room looked a bit odd and needed a little relocation.
One of the rooms in maintenance looked a bit cursed with the wall placement.
## Proof of Testing
It has been tested in game and should lint.

<details>
<summary>Screenshots/Videos</summary>
Nothing player facing for laser tag banners

![StrongDMM_qaACjcEG7n](https://github.com/user-attachments/assets/247ac222-a69a-4b6f-a105-e7cc24e3095a)

The bedsheet offset was not changed and is an issue unrelated to this PR or map

![image](https://github.com/user-attachments/assets/1a029d04-4740-43a8-af6b-8e22f0a3dcf0)

![image](https://github.com/user-attachments/assets/6fc630cd-cc52-4cd3-933d-4d2e86ef92ca)

![image](https://github.com/user-attachments/assets/bfe3ef2c-5dd1-43dd-93ed-995c0f7cd9ba)

![image](https://github.com/user-attachments/assets/964924b3-e637-4511-97de-47fe5d24f3b1)

![image](https://github.com/user-attachments/assets/4b6e2df0-a008-4019-88e7-c15a34441455)

![image](https://github.com/user-attachments/assets/f4f58324-5c1f-4682-9d79-9f8ce5eaa2ca)

Before (Engi firelocks)

![image](https://github.com/user-attachments/assets/4f041a65-c242-4d52-b3f0-cb00806157b9)

After (Engi firelocks)

![image](https://github.com/user-attachments/assets/8b04b773-ea12-4677-ad1c-7fc1bcf40d42)

  
</details>

## Changelog
:cl: Hardly
fix: Ouroboros laser tag banners no longer heal
fix: Added a missing vent in Ouroboros engineering lobby
tweak: Ouroboros flatpacker now starts as a flatpack, rather than pre-built
tweak: Repipes Ouroboros morgue, engineering guard post and dorms
tweak: Ouroboros morgue APC has been moved and is no longer on the top of a tray
tweak: Moved the firelocks in Ouroboros engine room one tile to the left
fix: Moves a misplaced maint wall in Ouroboros one tile to the left
/:cl:
