### PR TITLE
readds improved sutures/mesh to company imports

### DIFF
--- a/modular_nova/modules/company_imports/code/armament_datums/deforest_medical.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/deforest_medical.dm
@@ -56,6 +56,10 @@
 	item_type = /obj/item/stack/medical/suture
 	cost = PAYCHECK_LOWER
 
+datum/armament_entry/company_import/deforest/first_aid/medicated_sutures
+	item_type = /obj/item/stack/medical/suture/medicated
+	cost = PAYCHECK_LOWER * 2
+
 /datum/armament_entry/company_import/deforest/first_aid/red_sun
 	item_type = /obj/item/stack/medical/ointment/red_sun
 	cost = PAYCHECK_LOWER
@@ -67,6 +71,10 @@
 /datum/armament_entry/company_import/deforest/first_aid/mesh
 	item_type = /obj/item/stack/medical/mesh
 	cost = PAYCHECK_LOWER
+
+/datum/armament_entry/company_import/deforest/first_aid/advanced_mesh
+	item_type = /obj/item/stack/medical/mesh/advanced
+	cost = PAYCHECK_LOWER * 2
 
 /datum/armament_entry/company_import/deforest/first_aid/sterile_gauze
 	item_type = /obj/item/stack/medical/gauze/sterilized


### PR DESCRIPTION
## About The Pull Request
title

## How This Contributes To The Nova Sector Roleplay Experience
parity, ish. you can get these through buying the medical technician kit which comes with all sorts of other stuff, or you can roll for it through explorer surplus gacha. might as well cut the middleman

## Changelog

:cl:
add: DeForest is once again stocking medicated sutures and aloe-enhanced regenerative mesh for import through Cargo.
/:cl:
