### PR TITLE
External Shuttle Rework

### DIFF
--- a/code/datums/shuttles/_shuttle.dm
+++ b/code/datums/shuttles/_shuttle.dm
@@ -80,4 +80,5 @@
 /datum/map_template/shuttle/post_load(obj/docking_port/mobile/M)
 	if(movement_force)
 		M.movement_force = movement_force.Copy()
+	M.mark_external_doors()	// NOVA EDIT ADDITION
 	M.linkup()

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -546,6 +546,7 @@
 				enterTransit()
 				mode = SHUTTLE_ESCAPE
 				launch_status = ENDGAME_LAUNCHED
+				bolt_all_doors()	// NOVA EDIT ADDITION
 				setTimer(SSshuttle.emergency_escape_time * engine_coeff)
 				priority_announce(
 					text = "The emergency shuttle has left the station. Estimate [timeLeft(60 SECONDS)] minutes until the shuttle docks at [command_name()].",

--- a/modular_nova/master_files/code/modules/shuttle/shuttle.dm
+++ b/modular_nova/master_files/code/modules/shuttle/shuttle.dm
@@ -8,21 +8,85 @@
 	/// The sound range coeff for the landing and take off sound effect
 	var/sound_range = 11
 
-/obj/docking_port/mobile/proc/bolt_all_doors() // Expensive procs :(
+/obj/docking_port/mobile/proc/mark_external_doors()
 	var/list/turfs = return_ordered_turfs(x, y, z, dir)
+	var/list/bounds = return_coords()
 	for(var/i in 1 to turfs.len)
 		var/turf/checked_turf = turfs[i]
+
+		// Do not touch station airlocks
+		if (!shuttle_areas[get_area(checked_turf)])
+			continue
+
+		for(var/obj/machinery/door/airlock/airlock_door in checked_turf)
+			// Door on the border is external always
+			if (airlock_door.x == bounds[1] || airlock_door.y == bounds[2] || airlock_door.x == bounds[3] || airlock_door.y == bounds[4])
+				airlock_door.external = TRUE
+				continue
+
+			// If door facing space or mapped without atmos - it is external too
+			var/turf/T = get_step(airlock_door, WEST)
+			if(is_space_or_openspace(T) || T.initial_gas_mix == AIRLESS_ATMOS)
+				airlock_door.external = TRUE
+				continue
+			T = get_step(airlock_door, EAST)
+			if(is_space_or_openspace(T) || T.initial_gas_mix == AIRLESS_ATMOS)
+				airlock_door.external = TRUE
+				continue
+			T = get_step(airlock_door, NORTH)
+			if(is_space_or_openspace(T) || T.initial_gas_mix == AIRLESS_ATMOS)
+				airlock_door.external = TRUE
+				continue
+			T = get_step(airlock_door, SOUTH)
+			if(is_space_or_openspace(T) || T.initial_gas_mix == AIRLESS_ATMOS)
+				airlock_door.external = TRUE
+				continue
+
+			// All checks passed - you are internal
+			airlock_door.external = FALSE
+
+/obj/docking_port/mobile/proc/bolt_all_doors() // Expensive procs :(
+	var/list/turfs = return_ordered_turfs(x, y, z, dir)
+	var/list/airlock_cache = list()
+	for(var/i in 1 to turfs.len)
+		var/turf/checked_turf = turfs[i]
+
+		// Do not touch station airlocks
+		if (!shuttle_areas[get_area(checked_turf)])
+			continue
+
 		for(var/obj/machinery/door/airlock/airlock_door in checked_turf)
 			if(airlock_door.external)
 				airlock_door.close(force_crush = TRUE)
 				airlock_door.bolt()
+				// If airlock is controlled - bolt them all to avoid airlocks state mismatch
+				if(airlock_door.id_tag)
+					airlock_cache[airlock_door.id_tag] = TRUE
+					for(var/obj/machinery/door/airlock/synced_door in airlock_cache)
+						if (synced_door.id_tag == airlock_door.id_tag)
+							synced_door.close(force_crush = TRUE)
+							synced_door.bolt()
+							airlock_cache -= synced_door
+
+			else if(airlock_door.id_tag)
+				if(airlock_cache[airlock_door.id_tag])
+					airlock_door.close(force_crush = TRUE)
+					airlock_door.bolt()
+					continue
+				airlock_cache += airlock_door
 
 /obj/docking_port/mobile/proc/unbolt_all_doors()
 	var/list/turfs = return_ordered_turfs(x, y, z, dir)
 	for(var/i in 1 to turfs.len)
 		var/turf/checked_turf = turfs[i]
+
+		// Do not touch station airlocks
+		if (!shuttle_areas[get_area(checked_turf)])
+			continue
+
 		for(var/obj/machinery/door/airlock/airlock_door in checked_turf)
-			if(airlock_door.external)
+			// Do not unbolt button controlled exits
+			if(airlock_door.external && !airlock_door.id_tag)
 				airlock_door.unbolt()
 
 /obj/docking_port/mobile/proc/play_engine_sound(atom/distant_source, takeoff)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Added verb that will on shuttle load scan it's airlocks and mark them as external or not.
That that means - all shuttle doors will be properly bolted during the flight, and internal doors will stay anbolted.

Also tweaked shuttle door bolt-unbolt proc to ensure that no station airlocks are affected (hello ferry shuttle) and that button controlled airlocks will not be auto opened (hi pirates shuttle)

Added shuttle bolt call to escape shuttle request proc, because its overriding shuttle request, so it never calls it there
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

NT safety department prevents crew from jumping into the void during the shuttle transit
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Shuttle's door autobolting feature
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
