### PR TITLE
Brings back saltpetre to upgraded chem dispensers.

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -109,18 +109,19 @@
 	var/static/list/default_upgrade_reagents = list(
 		/datum/reagent/fuel/oil,
 		/datum/reagent/ammonia,
-		/datum/reagent/ash
+		/datum/reagent/ash,
 	)
 
 	var/static/list/default_upgrade2_reagents = list(
 		/datum/reagent/acetone,
 		/datum/reagent/phenol,
-		/datum/reagent/diethylamine
+		/datum/reagent/diethylamine,
+		/datum/reagent/saltpetre,
 	)
 
 	var/static/list/default_upgrade3_reagents = list(
 		/datum/reagent/medicine/mine_salve,
-		/datum/reagent/toxin
+		/datum/reagent/toxin,
 	)
 
 	var/static/list/default_emagged_reagents = list(
@@ -129,7 +130,7 @@
 		/datum/reagent/consumable/frostoil,
 		/datum/reagent/toxin/carpotoxin,
 		/datum/reagent/toxin/histamine,
-		/datum/reagent/medicine/morphine
+		/datum/reagent/medicine/morphine,
 	)
 	//NOVA EDIT CHANGE END
 


### PR DESCRIPTION
## About The Pull Request

This PR brings back saltpetre to upgraded chem dispensers. It's _meant to_ have saltpetre in upgraded dispensers, but a very-likely accidental omission since the days of the rodent made it so saltpetre was missing. I don't think it's gone for gameplay reasons, given how saltpetre is able to be made using 3 base ingredients that are already present. Base former(?)-upstream code has saltpetre in the list of upgraded reagents. If maintainers think this isn't a fix and was intended behavior then they can change the labels.

Also this changes the lists to have trailing commas as per the proper code style guide.

## How This Contributes To The Nova Sector Roleplay Experience

It kinda doesn't? It's a gameplay bug fix, not a roleplay addition. Still, bug fixes are nice and having saltpetre on demand is convenient for any advanced botanical needs.

## Proof of Testing

<details>
<summary>With and without upgrades.</summary>
Without Upgrades

![](https://github.com/user-attachments/assets/29aa293e-fcd5-4606-aff4-1f8191c3c838)

With Upgrades

![](https://github.com/user-attachments/assets/8a9a10d3-9e1c-45fb-97a8-e0dbcfa51af1)


</details>

## Changelog

:cl:
fix: After several years of its mistaken lacking, saltpetre is back in upgraded chemical dispensers.
/:cl:
