### PR TITLE
Fix: Augments+ Bodyshape Flags

### DIFF
--- a/modular_nova/modules/customization/modules/client/augment/limbs.dm
+++ b/modular_nova/modules/customization/modules/client/augment/limbs.dm
@@ -46,6 +46,7 @@
 		if(supports_digitigrade == TRUE && old_limb.limb_id == BODYPART_ID_DIGITIGRADE)
 			new_limb.limb_id = BODYPART_ID_DIGITIGRADE
 			new_limb.base_limb_id = BODYPART_ID_DIGITIGRADE
+			new_limb.bodyshape = old_limb.bodyshape
 		new_limb.replace_limb(augmented, special = TRUE)
 		qdel(old_limb)
 


### PR DESCRIPTION
## About The Pull Request

This one-line PR fixes a minor bug that caused digitigrade limbs to ignore bodytype flags when they were applied via the Augments+ screen, which caused that character's clothing to use non-digitigrade (incorrect) sprites.

I fixed the bug by ensuring `/datum/augment_item/proc/apply()` copies bodyshape flags from old digitigrade limbs to the new limbs, if that limb supports that flag.

## How This Contributes To The Nova Sector Roleplay Experience

The bug is purely visual. With the fix things like undersuits, oversuits, and shoes will now display properly for digitigrade characters who replaced their legs in the Augments+ screen.

## Proof of Testing

Before and after screenshots:
![Screenshot 2024-10-11 180508](https://github.com/user-attachments/assets/6b149ea0-0ccc-4f67-bd36-7a95a6879765) ![Screenshot 2024-10-11 175945](https://github.com/user-attachments/assets/5035aeaf-ed4e-4a8a-a44a-58a789aef5ed)

## Changelog

:cl: A.C.M.O.
fix: Fixed clothing displaying incorrect sprites when digitigrade legs are applied via the Augments+ screen.
/:cl:
