### PR TITLE
Adds a missing wire next to Icebox Interdyne's library

### DIFF
--- a/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1.dmm
+++ b/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1.dmm
@@ -7469,6 +7469,12 @@
 	fixed_underlay = list(icon='icons/turf/snow.dmi', icon_state="snow")
 	},
 /area/ruin/interdyne_planetary_base)
+"Wq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/interdyne_planetary_base/main/dorms)
 "WQ" = (
 /obj/structure/shipping_container/donk_co{
 	pixel_x = 6
@@ -8766,7 +8772,7 @@ ko
 kF
 lg
 ll
-lz
+Wq
 lZ
 mT
 mT


### PR DESCRIPTION

## About The Pull Request
Icebox Interdyne had an issue where their library was not connected to the powernet and had to be manually wired in.
This PR adds a single wire to fix it.
![StrongDMM_DttyLsS3Tv](https://github.com/user-attachments/assets/ca27708e-708b-4438-8fbf-30df11551d95)


## How This Contributes To The Nova Sector Roleplay Experience
Fixes an oversight and allows the break room to be powered properly without having to wire it up every time.

## Proof of Testing
It's a very simple fix. it works and should lint.
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl: Hardly
fix: Icebox Interdyne's library is now connected with the powernet
/:cl:
