### PR TITLE
Slime&Podperson tweaks

### DIFF
--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
@@ -41,9 +41,9 @@
 		if(H.nutrition > NUTRITION_LEVEL_ALMOST_FULL)
 			H.set_nutrition(NUTRITION_LEVEL_ALMOST_FULL)
 		if(light_amount > 0.2) //if there's enough light, heal
-			H.heal_overall_damage(0.2 * seconds_per_tick, 0.2 * seconds_per_tick, 0)
-			H.adjustStaminaLoss(-0.2 * seconds_per_tick)
-			H.adjustToxLoss(-0.2 * seconds_per_tick)
+			H.heal_overall_damage(0.5 * seconds_per_tick, 0.2 * seconds_per_tick, 0)
+			H.adjustStaminaLoss(-0.4 * seconds_per_tick)
+			H.adjustToxLoss(-0.1 * seconds_per_tick)
 			H.adjustOxyLoss(-0.2 * seconds_per_tick)
 
 	if(H.nutrition < NUTRITION_LEVEL_STARVING + 50)

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
@@ -41,7 +41,7 @@
 		if(H.nutrition > NUTRITION_LEVEL_ALMOST_FULL)
 			H.set_nutrition(NUTRITION_LEVEL_ALMOST_FULL)
 		if(light_amount > 0.2) //if there's enough light, heal
-			H.heal_overall_damage(0.5 * seconds_per_tick, 0.2 * seconds_per_tick, 0)
+			H.heal_overall_damage(0.5 * seconds_per_tick, 0.35 * seconds_per_tick, 0)
 			H.adjustStaminaLoss(-0.4 * seconds_per_tick)
 			H.adjustToxLoss(-0.1 * seconds_per_tick)
 			H.adjustOxyLoss(-0.2 * seconds_per_tick)

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -15,7 +15,6 @@
 	inherent_traits = list(
 		TRAIT_MUTANT_COLORS,
 		TRAIT_TOXINLOVER,
-		TRAIT_NOBLOOD,
 		TRAIT_EASYDISMEMBER,
 	)
 	/// Ability to allow them to shapeshift their body around.


### PR DESCRIPTION


## About The Pull Request

Removes slimes total-immunity to bleeding wounds, but leaves their passive healing untouched, buffs podperson healing slightly

## How This Contributes To The Nova Sector Roleplay Experience

Slimes having passive healing (unless wet), and also total blood immunity made them handsdown the best race for combat, this tones it back slightly so they're a bit more even with the other races, it also buffs the podperson healing (favoring brute) slightly, because for the downside of taking big-damage in the dark, they didn't heal very fast at all in the light.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  numbers change
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Slimes can bleed again, podpeople now heal slightly better in the light
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
