### PR TITLE
Fixes DrpMstr's donator item not being available to them in the loadout

### DIFF
--- a/modular_nova/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
+++ b/modular_nova/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
@@ -880,3 +880,8 @@
 	name = "Jumper Conversation Kit Box"
 	item_path = /obj/item/mod/skin_applier/jumper
 	ckeywhitelist = list("bonkaitheroris")
+
+/datum/loadout_item/suit/butter
+	name = "Butter Costume"
+	item_path = /obj/item/clothing/suit/costume/butter
+	ckeywhitelist = list("drpmstr", "pyritechimera")

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_suit.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_suit.dm
@@ -790,11 +790,6 @@
 	name = "Colourable Heart Sweater"
 	item_path = /obj/item/clothing/suit/heart_sweater
 
-/datum/loadout_item/suit/butter
-	name = "Butter Costume"
-	item_path = /obj/item/clothing/suit/costume/butter
-	ckeywhitelist = list("drpmstr, pyritechimera")
-
 // Fancy crop-top jackets
 
 /datum/loadout_item/suit/crop_jacket


### PR DESCRIPTION
## About The Pull Request
Turns out it's important to separate the ckeys in separate strings. 😅

## How This Contributes To The Nova Sector Roleplay Experience
Gives a donator their hard-earned donator item.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
It compiled, and I verified in-game beforehand that this was the fix.  

![image](https://github.com/user-attachments/assets/30b829e8-0232-4035-852e-4fbe396b6f4d)

</details>

## Changelog

:cl: GoldenAlpharex
fix: Fixes a donator's item not being available to them in the loadout menu.
/:cl: