### PR TITLE
[SEMI-MODULAR] Add; Timed Sleep Verb

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1209,6 +1209,12 @@
 	if(next_move > world.time)
 		return FALSE
 	if(HAS_TRAIT(src, TRAIT_INCAPACITATED))
+		// NOVA EDIT ADDITION BEGIN - Voluntary sleeping / Timed sleeping
+		// Allows resisting if the sleep verb was used
+		var/datum/status_effect/incapacitating/sleeping/sleep_effect = IsSleeping()
+		if(sleep_effect)
+			return sleep_effect.voluntary
+		// NOVA EDIT ADDITION END
 		return FALSE
 	return TRUE
 
@@ -1225,6 +1231,12 @@
 	changeNext_move(CLICK_CD_RESIST)
 
 	SEND_SIGNAL(src, COMSIG_LIVING_RESIST, src)
+	// NOVA EDIT ADDITION BEGIN - Voluntary sleeping / Timed sleeping
+	// Wakes up from timed sleep
+	if(IsSleeping())
+		SetSleeping(0)
+		return
+	// NOVA EDIT ADDITION END
 	//resisting grabs (as if it helps anyone...)
 	if(!HAS_TRAIT(src, TRAIT_RESTRAINED) && pulledby)
 		log_combat(src, pulledby, "resisted grab")

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -394,7 +394,9 @@
 		S = apply_status_effect(/datum/status_effect/incapacitating/sleeping, amount)
 	return S
 
-/mob/living/proc/SetSleeping(amount) //Sets remaining duration
+// NOVA EDIT - Voluntary sleep / Timed sleep
+// ORIGINAL: /mob/living/proc/SetSleeping(amount) //Sets remaining duration
+/mob/living/proc/SetSleeping(amount, is_voluntary = FALSE) //Sets remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_SLEEP, amount) & COMPONENT_NO_STUN)
 		return
 	if(HAS_TRAIT(src, TRAIT_GODMODE))
@@ -406,7 +408,9 @@
 	else if(S)
 		S.duration = world.time + amount
 	else
-		S = apply_status_effect(/datum/status_effect/incapacitating/sleeping, amount)
+		// NOVA EDIT - Voluntary sleep / Timed sleep
+		// ORIGINAL: S = apply_status_effect(/datum/status_effect/incapacitating/sleeping, amount)
+		S = apply_status_effect(/datum/status_effect/incapacitating/sleeping, amount, is_voluntary)
 	return S
 
 /mob/living/proc/AdjustSleeping(amount) //Adds to remaining duration
@@ -421,8 +425,10 @@
 		S = apply_status_effect(/datum/status_effect/incapacitating/sleeping, amount)
 	return S
 
+// NOVA EDIT - Voluntary sleep / Timed sleep
+// ORIGINAL: /mob/living/proc/PermaSleeping()
 ///Allows us to set a permanent sleep on a player (use with caution and remember to unset it with SetSleeping() after the effect is over)
-/mob/living/proc/PermaSleeping()
+/mob/living/proc/PermaSleeping(is_voluntary = FALSE)
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_SLEEP, -1) & COMPONENT_NO_STUN)
 		return
 	if(HAS_TRAIT(src, TRAIT_GODMODE))
@@ -430,8 +436,13 @@
 	var/datum/status_effect/incapacitating/sleeping/S = IsSleeping()
 	if(S)
 		S.duration = -1
+		// NOVA EDIT ADDITION BEGIN - Hide sleep duration if permanent
+		S.show_duration = FALSE
+		// NOVA EDIT ADDITION END
 	else
-		S = apply_status_effect(/datum/status_effect/incapacitating/sleeping, -1)
+		// NOVA EDIT - Voluntary sleep / Timed sleep
+		// ORIGINAL: S = apply_status_effect(/datum/status_effect/incapacitating/sleeping, -1)
+		S = apply_status_effect(/datum/status_effect/incapacitating/sleeping, -1, is_voluntary)
 	return S
 
 ///////////////////////// CLEAR STATUS /////////////////////////
@@ -440,7 +451,13 @@
 	AdjustStun(-60)
 	AdjustKnockdown(-60)
 	AdjustUnconscious(-60)
-	AdjustSleeping(-100)
+	// NOVA EDIT ADDITION BEGIN - Voluntary sleep / Timed sleep
+	// ORIGINAL: AdjustSleeping(-100)
+	// Disables shaking awake if the mob used the sleep verb
+	var/datum/status_effect/incapacitating/sleeping/sleep_effect = IsSleeping()
+	if(sleep_effect && !sleep_effect.voluntary)
+		AdjustSleeping(-100)
+	// NOVA EDIT ADDITION END
 	AdjustParalyzed(-60)
 	AdjustImmobilized(-60)
 

--- a/modular_nova/master_files/code/modules/timed_sleep/README.md
+++ b/modular_nova/master_files/code/modules/timed_sleep/README.md
@@ -1,0 +1,36 @@
+https://github.com/NovaSector/NovaSector/WaitForIt
+
+## Title: Timed Sleep
+
+MODULE ID: timed_sleep
+
+### Description:
+
+Overrides the sleep verb and some associated code chunks to implement player-timed sleep, and to account for whether or not sleeping was voluntary.
+
+### TG Proc Changes:
+
+- `/mob/living/mob_sleep()`: Overridden in `modular_nova/master_files/code/modules/timed_sleep/code/mob/living/living.dm`.
+- `/mob/living/can_resist()`: Added a conditional to allow resisting if the sleep verb was used.
+- `/mob/living/proc/execute_resist()`: Added conditional to allow resisting to wake up from timed sleep.
+- `/mob/living/proc/SetSleeping()`: Added var `is_voluntary` to differentiate sleep verb usage from blackouts.
+- `/mob/living/proc/PermaSleeping()`:
+  - Added var `is_voluntary` to differentiate sleep verb usage from blackouts.
+  - Hides sleep duration if permanent.
+
+### Defines:
+
+- N/A
+
+### Master file additions
+
+- `master_files/code/modules/timed_sleep/code/mob/living/living.dm`
+- `master_files/code/modules/timed_sleep/code/datums/status_effects/debuffs/debuffs.dm`
+
+### Included files that are not contained in this module:
+
+- N/A
+
+
+### Credits:
+- [@Floofies](https://github.com/Floofies)

--- a/modular_nova/master_files/code/modules/timed_sleep/code/datums/status_effects/debuffs/debuffs.dm
+++ b/modular_nova/master_files/code/modules/timed_sleep/code/datums/status_effects/debuffs/debuffs.dm
@@ -1,0 +1,11 @@
+// Voluntary sleeping / Timed sleeping
+/datum/status_effect/incapacitating/sleeping
+	show_duration = TRUE
+	var/voluntary = FALSE
+
+/datum/status_effect/incapacitating/sleeping/on_creation(mob/living/new_owner, set_duration, is_voluntary = FALSE)
+	voluntary = is_voluntary
+	// Hide sleep duration if permanent
+	if(set_duration == -1)
+		show_duration = FALSE
+	return ..()

--- a/modular_nova/master_files/code/modules/timed_sleep/code/mob/living/living.dm
+++ b/modular_nova/master_files/code/modules/timed_sleep/code/mob/living/living.dm
@@ -1,0 +1,17 @@
+// Voluntary sleeping / Timed sleeping
+/mob/living/mob_sleep()
+	if(IsSleeping())
+		to_chat(src, span_warning("You are already sleeping!"))
+		return
+	var/duration = tgui_input_number(
+		src,
+		"How many minutes do you want to sleep for? Enter 0 to sleep indefinitely. Resist to wake up.",
+		"Sleep: Duration",
+		max_value = INFINITY,
+		min_value = 0,
+		default = 1
+	)
+	if(duration == 0)
+		PermaSleeping(is_voluntary = TRUE)
+	else
+		SetSleeping(duration MINUTES, is_voluntary = TRUE)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6982,6 +6982,8 @@
 #include "modular_nova\master_files\code\modules\surgery\organs\external\wings\wings.dm"
 #include "modular_nova\master_files\code\modules\surgery\organs\internal\appendix\_appendix.dm"
 #include "modular_nova\master_files\code\modules\surgery\organs\internal\cyberimp\augments_internal.dm"
+#include "modular_nova\master_files\code\modules\timed_sleep\code\datums\status_effects\debuffs\debuffs.dm"
+#include "modular_nova\master_files\code\modules\timed_sleep\code\mob\living\living.dm"
 #include "modular_nova\master_files\code\modules\transport\tram\tram_displays.dm"
 #include "modular_nova\master_files\code\modules\uplink\suits.dm"
 #include "modular_nova\master_files\code\modules\vehicles\sealed.dm"


### PR DESCRIPTION
## About The Pull Request

This PR re-implements the sleep verb to allow the player to choose a custom sleep duration, in minutes. If the number 0 is entered, then the mob will sleep until they resist. Players who are sleeping voluntarily can't be shaken awake.

Also, the sleep status effect will now show its duration if it's not infinite.

## How This Contributes To The Nova Sector Roleplay Experience

The tweaks to the sleep verb contained in this PR will make sleeping much more immersive and useful! I have extensively play-tested and debugged this PR with a lot of players, and I can confirm that it successfully made this otherwise nearly-useless feature have more impact on the game.

## Proof of Testing

Draft status. Test proof TBD

Tested extensively to root out bugs and usability issues!

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl: A.C.M.O.
add: Added custom duration to sleep verb. Voluntarily sleeping players can't be shaken awake.
qol: Sleeping status effect now shows the duration if it isn't infinite.
/:cl:
