### PR TITLE
Adds Interdrobe to ghost cafe and removes a certain vine from ghost cafe

### DIFF
--- a/_maps/map_files/generic/CentCom_nova_z2.dmm
+++ b/_maps/map_files/generic/CentCom_nova_z2.dmm
@@ -9134,6 +9134,10 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding/cafedorms)
+"jBZ" = (
+/obj/machinery/vending/wardrobe/syndie_wardrobe/interdyne/ghost_cafe,
+/turf/open/misc/dirt/planet,
+/area/centcom/holding/cafepark)
 "jCs" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -9654,10 +9658,6 @@
 /turf/open/floor/wood,
 /area/centcom/interlink)
 "kHZ" = (
-/obj/structure/spacevine{
-	name = "thick vines";
-	opacity = 1
-	},
 /obj/machinery/vending/wardrobe/sec_wardrobe/red,
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
@@ -70890,7 +70890,7 @@ ayI
 ayI
 ayI
 ayI
-ayI
+aPf
 aPf
 aPf
 aPf
@@ -71147,7 +71147,7 @@ aPf
 ayI
 ayI
 ayI
-ayI
+jBZ
 ovH
 rUA
 qBC


### PR DESCRIPTION

## About The Pull Request
Adds Interdrobe to ghost cafe while removing the vine that is on red Secdrobe

## How This Contributes To The Nova Sector Roleplay Experience
Allows people to try out Interdyne's outfits without checking through chameleon's massive list, there was a subtype meant to be used for ghost cafe but it was never used anywhere.

The vine on the red Secdrobe was more annoying than anything, as you had to either break it or alt+click it in order to access the vending machine.

## Proof of Testing
Works, also a very simple change.

<details>
<summary>Screenshots/Videos</summary>

![StrongDMM_jmUkZhjKCS](https://github.com/user-attachments/assets/53a2a798-09d1-471f-a87f-da0b4185ee7a)

  
</details>

## Changelog
:cl: Hardly
map: Added Interdrobe to the ghost cafe
map: Removed the vine on redsec's vendor in ghost cafe
/:cl:
