### PR TITLE
Space Ruin - Black Market Trader Balance pass

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/blackmarket.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/blackmarket.dmm
@@ -316,7 +316,7 @@
 /area/ruin/space/has_grav/nova/blackmarket)
 "rF" = (
 /obj/machinery/telecomms/relay/preset/ruskie,
-/turf/open/floor/circuit/telecomms,
+/turf/open/floor/circuit,
 /area/ruin/space/has_grav/nova/blackmarket)
 "sb" = (
 /obj/structure/rack,

--- a/_maps/RandomRuins/SpaceRuins/nova/blackmarket.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/blackmarket.dmm
@@ -880,10 +880,6 @@
 /obj/structure/reagent_dispensers/fueltank/large,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/nova/blackmarket)
-"Rh" = (
-/obj/item/ammo_box/magazine/ammo_stack/s12gauge/prefilled/rubbershot,
-/turf/open/floor/iron/smooth_large,
-/area/ruin/space/has_grav/nova/blackmarket)
 "Rv" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -993,6 +989,7 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/rack,
 /obj/effect/turf_decal/bot_white,
+/obj/item/storage/medkit/ancient,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/nova/blackmarket)
 "WS" = (
@@ -1317,7 +1314,7 @@ PW
 Zh
 KI
 KQ
-Rh
+yS
 Zh
 tC
 yS

--- a/_maps/RandomRuins/SpaceRuins/nova/blackmarket.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/blackmarket.dmm
@@ -44,6 +44,7 @@
 "dm" = (
 /obj/structure/sink/kitchen/directional/south,
 /obj/effect/turf_decal/bot_white,
+/obj/effect/spawner/random/contraband/prison,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/nova/blackmarket)
 "du" = (
@@ -247,9 +248,7 @@
 /obj/machinery/light/dim/directional/west,
 /obj/structure/table,
 /obj/item/storage/box/nif_ghost_box/ghost_role,
-/obj/item/gun/ballistic/shotgun/automatic/dual_tube{
-	pixel_y = 8
-	},
+/obj/effect/spawner/random/weapon/black_market_trader,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/nova/blackmarket)
 "mQ" = (
@@ -314,6 +313,10 @@
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/light/red/dim/directional/south,
 /turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/nova/blackmarket)
+"rF" = (
+/obj/machinery/telecomms/relay/preset/ruskie,
+/turf/open/floor/circuit/telecomms,
 /area/ruin/space/has_grav/nova/blackmarket)
 "sb" = (
 /obj/structure/rack,
@@ -664,7 +667,6 @@
 "FG" = (
 /obj/structure/table,
 /obj/structure/sign/poster/contraband/random/directional/west,
-/obj/effect/spawner/random/contraband/armory,
 /obj/effect/spawner/random/contraband/prison,
 /obj/item/modular_computer/laptop/preset/civilian{
 	pixel_y = 1
@@ -733,6 +735,10 @@
 	},
 /turf/template_noop,
 /area/template_noop)
+"JI" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/nova/blackmarket)
 "JU" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/turf_decal/delivery/red,
@@ -861,6 +867,10 @@
 /obj/effect/spawner/random/engineering/material_cheap,
 /turf/open/floor/iron/smooth,
 /area/ruin/space/has_grav/nova/blackmarket)
+"Qd" = (
+/obj/effect/turf_decal/shuttle/exploration/typhon,
+/turf/open/floor/iron/dark/textured_large,
+/area/ruin/space/has_grav/nova/blackmarket)
 "Qu" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -870,6 +880,11 @@
 /turf/open/floor/iron/smooth_half{
 	dir = 8
 	},
+/area/ruin/space/has_grav/nova/blackmarket)
+"QL" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/light/small/dim/directional/north,
+/turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/nova/blackmarket)
 "QV" = (
 /obj/structure/sign/warning/docking/directional/south,
@@ -1412,7 +1427,7 @@ hO
 hO
 hO
 hd
-Zh
+Qd
 Pk
 MX
 hd
@@ -1447,8 +1462,8 @@ hO
 hO
 hO
 hO
-hO
 hd
+JI
 hd
 hd
 hd
@@ -1483,9 +1498,9 @@ hO
 hO
 hO
 hO
-hO
-hO
-hO
+hd
+QL
+rF
 hd
 hd
 eZ
@@ -1519,8 +1534,8 @@ hO
 hO
 hO
 hO
-hO
-hO
+hd
+hd
 hd
 hd
 oT

--- a/_maps/RandomRuins/SpaceRuins/nova/blackmarket.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/blackmarket.dmm
@@ -123,6 +123,10 @@
 	pixel_y = 5
 	},
 /obj/effect/spawner/random/food_or_drink/three_course_meal,
+/obj/effect/spawner/random/food_or_drink/refreshing_beverage{
+	pixel_x = 8;
+	pixel_y = 11
+	},
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/nova/blackmarket)
 "hv" = (
@@ -243,13 +247,8 @@
 /obj/machinery/light/dim/directional/west,
 /obj/structure/table,
 /obj/item/storage/box/nif_ghost_box/ghost_role,
-/obj/effect/spawner/random/food_or_drink/refreshing_beverage{
-	pixel_x = 8;
-	pixel_y = 11
-	},
-/obj/item/ammo_box/magazine/m9mm{
-	pixel_y = 3;
-	pixel_x = -8
+/obj/item/gun/ballistic/shotgun/automatic/dual_tube{
+	pixel_y = 8
 	},
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/nova/blackmarket)
@@ -881,6 +880,10 @@
 /obj/structure/reagent_dispensers/fueltank/large,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/nova/blackmarket)
+"Rh" = (
+/obj/item/ammo_box/magazine/ammo_stack/s12gauge/prefilled/rubbershot,
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/has_grav/nova/blackmarket)
 "Rv" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -942,7 +945,7 @@
 /obj/machinery/door/window/survival_pod/left/directional/south,
 /obj/machinery/light/floor,
 /obj/effect/turf_decal/bot_white/left,
-/obj/effect/spawner/random/engineering/tool_alien,
+/obj/effect/spawner/random/engineering/tool_advanced,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/nova/blackmarket)
 "UH" = (
@@ -956,8 +959,9 @@
 /area/ruin/space/has_grav/nova/blackmarket)
 "VF" = (
 /obj/effect/spawner/random/structure/closet_private,
-/obj/item/gun/ballistic/automatic/pistol,
 /obj/item/modular_computer/pda,
+/obj/item/storage/box/nif_ghost_box/ghost_role,
+/obj/item/storage/box/rubbershot,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/nova/blackmarket)
 "VG" = (
@@ -989,7 +993,6 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/rack,
 /obj/effect/turf_decal/bot_white,
-/obj/effect/spawner/random/engineering/tool_alien,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/nova/blackmarket)
 "WS" = (
@@ -1314,7 +1317,7 @@ PW
 Zh
 KI
 KQ
-yS
+Rh
 Zh
 tC
 yS
@@ -1383,7 +1386,7 @@ mZ
 UH
 eV
 sb
-hd
+Zh
 Zh
 Zh
 Zh

--- a/modular_nova/modules/mapping/code/mob_spawns.dm
+++ b/modular_nova/modules/mapping/code/mob_spawns.dm
@@ -40,6 +40,25 @@
 	handlebank(shady)
 	return ..()
 
+/obj/item/gun/energy/laser/carbine/cybersun/black_market_trader
+	desc = "A laser gun primarily used by syndicate security guards. It fires a rapid spray of low-power plasma beams. This one seems to have had its firing pin replaced."
+	pin = /obj/item/firing_pin
+
+/obj/effect/spawner/random/weapon/black_market_trader
+	name = "black market trader weapon spawner"
+	icon_state = "pistol"
+	loot = list(
+
+		/obj/item/gun/ballistic/shotgun/automatic/dual_tube = 80,
+		/obj/item/gun/energy/laser/carbine/cybersun/black_market_trader = 80,
+		/obj/item/gun/energy/e_gun/old = 50,
+		/obj/item/gun/ballistic/shotgun/automatic/combat = 30,
+		/obj/item/gun/ballistic/automatic/pistol/contraband = 30,
+		/obj/item/gun/ballistic/automatic/sol_rifle/evil  = 20,
+		/obj/item/gun/ballistic/automatic/sol_smg/evil = 20,
+		/obj/item/gun/ballistic/shotgun/bulldog/unrestricted,
+	)
+
 /obj/effect/mob_spawn/ghost_role/human/ds2
 	name = "DS2 personnel"
 	use_outfit_name = TRUE

--- a/modular_nova/modules/mapping/code/mob_spawns.dm
+++ b/modular_nova/modules/mapping/code/mob_spawns.dm
@@ -48,11 +48,9 @@
 	name = "black market trader weapon spawner"
 	icon_state = "pistol"
 	loot = list(
-
-		/obj/item/gun/ballistic/shotgun/automatic/dual_tube = 80,
 		/obj/item/gun/energy/laser/carbine/cybersun/black_market_trader = 80,
 		/obj/item/gun/energy/e_gun/old = 50,
-		/obj/item/gun/ballistic/shotgun/automatic/combat = 30,
+		/obj/item/gun/ballistic/shotgun/automatic/combat = 50,
 		/obj/item/gun/ballistic/automatic/pistol/contraband = 30,
 		/obj/item/gun/ballistic/automatic/sol_rifle/evil  = 20,
 		/obj/item/gun/ballistic/automatic/sol_smg/evil = 20,


### PR DESCRIPTION
## About The Pull Request

This one has been on my list for a few months but with the surgery n crap i just never got to it.

Simple:

Removes the two Alien tool spawns and replaces it with a single adv tool - i only ever meant for it to be 1 in the first place but the tools really should be find-only anyway.

Removes the Makarov and replaces it with a cycler - the Makarov's pretty powerful in its own sense, while it's also a perfectly fine starter weapon it kinda trivializes the role design too much. A cycler is just a stacked double barrel, sitting between a double barrel and the normal shotguns (max 4 inside vs 6 or 2 respectfully).

## How This Contributes To The Nova Sector Roleplay Experience

I made this role to be challenging, but i also gave it too many creature comforts in my last redesign so we're just dialing it back a little bit at a time until I'm happy with it. 

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
  
  
![image](https://github.com/user-attachments/assets/06629c72-5ea3-4b41-9c2f-0e2af924923d)

  
![image](https://github.com/user-attachments/assets/52527039-2854-46b1-ba00-3b1bfca70c69)

  
  
</details>

## Changelog
:cl:
add: Space ruin - Added an experimental tool to replace the alien tools for the BMD
add: Space ruin - Added a Cycler Shotgun to replace the Makarov
del: Space ruin - Removed the alien tools from the BMD Spawn as well as the Makarov
balance: Space ruin - Turned down the BMD Starter equipment
/:cl:
