### PR TITLE
XenoArch Artifacts Fixes And Additions

### DIFF
--- a/modular_nova/modules/xenoarchartifacts/artifacts/artifact_autocloner.dm
+++ b/modular_nova/modules/xenoarchartifacts/artifacts/artifact_autocloner.dm
@@ -50,6 +50,8 @@
 		/mob/living/simple_animal/hostile/mimic,
 		/mob/living/simple_animal/hostile/retaliate/goose,
 		/mob/living/basic/living_limb_flesh,
+		/mob/living/basic/bee/toxin, // Be me. Me bee.
+		/mob/living/basic/morph,
 	)
 	else
 		spawn_type = pick( // Useful for DNA Bunker, I guess?
@@ -77,6 +79,10 @@
 		/mob/living/basic/alien/maid,
 		/mob/living/carbon/human/species/monkey,
 		/mob/living/basic/pet/cat/fennec,
+		/mob/living/basic/slime/random, // Free slimes!
+		/mob/living/basic/lightgeist,
+		/mob/living/basic/mushroom,
+		/mob/living/basic/mothroach,
 	)
 
 /obj/machinery/auto_cloner/process(seconds_per_tick)

--- a/modular_nova/modules/xenoarchartifacts/artifacts/artifact_replicator.dm
+++ b/modular_nova/modules/xenoarchartifacts/artifacts/artifact_replicator.dm
@@ -66,9 +66,12 @@
 		/obj/effect/spawner/random/techstorage/tcomms_all,
 		/obj/effect/spawner/random/trash/garbage,
 		/obj/effect/spawner/random/trash/deluxe_garbage,
+		/obj/effect/spawner/random/contraband/grenades,
+		/obj/effect/spawner/random/contraband/grenades/dangerous, // Now we are talking
+		/obj/effect/spawner/random/contraband/armory,
 	)
 
-	var/quantity = rand(5,15)
+	var/quantity = rand(3,8)
 	for (var/i in 1 to quantity)
 		var/button_desc = "a [pick("yellow", "purple", "green", "blue", "red", "orange", "white", "black", "lime", "pink", "gray", "bloody")], "
 		button_desc += "[pick("round", "square", "diamond", "heart", "dog", "human", "cat", "lizard", "skull", "syringe", "disk", "pen", "circuitboard")]-shaped "

--- a/modular_nova/modules/xenoarchartifacts/effects/blood.dm
+++ b/modular_nova/modules/xenoarchartifacts/effects/blood.dm
@@ -22,6 +22,8 @@
 	. = ..()
 	if(!.)
 		return
+	if(issynthetic(user))
+		return
 	to_chat(user, span_notice("Your body feels full, somehow."))
 	regen_target(user, 15)
 
@@ -31,6 +33,8 @@
 		return
 	var/turf/curr_turf = get_turf(holder)
 	for(var/mob/living/receiver in range(range, curr_turf))
+		if(issynthetic(receiver))
+			continue
 		to_chat(receiver, span_notice("Your chest feels warm."))
 		regen_target(receiver, 5 * seconds_per_tick)
 
@@ -40,17 +44,22 @@
 		return
 	var/turf/curr_turf = get_turf(holder)
 	for(var/mob/living/receiver in range(range, curr_turf))
+		if(issynthetic(receiver))
+			continue
 		to_chat(receiver, span_notice("Your chest feels warm."))
 		regen_target(receiver, 25 * seconds_per_tick)
 
 /datum/artifact_effect/blood_regen/do_effect_destroy()
 	var/turf/curr_turf = get_turf(holder)
 	for(var/mob/living/receiver in range(7, curr_turf))
+		if(issynthetic(receiver))
+			continue
 		to_chat(receiver, span_notice("Your chest feels warm."))
 		regen_target(receiver, 100)
 
 /datum/artifact_effect/blood_drain
 	log_name = "Blood drain"
+	type_name = ARTIFACT_EFFECT_ORGANIC
 
 /**
  * Drains mob's blood
@@ -70,6 +79,8 @@
 	. = ..()
 	if(!.)
 		return
+	if(issynthetic(user))
+		return
 	to_chat(user, span_warning("Blood starts pouring out of your pores!"))
 	suck(user, 50)
 	return TRUE
@@ -80,6 +91,8 @@
 		return
 	var/turf/curr_turf = get_turf(holder)
 	for(var/mob/living/receiver in range(range, curr_turf))
+		if(issynthetic(receiver))
+			continue
 		to_chat(receiver, span_warning("Your nose bleeds."))
 		suck(receiver, 5 * seconds_per_tick)
 
@@ -89,6 +102,8 @@
 		return
 	var/turf/curr_turf = get_turf(holder)
 	for(var/mob/living/carbon/human_receiver in range(range, curr_turf))
+		if(issynthetic(human_receiver))
+			continue
 		var/weakness = get_anomaly_protection(human_receiver)
 		if(weakness >= 0.7)
 			var/constructed_flags = (MOB_VOMIT_BLOOD | MOB_VOMIT_HARM | MOB_VOMIT_MESSAGE | MOB_VOMIT_FORCE)
@@ -98,5 +113,7 @@
 /datum/artifact_effect/blood_drain/do_effect_destroy()
 	var/turf/curr_turf = get_turf(holder)
 	for(var/mob/living/receiver in range(7, curr_turf))
+		if(issynthetic(receiver))
+			continue
 		to_chat(receiver, span_warning("You feel empty."))
 		suck(receiver, 75)

--- a/modular_nova/modules/xenoarchartifacts/effects/celldrain.dm
+++ b/modular_nova/modules/xenoarchartifacts/effects/celldrain.dm
@@ -8,8 +8,8 @@
 		return
 	for(var/obj/item/stock_parts/power_store/cell in user.contents)
 		cell.use(1e10, TRUE) // uh oh
-		if(issilicon(user))
-			to_chat(user, span_notice("SYSTEM ALERT: Massive energy drain detected!"))
+	if(issilicon(user))
+		to_chat(user, span_notice("SYSTEM ALERT: Massive energy drain detected!"))
 
 /datum/artifact_effect/celldrain/do_effect_aura(seconds_per_tick)
 	. = ..()

--- a/modular_nova/modules/xenoarchartifacts/effects/dnaswitch.dm
+++ b/modular_nova/modules/xenoarchartifacts/effects/dnaswitch.dm
@@ -43,6 +43,8 @@
  * * chance - chance to mutate mob
  */
 /datum/artifact_effect/dnaswitch/proc/roll_and_change_genes(mob/living/carbon/human/receiver, chance)
+	if(issynthetic(receiver))
+		return
 	var/weakness = get_anomaly_protection(receiver)
 	if(!prob(weakness * 100))
 		return

--- a/modular_nova/modules/xenoarchartifacts/effects/gas.dm
+++ b/modular_nova/modules/xenoarchartifacts/effects/gas.dm
@@ -46,21 +46,21 @@
 	. = ..()
 	if(!.)
 		return
-	var/turf/holder_loc = get_turf(src)
+	var/turf/holder_loc = get_turf(holder)
 	if(holder_loc)
-		assume_gas(current_gas_type, rand(2, 15))
+		assume_gas(current_gas_type, rand(2, 25))
 
 /datum/artifact_effect/gas/do_effect_aura(seconds_per_tick)
 	. = ..()
 	if(!.)
 		return
-	var/turf/holder_loc = get_turf(src)
+	var/turf/holder_loc = get_turf(holder)
 	if(holder_loc)
-		assume_gas(current_gas_type, pick(0, rand(0,5)))
+		assume_gas(current_gas_type, pick(0, rand(0,50)))
 
 /datum/artifact_effect/gas/do_effect_destroy(seconds_per_tick)
 	. = ..()
-	var/turf/holder_loc = get_turf(src)
+	var/turf/holder_loc = get_turf(holder)
 	if(holder_loc)
 		assume_gas(current_gas_type, 75 * seconds_per_tick)
 

--- a/modular_nova/modules/xenoarchartifacts/effects/gravity.dm
+++ b/modular_nova/modules/xenoarchartifacts/effects/gravity.dm
@@ -24,7 +24,7 @@
 	switch(grav_type)
 		if (GRAVITY_MAYHEM)
 			for(var/atom/movable/to_throw in range(range, curr_turf))
-				mayhem_throw(to_throw, curr_turf, 1)
+				mayhem_throw(to_throw, 1)
 		if (GRAVITY_REPEL)
 			for(var/atom/movable/to_throw in range(range, curr_turf))
 				repel(to_throw, curr_turf)

--- a/modular_nova/modules/xenoarchartifacts/effects/machinery_mess.dm
+++ b/modular_nova/modules/xenoarchartifacts/effects/machinery_mess.dm
@@ -14,8 +14,8 @@
 	try_hack_borg(seconds_per_tick)
 
 /datum/artifact_effect/machinery_mess/do_effect_destroy()
-	try_animate()
-	try_hack_borg()
+	try_animate(2)
+	try_hack_borg(2)
 
 /**
  * Tries to animate nearby machinery into angry mobs.

--- a/modular_nova/modules/xenoarchartifacts/effects/stun.dm
+++ b/modular_nova/modules/xenoarchartifacts/effects/stun.dm
@@ -9,7 +9,7 @@
 	. = ..()
 	if(!.)
 		return
-	if(apply_stun(user, 200)) // Instant stun
+	if(apply_stun(user, 200, 2)) // Instant stun
 		to_chat(user, span_warning("A powerful force overwhelms your consciousness."))
 
 /datum/artifact_effect/stun/do_effect_aura(seconds_per_tick)
@@ -20,7 +20,7 @@
 	for(var/mob/living/living_mob in range(range, curr_turf))
 		if(!SPT_PROB(10, seconds_per_tick))
 			continue
-		if(apply_stun(living_mob, 12.5 * seconds_per_tick, seconds_per_tick))
+		if(apply_stun(living_mob, 12.5, seconds_per_tick))
 			to_chat(living_mob, span_warning("Your body goes numb for a moment."))
 
 /datum/artifact_effect/stun/do_effect_pulse(seconds_per_tick)
@@ -32,13 +32,13 @@
 	for(var/mob/living/living_mob in range(range, curr_turf))
 		if(!SPT_PROB(25, seconds_per_tick))
 			continue
-		if(apply_stun(living_mob, 5 * used_power * seconds_per_tick))
+		if(apply_stun(living_mob, 5 * used_power, seconds_per_tick))
 			to_chat(living_mob, span_warning("A wave of energy overwhelms your senses!"))
 
 /datum/artifact_effect/stun/do_effect_destroy()
 	var/turf/curr_turf = get_turf(holder)
 	for(var/mob/living/living_mob in range(range+3, curr_turf))
-		if(apply_stun(living_mob, 200))
+		if(apply_stun(living_mob, 200, 2))
 			to_chat(living_mob, span_warning("A <b>massive</b> wave of energy overwhelms your senses!"))
 
 /**

--- a/modular_nova/modules/xenoarchartifacts/effects/temperature.dm
+++ b/modular_nova/modules/xenoarchartifacts/effects/temperature.dm
@@ -47,7 +47,7 @@
 
 /datum/artifact_effect/temperature/cold
 	log_name = "Cold"
-	target_temp_low = 3
+	target_temp_low = TCMB
 	target_temp_high = 180
 
 /datum/artifact_effect/temperature/cold/do_effect_touch(mob/user)
@@ -56,6 +56,7 @@
 		return
 	var/datum/gas_mixture/env = .
 	env.temperature = clamp(env.temperature - 100, target_temp_low, target_temp_high)
+	holder.air_update_turf(FALSE, FALSE)
 	to_chat(user, span_warning("A chill passes up your spine!"))
 
 /datum/artifact_effect/temperature/cold/do_effect_aura(seconds_per_tick)
@@ -65,6 +66,7 @@
 	var/datum/gas_mixture/env = .
 	if(env.temperature > target_temp)
 		env.temperature -= 50 * seconds_per_tick
+		holder.air_update_turf(FALSE, FALSE)
 
 /datum/artifact_effect/temperature/cold/do_effect_destroy()
 	. = ..()
@@ -72,18 +74,25 @@
 		return
 	var/datum/gas_mixture/env = .
 	env.temperature = target_temp_low
+	holder.air_update_turf(FALSE, FALSE)
 
 /datum/artifact_effect/temperature/heat
 	log_name = "Heat"
 	target_temp_low = 300
 	target_temp_high = 1000
 
+/datum/artifact_effect/temperature/heat/New()
+	. = ..()
+	target_temp_high = rand(1000, 20000)
+
 /datum/artifact_effect/temperature/heat/do_effect_touch(mob/user)
 	. = ..()
 	if(!.)
 		return
 	var/datum/gas_mixture/env = .
-	env.temperature = clamp(env.temperature + 100, target_temp_low, target_temp_high)
+	var/amount_to_change = (target_temp_high - env.temperature) / 4
+	env.temperature = clamp(env.temperature + amount_to_change, target_temp_low, target_temp_high)
+	holder.air_update_turf(FALSE, FALSE)
 	to_chat(user, span_warning("You feel a wave of heat travel up your spine!"))
 
 /datum/artifact_effect/temperature/heat/do_effect_aura(seconds_per_tick)
@@ -91,8 +100,10 @@
 	if(!.)
 		return
 	var/datum/gas_mixture/env = .
+	var/amount_to_change = (target_temp_high - env.temperature) / 8
 	if(env.temperature < target_temp)
-		env.temperature += 50 * seconds_per_tick
+		env.temperature += amount_to_change * seconds_per_tick
+		holder.air_update_turf(FALSE, FALSE)
 
 /datum/artifact_effect/temperature/heat/do_effect_destroy()
 	. = ..()
@@ -100,3 +111,4 @@
 		return
 	var/datum/gas_mixture/env = .
 	env.temperature = target_temp_high
+	holder.air_update_turf(FALSE, FALSE)

--- a/modular_nova/modules/xenoarchartifacts/machines/geosample_analyzer.dm
+++ b/modular_nova/modules/xenoarchartifacts/machines/geosample_analyzer.dm
@@ -16,6 +16,8 @@
 	icon = 'modular_nova/modules/xenoarchartifacts/icons/machinery.dmi'
 	icon_state = "spectrometer"
 
+	circuit = /obj/item/circuitboard/machine/radiocarbon_spectrometer
+
 	use_power = IDLE_POWER_USE // 1 = idle, 2 = active
 	idle_power_usage = 20
 	active_power_usage = 3000

--- a/modular_nova/modules/xenoarchartifacts/obj/artifact_stabilizer.dm
+++ b/modular_nova/modules/xenoarchartifacts/obj/artifact_stabilizer.dm
@@ -12,7 +12,7 @@
 		"Potassium refrigerant cloud",
 		"Mercury dispersion wave",
 		"Iron wafer conduction field",
-		"Calcium binary deoxidiser",
+		"Calcium binary deoxidizer",
 		"Chlorine diffusion emissions",
 		"Phoron saturated field", // Phoron is left intentionally.
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Some bug fixes and additions to my xenoarch artifacts.

Main things:
- Added some more mobs to autocloner
- Reduced replicator buttons amount and added dangerous stugg
- Blood/DNAswitch effects no longer work on synths
- Gas effect now works
- Gravity mayhem effect now works
- Machinery mess effect works properly on destroy
- Stun effect now works properly
- Temperature effect now simulates the turf after temp change
- Temperature Heat effect now has random high target temp
- Fixed typo in stabilizing fields, which prohibited players from stabilizing boulders
- Radiocarbon spectrometer can now be disassembled

## How This Contributes To The Nova Sector Roleplay Experience

Less bug == good 💯 %

## Proof of Testing

Do I really need to prove that bug fixes work?
It's mostly value tweaks.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: SuperDrish
fix: Some xenoarch effects now work properly. DNAswitch and Blood effects no longer work on synths. Calcium binary deoxidizer boulders now can be stabilized. Radiocarbon spectrometer now can be disassembled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
