### PR TITLE
Adds LTSRBT boards to the trash piles, smuggler satchels, and Underworld Connections quirk's mail goodies

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -176,6 +176,7 @@ GLOBAL_LIST_INIT(uncommon_loot, list(//uncommon: useful items
 		/obj/item/spear = 1,
 		/obj/item/weldingtool/largetank = 1,
 		/obj/item/market_uplink/blackmarket = 1,
+		/obj/item/circuitboard/machine/ltsrbt = 1, //NOVA EDIT ADDITION - More widespread Black Market
 		) = 8,
 
 	list(//equipment

--- a/code/game/objects/effects/spawners/random/contraband.dm
+++ b/code/game/objects/effects/spawners/random/contraband.dm
@@ -13,6 +13,7 @@
 		/obj/item/clothing/under/syndicate/tacticool = 20,
 		/obj/item/food/grown/cannabis/white = 10,
 		/obj/item/storage/box/fireworks/dangerous = 10,
+		/obj/item/circuitboard/machine/ltsrbt = 10, //NOVA EDIT ADDITION - More widespread Black Market
 		/obj/item/storage/pill_bottle/zoom = 10,
 		/obj/item/storage/pill_bottle/happy = 10,
 		/obj/item/storage/pill_bottle/lsd = 10,

--- a/modular_nova/master_files/code/game/objects/structures/trash_pile.dm
+++ b/modular_nova/master_files/code/game/objects/structures/trash_pile.dm
@@ -18,7 +18,6 @@
 
 /obj/structure/trash_pile/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/climbable)
 	icon_state = pick(
 		"pile1",
 		"pile2",

--- a/modular_nova/modules/underworld_connections/code/underworld_connections_quirk.dm
+++ b/modular_nova/modules/underworld_connections/code/underworld_connections_quirk.dm
@@ -7,7 +7,7 @@
 	lose_text = span_notice("Your contacts to the underworld have gone quiet.")
 	medical_record_text = "Patient records may have been tampered with in the past."
 	quirk_flags = QUIRK_HIDE_FROM_SCAN
-	mail_goodies = list(/obj/item/storage/briefcase/secure)
+	mail_goodies = list(/obj/item/circuitboard/machine/ltsrbt, /obj/item/stack/ore/bluespace_crystal/artificial, /datum/stock_part/ansible)
 
 /datum/quirk/item_quirk/underworld_connections/add_unique(client/client_source)
 	if (ishuman(quirk_holder))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Effectively a follow-up to #4366. You can now create Black Markets a -little- bit more reliably using the aforementioned methods; as the LTSRBT's board can now be acquired from the trash piles with an incredibly small chance, higher chance for the smuggler satchels; and probably the more reliable way of Cargo mail.
Also fixed a regression related to trash piles, as you could previously climb into them, but that's been erroneously removed with the addition of a climbing element.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
As per what I've heard, we do want more shady business going on; and this should help with that.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/ed11efd2-9fc0-4412-998c-c4911caaf5e2)
![image](https://github.com/user-attachments/assets/85cd7ab7-341e-48ad-b14f-9fbcd3bd4028)
![image](https://github.com/user-attachments/assets/e1e51638-440b-4e0d-917a-18008463e8ee)
![image](https://github.com/user-attachments/assets/2db384d1-6ad1-460a-b324-f264269c20be)
![image](https://github.com/user-attachments/assets/5241894a-a9d7-4ddb-84da-6ab71a961d25)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Stalkeros
add: Long-to-Short Range Bluespace Transceiver boards can now be acquired from: trash piles, smuggler satchels, and Underworld Connections quirk's mail.
fix: Trash piles are once again climbable-into.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
