### PR TITLE
Fixes orbit menu job filter not showing colors for Nova jobs

### DIFF
--- a/tgui/packages/tgui/interfaces/Orbit/constants.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/constants.ts
@@ -21,7 +21,16 @@ type Department = {
 export const DEPARTMENT2COLOR: Record<string, Department> = {
   cargo: {
     color: 'brown',
+    /* NOVA EDIT CHANGE START - ORIGINAL:
     trims: ['Bitrunner', 'Cargo Technician', 'Shaft Miner', 'Quartermaster'],
+    */
+    trims: [
+      'Bitrunner',
+      'Cargo Technician',
+      'Customs Agent',
+      'Shaft Miner',
+      'Quartermaster',
+    ],
   },
   command: {
     color: 'blue',
@@ -35,7 +44,16 @@ export const DEPARTMENT2COLOR: Record<string, Department> = {
   },
   engineering: {
     color: 'orange',
+    /* NOVA EDIT CHANGE START - ORIGINAL:
     trims: ['Atmospheric Technician', 'Chief Engineer', 'Station Engineer'],
+    */
+    trims: [
+      'Atmospheric Technician',
+      'Chief Engineer',
+      'Engineering Guard',
+      'Station Engineer',
+      'Telecomms Specialist',
+    ], // NOVA EDIT CHANGE END
   },
   medical: {
     color: 'teal',
@@ -45,15 +63,35 @@ export const DEPARTMENT2COLOR: Record<string, Department> = {
       'Coroner',
       'Medical Doctor',
       'Paramedic',
+      'Orderly', // NOVA EDIT ADDITION
+      'Virologist', // NOVA EDIT ADDITION
     ],
   },
   science: {
     color: 'pink',
+    /* NOVA EDIT CHANGE START - ORIGINAL:
     trims: ['Geneticist', 'Research Director', 'Roboticist', 'Scientist'],
+    */
+    trims: [
+      'Geneticist',
+      'Research Director',
+      'Roboticist',
+      'Science Guard',
+      'Scientist',
+    ], // NOVA EDIT CHANGE END
   },
   security: {
     color: 'red',
+    /* NOVA EDIT CHANGE START - ORIGINAL:
     trims: ['Detective', 'Head of Security', 'Security Officer', 'Warden'],
+    */
+    trims: [
+      'Corrections Officer',
+      'Detective',
+      'Head of Security',
+      'Security Officer',
+      'Warden',
+    ], // NOVA EDIT CHANGE END
   },
   service: {
     color: 'green',


### PR DESCRIPTION
## About The Pull Request

Tin.

Fixes https://github.com/NovaSector/NovaSector/issues/3549

## How This Contributes To The Nova Sector Roleplay Experience

Parity with TG features

## Proof of Testing

<details>
<summary>Working</summary>

![L7r5jQA2cv](https://github.com/user-attachments/assets/319b9c97-3ae1-473e-8760-21a99c7ee094)

![wzg6rHPAbv](https://github.com/user-attachments/assets/dd79378f-56ad-4db8-8105-f6ffd481db22)

![Vgy7fi2wrj](https://github.com/user-attachments/assets/91f4e951-7b28-480f-b327-bc5dd23c9968)

  
</details>

## Changelog

:cl:
fix: fixes orbit menu job filter not showing department colors for Nova jobs
/:cl: