### PR TITLE
Fixes Void Raptor solars

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -3749,6 +3749,7 @@
 /area/station/command/heads_quarters/rd)
 "bbz" = (
 /obj/machinery/power/smes,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/solars/port/fore)
 "bbN" = (
@@ -41847,6 +41848,7 @@
 /area/station/service/bar)
 "lOz" = (
 /obj/machinery/power/smes,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/solars/starboard/aft)
 "lOC" = (
@@ -64671,6 +64673,7 @@
 /area/station/medical/medbay/lobby)
 "sbU" = (
 /obj/machinery/power/smes,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/solars/port/aft)
 "scd" = (
@@ -77313,6 +77316,7 @@
 /area/station/service/kitchen/abandoned)
 "vwi" = (
 /obj/machinery/power/smes,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/solars/starboard/fore)
 "vwl" = (


### PR DESCRIPTION

## About The Pull Request

Solar SMES units were missing the wire underneath them. Fixed.

## How This Contributes To The Nova Sector Roleplay Experience

Max fixes, etc.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: Void Raptor solar array SMES units are now properly connected to the grid.
/:cl:
