### PR TITLE
Fixes missing ) in the Random Event admin messages

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -112,7 +112,7 @@
 	// NOVA EDIT ADDITION BEGIN - Event notification - Makes an attention-grabbing sound, gives admins two notifications spread over RANDOM_EVENT_ADMIN_INTERVENTION_TIME instead of just the one.
 	message_admins("<font color='[COLOR_ADMIN_PINK]'>Random Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME)]: [name]. (\
 		<a href='?src=[REF(src)];cancel=1'>CANCEL</a> | \
-		<a href='?src=[REF(src)];different_event=1'>SOMETHING ELSE</a></font>")
+		<a href='?src=[REF(src)];different_event=1'>SOMETHING ELSE</a>)</font>")
 	for(var/client/staff as anything in GLOB.admins)
 		if(staff?.prefs.read_preference(/datum/preference/toggle/comms_notification))
 			SEND_SOUND(staff, sound('sound/misc/server-ready.ogg'))
@@ -121,7 +121,7 @@
 	if(triggering)
 		message_admins("<font color='[COLOR_ADMIN_PINK]'>Random Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME * 0.5)]: [name]. (\
 		<a href='?src=[REF(src)];cancel=1'>CANCEL</a> | \
-		<a href='?src=[REF(src)];different_event=1'>SOMETHING ELSE</a></font>")
+		<a href='?src=[REF(src)];different_event=1'>SOMETHING ELSE</a>)</font>")
 		sleep(RANDOM_EVENT_ADMIN_INTERVENTION_TIME * 0.5)
 	// NOVA EDIT ADDITION END - Event notification
 


### PR DESCRIPTION
## About The Pull Request
It was missing a parenthesis at the end, for *so* long now, and I finally got around to fixing it.

## How This Contributes To The Nova Sector Roleplay Experience
It makes me less annoyed when I look at chat when admined up, I'd say that's a positive improvement for everyone.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
Much nicer, wouldn't you say?
  
![image](https://github.com/user-attachments/assets/98daa9b1-a0e3-4a5b-b5bc-cea482e7826d)

</details>

## Changelog

:cl: GoldenAlpharex
fix: Fixed a CRITICAL bug where the "Random Event" admin message missing a closing parenthesis at its end.
/:cl: