### PR TITLE
Removes Regular Fireaxe from being equipped in exosuits (no sprites)

### DIFF
--- a/code/__DEFINES/~nova_defines/colony_fabricator_misc.dm
+++ b/code/__DEFINES/~nova_defines/colony_fabricator_misc.dm
@@ -31,7 +31,7 @@ GLOBAL_LIST_INIT(colonist_suit_allowed, list(
 	/obj/item/tank/internals,
 	/obj/item/storage/belt/holster,
 	/obj/item/construction,
-	/obj/item/fireaxe,
+	/obj/item/fireaxe/boneaxe,
 	/obj/item/pipe_dispenser,
 	/obj/item/storage/bag,
 	/obj/item/pickaxe,

--- a/modular_nova/modules/kahraman_equipment/code/clothing/mod.dm
+++ b/modular_nova/modules/kahraman_equipment/code/clothing/mod.dm
@@ -33,7 +33,7 @@
 		/obj/item/tank/internals,
 		/obj/item/storage/belt/holster,
 		/obj/item/construction,
-		/obj/item/fireaxe,
+		/obj/item/fireaxe/metal_h2_axe,
 		/obj/item/pipe_dispenser,
 		/obj/item/storage/bag,
 		/obj/item/pickaxe,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Removes the regular Fireaxe from the Modsuit and Colonist exosuit allowed lists, as there are no sprites for it, and added the boneaxe to the colonist one so it allows those that use the bone axe to still carry it.

## How This Contributes To The Nova Sector Roleplay Experience

People stop using on an exosuit an item they were not prepared for, and thus not get an ERROR overlay on them.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  It's a removal of functionality.
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Modsuits and Colonist type exosuits (gear harness) can no longer hold _any_ fireaxes. They can still hold H2 fireaxes just fine and the later set can still also hold the bone axe as originally intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
