### PR TITLE
Snowglobe Perma Tweaks

### DIFF
--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -1643,6 +1643,7 @@
 "atB" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -3159,11 +3160,12 @@
 	},
 /area/station/hallway/primary/aftporthall)
 "aOs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/prison)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Work Room"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/prison/work)
 "aOx" = (
 /obj/effect/turf_decal/tile/blue/half,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -6687,7 +6689,7 @@
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/aft)
 "bNj" = (
-/obj/machinery/hydroponics/soil,
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
 "bNx" = (
@@ -7452,6 +7454,12 @@
 "bYL" = (
 /turf/closed/wall,
 /area/station/cargo/miningdock)
+"bYU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/station/security/prison/shower)
 "bYV" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/mess,
@@ -9553,8 +9561,10 @@
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "cCD" = (
-/obj/machinery/door/airlock/public/glass,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Exercise Room"
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison/workout)
 "cCE" = (
@@ -11976,6 +11986,7 @@
 /area/station/security/prison/work)
 "dlp" = (
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/vending/dorms,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "dlu" = (
@@ -14639,6 +14650,16 @@
 /obj/effect/turf_decal/bot_blue,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/storage)
+"dWg" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/public/glass{
+	name = "Prison Study"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
 "dWi" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
@@ -17779,6 +17800,7 @@
 /area/station/service/chapel/storage)
 "ePs" = (
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "ePv" = (
@@ -19190,7 +19212,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aftporthall)
 "fjt" = (
-/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/airlock/public/glass{
+	name = "Work Room"
+	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison/work)
@@ -19549,6 +19573,10 @@
 /area/station/hallway/primary/forestarboardhall)
 "fpm" = (
 /obj/structure/closet/secure_closet/freezer/meat/all_access,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
 /turf/open/floor/iron/checker,
 /area/station/security/prison/mess)
 "fpH" = (
@@ -24384,10 +24412,12 @@
 /area/station/hallway/primary)
 "gDw" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/public/glass,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/public/glass{
+	name = "Work Room"
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison/work)
 "gDz" = (
@@ -24909,6 +24939,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/large,
 /area/station/cargo/sorting)
+"gKA" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/wood/large,
+/area/station/security/prison)
 "gKI" = (
 /obj/effect/turf_decal/trimline/blue/line,
 /obj/machinery/computer/atmos_control/nitrogen_tank{
@@ -27441,8 +27475,12 @@
 /turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "htp" = (
-/turf/open/floor/iron/freezer,
-/area/station/security/prison/shower)
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/prison/directional/west,
+/turf/open/floor/wood/large,
+/area/station/security/prison)
 "htr" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/mapping_helpers/broken_floor,
@@ -28245,6 +28283,11 @@
 "hEJ" = (
 /obj/structure/cable,
 /obj/structure/closet/secure_closet/freezer/kitchen/all_access,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box{
+	pixel_x = 0;
+	pixel_y = 5
+	},
 /turf/open/floor/iron/checker,
 /area/station/security/prison/mess)
 "hEK" = (
@@ -29999,6 +30042,7 @@
 	pixel_y = -5
 	},
 /obj/machinery/newscaster/directional/south,
+/obj/item/seeds/potato,
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
 "idh" = (
@@ -31470,10 +31514,10 @@
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/secondary/recreation)
 "iwt" = (
-/obj/machinery/hydroponics/soil,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
 "iwy" = (
@@ -35231,10 +35275,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "jyo" = (
-/obj/machinery/shower/directional/west,
-/obj/structure/drain,
-/turf/open/floor/iron/freezer,
-/area/station/security/prison/shower)
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/security/prison)
 "jyr" = (
 /obj/structure/closet/secure_closet/injection,
 /obj/effect/turf_decal/trimline/white/line{
@@ -37787,6 +37833,12 @@
 	dir = 8
 	},
 /area/station/engineering/lobby)
+"kfE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
 "kfJ" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -38751,8 +38803,12 @@
 /area/station/ai_monitored/command/storage/eva)
 "ksJ" = (
 /obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/freezer,
-/area/station/security/prison/shower)
+/obj/structure/chair/sofa/corner{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/wood/large,
+/area/station/security/prison)
 "ksK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/red,
@@ -43307,10 +43363,10 @@
 /turf/open/floor/carpet/red,
 /area/station/service/lawoffice)
 "lDu" = (
-/obj/machinery/light/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/freezer,
-/area/station/security/prison/shower)
+/obj/structure/chair/sofa/left,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/wood/large,
+/area/station/security/prison)
 "lDD" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/records/medical/laptop{
@@ -49397,6 +49453,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos/lesser)
+"nrn" = (
+/obj/machinery/shower/directional/east,
+/obj/structure/drain,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/freezer,
+/area/station/security/prison/shower)
 "nrx" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -59829,9 +59891,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/law)
 "qiJ" = (
-/obj/machinery/hydroponics/soil,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
 "qiR" = (
@@ -60705,13 +60767,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_arcade)
 "qua" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/door/airlock/bathroom{
-	name = "Restroom"
+	name = "Showers"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "quh" = (
@@ -63816,6 +63878,7 @@
 /area/station/science/explab)
 "rnH" = (
 /obj/effect/turf_decal/tile/dark_green,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron/dark/side{
 	dir = 9
 	},
@@ -67281,6 +67344,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/iron/dark/side,
 /area/station/security/prison/rec)
 "skJ" = (
@@ -70175,9 +70239,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/abandon_cafeteria)
 "sXB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "sXG" = (
@@ -70725,6 +70789,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_half,
 /area/station/cargo/miningfoyer)
+"tfU" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood/large,
+/area/station/security/prison)
 "tfX" = (
 /obj/effect/turf_decal/tile/dark_blue,
 /obj/machinery/newscaster/directional/south,
@@ -72871,11 +72939,12 @@
 /turf/open/floor/iron/small,
 /area/station/medical/psychology)
 "tJc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/structure/chair/sofa/right{
+	dir = 4
 	},
-/turf/open/floor/iron/freezer,
-/area/station/security/prison/shower)
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood/large,
+/area/station/security/prison)
 "tJf" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -72888,10 +72957,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "tJl" = (
-/obj/machinery/hydroponics/soil,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
 "tJp" = (
@@ -76302,6 +76371,14 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/item/reagent_containers/cup/bucket{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/cup/bucket{
+	pixel_x = -4;
+	pixel_y = -1
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -77016,6 +77093,7 @@
 	},
 /obj/machinery/seed_extractor,
 /obj/machinery/light/directional/north,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
 "uPR" = (
@@ -77043,10 +77121,10 @@
 	},
 /area/station/cargo/warehouse)
 "uQq" = (
-/obj/machinery/hydroponics/soil,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
 "uQt" = (
@@ -79048,6 +79126,12 @@
 	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/command/bridge)
+"vqX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/station/security/prison/shower)
 "vre" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/bar{
@@ -81001,6 +81085,12 @@
 	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/security/office)
+"vSL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/security/prison)
 "vSP" = (
 /obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 1
@@ -82363,6 +82453,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/newsroom)
+"wmc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/prison)
 "wmd" = (
 /obj/structure/flora/bush/flowers_pp/style_2,
 /obj/structure/window/fulltile,
@@ -83855,6 +83950,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_cafeteria)
+"wFN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/station/security/prison)
 "wFQ" = (
 /obj/structure/table,
 /obj/item/pai_card{
@@ -86155,10 +86256,12 @@
 /area/station/commons/dorms)
 "xkx" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/public/glass,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/public/glass{
+	name = "Exercise Room"
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison/workout)
 "xkD" = (
@@ -244959,7 +245062,7 @@ jpw
 iaJ
 oiO
 vDf
-fjt
+aOs
 npb
 pNB
 pNB
@@ -245216,7 +245319,7 @@ avb
 sXg
 oiO
 vDf
-fjt
+aOs
 ydy
 lgc
 lgc
@@ -248546,7 +248649,7 @@ sJf
 lwn
 gWE
 gWE
-gWE
+nrn
 jFX
 wVd
 ezw
@@ -248801,9 +248904,9 @@ vMu
 vMu
 sJf
 ePs
-htp
-htp
-htp
+iAU
+bYU
+kjs
 jFX
 hum
 ezw
@@ -249058,11 +249161,11 @@ vMu
 vMu
 sJf
 vej
-iAU
-htp
-kjs
-jFX
-axm
+vqX
+sXB
+sXB
+qua
+kfE
 ezw
 uqd
 dKb
@@ -249313,13 +249416,13 @@ vMu
 vMu
 vMu
 vMu
-sJf
-lDu
-sXB
-sXB
-sXB
-qua
-aOs
+jFX
+jFX
+jFX
+jFX
+jFX
+jFX
+axm
 ezw
 uqd
 dKb
@@ -249570,13 +249673,13 @@ jcZ
 vMu
 vMu
 vMu
-sJf
+jFX
 ksJ
 tJc
 htp
-kjs
-jFX
-axm
+wFN
+dWg
+vSL
 atB
 drR
 ovW
@@ -249827,11 +249930,11 @@ jcZ
 vMu
 vMu
 vMu
-sJf
+jFX
+lDu
+tfU
 jyo
-jyo
-jyo
-jyo
+gKA
 jFX
 dlp
 lMs
@@ -250084,11 +250187,11 @@ jcZ
 vMu
 vMu
 vMu
-sJf
-sJf
-sJf
-sJf
-sJf
+jFX
+wmc
+wmc
+wmc
+jFX
 jFX
 jFX
 jFX


### PR DESCRIPTION
## About The Pull Request

This PR alters a few small elements of Snowglobe Stations permabrig to improve gameplay:

-The dirt mounds in the permabrig have been replaced with hydroponics trays
-The shower has been cut in half, and a study nook added in the new space.
-Prisoners now start with eggs, 4 more slabs of meat, and potato seeds
-Permabrig doors are named correctly now

-Also the janitors start with 2 buckets in the closet because I realized I forgot that and it's been haunting my every waking moment since.

## How This Contributes To The Nova Sector Roleplay Experience

-The dirt mounds were a bad idea, the intent was to give prisoners more "work" since they literally have to stay in place all shift. This ended up being bad because its enough work that you just don't want to garden in response, so the room might as well not be there. With proper hydro trays, it will be MUCH easier for prisoners of all botanical skill levels to contribute to the station and to perma by growing their own food. Adding potato seeds and eggs is a thinly veiled attempt to make it easy to make rootwiches in snowglobes perma. I'll admit it.

-The shower was massive and a waste of space. I halved it and turned the other half into a nook with a couch and a bookshelf. This is to add a spot for prisoners to have quiet time, or use as a wildcard room to plan/commit an escape attempt.

-Someone pointed out that the custodial closet lacks buckets and I cannot stop thinking about it.

## Proof of Testing

<details>

New hydro trays:
![hydro](https://github.com/user-attachments/assets/e6e51448-878f-455a-8fb6-7170dbab29d8)

Altered shower:
![shower](https://github.com/user-attachments/assets/f5ffd0b4-27e1-439c-a1c8-07964ec121a8)

Kitchen Supplies:
![kitchen](https://github.com/user-attachments/assets/00a89d20-6d41-49f4-ad82-ca6b36dbd661)

Buckets:
![buckets](https://github.com/user-attachments/assets/da5dc4db-7b66-4d15-8c26-59395a4a9040)
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Snowglobes garden uses hydro trays now instead of dirt.
/:cl:

