### PR TITLE
Removes the branded name from the detectives revolver.

### DIFF
--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -33,7 +33,7 @@
 	contains = list(/obj/item/ammo_box/c38/match/bouncy)
 
 /datum/supply_pack/goody/mars_single
-	name = "Colt Detective Special Single-Pack"
+	name = "Cik Detective Special Single-Pack" // NOVA CHANGE - Branded name away, original: "Colt Detective Special Single-Pack"
 	desc = "The HoS took your gun and your badge? No problem! Just pay the absurd taxation fee and you too can be reunited with the lethal power of a .38!"
 	cost = PAYCHECK_CREW * 40 //they really mean a premium here
 	access_view = ACCESS_WEAPONS

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -110,7 +110,7 @@
 	fire_sound = 'sound/weapons/gun/revolver/shot.ogg'
 
 /obj/item/gun/ballistic/revolver/c38/detective
-	name = "\improper Colt Detective Special"
+	name = "\improper Cik Detective Special" // NOVA CHANGE - Branded name away, original: name = "\improper Colt Detective Special"
 	desc = "A classic, if not outdated, law enforcement firearm. Uses .38 Special rounds. \nSome spread rumors that if you loosen the barrel with a wrench, you can \"improve\" it."
 
 	can_modify_ammo = TRUE

--- a/modular_nova/modules/moretraitoritems/code/weapons.dm
+++ b/modular_nova/modules/moretraitoritems/code/weapons.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/ballistic/revolver/ocelot
-	name = "Colt Peacemaker revolver"
+	name = "Cik Peacemaker revolver"
 	desc = "A modified Peacemaker revolver that chambers .357 ammo. Less powerful than the regular .357, but ricochets a lot more." // We need tension...conflict. The world today has become too soft. We're living in an age where true feelings are suppressed. So we're going to shake things up a bit. We'll create a world dripping with tension... ...a world filled with greed and suspicion, bravery and cowardice.
 	// this could probably be made funnier by reducing its damage multiplier but also making it so that every fired bullet has the wacky ricochets
 	// but that's a different plate of cookies for a different glass of milk


### PR DESCRIPTION


## About The Pull Request
Having a trademarked brand, and gun name with said brand name, presented in-game probably isn't wise.

## How This Contributes To The Nova Sector Roleplay Experience

Shouldn't be much of a difference, outside of it not being called 'colt' anymore

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  just a text change
</details>

## Changelog
:cl:
spellcheck: The detectives revolver no longer bears a trademarked brand.
/:cl:
