### PR TITLE
allows the pumkin to be equipped onto the neck

### DIFF
--- a/modular_nova/modules/modular_items/code/head.dm
+++ b/modular_nova/modules/modular_items/code/head.dm
@@ -1,0 +1,3 @@
+// Make it so pumpkin heads can be used in the neck, so that synths can cosplay as a dullahan for hallowen
+/obj/item/clothing/head/utility/hardhat/pumpkinhead
+	slot_flags = ITEM_SLOT_HEAD | ITEM_SLOT_NECK

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8057,6 +8057,7 @@
 #include "modular_nova\modules\modular_items\code\ciggies.dm"
 #include "modular_nova\modules\modular_items\code\cross.dm"
 #include "modular_nova\modules\modular_items\code\designs.dm"
+#include "modular_nova\modules\modular_items\code\head.dm"
 #include "modular_nova\modules\modular_items\code\makeshift.dm"
 #include "modular_nova\modules\modular_items\code\modular_glasses.dm"
 #include "modular_nova\modules\modular_items\code\necklace.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

It allows the pumkin (and blumkin!) heads to be wearable onto the neck and head slots, instead of just head, allowing usage of it for dullahan and synthetics, or other mobs with detachable heads, I think slimes work too. 

The item has a low mechanical impact, as it gives a malus to fishing, no armor, but does generate light.

## How This Contributes To The Nova Sector Roleplay Experience

Allows people to disguise themselves as the headless rider without admin shenanigans.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/c3038ffd-50d3-4eaf-aee1-1a2f005e5225)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Allows the pumpkin/blumpkin head to be used on the neck slot, Synths and Dullahans rejoice!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
