### PR TITLE
disables phasic ammo printing

### DIFF
--- a/modular_nova/modules/aesthetics/guns/code/guns.dm
+++ b/modular_nova/modules/aesthetics/guns/code/guns.dm
@@ -314,6 +314,9 @@
 	name = "enchanted rifle round"
 	can_be_printed = FALSE // these are Really Really Better Rubbers
 
+/obj/item/ammo_casing/strilka310/phasic
+	can_be_printed = FALSE // shot from cargo to sec with cameras needed to see if you hit your target, it can be fun for event where we play extreme battleships.
+
 // overrides for tgcode's .223 (formerly 5.56), used in the M90-gl - renamed to .277 Aestus
 /obj/item/ammo_casing/a223
 	name = ".277 Aestus casing"
@@ -326,6 +329,7 @@
 	<i>PHASIC: Ignores all surfaces except organic matter.</i>"
 	advanced_print_req = TRUE
 	custom_materials = AMMO_MATS_PHASIC
+	can_be_printed = FALSE // shot from cargo to sec with cameras needed to see if you hit your target, it can be fun for event where we play extreme battleships.
 
 // shotgun ammo overrides moved to modular_nova\modules\shotgunrebalance\code\shotgun.dm
 
@@ -440,6 +444,7 @@
 	<i>PHASIC: Ignores all surfaces except organic matter.</i>"
 	advanced_print_req = TRUE
 	custom_materials = AMMO_MATS_PHASIC
+	can_be_printed = FALSE // shot from cargo to sec with cameras needed to see if you hit your target, it can be fun for event where we play extreme battleships.
 
 /obj/item/ammo_casing/a357/heartseeker
 	desc = "A .357 heartseeker bullet casing.\


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disables the a375, m223 and 310 ammo types from producing their phasic variants on the workbench

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Admin Request.

And common, we got at least five different places where the kind of combat you would use this on doesnt allow for this kind of fight, its ambush combat where it would be felt unfair even on tg.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/5541e0dd-7900-4288-bea3-575b51f224ae)

![image](https://github.com/user-attachments/assets/f1cd5571-f461-4268-87b3-4837aa6ad741)

![image](https://github.com/user-attachments/assets/d4ea14c1-d8af-45e9-865b-1cf3fec5afb4)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Removed the a375, m223 and 310 ammo phasic variants from the ammo workbench. (Unless the workbench is adminbused).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
