### PR TITLE
make able read paper from folder

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -367,7 +367,7 @@
 		return UI_CLOSE
 	if(!user.can_read(src))
 		return UI_CLOSE
-	if(in_contents_of(/obj/machinery/door/airlock) || in_contents_of(/obj/item/clipboard) || in_contents_of(/obj/item/folder)) // NOVA EDIT - ORIGINAL: if(in_contents_of(/obj/machinery/door/airlock) || in_contents_of(/obj/item/clipboard))
+	if(in_contents_of(/obj/machinery/door/airlock) || in_contents_of(/obj/item/clipboard) || in_contents_of(/obj/item/folder)) // NOVA EDIT CHANGE - ORIGINAL: if(in_contents_of(/obj/machinery/door/airlock) || in_contents_of(/obj/item/clipboard))
 		return UI_INTERACTIVE
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

Improved due to the complexity of running a bureaucracy (I don't have enough GBP on TG for this QoL)

## How This Contributes To The Nova Sector Roleplay Experience

Conveniently store photos and papers in a folder without having to reach in and disorder them

## Changelog

:cl:
qol: make able reading the paper in the folder
/:cl:
