### PR TITLE
Bitrunning prefloading

### DIFF
--- a/code/modules/bitrunning/server/obj_generation.dm
+++ b/code/modules/bitrunning/server/obj_generation.dm
@@ -38,8 +38,14 @@
 
 
 /// Generates a new avatar for the bitrunner.
-/obj/machinery/quantum_server/proc/generate_avatar(turf/destination, datum/outfit/netsuit)
+/obj/machinery/quantum_server/proc/generate_avatar(turf/destination, datum/outfit/netsuit, datum/preferences/prefs, include_loadout = FALSE) // NOVA EDIT - Prefs argument
 	var/mob/living/carbon/human/avatar = new(destination)
+
+	// NOVA EDIT START - PREFS!
+	if(!isnull(prefs))
+		prefs.safe_transfer_prefs_to(avatar)
+	ADD_TRAIT(avatar, TRAIT_CANNOT_CRYSTALIZE, "Bitrunning") // Stops the funny ethereal bug
+	// NOVA EDIT END
 
 	var/outfit_path = generated_domain.forced_outfit || netsuit
 	var/datum/outfit/to_wear = new outfit_path()
@@ -76,6 +82,11 @@
 			new /obj/item/storage/medkit/regular,
 			new /obj/item/flashlight,
 		)
+
+	// NOVA EDIT START
+	if(include_loadout)
+		avatar.equip_outfit_and_loadout(new /datum/outfit(), prefs)
+	// NOVA EDIT END
 
 	var/obj/item/card/id/outfit_id = avatar.wear_id
 	if(outfit_id)

--- a/code/modules/bitrunning/server/util.dm
+++ b/code/modules/bitrunning/server/util.dm
@@ -148,7 +148,14 @@
 	if(isnull(entry_atom))
 		return
 
-	var/mob/living/carbon/new_avatar = generate_avatar(get_turf(entry_atom), netsuit)
+	// NOVA EDIT BEGIN - PREFS!
+	var/datum/preferences/pref
+	var/load_loadout = FALSE
+	var/obj/item/bitrunning_disk/prefs/prefdisk = locate() in neo.get_contents()
+	if(prefdisk)
+		load_loadout = prefdisk.include_loadout
+		pref = prefdisk.loaded_preference
+	var/mob/living/carbon/new_avatar = generate_avatar(get_turf(entry_atom), netsuit, pref, include_loadout = load_loadout)
 	stock_gear(new_avatar, neo, generated_domain)
 
 	// Cleanup for domains with one time use custom spawns

--- a/modular_nova/modules/bitrunning/code/disks.dm
+++ b/modular_nova/modules/bitrunning/code/disks.dm
@@ -17,6 +17,50 @@
 		/obj/item/storage/pouch/cin_medkit,
 	)
 
+/obj/item/bitrunning_disk/prefs
+	name = "DeForest biological simulation disk"
+	desc = "A disk containing the biological simulation data necessary to load custom characters into bitrunning domains."
+	icon = 'icons/obj/devices/circuitry_n_data.dmi'
+	base_icon_state = "datadisk"
+	icon_state = "datadisk0"
+
+	w_class = WEIGHT_CLASS_SMALL
+
+	var/datum/preferences/loaded_preference
+
+	var/include_loadout = FALSE
+
+/obj/item/bitrunning_disk/prefs/examine(mob/user)
+	. = ..()
+	if(!isnull(loaded_preference))
+		var/name = loaded_preference.read_preference(/datum/preference/name/real_name)
+		. += "It currently has the character [name] loaded, with loadouts [(include_loadout ? "enabled" : "disabled")]"
+		. += span_notice("Alt-Click to change loadout loading")
+
+/obj/item/bitrunning_disk/prefs/click_alt(mob/user)
+	include_loadout = !include_loadout // We just switch this around. Elegant!
+	balloon_alert(user, include_loadout ? "Loadout enabled" : "Loadout disabled")
+
+/obj/item/bitrunning_disk/prefs/attack_self(mob/user, modifiers)
+	. = ..()
+
+	var/list/prefdata_names = user.client.prefs?.create_character_profiles()
+	if(isnull(prefdata_names))
+		return
+
+	var/response = tgui_alert(user, message = "Change selected prefs?", title = "Prefchange", buttons = list("Yes", "No"))
+	if(isnull(response) || response == "No")
+		return
+	var/choice = tgui_input_list(user, message = "Select a character",  title = "Character selection", items = prefdata_names)
+	if(isnull(choice) || !user.is_holding(src))
+		return
+
+	loaded_preference = new(user.client)
+	loaded_preference.load_character(prefdata_names.Find(choice))
+
+	balloon_alert(user, "Character set")
+	to_chat(user, span_notice("Character set to [choice] sucessfully!"))
+
 /datum/orderable_item/bitrunning_tech/ability_tier0
 	cost_per_order = 350
 	item_path = /obj/item/bitrunning_disk/ability/tier0
@@ -99,3 +143,8 @@
 
 /datum/orderable_item/bitrunning_tech/ability_tier3
 	desc = "This disk contains a program that lets you shapeshift into a lesser ashdrake, a polar bear, a holy juggernaut, or a holy wraith; or cast Death Loop."
+
+/datum/orderable_item/bitrunning_tech/pref_item
+	cost_per_order = 500
+	item_path = /obj/item/bitrunning_disk/prefs
+	desc = "This disk contains a program that lets you load in custom characters."

--- a/modular_nova/modules/bitrunning/code/outfit.dm
+++ b/modular_nova/modules/bitrunning/code/outfit.dm
@@ -1,0 +1,2 @@
+/datum/outfit/job/bitrunner
+	r_pocket = /obj/item/bitrunning_disk/prefs

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7141,6 +7141,7 @@
 #include "modular_nova\modules\bitrunning\code\disks.dm"
 #include "modular_nova\modules\bitrunning\code\flair.dm"
 #include "modular_nova\modules\bitrunning\code\mobs.dm"
+#include "modular_nova\modules\bitrunning\code\outfit.dm"
 #include "modular_nova\modules\bitrunning\code\spells.dm"
 #include "modular_nova\modules\bitrunning\code\virtual_domains\ancient_milsim\area.dm"
 #include "modular_nova\modules\bitrunning\code\virtual_domains\ancient_milsim\choice_beacon.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Blatant copy of https://github.com/Bubberstation/Bubberstation/pull/1551
Adds a new disk to bitrunning, which allows you to load any of your prefslots in, and then spawn in the domain as that character; includes additional loadout toggles so you can chose whether you want to bring in some of your stuff in or not.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
I'll quote the copied-from PR
> People keep bullying me to add sex to bitrunning and who am I to say no
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/2c49f46a-bb5d-4e95-acd4-a658fa12ac5b)
![image](https://github.com/user-attachments/assets/95dbd748-34ab-427b-a3d2-ad2115932b78)
![image](https://github.com/user-attachments/assets/b97d3b13-deff-43f5-ad0f-dd264c2b5053)

Blind domains still keep you blind, and you can disconnect just fine.
![image](https://github.com/user-attachments/assets/868da793-a313-4721-9d4e-4354189e46e2)
![image](https://github.com/user-attachments/assets/70e14dd1-e036-418e-b894-d804f3f43585)
(Aghost view of the character in the exact same domain; I am certainly a kobold.)
![image](https://github.com/user-attachments/assets/cd1fb5bb-ab4b-449e-a3b8-7312c280bbdf)
![image](https://github.com/user-attachments/assets/a170d137-adf7-4816-8cc5-810fd711ddee)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Stalkeros, Majkl-J for the original PR
add: Adds prefloading to bitrunning
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
