### PR TITLE
[MODULAR] Add: Augments+ Ears & Extras

### DIFF
--- a/code/__DEFINES/~nova_defines/augment.dm
+++ b/code/__DEFINES/~nova_defines/augment.dm
@@ -16,6 +16,7 @@
 #define AUGMENT_SLOT_LIVER			"Liver"
 #define AUGMENT_SLOT_STOMACH		"Stomach"
 #define AUGMENT_SLOT_EYES			"Eyes"
+#define AUGMENT_SLOT_EARS			"Ears"
 #define AUGMENT_SLOT_TONGUE			"Tongue"
 //Implants - we add an "implant" suffix because the defines need to be unique
 #define AUGMENT_CATEGORY_IMPLANTS				"Implants"

--- a/modular_nova/modules/customization/modules/client/augment/implants.dm
+++ b/modular_nova/modules/customization/modules/client/augment/implants.dm
@@ -24,6 +24,10 @@
 /datum/augment_item/implant/l_arm
 	slot = AUGMENT_SLOT_LEFT_ARM_IMPLANT
 
+/datum/augment_item/implant/l_arm/charging_implant
+	name = "Left Charging Cord Implant"
+	path = /obj/item/organ/internal/cyberimp/arm/power_cord
+
 /datum/augment_item/implant/l_arm/civilian_lighter
 	name = "Left Thumbtip Lighter"
 	cost = 2
@@ -82,6 +86,10 @@
 //RIGHT ARM IMPLANTS
 /datum/augment_item/implant/r_arm
 	slot = AUGMENT_SLOT_RIGHT_ARM_IMPLANT
+
+/datum/augment_item/implant/r_arm/charging_implant
+	name = "Right Charging Cord Implant"
+	path = /obj/item/organ/internal/cyberimp/arm/power_cord/right_arm
 
 /datum/augment_item/implant/r_arm/civilian_lighter
 	name = "Right Thumbtip Lighter"

--- a/modular_nova/modules/customization/modules/client/augment/organs.dm
+++ b/modular_nova/modules/customization/modules/client/augment/organs.dm
@@ -13,34 +13,44 @@
 //HEARTS
 /datum/augment_item/organ/heart
 	slot = AUGMENT_SLOT_HEART
+	allowed_biotypes = MOB_ORGANIC | MOB_ROBOTIC
+
+/datum/augment_item/organ/heart/normal
+	name = "Organic heart"
+	path = /obj/item/organ/internal/heart
 
 /datum/augment_item/organ/heart/cybernetic
 	name = "Cybernetic heart"
 	path = /obj/item/organ/internal/heart/cybernetic
 
+/datum/augment_item/organ/heart/synth
+	name = "Hydraulic pump engine"
+	path =/obj/item/organ/internal/heart/synth
+
 //LUNGS
 /datum/augment_item/organ/lungs
 	slot = AUGMENT_SLOT_LUNGS
+	allowed_biotypes = MOB_ORGANIC | MOB_ROBOTIC
+
+/datum/augment_item/organ/lungs/normal
+	name = "Organic lungs"
+	path = /obj/item/organ/internal/lungs
 
 /datum/augment_item/organ/lungs/hot
 	name = "Lungs Adapted to Heat"
-	slot = AUGMENT_SLOT_LUNGS
 	path = /obj/item/organ/internal/lungs/hot
 	cost = 1
 
 /datum/augment_item/organ/lungs/cold
 	name = "Cold-Adapted Lungs"
-	slot = AUGMENT_SLOT_LUNGS
 	path = /obj/item/organ/internal/lungs/cold
 	cost = 1
 /datum/augment_item/organ/lungs/toxin
 	name = "Lungs Adapted to Toxins"
-	slot = AUGMENT_SLOT_LUNGS
 	path = /obj/item/organ/internal/lungs/toxin
 	cost = 1
 /datum/augment_item/organ/lungs/oxy
 	name = "Low-Pressure Adapted Lungs"
-	slot = AUGMENT_SLOT_LUNGS
 	path = /obj/item/organ/internal/lungs/oxy
 	cost = 1
 /datum/augment_item/organ/lungs/cybernetic
@@ -50,18 +60,36 @@
 //LIVERS
 /datum/augment_item/organ/liver
 	slot = AUGMENT_SLOT_LIVER
+	allowed_biotypes = MOB_ORGANIC | MOB_ROBOTIC
+
+/datum/augment_item/organ/liver/normal
+	name = "Organic Liver"
+	path = /obj/item/organ/internal/liver
 
 /datum/augment_item/organ/liver/cybernetic
 	name = "Cybernetic liver"
 	path = /obj/item/organ/internal/liver/cybernetic
 
+/datum/augment_item/organ/liver/cybernetic
+	name = "Reagent processing unit"
+	path = /obj/item/organ/internal/liver/synth
+
 //STOMACHES
 /datum/augment_item/organ/stomach
 	slot = AUGMENT_SLOT_STOMACH
+	allowed_biotypes = MOB_ORGANIC | MOB_ROBOTIC
+
+/datum/augment_item/organ/stomach/normal
+	name = "Organic stomach"
+	path = /obj/item/organ/internal/stomach
 
 /datum/augment_item/organ/stomach/cybernetic
 	name = "Cybernetic stomach"
 	path = /obj/item/organ/internal/stomach/cybernetic
+
+/datum/augment_item/organ/stomach/synth
+	name = "Synthetic bio-reactor"
+	path = /obj/item/organ/internal/stomach/synth
 
 /datum/augment_item/organ/stomach/lithovore
 	name = "Lithovore Stomach"
@@ -75,6 +103,11 @@
 //EYES
 /datum/augment_item/organ/eyes
 	slot = AUGMENT_SLOT_EYES
+	allowed_biotypes = MOB_ORGANIC | MOB_ROBOTIC
+
+/datum/augment_item/organ/eyes/normal
+	name = "Organic eyes"
+	path = /obj/item/organ/internal/eyes
 
 /datum/augment_item/organ/eyes/cybernetic
 	name = "Cybernetic eyes"
@@ -87,13 +120,11 @@
 /datum/augment_item/organ/eyes/highlumi
 	name = "High-luminosity eyes"
 	path = /obj/item/organ/internal/eyes/robotic/glow
-	allowed_biotypes = MOB_ORGANIC|MOB_ROBOTIC
 	cost = 1
 
 /datum/augment_item/organ/eyes/highlumi/moth
 	name = "High Luminosity Moth Eyes"
 	path = /obj/item/organ/internal/eyes/robotic/glow/moth
-	allowed_biotypes = MOB_ORGANIC|MOB_ROBOTIC
 	cost = 1
 
 /datum/augment_item/organ/eyes/binoculars
@@ -104,6 +135,7 @@
 //TONGUES
 /datum/augment_item/organ/tongue
 	slot = AUGMENT_SLOT_TONGUE
+	allowed_biotypes = MOB_ORGANIC | MOB_ROBOTIC
 
 /datum/augment_item/organ/tongue/normal
 	name = "Organic tongue"
@@ -132,3 +164,16 @@
 /datum/augment_item/organ/tongue/forked/filterless
 	name = "Forked tongue (Without TTS Filter)"
 	path = /obj/item/organ/internal/tongue/lizard/filterless
+
+//EARS
+/datum/augment_item/organ/ears
+	slot = AUGMENT_SLOT_EARS
+	allowed_biotypes = MOB_ORGANIC | MOB_ROBOTIC
+
+/datum/augment_item/organ/ears/normal
+	name = "Organic ears"
+	path = /obj/item/organ/internal/ears
+
+/datum/augment_item/organ/ears/cybernetic
+	name = "Cybernetic ears"
+	path = /obj/item/organ/internal/ears/cybernetic

--- a/modular_nova/modules/roundstart_implants/code/loadout_subtypes.dm
+++ b/modular_nova/modules/roundstart_implants/code/loadout_subtypes.dm
@@ -10,6 +10,10 @@
 	zone = BODY_ZONE_R_ARM
 	slot = ORGAN_SLOT_RIGHT_ARM_AUG
 
+/obj/item/organ/internal/cyberimp/arm/power_cord/right_arm
+	zone = BODY_ZONE_R_ARM
+	slot = ORGAN_SLOT_RIGHT_ARM_AUG
+
 /obj/item/organ/internal/cyberimp/arm/lighter/left_arm
 	zone = BODY_ZONE_L_ARM
 	slot = ORGAN_SLOT_LEFT_ARM_AUG


### PR DESCRIPTION
## About The Pull Request

This draft PR aims to add more organ and implant options to the Augments+ screen, including an ears organ category.

Work in progress!

## How This Contributes To The Nova Sector Roleplay Experience

As our community has evolved to be more character focused, our options to create and customize synthetic species have slowly improved. Synthetic characters come in all shapes, sizes, and configurations. Thanks to the work done in PR #3738 we are now able to create more interesting organic/synthetic hybrid custom species via the selection of species limbs, and this PR aims to improve selection of organs and implants.

## Proof of Testing

Draft status. Testing TBD.

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl: A.C.M.O.
add: Added an ears category and cybernetic ears to the Augments+ screen.
add: Added several missing organic organs to the Augments+ screen.
/:cl:
