### PR TITLE
Expands the item and ability selection of bitrunning disks (ft. Finally Being Able To Treat Your Teammates)

### DIFF
--- a/modular_nova/modules/bitrunning/code/virtual_domains/disks.dm
+++ b/modular_nova/modules/bitrunning/code/virtual_domains/disks.dm
@@ -84,7 +84,7 @@
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC|SPELL_REQUIRES_HUMAN
 
 	invocation = "NullReferenceException: Object reference not set to an instance of an object at Necrosis.Start."
-	invocation_type = INVOCATION_WHISPER
+	invocation_type = INVOCATION_SHOUT
 
 /datum/action/cooldown/spell/death_loop/is_valid_target(atom/cast_on)
 	return isliving(cast_on)
@@ -92,7 +92,7 @@
 /datum/action/cooldown/spell/death_loop/cast(mob/living/cast_on)
 	. = ..()
 	cast_on.visible_message(
-		span_warning("Faintest glitches and binary code lines briefly cover the  [cast_on]!"),
+		span_warning("Faintest glitches and binary code lines briefly cover [cast_on]!"),
 		span_notice("You memory hack your digital mortality!"),
 	)
 	ADD_TRAIT(cast_on, TRAIT_NODEATH, REF(src))

--- a/modular_nova/modules/bitrunning/code/virtual_domains/disks.dm
+++ b/modular_nova/modules/bitrunning/code/virtual_domains/disks.dm
@@ -1,29 +1,100 @@
 /obj/item/bitrunning_disk/item/tier1/Initialize(mapload)
 	. = ..()
 	selectable_items += list(
-		/obj/item/storage/belt/military/snack,
+		/obj/item/storage/belt/military,
 	)
 
 /obj/item/bitrunning_disk/item/tier2/Initialize(mapload)
 	. = ..()
 	selectable_items += list(
 		/obj/item/clothing/head/helmet,
+		/obj/item/melee/energy/sword/saber/blue,
+		/obj/item/storage/medkit/expeditionary/surplus,
 	)
 
 /obj/item/bitrunning_disk/item/tier3/Initialize(mapload)
 	. = ..()
 	selectable_items += list(
-		/obj/item/clothing/neck/necklace/memento_mori,
+		/obj/item/autosurgeon/syndicate/nodrop,
 	)
 
 /obj/item/bitrunning_disk/ability/tier1/Initialize(mapload)
 	. = ..()
 	selectable_actions += list(
 	/datum/action/cooldown/spell/touch/lay_on_hands,
+	/datum/action/cooldown/spell/conjure/flare,
+	)
+
+/obj/item/bitrunning_disk/ability/tier2/Initialize(mapload)
+	. = ..()
+	selectable_actions += list(
+	/datum/action/cooldown/adrenaline,
+	/datum/action/cooldown/spell/charge,
 	)
 
 /obj/item/bitrunning_disk/ability/tier3/Initialize(mapload)
 	. = ..()
 	selectable_actions += list(
-	/datum/action/cooldown/spell/timestop,
+	/datum/action/cooldown/mob_cooldown/charge/basic_charge,
+	/datum/action/cooldown/spell/touch/scream_for_me,
+	/datum/action/cooldown/spell/death_loop,
 	)
+
+/datum/orderable_item/bitrunning_tech/item_tier1
+	desc = "This disk contains a program that lets you equip a medical beamgun, a C4 explosive, a box of infinite pizza, or a military webbing."
+
+/datum/orderable_item/bitrunning_tech/item_tier2
+	desc = "This disk contains a program that lets you equip a luxury medipen, a pistol, an armour vest, a helmet, an energy sword, or an expeditionary medkit."
+
+/datum/orderable_item/bitrunning_tech/item_tier3
+	desc = "This disk contains a program that lets you equip an advanced energy gun, a dual bladed energy sword, a minibomb, or an anti-drop implanter."
+
+/datum/orderable_item/bitrunning_tech/ability_tier1
+	desc = "This disk contains a program that lets you cast Summon Cheese, Summon Light Source, Lesser Heal, or Mending Touch."
+
+/datum/orderable_item/bitrunning_tech/ability_tier2
+	desc = "This disk contains a program that lets you cast Fireball, Lightning Bolt, Forcewall, Adrenaline Rush, or Charge Item."
+
+/datum/orderable_item/bitrunning_tech/ability_tier3
+	desc = "This disk contains a program that lets you shapeshift into a lesser ashdrake, or a polar bear; or cast Basic Charge, Sanguine Strike, or Death Loop."
+
+/datum/action/cooldown/spell/conjure/flare
+	name = "Summon Light Source"
+	desc = "This spell creates a green flare."
+
+	button_icon = 'modular_nova/modules/modular_weapons/icons/obj/company_and_or_faction_based/saibasan/projectiles.dmi'
+	button_icon_state = "flare_burn-on"
+
+	school = SCHOOL_CONJURATION
+	cooldown_time = 10 SECONDS
+	invocation_type = INVOCATION_NONE
+	spell_requirements = NONE
+
+	summon_radius = 0
+	summon_type = list(/obj/item/flashlight/flare/plasma_projectile)
+
+/datum/action/cooldown/spell/death_loop
+	name = "Death Loop"
+	desc = "Makes the caster unable to die unwillingly via a forced memory leak delaying the death state assignation."
+
+	button_icon = 'icons/mob/actions/actions_items.dmi'
+	button_icon_state = "bci_plus"
+	sound = 'sound/magic/staff_healing.ogg'
+	cooldown_time = 10 SECONDS
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC|SPELL_REQUIRES_HUMAN
+
+	invocation = "NullReferenceException: Object reference not set to an instance of an object at Necrosis.Start."
+	invocation_type = INVOCATION_WHISPER
+
+/datum/action/cooldown/spell/death_loop/is_valid_target(atom/cast_on)
+	return isliving(cast_on)
+
+/datum/action/cooldown/spell/death_loop/cast(mob/living/cast_on)
+	. = ..()
+	cast_on.visible_message(
+		span_warning("Faintest glitches and binary code lines briefly cover the  [cast_on]!"),
+		span_notice("You memory hack your digital mortality!"),
+	)
+	ADD_TRAIT(cast_on, TRAIT_NODEATH, REF(src))
+	ADD_TRAIT(cast_on, TRAIT_SUCCUMB_OVERRIDE, REF(src))
+	Remove(cast_on)

--- a/modular_nova/modules/bitrunning/code/virtual_domains/disks.dm
+++ b/modular_nova/modules/bitrunning/code/virtual_domains/disks.dm
@@ -1,0 +1,29 @@
+/obj/item/bitrunning_disk/item/tier1/Initialize(mapload)
+	. = ..()
+	selectable_items += list(
+		/obj/item/storage/belt/military/snack,
+	)
+
+/obj/item/bitrunning_disk/item/tier2/Initialize(mapload)
+	. = ..()
+	selectable_items += list(
+		/obj/item/clothing/head/helmet,
+	)
+
+/obj/item/bitrunning_disk/item/tier3/Initialize(mapload)
+	. = ..()
+	selectable_items += list(
+		/obj/item/clothing/neck/necklace/memento_mori,
+	)
+
+/obj/item/bitrunning_disk/ability/tier1/Initialize(mapload)
+	. = ..()
+	selectable_actions += list(
+	/datum/action/cooldown/spell/touch/lay_on_hands,
+	)
+
+/obj/item/bitrunning_disk/ability/tier3/Initialize(mapload)
+	. = ..()
+	selectable_actions += list(
+	/datum/action/cooldown/spell/timestop,
+	)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7052,6 +7052,7 @@
 #include "modular_nova\modules\better_vox\code\vox_clothing.dm"
 #include "modular_nova\modules\better_vox\code\vox_species.dm"
 #include "modular_nova\modules\better_vox\code\vox_sprite_accessories.dm"
+#include "modular_nova\modules\bitrunning\code\virtual_domains\disks.dm"
 #include "modular_nova\modules\bitrunning\code\virtual_domains\ancient_milsim\area.dm"
 #include "modular_nova\modules\bitrunning\code\virtual_domains\ancient_milsim\choice_beacon.dm"
 #include "modular_nova\modules\bitrunning\code\virtual_domains\ancient_milsim\disk.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Expands the amount of items and abilities that the bitrunning disks have, roughly according to whatever loose notes were present in their documentation and following the 'don't bother about balance' wording it had.
So far, the new spells and items are, tiered by... tier:
T1 gear: empty military webbing;
T1 spell: Lay On Hands (transfer mob damage to self), Summon Light Source (create a lit Hoshi flare on self);
T2 gear: basic helmet, blue energy sword, surplus expeditionay medkit (advanced sutures, meshes, health HUD, health analyzer);
T2 spell: Adrenaline Rush! (sic) (injects self with determination, pump-up and synaptizine, before forcing an adrenaline rush that gives a hefty stamina damage via borg Tiring Solution and Confusing Solution. Two minutes long delay after use), Charge (recharge item in hand, you know the one);
T3 gear: Nodrop implant autosurgeon;
T3 spell: Mob Charge (after a momentary delay, rush headfirst into stuff. Breaks walls), Scream For Me (cause a lot of bleeding wounds across all of the target's limbs), Death Loop (Makes you 'revivable' by causing semi-immortality; can be circumvented at user's will. One use - deletes the spell after casting for obvious reasons.) 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Initial reason for this PR, is to let bitrunners finally revive each other one way or another - the inability to treat your teammates (and having to prepare for every run with a *sort of but not really* paranoia for death) always felt like something entirely unintended and really hurting the gameplay. Or more specifically, team cohesion assuming that all of the three pods are full as intended.
So far, the amount of gear that was initially available in disks didn't let one to differentiate their playstyle - you were basically insisted to go for the meta loadout that you're probably more or less aware of.  I'll hope that the newly added abilities, medical ones and the death preventing one in particular, will cause for dedicated medics to appear.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/2c40a6a9-df94-4c8b-b2b9-8f58ac3e7d89)
![image](https://github.com/user-attachments/assets/8d64e15b-6bed-4626-a28f-72c3b127bfd1)
![image](https://github.com/user-attachments/assets/caaf29de-3934-4cc5-b1d0-5ffe8f034deb)
![image](https://github.com/user-attachments/assets/5fca458e-51e8-499a-b9a4-97b049f02875)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Stalkeros
add: A plethora of new bitrunning item/ability entries have been added to the already existing disks!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
