### PR TITLE
low tiles alert users upon trying to move out

### DIFF
--- a/modular_nova/master_files/code/modules/mob/living/living.dm
+++ b/modular_nova/master_files/code/modules/mob/living/living.dm
@@ -1,3 +1,7 @@
+/mob/living
+	/// When was the last time this mob was alerted to a height difference in turfs that necessitates climbing out?
+	COOLDOWN_DECLARE(last_height_alert)
+
 /mob/living/set_pull_offsets(mob/living/pull_target, grab_state)
 	. = ..()
 	SEND_SIGNAL(pull_target, COMSIG_LIVING_SET_PULL_OFFSET)

--- a/modular_nova/modules/liquids/code/liquid_systems/liquid_turf.dm
+++ b/modular_nova/modules/liquids/code/liquid_systems/liquid_turf.dm
@@ -323,19 +323,14 @@
 //Could probably have the variables on the turf level, and the behaviours being activated/deactived on the component level as the vars are updated
 /turf/open/CanPass(atom/movable/mover, turf/location)
 	if(isliving(mover) && !(mover.movement_type & (FLYING | FLOATING)))
+		var/mob/living/living_mover = mover
 		var/turf/current_turf = get_turf(mover)
 		if(current_turf && current_turf.turf_height - turf_height <= -TURF_HEIGHT_BLOCK_THRESHOLD)
+			if(COOLDOWN_FINISHED(living_mover, last_height_alert))
+				COOLDOWN_START(living_mover, last_height_alert, 1 SECONDS)
+				living_mover.balloon_alert(living_mover, "too high, climb out!")
 			return FALSE
 	return ..()
-
-/turf/open/Exit(atom/movable/mover, atom/newloc)
-	. = ..()
-	if(. && isliving(mover) && mover.has_gravity() && isturf(newloc))
-		var/mob/living/moving_mob = mover
-		var/turf/new_turf = get_turf(newloc)
-		if(new_turf && new_turf.turf_height - turf_height <= -TURF_HEIGHT_BLOCK_THRESHOLD)
-			moving_mob.on_fall()
-			moving_mob.onZImpact(new_turf, 1)
 
 // Handles climbing up and down between turfs with height differences, as well as manipulating others to do the same.
 /turf/open/mouse_drop_receive(mob/living/dropped_mob, mob/living/user, params)


### PR DESCRIPTION
## About The Pull Request

Attempting to exit a lowered turf  by walking (e.g. pool tiles) now alerts you (on a one-second cooldown) that you need to climb out.

## How This Contributes To The Nova Sector Roleplay Experience

pool tile guerilla warfare counterplay made slightly more obvious

## Proof of Testing
![image](https://github.com/user-attachments/assets/57491ed2-24b4-4902-9554-1d12b4a306b4)

## Changelog

:cl:
qol: Lowered turfs now give a balloon alert when you need to climb out of them to cross onto another tile.
/:cl: