### PR TITLE
removes the safety from the SC/FISHER

### DIFF
--- a/modular_nova/modules/gun_safety/code/safety_additions.dm
+++ b/modular_nova/modules/gun_safety/code/safety_additions.dm
@@ -39,6 +39,9 @@
 /obj/item/gun/energy/recharge/kinetic_accelerator/give_gun_safeties()
 	return
 
+/obj/item/gun/energy/recharge/fisher/give_gun_safeties()
+	return
+
 // Syringe Guns
 
 /obj/item/gun/syringe/blowgun/give_gun_safeties()


### PR DESCRIPTION
## About The Pull Request
title. forgot to push this lol mb

## How This Contributes To The Nova Sector Roleplay Experience
fisher can't do damage and if it has a safety on by default it breaks the underbarrel on the Ansem/SC

## Changelog

:cl:
fix: The Ansem/SC's underbarrel light disruptor now works.
/:cl:
