### PR TITLE
Fix synthetic check on crew monitor

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -261,6 +261,11 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			if (jobs[trim_assignment] != null)
 				entry["ijob"] = jobs[trim_assignment]
 
+		// NOVA EDIT ADDITION START - Checking for robotic race
+		if (issynthetic(tracked_human))
+			entry["is_robot"] = TRUE
+		// NOVA EDIT ADDITION END
+
 		// Broken sensors show garbage data
 		if (uniform.has_sensor == BROKEN_SENSORS)
 			entry["life_status"] = rand(0,1)
@@ -273,10 +278,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			entry["can_track"] = tracked_living_mob.can_track()
 			results[++results.len] = entry
 			continue
-		// NOVA EDIT ADDITION START - Checking for robotic race
-		if (issynthetic(tracked_human))
-			entry["is_robot"] = TRUE
-		// NOVA EDIT ADDITION END
+
 		// Current status
 		if (sensor_mode >= SENSOR_LIVING)
 			entry["life_status"] = tracked_living_mob.stat


### PR DESCRIPTION
## About The Pull Request

After a TG change, fixes synth tagging on the crew monitor, putting it before the potential early continue

## How This Contributes To The Nova Sector Roleplay Experience

Crew monitor correctly labels synthetics as synthetics.

## Changelog

:cl: LT3
fix: Fixed crew monitor sometimes labelling synthetics as organic creatures
/:cl:
