### PR TITLE
Adds Functional/ Non-Functional modes to suits

### DIFF
--- a/modular_nova/modules/clothing_improvements/code/functional_toggle.dm
+++ b/modular_nova/modules/clothing_improvements/code/functional_toggle.dm
@@ -67,11 +67,22 @@ Use CTRL + SHIFT + LEFT CLICK to turn them on and off.
 /obj/item/clothing/suit/space
 	only_functional = TRUE
 
+// Stuff that gives other effects, like reactive armor, reflective armor, etc.
+
 /obj/item/clothing/suit/armor/reactive
 	only_functional = TRUE
 
 /obj/item/clothing/suit/hooded/ablative
 	only_functional = TRUE
 
-/obj/item/clothing/suit/armor/heavy //includes adamantine armor.
+/obj/item/clothing/suit/armor/heavy/adamantine
+	only_functional = TRUE
+
+/obj/item/clothing/suit/armor/laserproof
+	only_functional = TRUE
+
+/obj/item/clothing/suit/hooded/berserker
+	only_functional = TRUE
+
+/obj/item/clothing/suit/armor/abductor/vest
 	only_functional = TRUE

--- a/modular_nova/modules/clothing_improvements/code/functional_toggle.dm
+++ b/modular_nova/modules/clothing_improvements/code/functional_toggle.dm
@@ -1,0 +1,77 @@
+/*
+Functional Toggle lets you convert stuff to functional (exo suit), with armor, cold and heat protection values, to non functional (neck), with all those set to zero.
+It allows people to use a jacket over a piece or armor and only sacrifice the minimal amount of functionality in the pursuit of design.
+Use CTRL + SHIFT + LEFT CLICK to turn them on and off.
+*/
+
+
+/obj/item/clothing/suit/
+	var/only_functional = FALSE
+
+/obj/item/clothing/suit/Initialize (mapload)
+	. = ..()
+	
+	register_context()
+
+/obj/item/clothing/suit/examine(mob/user)
+	. = ..()
+	
+	if (!only_functional)
+		. += span_info("Ctrl + Shift + Left Click to swap between functional (suit) and non-functional (neck) mode.")
+
+/obj/item/clothing/suit/click_ctrl_shift(mob/user)
+	if(!iscarbon(user))
+		return NONE
+	if (only_functional)
+		return NONE
+	var/mob/living/carbon/char = user
+	if((char.get_item_by_slot(ITEM_SLOT_NECK) == src) || (char.get_item_by_slot(ITEM_SLOT_OCLOTHING) == src))
+		to_chat(user, span_warning("You can't adjust [src] while wearing it!"))
+		return CLICK_ACTION_BLOCKING
+	if(!user.is_holding(src))
+		to_chat(user, span_warning("You must be holding [src] in order to adjust it!"))
+		return CLICK_ACTION_BLOCKING
+	if(slot_flags & ITEM_SLOT_OCLOTHING)
+		slot_flags = ITEM_SLOT_NECK
+		cold_protection = null
+		heat_protection = null
+		slowdown = 0
+		set_armor(/datum/armor/none)
+		user.visible_message(span_notice("[user] adjusts their [src] for non-functional use."), span_notice("You adjust your [src] for non-functional use."))
+	else
+		slot_flags = initial(slot_flags)
+		cold_protection = initial(cold_protection)
+		heat_protection = initial(heat_protection)
+		slowdown = initial(slowdown)
+		set_armor(initial(armor_type))
+		user.visible_message(span_notice("[user] adjusts their [src] for functional use."), span_notice("You adjust your [src] for functional use."))
+	return CLICK_ACTION_SUCCESS
+
+/obj/item/clothing/suit/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	. = ..()
+	
+	var/changed = FALSE
+	
+	if(!only_functional)
+		if (slot_flags == ITEM_SLOT_NECK)
+			context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB] = "Toggle functional mode"
+			changed = TRUE
+		else
+			context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB] = "Toggle non-functional mode"
+			changed = TRUE
+		
+	return changed ? CONTEXTUAL_SCREENTIP_SET : .
+
+// Add the things here that shouldn't have this functionality.
+
+/obj/item/clothing/suit/space
+	only_functional = TRUE
+
+/obj/item/clothing/suit/armor/reactive
+	only_functional = TRUE
+
+/obj/item/clothing/suit/hooded/ablative
+	only_functional = TRUE
+
+/obj/item/clothing/suit/armor/heavy //includes adamantine armor.
+	only_functional = TRUE

--- a/modular_nova/modules/kahraman_equipment/code/clothing/clothing.dm
+++ b/modular_nova/modules/kahraman_equipment/code/clothing/clothing.dm
@@ -49,7 +49,7 @@
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 	worn_icon_teshari = 'modular_nova/modules/kahraman_equipment/icons/clothes/clothing_worn_teshari.dmi'
 	worn_icon_state = "jacket"
-	slot_flags = ITEM_SLOT_OCLOTHING|ITEM_SLOT_NECK
+	slot_flags = ITEM_SLOT_OCLOTHING
 	armor_type = /datum/armor/colonist_clothing
 	resistance_flags = NONE
 	allowed = null
@@ -207,7 +207,6 @@
 	worn_icon_teshari = 'modular_nova/modules/kahraman_equipment/icons/clothes/clothing_worn_teshari.dmi'
 	worn_icon_state = "mask"
 	flags_inv = HIDEEYES|HIDEFACE|HIDEFACIALHAIR|HIDESNOUT
-	armor_type = /datum/armor/colonist_hazard
 
 /obj/item/clothing/mask/gas/atmos/frontier_colonist/Initialize(mapload)
 	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7284,6 +7284,7 @@
 #include "modular_nova\modules\clock_cult\code\structures\traps\senders\lever.dm"
 #include "modular_nova\modules\clock_cult\code\structures\traps\senders\pressure_sensor.dm"
 #include "modular_nova\modules\clothing_improvements\code\chaplain.dm"
+#include "modular_nova\modules\clothing_improvements\code\functional_toggle.dm"
 #include "modular_nova\modules\clothing_improvements\code\holsters.dm"
 #include "modular_nova\modules\colony_fabricator\code\cargo_packs.dm"
 #include "modular_nova\modules\colony_fabricator\code\colony_fabricator.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It gives a new interaction to all items under /obj/item/clothing/suit, which is, almost everything that can be put onto the exo suit slot, so jackets, armors, etc, which lets them be used onto the neck slot, without their advantages, ie, armor, heat and cold protection, slowdown or speed up. It also has a list of things that dont get this interaction (which is easily VV able, btw!) so that we dont have a lot of people running reactive armors or ablative armors with another armor all of the sudden!

It also removes the Snowflake armor that the frontier gasmask had, because it was on the same file that the frontier stuff which already allowed armor layer stacking was, and had no sense we were having a secret item that gave Laser III protection.

The interaction, which appears on the context menu, is similar to that of the goliath cloak, and allows with using ctrl + shift + left click to switch between the modes, which will allow to wear the item on the neck or the suit.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Addresses this: https://discord.com/channels/1171566433923239977/1247500111454539838/1247500111454539838

It expands significantly the fashion options while at the same time snipping two minor powergaming issues that were abused in the past.


## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/ddc893f9-f209-47e0-9397-f70ac29d6c34)

![image](https://github.com/user-attachments/assets/970dd550-9262-4b25-aa65-3482c0443933)

![image](https://github.com/user-attachments/assets/895cca7f-2e50-49e9-bb30-f84b9ced0c2a)

![image](https://github.com/user-attachments/assets/113265a9-88ab-411d-a914-f0dc3deda7ae)

![image](https://github.com/user-attachments/assets/1b18fea3-4bb9-4826-99d3-06add64d67bd)

![image](https://github.com/user-attachments/assets/8db10273-1b84-415b-ae1b-81bf3c3bb4bd)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Most™ Jackets, Suits, Tops, some armors and other exosuit equipment can now be toggled (CTRL+SHIFT+LEFT CLICK) to change between functional and non functional uses. The former their usual configuration, the latter featureless but able to be used on the neck.
balance: frontier jackets no longer can be stacked to get a boost on armor.
balance: frontier mask uses the same kind of armor the atmos, captain and CC masks have. It no longer gives Laser armor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
