### PR TITLE
Primitive vending machines are free again

### DIFF
--- a/modular_nova/modules/ashwalkers/code/buildings/ash_clothing_vendor.dm
+++ b/modular_nova/modules/ashwalkers/code/buildings/ash_clothing_vendor.dm
@@ -6,6 +6,9 @@
 	icon_state = "ashclothvendor"
 	icon_deny = "necrocrate"
 
+	onstation = FALSE // we don't ever want these to be targetable by the brand intelligence event.
+	all_products_free = TRUE // we don't want them to charge anything either. it's a box.
+
 	products = list( //Relatively normal to have, I GUESS
 		/obj/item/clothing/under/costume/gladiator/ash_walker/tribal = 15,
 		/obj/item/clothing/under/costume/gladiator/ash_walker/chestwrap = 15,
@@ -34,7 +37,3 @@
 		/obj/item/clothing/accessory/skullcodpiece = 5,
 		/obj/item/clothing/accessory/talisman = 5,
 	)
-
-/obj/machinery/vending/ashclothingvendor/Initialize(mapload)
-	. = ..()
-	onstation = FALSE

--- a/modular_nova/modules/ashwalkers/code/buildings/ash_clothing_vendor.dm
+++ b/modular_nova/modules/ashwalkers/code/buildings/ash_clothing_vendor.dm
@@ -5,7 +5,6 @@
 	icon = 'modular_nova/modules/ashwalkers/icons/vending.dmi'
 	icon_state = "ashclothvendor"
 	icon_deny = "necrocrate"
-	all_products_free = TRUE
 
 	products = list( //Relatively normal to have, I GUESS
 		/obj/item/clothing/under/costume/gladiator/ash_walker/tribal = 15,
@@ -35,3 +34,7 @@
 		/obj/item/clothing/accessory/skullcodpiece = 5,
 		/obj/item/clothing/accessory/talisman = 5,
 	)
+
+/obj/machinery/vending/ashclothingvendor/Initialize(mapload)
+	. = ..()
+	onstation = FALSE

--- a/modular_nova/modules/ashwalkers/code/buildings/ash_clothing_vendor.dm
+++ b/modular_nova/modules/ashwalkers/code/buildings/ash_clothing_vendor.dm
@@ -5,6 +5,7 @@
 	icon = 'modular_nova/modules/ashwalkers/icons/vending.dmi'
 	icon_state = "ashclothvendor"
 	icon_deny = "necrocrate"
+	all_products_free = TRUE
 
 	products = list( //Relatively normal to have, I GUESS
 		/obj/item/clothing/under/costume/gladiator/ash_walker/tribal = 15,
@@ -34,7 +35,3 @@
 		/obj/item/clothing/accessory/skullcodpiece = 5,
 		/obj/item/clothing/accessory/talisman = 5,
 	)
-
-/obj/machinery/vending/ashclothingvendor/Initialize(mapload)
-	. = ..()
-	onstation = FALSE

--- a/modular_nova/modules/faction/maps/shuttles/tradership_faction.dmm
+++ b/modular_nova/modules/faction/maps/shuttles/tradership_faction.dmm
@@ -1118,7 +1118,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/coffee,
+/obj/machinery/vending/coffee{
+	onstation = 0
+	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
@@ -1795,7 +1797,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/cigarette,
+/obj/machinery/vending/cigarette{
+	onstation = 0
+	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/poster/contraband/random{
@@ -1903,7 +1907,8 @@
 /area/shuttle/trader/bar)
 "cX" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/power/smes/full/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/power/smes/full
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,

--- a/modular_nova/modules/faction/maps/shuttles/tradership_faction.dmm
+++ b/modular_nova/modules/faction/maps/shuttles/tradership_faction.dmm
@@ -1903,8 +1903,7 @@
 /area/shuttle/trader/bar)
 "cX" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/power/smes/full/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/power/smes/full,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
 /turf/open/floor/plating,

--- a/modular_nova/modules/faction/maps/shuttles/tradership_faction.dmm
+++ b/modular_nova/modules/faction/maps/shuttles/tradership_faction.dmm
@@ -1118,9 +1118,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/coffee{
-	onstation = 0
-	},
+/obj/machinery/vending/coffee,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
@@ -1797,9 +1795,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/cigarette{
-	onstation = 0
-	},
+/obj/machinery/vending/cigarette,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/poster/contraband/random{
@@ -1907,8 +1903,7 @@
 /area/shuttle/trader/bar)
 "cX" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/power/smes/full
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/power/smes/full/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,

--- a/modular_nova/modules/primitive_catgirls/code/clothing_vendor.dm
+++ b/modular_nova/modules/primitive_catgirls/code/clothing_vendor.dm
@@ -3,11 +3,11 @@
 	desc = "It's a big wardrobe filled up with all sorts of clothing."
 	icon = 'icons/obj/storage/closet.dmi'
 	icon_state = "cabinet"
-
 	use_power = FALSE
-
 	shut_up = TRUE
 	vend_reply = null
+	onstation = FALSE // we don't ever want these to be targetable by the brand intelligence event.
+	all_products_free = TRUE // we don't want them to charge anything either. it's a wardrobe.
 
 	products = list(
 		/obj/item/clothing/under/dress/skirt/primitive_catgirl_body_wraps = 15,
@@ -43,11 +43,6 @@
 		/obj/item/clothing/head/costume/nova/papakha/white = 5,
 		/obj/item/clothing/head/hair_tie = 5,
 	)
-
-/obj/machinery/vending/primitive_catgirl_clothing_vendor/Initialize(mapload)
-	. = ..()
-
-	onstation = FALSE
 
 /obj/machinery/vending/primitive_catgirl_clothing_vendor/speak(message)
 	return

--- a/modular_nova/modules/primitive_catgirls/code/clothing_vendor.dm
+++ b/modular_nova/modules/primitive_catgirls/code/clothing_vendor.dm
@@ -8,7 +8,6 @@
 
 	shut_up = TRUE
 	vend_reply = null
-	all_products_free = TRUE
 
 	products = list(
 		/obj/item/clothing/under/dress/skirt/primitive_catgirl_body_wraps = 15,
@@ -44,6 +43,11 @@
 		/obj/item/clothing/head/costume/nova/papakha/white = 5,
 		/obj/item/clothing/head/hair_tie = 5,
 	)
+
+/obj/machinery/vending/primitive_catgirl_clothing_vendor/Initialize(mapload)
+	. = ..()
+
+	onstation = FALSE
 
 /obj/machinery/vending/primitive_catgirl_clothing_vendor/speak(message)
 	return

--- a/modular_nova/modules/primitive_catgirls/code/clothing_vendor.dm
+++ b/modular_nova/modules/primitive_catgirls/code/clothing_vendor.dm
@@ -8,6 +8,7 @@
 
 	shut_up = TRUE
 	vend_reply = null
+	all_products_free = TRUE
 
 	products = list(
 		/obj/item/clothing/under/dress/skirt/primitive_catgirl_body_wraps = 15,
@@ -43,11 +44,6 @@
 		/obj/item/clothing/head/costume/nova/papakha/white = 5,
 		/obj/item/clothing/head/hair_tie = 5,
 	)
-
-/obj/machinery/vending/primitive_catgirl_clothing_vendor/Initialize(mapload)
-	. = ..()
-
-	onstation = FALSE
 
 /obj/machinery/vending/primitive_catgirl_clothing_vendor/speak(message)
 	return


### PR DESCRIPTION
## About The Pull Request

Tin. Updates a few vending machines that were hardcoded to manipulate `onstation` in ways that are no longer needed as of https://github.com/tgstation/tgstation/pull/86548.

## How This Contributes To The Nova Sector Roleplay Experience

Bugfix

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/31788097-7d5c-47a8-b815-d14728b2a8f0)

![image](https://github.com/user-attachments/assets/5f20d140-c838-4b76-ad04-e5387573abab)
  
</details>

## Changelog

:cl:
fix: fixed primitive 'vendors' (the ash clothing box and icecat wardrobe) costing money when they should be free
/:cl: