### PR TITLE
Fixes Aggressive Brushing

### DIFF
--- a/modular_nova/modules/hairbrush/code/hairbrush.dm
+++ b/modular_nova/modules/hairbrush/code/hairbrush.dm
@@ -19,7 +19,7 @@
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /// Brushes someone, giving them a small mood boost
-/obj/item/hairbrush/proc/brush(mob/living/target, mob/user)
+/obj/item/hairbrush/proc/brush(mob/living/target, mob/living/user)
 	if(ishuman(target))
 		var/mob/living/carbon/human/human_target = target
 		var/obj/item/bodypart/head = human_target.get_bodypart(BODY_ZONE_HEAD)
@@ -34,8 +34,8 @@
 		if(!do_after(user, brush_speed, human_target))
 			return
 
-		// Do 1 brute to their head if they're bald. Should've been more careful.
-		if(human_target.hairstyle == "Bald" || human_target.hairstyle == "Skinhead" && is_species(human_target, /datum/species/human)) //It can be assumed most anthros have hair on them!
+		// Combat mode gives one brute damage.
+		if(user.combat_mode)
 			human_target.visible_message(span_warning("[usr] scrapes the bristles uncomfortably over [human_target]'s scalp."), span_warning("You scrape the bristles uncomfortably over [human_target]'s scalp."))
 			head.receive_damage(1)
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adjusts the hairbrush to require you to use combat mode to do 1 brute of annoyance to someone, instead of checking against their hairstyle and species.

## How This Contributes To The Nova Sector Roleplay Experience

Removing a touch of bad code that didn't work as intended, making the funny interaction intentional.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: hairbrushes no longer unintentionally damage friends. you now need combat mode for aggressive brushies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
