### PR TITLE
Bluespace snail shells will no longer eat additional inserted anomaly cores

### DIFF
--- a/modular_nova/master_files/code/modules/mob/living/carbon/human/species_type/snail.dm
+++ b/modular_nova/master_files/code/modules/mob/living/carbon/human/species_type/snail.dm
@@ -122,7 +122,7 @@
 	emptyStorage()
 	create_storage(max_specific_storage = WEIGHT_CLASS_GIGANTIC, max_total_storage = 35, max_slots = 30, storage_type = /datum/storage/bag_of_holding)
 	for(var/obj/item/stored_item in old_inventory)
-		insert_item(stored_item)
+		atom_storage.attempt_insert(stored_item, override = TRUE, messages = FALSE, force = TRUE)
 	name = "snail shell of holding"
 	update_appearance()
 


### PR DESCRIPTION
## About The Pull Request

Tin, currently they just keep performing the same upgrade even when it's already done, consuming the core in the process. Now they'll just enter the backpack and be stored like normal.

## How This Contributes To The Nova Sector Roleplay Experience

Fixes an oversight

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![dreamseeker_MVc3FZV8C8](https://github.com/user-attachments/assets/df9a3cb8-a96d-46e2-850b-6fbd54a0c12e)
  
![dreamseeker_40NHzbCYZc](https://github.com/user-attachments/assets/f6787216-b442-464b-93b4-00e1ee205892)

</details>

## Changelog

:cl:
fix: bluespace-upgraded snail shells will no longer eat additional inserted bluespace anomaly cores
qol: the bluespace upgrading process no longer dumps all your snail shell contents on the floor
/:cl:

