### PR TITLE
Plastic panels no longer multiply by 10 times their cost when built.

### DIFF
--- a/modular_nova/modules/colony_fabricator/code/design_datums/construction.dm
+++ b/modular_nova/modules/colony_fabricator/code/design_datums/construction.dm
@@ -114,7 +114,7 @@
 		/datum/material/plastic = HALF_SHEET_MATERIAL_AMOUNT,
 		/datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT,
 	)
-	build_path = /obj/item/stack/sheet/plastic_wall_panel/ten
+	build_path = /obj/item/stack/sheet/plastic_wall_panel
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_CONSTRUCTION + FABRICATOR_SUBCATEGORY_STRUCTURES,


### PR DESCRIPTION
## About The Pull Request

This PR simply makes printing plastic panelling from a Rapid Construction Fabricator not cause it to print 10 sheets for the cost of one sheet, and instead just prints one sheet for the cost of one sheet. Revolutionary bug fix right here.

## How This Contributes To The Nova Sector Roleplay Experience

You can currently put plastic panels back into the RCF, leading to infinite materials duping. I'm planning on doing a downstream colonization event and infinite materials from basically just printing them is not great.

## Proof of Testing
<details>
<summary>
One panel in, one panel out. 
</summary>

![](https://github.com/user-attachments/assets/44793d3e-0c41-473d-8930-d6e91de32bb6)
![](https://github.com/user-attachments/assets/604a37d2-dc02-42a8-a75a-7332930db2cd)
</details>

## Changelog
:cl:
fix: Fixed an infinite duplication exploit with the rapid construction fabricator printing 10 plastic panels for the cost of one.
/:cl: