### PR TITLE
Makes colony appliances show descriptions in the rapid construction fabricator.

### DIFF
--- a/modular_nova/modules/colony_fabricator/code/appliances/chem_machines.dm
+++ b/modular_nova/modules/colony_fabricator/code/appliances/chem_machines.dm
@@ -25,6 +25,7 @@
 
 /obj/item/flatpacked_machine/water_synth
 	name = "water synthesizer parts kit"
+	desc = /obj/machinery/plumbing/synthesizer/water_synth::desc
 	icon = 'modular_nova/modules/colony_fabricator/icons/chemistry_machines.dmi'
 	icon_state = "water_synth_parts"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -68,6 +69,7 @@
 
 /obj/item/flatpacked_machine/hydro_synth
 	name = "hydroponics chemical synthesizer parts kit"
+	desc = /obj/machinery/plumbing/synthesizer/colony_hydroponics::desc
 	icon = 'modular_nova/modules/colony_fabricator/icons/chemistry_machines.dmi'
 	icon_state = "hydro_synth_parts"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -134,6 +136,7 @@
 
 /obj/item/flatpacked_machine/sustenance_machine
 	name = "sustenance dispenser parts kit"
+	desc = /obj/machinery/chem_dispenser/frontier_appliance::desc
 	icon = 'modular_nova/modules/colony_fabricator/icons/chemistry_machines.dmi'
 	icon_state = "dispenser_parts"
 	w_class = WEIGHT_CLASS_NORMAL

--- a/modular_nova/modules/colony_fabricator/code/appliances/co2_cracker.dm
+++ b/modular_nova/modules/colony_fabricator/code/appliances/co2_cracker.dm
@@ -110,6 +110,7 @@ GLOBAL_LIST_INIT(cracker_reactions, cracker_reactions_list())
 
 /obj/item/flatpacked_machine/co2_cracker
 	name = "CO2 cracker parts kit"
+	desc = /obj/machinery/electrolyzer/co2_cracker::desc
 	icon = 'modular_nova/modules/colony_fabricator/icons/parts_kits.dmi'
 	icon_state = "co2_cracker"
 	type_to_deploy = /obj/machinery/electrolyzer/co2_cracker

--- a/modular_nova/modules/colony_fabricator/code/appliances/foodricator.dm
+++ b/modular_nova/modules/colony_fabricator/code/appliances/foodricator.dm
@@ -38,6 +38,7 @@
 
 /obj/item/flatpacked_machine/organics_ration_printer
 	name = "organic rations printer parts kit"
+	desc = /obj/machinery/biogenerator/foodricator::desc
 	icon = 'modular_nova/modules/colony_fabricator/icons/foodricator.dmi'
 	icon_state = "biogenerator_parts"
 	type_to_deploy = /obj/machinery/biogenerator/foodricator

--- a/modular_nova/modules/colony_fabricator/code/appliances/kitchen_appliances/griddle.dm
+++ b/modular_nova/modules/colony_fabricator/code/appliances/kitchen_appliances/griddle.dm
@@ -26,6 +26,7 @@
 
 /obj/item/flatpacked_machine/frontier_griddle
 	name = "flat-packed tabletop griddle"
+	desc = /obj/machinery/griddle/frontier_tabletop::desc
 	icon = 'modular_nova/modules/colony_fabricator/icons/kitchen_stuff/griddle.dmi'
 	icon_state = "griddle_parts"
 	w_class = WEIGHT_CLASS_NORMAL

--- a/modular_nova/modules/colony_fabricator/code/appliances/kitchen_appliances/macrowave.dm
+++ b/modular_nova/modules/colony_fabricator/code/appliances/kitchen_appliances/macrowave.dm
@@ -30,6 +30,7 @@
 
 /obj/item/flatpacked_machine/macrowave
 	name = "microwave oven parts kit"
+	desc = /obj/machinery/microwave/frontier_printed::desc
 	icon = 'modular_nova/modules/colony_fabricator/icons/kitchen_stuff/microwave.dmi'
 	icon_state = "packed_microwave"
 	w_class = WEIGHT_CLASS_NORMAL

--- a/modular_nova/modules/colony_fabricator/code/appliances/kitchen_appliances/range.dm
+++ b/modular_nova/modules/colony_fabricator/code/appliances/kitchen_appliances/range.dm
@@ -26,6 +26,7 @@
 
 /obj/item/flatpacked_machine/frontier_range
 	name = "frontier range parts kit"
+	desc = /obj/machinery/oven/range_frontier::desc
 	icon = 'modular_nova/modules/colony_fabricator/icons/kitchen_stuff/range.dmi'
 	icon_state = "range_packed"
 	w_class = WEIGHT_CLASS_NORMAL

--- a/modular_nova/modules/colony_fabricator/code/appliances/recycler.dm
+++ b/modular_nova/modules/colony_fabricator/code/appliances/recycler.dm
@@ -70,6 +70,7 @@
 
 /obj/item/flatpacked_machine/recycler
 	name = "recycler parts kit"
+	desc = /obj/machinery/colony_recycler::desc
 	icon = 'modular_nova/modules/colony_fabricator/icons/parts_kits.dmi'
 	icon_state = "recycler"
 	type_to_deploy = /obj/machinery/colony_recycler

--- a/modular_nova/modules/colony_fabricator/code/appliances/wind_turbine.dm
+++ b/modular_nova/modules/colony_fabricator/code/appliances/wind_turbine.dm
@@ -77,6 +77,7 @@
 // Item for deploying wind turbines
 /obj/item/flatpacked_machine/wind_turbine
 	name = "flat-packed miniature wind turbine"
+	desc = /obj/machinery/power/colony_wind_turbine::desc
 	icon = 'modular_nova/modules/colony_fabricator/icons/wind_turbine.dmi'
 	icon_state = "turbine_packed"
 	type_to_deploy = /obj/machinery/power/colony_wind_turbine

--- a/modular_nova/modules/colony_fabricator/code/colony_fabricator.dm
+++ b/modular_nova/modules/colony_fabricator/code/colony_fabricator.dm
@@ -6,7 +6,6 @@
 	icon = 'modular_nova/modules/colony_fabricator/icons/machines.dmi'
 	icon_state = "colony_lathe"
 	base_icon_state = "colony_lathe"
-	production_animation = null
 	circuit = null
 	production_animation = "colony_lathe_n"
 	light_color = LIGHT_COLOR_BRIGHT_YELLOW
@@ -87,6 +86,8 @@
 
 /obj/item/flatpacked_machine
 	name = "flat-packed rapid construction fabricator"
+	/// For all flatpacked machines, set the desc to the type_to_deploy followed by ::desc to reuse the type_to_deploy's description
+	desc = /obj/machinery/rnd/production/colony_lathe::desc
 	icon = 'modular_nova/modules/colony_fabricator/icons/packed_machines.dmi'
 	icon_state = "colony_lathe_packed"
 	w_class = WEIGHT_CLASS_BULKY
@@ -97,7 +98,6 @@
 
 /obj/item/flatpacked_machine/Initialize(mapload)
 	. = ..()
-	desc = initial(type_to_deploy.desc)
 	give_deployable_component()
 	give_manufacturer_examine()
 

--- a/modular_nova/modules/colony_fabricator/code/construction/doors.dm
+++ b/modular_nova/modules/colony_fabricator/code/construction/doors.dm
@@ -18,6 +18,7 @@
 
 /obj/item/flatpacked_machine/shutter_kit
 	name = "prefab shutters parts kit"
+	desc = /obj/machinery/door/poddoor/shutters/colony_fabricator/preopen::desc
 	icon = 'modular_nova/modules/colony_fabricator/icons/doors/packed.dmi'
 	icon_state = "shutters_parts"
 	type_to_deploy = /obj/machinery/door/poddoor/shutters/colony_fabricator/preopen
@@ -44,6 +45,7 @@
 
 /obj/item/flatpacked_machine/airlock_kit
 	name = "prefab airlock parts kit"
+	desc = /obj/machinery/door/airlock/colony_prefab::desc
 	icon = 'modular_nova/modules/colony_fabricator/icons/doors/packed.dmi'
 	icon_state = "airlock_parts"
 	type_to_deploy = /obj/machinery/door/airlock/colony_prefab

--- a/modular_nova/modules/colony_fabricator/code/construction/manual_door.dm
+++ b/modular_nova/modules/colony_fabricator/code/construction/manual_door.dm
@@ -70,6 +70,7 @@
 // Parts kit for putting the door together
 /obj/item/flatpacked_machine/airlock_kit_manual
 	name = "prefab manual airlock parts kit"
+	desc = /obj/structure/mineral_door/manual_colony_door::desc
 	icon = 'modular_nova/modules/colony_fabricator/icons/doors/packed.dmi'
 	icon_state = "airlock_parts_manual"
 	type_to_deploy = /obj/structure/mineral_door/manual_colony_door

--- a/modular_nova/modules/colony_fabricator/code/design_datums/flatpack_machines.dm
+++ b/modular_nova/modules/colony_fabricator/code/design_datums/flatpack_machines.dm
@@ -227,9 +227,6 @@
 
 /datum/design/flatpack_turbine_team_fortress_two
 	name = "Flat-Packed Miniature Wind Turbine"
-	desc = "A deployable fabricator capable of producing other flat-packed machines and other special equipment tailored for \
-		rapidly constructing functional structures given resources and power. While it cannot be upgraded, it can be repacked \
-		and moved to any location you see fit. This one makes specialized engineering designs and tools."
 	id = "flatpack_turbine_team_fortress_two"
 	build_type = COLONY_FABRICATOR
 	materials = list(

--- a/modular_nova/modules/colony_fabricator/code/machines/arc_furnace.dm
+++ b/modular_nova/modules/colony_fabricator/code/machines/arc_furnace.dm
@@ -218,6 +218,7 @@
 
 /obj/item/flatpacked_machine/arc_furnace
 	name = "flat-packed arc furnace"
+	desc = /obj/machinery/arc_furnace::desc
 	icon_state = "arc_furnace_folded"
 	type_to_deploy = /obj/machinery/arc_furnace
 	custom_materials = list(

--- a/modular_nova/modules/colony_fabricator/code/machines/ore_silo.dm
+++ b/modular_nova/modules/colony_fabricator/code/machines/ore_silo.dm
@@ -18,6 +18,7 @@
 // Item for deploying ore silos
 /obj/item/flatpacked_machine/ore_silo
 	name = "flat-packed ore silo"
+	desc = /obj/machinery/ore_silo/colony_lathe::desc
 	icon = 'modular_nova/modules/colony_fabricator/icons/ore_silo.dmi'
 	icon_state = "ore_silo"
 	type_to_deploy = /obj/machinery/ore_silo/colony_lathe

--- a/modular_nova/modules/colony_fabricator/code/machines/power_storage_unit.dm
+++ b/modular_nova/modules/colony_fabricator/code/machines/power_storage_unit.dm
@@ -60,6 +60,7 @@
 
 /obj/item/flatpacked_machine/station_battery
 	name = "flat-packed stationary battery"
+	desc = /obj/machinery/power/smes/battery_pack::desc
 	icon_state = "battery_small_packed"
 	type_to_deploy = /obj/machinery/power/smes/battery_pack
 	custom_materials = list(
@@ -92,6 +93,7 @@
 
 /obj/item/flatpacked_machine/large_station_battery
 	name = "flat-packed large stationary battery"
+	desc = /obj/machinery/power/smes/battery_pack/large::desc
 	icon_state = "battery_large_packed"
 	type_to_deploy = /obj/machinery/power/smes/battery_pack/large
 	custom_materials = list(

--- a/modular_nova/modules/colony_fabricator/code/machines/rtg.dm
+++ b/modular_nova/modules/colony_fabricator/code/machines/rtg.dm
@@ -32,6 +32,7 @@
 
 /obj/item/flatpacked_machine/rtg
 	name = "flat-packed radioisotope thermoelectric generator"
+	desc = /obj/machinery/power/rtg/portable::desc
 	icon_state = "rtg_packed"
 	type_to_deploy = /obj/machinery/power/rtg/portable
 	custom_materials = list(

--- a/modular_nova/modules/colony_fabricator/code/machines/solar_panels.dm
+++ b/modular_nova/modules/colony_fabricator/code/machines/solar_panels.dm
@@ -33,6 +33,7 @@
 
 /obj/item/flatpacked_machine/solar
 	name = "flat-packed solar panel"
+	desc = /obj/machinery/power/solar/deployable::desc
 	icon_state = "solar_panel_packed"
 	type_to_deploy = /obj/machinery/power/solar/deployable
 	deploy_time = 2 SECONDS
@@ -77,6 +78,7 @@
 
 /obj/item/flatpacked_machine/solar_tracker
 	name = "flat-packed solar tracker"
+	desc = /obj/machinery/power/tracker/deployable::desc
 	icon_state = "solar_tracker_packed"
 	type_to_deploy = /obj/machinery/power/tracker/deployable
 	deploy_time = 3 SECONDS

--- a/modular_nova/modules/colony_fabricator/code/machines/solid_fuel_generator.dm
+++ b/modular_nova/modules/colony_fabricator/code/machines/solid_fuel_generator.dm
@@ -51,6 +51,7 @@
 
 /obj/item/flatpacked_machine/fuel_generator
 	name = "flat-packed S.O.F.I.E.-type portable generator"
+	desc = /obj/machinery/power/port_gen/pacman/solid_fuel::desc
 	icon_state = "fuel_generator_packed"
 	type_to_deploy = /obj/machinery/power/port_gen/pacman/solid_fuel
 	custom_materials = list(

--- a/modular_nova/modules/colony_fabricator/code/machines/stirling_generator.dm
+++ b/modular_nova/modules/colony_fabricator/code/machines/stirling_generator.dm
@@ -125,6 +125,7 @@
 
 /obj/item/flatpacked_machine/stirling_generator
 	name = "flat-packed stirling generator"
+	desc = /obj/machinery/power/stirling_generator::desc
 	icon = 'modular_nova/modules/colony_fabricator/icons/stirling_generator/packed_machines.dmi'
 	icon_state = "stirling"
 	type_to_deploy = /obj/machinery/power/stirling_generator

--- a/modular_nova/modules/colony_fabricator/code/machines/thermomachine.dm
+++ b/modular_nova/modules/colony_fabricator/code/machines/thermomachine.dm
@@ -45,6 +45,7 @@
 
 /obj/item/flatpacked_machine/thermomachine
 	name = "flat-packed atmospheric temperature regulator"
+	desc = /obj/machinery/atmospherics/components/unary/thermomachine/deployable::desc
 	icon_state = "thermomachine_packed"
 	type_to_deploy = /obj/machinery/atmospherics/components/unary/thermomachine/deployable
 	custom_materials = list(

--- a/modular_nova/modules/kahraman_equipment/code/gps_beacon.dm
+++ b/modular_nova/modules/kahraman_equipment/code/gps_beacon.dm
@@ -14,6 +14,7 @@
 
 /obj/item/flatpacked_machine/gps_beacon
 	name = "packed GPS beacon"
+	desc = /obj/item/gps/computer/beacon::desc
 	icon = 'modular_nova/modules/kahraman_equipment/icons/gps_beacon.dmi'
 	icon_state = "beacon_folded"
 	w_class = WEIGHT_CLASS_SMALL

--- a/modular_nova/modules/kahraman_equipment/code/ore_thumper.dm
+++ b/modular_nova/modules/kahraman_equipment/code/ore_thumper.dm
@@ -254,6 +254,7 @@
 // Item for deploying ore thumpers
 /obj/item/flatpacked_machine/ore_thumper
 	name = "flat-packed ore thumper"
+	desc = /obj/machinery/power/colony_ore_thumper::desc
 	icon = 'modular_nova/modules/kahraman_equipment/icons/ore_thumper_item.dmi'
 	icon_state = "thumper_packed"
 	type_to_deploy = /obj/machinery/power/colony_ore_thumper

--- a/modular_nova/modules/kahraman_equipment/code/organic_printer.dm
+++ b/modular_nova/modules/kahraman_equipment/code/organic_printer.dm
@@ -32,6 +32,7 @@
 // Deployable item for cargo for the organics printer
 /obj/item/flatpacked_machine/organics_printer
 	name = "organic materials printer parts kit"
+	desc = /obj/machinery/biogenerator/organic_printer::desc
 	icon = 'modular_nova/modules/kahraman_equipment/icons/biogenerator.dmi'
 	icon_state = "biogenerator_parts"
 	type_to_deploy = /obj/machinery/biogenerator/organic_printer


### PR DESCRIPTION
## About The Pull Request

This PR makes colony appliances show descriptions in the colony lathe's menus. Yeah.

The title soooomewhat omits the fact that this is through a minor refactor of how descriptions of flatpacked machines works, now inheriting descriptions with what the code style guide now recommends. In practice, this means flatpacked machines can now have different descriptions from the machines they deploy while only having to touch the desc variable. Also the wind turbine showing the wrong description is fixed and a random useless variable was removed (it got overwritten only two lines down and was redundant to begin with because its the same value as parent).

## How This Contributes To The Nova Sector Roleplay Experience

It's neat to know what a CO2 Scrubber does before you print it.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/76097299-bda0-46f8-b04e-a05159b08cc4)
  
![image](https://github.com/user-attachments/assets/57d00200-787a-4eab-855e-53624a8ff127)

</details>

## Changelog

:cl:
fix: Colony appliances now show their description in the rapid construction fabricator's menus.
fix: Wind turbines no longer pretend they're rapid construction fabricators, a way cooler machine than they'll ever be.
refactor: Flatpacked machines now copy descriptions in a different and cleaner way, allowing for custom descriptions between the flatpack and the machine it deploys.
/:cl:
