### PR TITLE
Adjust Pavise, Hammer and Shovel based on heartkin feedback

### DIFF
--- a/modular_nova/modules/reagent_forging/code/forge_weapons.dm
+++ b/modular_nova/modules/reagent_forging/code/forge_weapons.dm
@@ -240,7 +240,7 @@
 
 /obj/item/shield/buckler/reagent_weapon/pavise
 	name = "forged pavise shield"
-	desc = "An oblong shield used by ancient crossbowmen as cover while reloading. Probably just as useful with an actual gun."
+	desc = "An oblong shield used by ancient crossbowmen as cover while reloading. Probably just as useful with an actual gun. Can be wielded in both hands to cover yourself and clobber others more effectively."
 	icon_state = "pavise"
 	inhand_icon_state = "pavise"
 	worn_icon_state = "pavise_back"

--- a/modular_nova/modules/reagent_forging/code/forge_weapons.dm
+++ b/modular_nova/modules/reagent_forging/code/forge_weapons.dm
@@ -181,6 +181,16 @@
 	AddComponent(/datum/component/two_handed, force_unwielded = 10, force_wielded = 25, require_twohands = TRUE)
 	AddElement(/datum/element/kneejerk)
 
+/obj/item/forging/reagent_weapon/hammer/attack(mob/living/target, mob/living/user)
+	var/relative_direction = get_cardinal_dir(src, target)
+	var/atom/throw_target = get_edge_target_turf(target, relative_direction)
+	. = ..()
+	if(HAS_TRAIT(user, TRAIT_PACIFISM) || !HAS_TRAIT(src, TRAIT_WIELDED))
+		return
+	else if(!QDELETED(target) && !target.anchored)
+		var/whack_speed = (2)
+		target.throw_at(throw_target, 2, whack_speed, user, gentle = TRUE)
+
 /obj/item/shield/buckler/reagent_weapon
 	name = "forged buckler shield"
 	desc = "A small, round shield best used in tandem with a melee weapon in close-quarters combat."
@@ -234,12 +244,31 @@
 	icon_state = "pavise"
 	inhand_icon_state = "pavise"
 	worn_icon_state = "pavise_back"
-	block_chance = 50
+	block_chance = 45
 	force = 12
 	item_flags = SLOWS_WHILE_IN_HAND
 	w_class = WEIGHT_CLASS_HUGE
 	slot_flags = ITEM_SLOT_BACK
-	max_integrity = 300 //tanky
+	max_integrity = 300
+	var/wielded = FALSE
+	var/unwielded_block_chance = 45
+	var/wielded_block_chance = 65
+
+/obj/item/shield/buckler/reagent_weapon/pavise/Initialize(mapload)
+	. = ..()
+	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, PROC_REF(on_wield))
+	RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, PROC_REF(on_unwield))
+	AddComponent(/datum/component/two_handed, force_unwielded = 12, force_wielded = 15)
+
+/obj/item/shield/buckler/reagent_weapon/pavise/proc/on_wield()
+	SIGNAL_HANDLER
+	wielded = TRUE
+	block_chance = wielded_block_chance
+
+/obj/item/shield/buckler/reagent_weapon/pavise/proc/on_unwield()
+	SIGNAL_HANDLER
+	wielded = FALSE
+	block_chance = unwielded_block_chance
 
 /obj/item/pickaxe/reagent_weapon
 	name = "forged pickaxe"
@@ -253,7 +282,7 @@
 
 /obj/item/shovel/reagent_weapon
 	name = "forged shovel"
-	toolspeed = 0.75
+	toolspeed = 0.60
 
 /obj/item/shovel/reagent_weapon/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Gives the forged hammer the same pushback the Hammer Crusher has.
Gives the Forged Pavise two modes, unwielded which has 45 block chance (so -5 of what it had now) and 65 when wielded (-10 of what it had before the balance pass, so we dont have forgable adamantine), it also does 3 more damage when wielded.
Makes the Forged Shovel as fast as a drill

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Makes the hammer a bit more interesting than just a bit more damage, as it deals a total of 50 damage against mobs and push back, it makes it significant against bears, which have 300 max health and has that high speed attack.
Makes the Pavise closer than to the original idea of it was, while also not making a direct replica of the adamantine shield, while also allowed those that use it in one hand to have the option to enjoy a good shield with ofensive capabilities.
The Shovel speed buff was related to it being disregarded in favour of the pickaxe. (In comparison, Station best shovel, the entrenching tool, is speed 0.25)

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
  
![image](https://github.com/user-attachments/assets/1b8f70ac-99fa-4ccd-ba5f-9a12016d32ae)

![image](https://github.com/user-attachments/assets/b847830d-d925-43e6-bbd1-677be319bd11)

![image](https://github.com/user-attachments/assets/5fabab97-23f6-49ed-8ac4-63a7aa10b072)

  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The Forged Pavise can be wielded again! If one handed it has force 12 and block 45, if two handed 15 force and block 65.
balance: The Forged Hammer can push others out of the way in the same way the PK Crusher Hammer can!
balance: The Forged Shovel now digs as fast as a regular mining drill, as long as you put your back into it!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
