### PR TITLE
fix announcer text len

### DIFF
--- a/modular_nova/modules/moretraitoritems/code/traitor_announcer.dm
+++ b/modular_nova/modules/moretraitoritems/code/traitor_announcer.dm
@@ -43,7 +43,7 @@
 		balloon_alert(user, "bad title!")
 		return
 
-	var/input = sanitize_text(reject_bad_text(tgui_input_text(user, "Choose the bodytext of the announcement.", "Announcement Text", multiline = TRUE), ascii_only = FALSE))
+	var/input = sanitize_text(reject_bad_text(tgui_input_text(user, "Choose the bodytext of the announcement.", "Announcement Text", multiline = TRUE), max_length = MAX_MESSAGE_LEN, ascii_only = FALSE))
 	if(!input)
 		balloon_alert(user, "bad text!")
 		return


### PR DESCRIPTION
## About The Pull Request

Fixes allowable size for input to traitor announcer

## How This Contributes To The Nova Sector Roleplay Experience

Ability to enter large messages for annonces 512 -> 2048 characters

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/eea11174-81bf-4ab6-aa11-ab95af24d73e)  

</details>

## Changelog

:cl:
fix: fixed input size for traitor announcer (512 -> 2048 chars)
/:cl:

