### PR TITLE
Fixes moth dash granting permanent flight in certain circumstances

### DIFF
--- a/modular_nova/modules/customization/modules/surgery/organs/wings.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/wings.dm
@@ -85,8 +85,8 @@
 
 	var/atom/dash_target = get_edge_target_turf(owner, owner.dir) //gets the user's direction
 
+	ADD_TRAIT(owner, TRAIT_MOVE_FLOATING, LEAPING_TRAIT)
 	if (owner.throw_at(dash_target, jumpdistance, jumpspeed, spin = FALSE, diagonals_first = TRUE, callback = TRAIT_CALLBACK_REMOVE(owner, TRAIT_MOVE_FLOATING, LEAPING_TRAIT)))
-		ADD_TRAIT(owner, TRAIT_MOVE_FLOATING, LEAPING_TRAIT)
 		playsound(owner, 'sound/voice/moth/moth_flutter.ogg', 50, TRUE, TRUE)
 		owner.visible_message(span_warning("[usr] propels themselves forwards with a heavy wingbeat!"))
 		COOLDOWN_START(src, dash_cooldown, 6 SECONDS)
@@ -94,6 +94,7 @@
 		if(istype(dash_user))
 			dash_user.adjustStaminaLoss(37.5) //Given the risk of flying into things and crashing quite violently, you get four of these. Every one slows you down anyway.
 	else
+		REMOVE_TRAIT(owner, TRAIT_MOVE_FLOATING, LEAPING_TRAIT)
 		to_chat(owner, span_warning("Something prevents you from dashing forward!"))
 
 /datum/emote/living/mothic_dash


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/4348

## How This Contributes To The Nova Sector Roleplay Experience

Fixes an exploitable bug

## Proof of Testing

<details>
<summary>move_floating goes away like it should now</summary>
  
![image](https://github.com/user-attachments/assets/aa7c1223-5115-479f-a658-e25069ed9e71)


</details>

## Changelog

:cl:
fix: fixed a bug that could sometimes cause moths to retain the flight trait indefinitely when using their dash
/:cl:
