### PR TITLE
Examine will no longer exclaim for everything

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -575,7 +575,7 @@
 		var/list/result = examinify.examine(src)
 		var/atom_title = examinify.examine_title(src, thats = TRUE)
 		SEND_SIGNAL(src, COMSIG_MOB_EXAMINING, examinify, result)
-		result_combined = (atom_title ? "[span_slightly_larger("[atom_title]![EXAMINE_SECTION_BREAK]")]" : "") + jointext(result, "<br>") // NOVA EDIT CHANGE - No more separator_hr + exclamation point for mobs - ORIGINAL: result_combined = (atom_title ? "[span_slightly_larger(separator_hr("[atom_title]."))]" : "") + jointext(result, "<br>")
+		result_combined = (atom_title ? "[span_slightly_larger("[atom_title][ismob(examinify) ? "!" :"."][EXAMINE_SECTION_BREAK]")]" : "") + jointext(result, "<br>") // NOVA EDIT CHANGE - No more separator_hr + exclamation point for mobs - ORIGINAL: result_combined = (atom_title ? "[span_slightly_larger(separator_hr("[atom_title]."))]" : "") + jointext(result, "<br>")
 		result_combined = replacetext(result_combined, "<hr><br>", "<hr>") // NOVA EDIT ADDITION - bit of a hack here to make sure we don't get linebreaks coming after headers
 
 	to_chat(src, examine_block(span_infoplain(result_combined)))


### PR DESCRIPTION
## About The Pull Request

It will only do that for mobs.

## How This Contributes To The Nova Sector Roleplay Experience

It was like that before I think?

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/4311555f-d03b-48bd-ba3b-3949d55938e5)

</details>

## Changelog

:cl:
spellcheck: examining a mob will use an exclamation point after the thing's name, for everything else you get a period
/:cl:

