### PR TITLE
Allows golem arms to dredge boulders from ore vents

### DIFF
--- a/code/game/objects/structures/lavaland/ore_vent.dm
+++ b/code/game/objects/structures/lavaland/ore_vent.dm
@@ -119,7 +119,6 @@
 		to_chat(user, span_notice("You can't quite find the weakpoint of [src]... Perhaps it needs to be scanned first?"))
 		return
 	to_chat(user, span_notice("You start striking [src] with your golem's fist, attempting to dredge up a boulder..."))
-
 	for(var/i in 1 to 3)
 		/* NOVA EDIT CHANGE START - ORIGINAL:
 		if(do_after(user, boulder_size * 1 SECONDS, src))


### PR DESCRIPTION

## About The Pull Request
Golem arms now grant the BOULDER_BREAKER trait, so humans / otherwise with golem arms granted by the augments+ menu or inhumane surgery can now dredge boulders from ore vents and process them by hand.

Also fixes an exploit related to ore vents and adds more feedback when dredging up boulders.
## How This Contributes To The Nova Sector Roleplay Experience
This gives golem arms a unique advantage over just getting a drill implant and offers the potential for things like a pacifistic miner or a golem hybrid, as well as allowing more interactions with the ore vent / boulder system than going ":n upgrade the boulder matrix please." 

Also, exploits bad.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/cb785f05-5fb3-4dbf-b7c4-f06edd1c91ef)

![image](https://github.com/user-attachments/assets/7874e448-cbf6-4251-97fe-1286cf6c90bc)

![image](https://github.com/user-attachments/assets/ce458a8f-c77e-43f7-a535-4f47ac1cad28)

</details>

## Changelog
:cl:
add: golem arms can now dredge boulders from ore vents, as well as process them by hand
fix: fixed an exploit related to ore vents
/🆑 
