### PR TITLE
Precolored sneakers no longer allow greyscale in loadout

### DIFF
--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_shoes.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_shoes.dm
@@ -119,34 +119,42 @@
 /datum/loadout_item/shoes/black_sneakers
 	name = "Black Sneakers"
 	item_path = /obj/item/clothing/shoes/sneakers/black
+	can_be_greyscale = DONT_GREYSCALE
 
 /datum/loadout_item/shoes/blue_sneakers
 	name = "Blue Sneakers"
 	item_path = /obj/item/clothing/shoes/sneakers/blue
+	can_be_greyscale = DONT_GREYSCALE
 
 /datum/loadout_item/shoes/brown_sneakers
 	name = "Brown Sneakers"
 	item_path = /obj/item/clothing/shoes/sneakers/brown
+	can_be_greyscale = DONT_GREYSCALE
 
 /datum/loadout_item/shoes/green_sneakers
 	name = "Green Sneakers"
 	item_path = /obj/item/clothing/shoes/sneakers/green
+	can_be_greyscale = DONT_GREYSCALE
 
 /datum/loadout_item/shoes/purple_sneakers
 	name = "Purple Sneakers"
 	item_path = /obj/item/clothing/shoes/sneakers/purple
+	can_be_greyscale = DONT_GREYSCALE
 
 /datum/loadout_item/shoes/orange_sneakers
 	name = "Orange Sneakers"
 	item_path = /obj/item/clothing/shoes/sneakers/orange
+	can_be_greyscale = DONT_GREYSCALE
 
 /datum/loadout_item/shoes/yellow_sneakers
 	name = "Yellow Sneakers"
 	item_path = /obj/item/clothing/shoes/sneakers/yellow
+	can_be_greyscale = DONT_GREYSCALE
 
 /datum/loadout_item/shoes/white_sneakers
 	name = "White Sneakers"
 	item_path = /obj/item/clothing/shoes/sneakers/white
+	can_be_greyscale = DONT_GREYSCALE
 
 /*
 *	LEG WRAPS


### PR DESCRIPTION
## About The Pull Request

Closes https://github.com/NovaSector/NovaSector/issues/4389

Not really a big issue since you can rename things in the grand scheme of things, but this fixes name discrepancy potential. Just use the colorable version if you want to color them yourself.

## How This Contributes To The Nova Sector Roleplay Experience

Fixes an oversight.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![pdPcEH7cOZ](https://github.com/user-attachments/assets/328cf50d-9cb8-4e43-9a52-399d67de64cf)

</details>

## Changelog

:cl:
fix: specific-colored loadout sneakers no longer allow you to change greyscale colors (use the 'colorable' version for that)
/:cl: