### PR TITLE
[MODULAR] Add: Ethereal Music Synthesizer

### DIFF
--- a/modular_nova/master_files/code/modules/mob/living/carbon/human/species_type/ethereal.dm
+++ b/modular_nova/master_files/code/modules/mob/living/carbon/human/species_type/ethereal.dm
@@ -1,3 +1,14 @@
+/datum/species/ethereal/on_species_gain(mob/living/carbon/human/new_ethereal, datum/species/old_species, pref_load)
+	. = ..()
+	var/datum/action/sing_tones/sing_action = new
+	sing_action.Grant(new_ethereal)
+
+/datum/species/ethereal/on_species_loss(mob/living/carbon/human/former_ethereal, datum/species/new_species, pref_load)
+	. = ..()
+	var/datum/action/action_to_remove = locate(/datum/action/sing_tones) in former_ethereal.actions
+	if(action_to_remove)
+		qdel(action_to_remove)
+
 /datum/species/ethereal/create_pref_unique_perks()
 	var/list/to_add = list()
 

--- a/modular_nova/modules/ethereal_instrument/README.md
+++ b/modular_nova/modules/ethereal_instrument/README.md
@@ -1,0 +1,18 @@
+https://github.com/NovaSector/NovaSector/pull/WaitAndSee
+
+## Title: All the emotes.
+
+MODULE ID: ethereal_instrument
+
+### Description:
+
+Adds an action to Ethereal species that allows them to synthesize music using their discharger organ.
+
+### Master file additions
+
+- Edited `modular_nova/master_files/code/modules/mob/living/carbon/human/species_type/ethereal.dm`
+  - Added override `/datum/species/ethereal/on_species_gain()`
+  - Added override `/datum/species/ethereal/on_species_loss()`
+
+### Credits:
+- [@Floofies](https://github.com/Floofies)

--- a/modular_nova/modules/ethereal_instrument/ethereal_synth.dm
+++ b/modular_nova/modules/ethereal_instrument/ethereal_synth.dm
@@ -1,0 +1,7 @@
+/obj/item/instrument/ethereal_synth
+	name = "electric discharger synth"
+	desc = "A sophisticated ethereal organ, capable of synthesising music via electrical discharge."
+	icon = 'icons/obj/medical/organs/organs.dmi'
+	icon_state = "electrotongue"
+	inhand_icon_state = null
+	allowed_instrument_ids = list("square", "sine", "saw")

--- a/modular_nova/modules/ethereal_instrument/synth_action.dm
+++ b/modular_nova/modules/ethereal_instrument/synth_action.dm
@@ -1,0 +1,27 @@
+/datum/action/sing_tones
+	name = "Sing Tones"
+	desc = "Use your electric discharger to sing!"
+	button_icon = 'icons/obj/art/musician.dmi'
+	button_icon_state = "xylophone"
+	var/obj/item/instrument/ethereal_synth/tone_synth
+
+/datum/action/sing_tones/Grant(mob/grant_to)
+	tone_synth = new
+	return ..()
+
+/datum/action/sing_tones/Remove(mob/remove_from)
+	QDEL_NULL(tone_synth)
+	return ..()
+
+/datum/action/sing_tones/IsAvailable(feedback)
+	var/mob/living/carbon/human/human_target = owner
+	var/obj/item/organ/internal/tongue/ethereal/discharger = human_target.get_organ_slot(ORGAN_SLOT_TONGUE)
+	if(discharger && istype(discharger, /obj/item/organ/internal/tongue/ethereal))
+		return ..()
+	return FALSE
+
+/datum/action/sing_tones/Trigger(trigger_flags)
+	. = ..()
+	if(!.)
+		return
+	tone_synth.interact(owner)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7722,6 +7722,8 @@
 #include "modular_nova\modules\envirosuit_kits\code\cosmetic_envirosuits.dm"
 #include "modular_nova\modules\envirosuit_kits\code\envirosuit_boxes.dm"
 #include "modular_nova\modules\escape_menu\code\escape_menu_nova.dm"
+#include "modular_nova\modules\ethereal_instrument\ethereal_synth.dm"
+#include "modular_nova\modules\ethereal_instrument\synth_action.dm"
 #include "modular_nova\modules\events\code\_event_globalvars.dm"
 #include "modular_nova\modules\events\code\event_spawner.dm"
 #include "modular_nova\modules\events\code\event_spawner_menu.dm"


### PR DESCRIPTION
## About The Pull Request

This PR adds an action inherent to Ethereal species that allows them to access an internal music synthesizer; it requires `/obj/item/organ/internal/tongue/ethereal` in order to function, and is limited to 3 instruments, "square wave", "sine wave", and "saw wave".

## How This Contributes To The Nova Sector Roleplay Experience

Adds a bit of unique flair to Ethereal species by allowing their electrical properties to be used for musical purposes. 😄

## Proof of Testing

Draft status. Testing TBD.

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl: A.C.M.O.
add: Added an action to Ethereal species that uses their electric discharger organ as a music synthesizer.
/:cl:
