### PR TITLE
Fixes the disposals outside of Wawa's NTrep office.

### DIFF
--- a/_maps/nova/automapper/templates/wawastation/wawastation_ntrep_office.dmm
+++ b/_maps/nova/automapper/templates/wawastation/wawastation_ntrep_office.dmm
@@ -23,6 +23,7 @@
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "e" = (
@@ -215,6 +216,15 @@
 /obj/machinery/light/warm/directional/south,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/nt_rep)
+"z" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/command)
 "A" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -230,6 +240,7 @@
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "D" = (
@@ -419,7 +430,7 @@ J
 J
 J
 t
-d
+z
 d
 d
 M


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fluffles spotted this. Automapper issue. Not upstream. Missing a few sections of disposal piping.

## How This Contributes To The Nova Sector Roleplay Experience

map issue bad.

## Proof of Testing

before - 
![image](https://github.com/user-attachments/assets/70a73c88-d09b-4ff1-a3de-6aaf93b14f6c)

after - 
![image](https://github.com/user-attachments/assets/f648deff-0670-47fe-9dca-be7b747ad320)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: disposals outside of the NTrep office on Wawa are no longer broken.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
