### PR TITLE
Removes the service bell ambience from Hilberts areas.

### DIFF
--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -406,7 +406,7 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	has_gravity = TRUE
 	area_flags = NOTELEPORT | HIDDEN_AREA
 	static_lighting = TRUE
-	ambientsounds = list('sound/ambience/ruin/servicebell.ogg')
+	//ambientsounds = list('sound/ambience/ruin/servicebell.ogg') NOVA EDIT REMOVAL
 	var/roomnumber = 0
 	var/obj/item/hilbertshotel/parentSphere
 	var/datum/turf_reservation/reservation


### PR DESCRIPTION
## About The Pull Request

Does what it says on the tin. It's loud. It's obnoxious. And it repeats every 30-60 seconds. Not everyone knows that it's an ambient effect either. Another terrible micro PR from sqn.

## How This Contributes To The Nova Sector Roleplay Experience

Do you want to hear a service bell ring, on average, 80 times an hour while trying to do things in Hilberts/infinite dorms? No.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/7f745409-de0c-4367-a553-e5446b524fea)

</details>

## Changelog
:cl:
del: hilberts areas no longer play the service bell ambience.
/:cl:
