### PR TITLE
fixes rengo bayonet offset + makes it properly 2h

### DIFF
--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/xhihao_light_arms/rifle.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/xhihao_light_arms/rifle.dm
@@ -17,6 +17,7 @@
 	tac_reloads = TRUE
 	internal_magazine = FALSE
 	can_be_sawn_off = FALSE
+	weapon_weight = WEAPON_HEAVY
 
 /obj/item/gun/ballistic/rifle/sporterized/Initialize(mapload)
 	. = ..()
@@ -24,7 +25,7 @@
 	AddComponent(/datum/component/scope, range_modifier = 1.5)
 
 /obj/item/gun/ballistic/rifle/sporterized/add_bayonet_point()
-	AddComponent(/datum/component/bayonet_attachable, offset_x = 35)
+	AddComponent(/datum/component/bayonet_attachable, offset_x = 35, offset_y = 12)
 
 /obj/item/gun/ballistic/rifle/sporterized/give_manufacturer_examine()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_XHIHAO)


### PR DESCRIPTION
## About The Pull Request
title. rengo bayonet offset from 0 -> 12 so it's not floating off at the bottom

also adds `weapon_weight = WEAPON_HEAVY` because apparently that's not defined on a base level for bolt rifles? weird.
## How This Contributes To The Nova Sector Roleplay Experience

funny bolt-action should probably be 2h. floating bayonet kinda goofy to look at

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/b7f49cb4-a51a-45bd-8d92-212b183d09e0)

  
</details>

## Changelog

:cl:
fix: The Rengo precision rifle's bayonet lug is no longer haunted, and the bayonet is properly flush with the barrel.
fix: The Rengo precision rifle now requires two hands to wield and fire, as intended.
:cl:

