### PR TITLE
Gives borg bacon/cloth snacks a proper taste

### DIFF
--- a/modular_nova/modules/borg_buffs/code/snack_dispensor.dm
+++ b/modular_nova/modules/borg_buffs/code/snack_dispensor.dm
@@ -147,6 +147,7 @@
 	desc = "BACON!!!"
 	icon = 'modular_nova/master_files/icons/obj/food/snacks.dmi'
 	icon_state = "bacon_strip"
+	taste_description = "bacon... ish"
 	foodtypes = MEAT
 
 /obj/item/food/cookie/cloth
@@ -154,4 +155,5 @@
 	desc = "A cookie that appears to be made out of... some form of cloth?"
 	icon = 'modular_nova/master_files/icons/obj/food/snacks.dmi'
 	icon_state = "cookie_cloth"
+	taste_description = "doughy cloth"
 	foodtypes = CLOTH

--- a/modular_nova/modules/borg_buffs/code/snack_dispensor.dm
+++ b/modular_nova/modules/borg_buffs/code/snack_dispensor.dm
@@ -147,7 +147,7 @@
 	desc = "BACON!!!"
 	icon = 'modular_nova/master_files/icons/obj/food/snacks.dmi'
 	icon_state = "bacon_strip"
-	taste_description = "bacon... ish"
+	tastes = list("bacon... ish" = 1)
 	foodtypes = MEAT
 
 /obj/item/food/cookie/cloth
@@ -155,5 +155,5 @@
 	desc = "A cookie that appears to be made out of... some form of cloth?"
 	icon = 'modular_nova/master_files/icons/obj/food/snacks.dmi'
 	icon_state = "cookie_cloth"
-	taste_description = "doughy cloth"
+	tastes = list("doughy cloth" = 1)
 	foodtypes = CLOTH


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

These had no tastes set, so they just tasted like cookies. If you're gonna eat something that looks like bacon, let's at least pretend it tastes like a vague facsimile of bacon. 

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: borg snacks now taste better. ish.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
