### PR TITLE
Snowglobe Nitpicks

### DIFF
--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -12403,6 +12403,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"dqA" = (
+/obj/machinery/computer/crew{
+	dir = 1
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/treatment_center)
 "dqF" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -15124,6 +15130,16 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms)
+"edu" = (
+/obj/effect/turf_decal/tile/blue/full,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/computer/records/medical,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/treatment_center)
 "edB" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/steam_vent,
@@ -33113,8 +33129,7 @@
 /area/station/service/greenroom)
 "iSR" = (
 /obj/machinery/mineral/ore_redemption{
-	input_dir = 8;
-	output_dir = 4
+	input_dir = 8
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
@@ -88211,13 +88226,13 @@
 /turf/open/floor/plating,
 /area/station/command/teleporter)
 "xJz" = (
-/obj/machinery/door/airlock/security{
-	name = "Orderly's Office"
-	},
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/medical/orderly,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medical Front Desk"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/white/smooth_half{
 	dir = 8
 	},
@@ -266443,8 +266458,8 @@ bwA
 wyn
 vQr
 nuP
-eZJ
-wjK
+dqA
+edu
 ryh
 hjO
 omv

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -5814,9 +5814,11 @@
 /turf/open/floor/wood,
 /area/station/service/newsroom)
 "bAu" = (
-/obj/machinery/stasis,
 /obj/machinery/defibrillator_mount/directional/south,
 /obj/effect/turf_decal/tile/blue/half,
+/obj/structure/bed/medical{
+	dir = 4
+	},
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/treatment_center)
 "bAy" = (
@@ -12403,12 +12405,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
-"dqA" = (
-/obj/machinery/computer/crew{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
 "dqF" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -15130,16 +15126,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms)
-"edu" = (
-/obj/effect/turf_decal/tile/blue/full,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/computer/records/medical,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
 "edB" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/steam_vent,
@@ -27555,11 +27541,11 @@
 /area/station/hallway/primary/forestarboardhall)
 "hui" = (
 /obj/machinery/defibrillator_mount/directional/north,
-/obj/structure/bed/medical{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 1
+	},
+/obj/structure/bed/medical{
+	dir = 4
 	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
@@ -29718,6 +29704,12 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"hZe" = (
+/obj/machinery/computer/crew{
+	dir = 1
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/treatment_center)
 "hZi" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 4
@@ -30911,7 +30903,7 @@
 /turf/open/floor/wood,
 /area/station/maintenance/hiddenlibrary)
 "ioV" = (
-/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/computer/warrant,
 /turf/open/floor/carpet/red,
 /area/station/security/office)
 "ipa" = (
@@ -33128,9 +33120,7 @@
 /turf/open/floor/carpet/donk,
 /area/station/service/greenroom)
 "iSR" = (
-/obj/machinery/mineral/ore_redemption{
-	input_dir = 8
-	},
+/obj/machinery/mineral/ore_redemption,
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -58517,6 +58507,16 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/commons/vacant_room)
+"pMi" = (
+/obj/effect/turf_decal/tile/blue/full,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/computer/records/medical,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/treatment_center)
 "pMk" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/drugs,
@@ -69262,12 +69262,12 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/service/hydroponics)
 "sIP" = (
-/obj/structure/bed/medical{
-	dir = 4
-	},
 /obj/machinery/defibrillator_mount/directional/north,
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 1
+	},
+/obj/machinery/stasis{
+	dir = 4
 	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
@@ -266458,8 +266458,8 @@ bwA
 wyn
 vQr
 nuP
-dqA
-edu
+hZe
+pMi
 ryh
 hjO
 omv


### PR DESCRIPTION

## About The Pull Request

This is a tiny patch to Snowglobe Station. 3 things in medbay are altered, 1 in cargo, 1 in sec.

-Both stasis beds now are in line of sight of the entrance. Before there was one bed near the waiting room, and one at the far wall. Now if two victims are dragged in at once, medics no longer have to arbitrarily elongate one patients suffering by dragging them across the bay.

-The front desk is changed from orderly to general now. Medical personnel really should be allowed to man the desk.

-Crew Monitoring and records console added to exam room. Before if you wanted to look up a medical record, you had to BREAK INTO THE FRONT DESK which is insane. I put an additional set so it's easier to make sure someone your about to treat doesn't require special considerations. 

-Cargo ORM reset to default input and output. I totally copied another maps when I was new to SDMM oops.

-Warrant console added to security. Sec kind of needs to be able to do their job properly, i guess.

## How This Contributes To The Nova Sector Roleplay Experience

Small changes that I think improve playing on snowglobe immensely. Also medbay was, very half-baked it turns out and this will probably make it a hell of a lot less prickly to play in.

## Proof of Testing

(current byond  isnt compiling correctly and I know these changes wont break anything so I just took sdmm screenshots)

<details>

Medbay
![movedbeds](https://github.com/user-attachments/assets/bb20ba6e-d302-448e-adab-0b23dc614437)

Fixed ORM
![fixedorm](https://github.com/user-attachments/assets/cbee7404-d0ec-4ab6-8cbd-3500cd3591d0)

Warrant Console
![warrantconsole](https://github.com/user-attachments/assets/7bbb80f7-a8c1-40d1-bf61-dcf84a34bf33)
  
</details>

## Changelog

:cl:
qol: Snowglobe medbay, cargo, and sec tweaks.
/:cl:
