### PR TITLE
Cleans up and fixes the Ouroboros medical department

### DIFF
--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -1935,6 +1935,9 @@
 	network = list("ss13","medbay")
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aDU" = (
@@ -33363,12 +33366,6 @@
 	dir = 1
 	},
 /area/station/service/kitchen/diner)
-"jIs" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/closed/wall,
-/area/station/medical/storage)
 "jIw" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/effect/turf_decal/siding/thinplating_new/light{
@@ -60087,7 +60084,7 @@
 	dir = 1
 	},
 /obj/machinery/button/door/directional/south{
-	id = "surg_privacy";
+	id = "surg_a_privacy";
 	name = "privacy shutters control"
 	},
 /obj/effect/turf_decal/box/white,
@@ -78102,6 +78099,9 @@
 	},
 /obj/structure/railing{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 1
 	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
@@ -120315,7 +120315,7 @@ qlP
 qlP
 dqe
 amw
-jIs
+bhd
 bhd
 glB
 bhd

--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -1188,12 +1188,6 @@
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"asJ" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/closed/wall,
-/area/station/medical/paramedic)
 "asP" = (
 /obj/machinery/computer/atmos_control/plasma_tank,
 /obj/effect/turf_decal/box,
@@ -2601,9 +2595,8 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/iron/stairs{
-	dir = 8
-	},
+/obj/structure/stairs/west,
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "aPb" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
@@ -4118,12 +4111,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
-"bkT" = (
-/obj/effect/turf_decal/bot_white,
-/obj/machinery/light/warm/directional/west,
-/obj/structure/bed/medical/emergency,
-/turf/open/floor/iron/dark,
-/area/station/medical/medbay/central)
 "bla" = (
 /obj/effect/turf_decal/bot,
 /obj/item/stack/sheet/glass/fifty{
@@ -4705,10 +4692,10 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/light/cold/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/railing/corner/end{
+	dir = 8
+	},
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -12065,11 +12052,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "dBb" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red/real_red,
 /obj/machinery/light/directional/south,
+/obj/structure/railing/corner/end{
+	dir = 8
+	},
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -22025,9 +22012,9 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "gvp" = (
-/obj/machinery/light/warm/directional/east,
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/light/warm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
 "gwj" = (
@@ -24224,6 +24211,9 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "hea" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
 /turf/open/floor/wood/tile,
 /area/station/medical/psychology)
 "hed" = (
@@ -24466,6 +24456,9 @@
 "hgE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/railing/corner/end{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -33550,12 +33543,6 @@
 /obj/effect/landmark/start/detective,
 /turf/open/floor/wood/tile,
 /area/station/security/detectives_office)
-"jMg" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/closed/wall,
-/area/station/medical/paramedic)
 "jMo" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -34165,10 +34152,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/warning,
 /obj/effect/turf_decal/bot_white,
-/obj/machinery/camera/directional/south{
-	c_tag = "Medbay - Morgue";
-	network = list("ss13","medbay")
-	},
 /obj/machinery/light/small/blacklight/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
@@ -34472,12 +34455,6 @@
 	},
 /turf/open/floor/carpet/cyan,
 /area/station/command/heads_quarters/blueshield)
-"jYP" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/closed/wall/r_wall,
-/area/station/medical/chemistry)
 "jZl" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
 	dir = 1
@@ -40147,7 +40124,7 @@
 	dir = 1
 	},
 /obj/machinery/button/door/directional/south{
-	id = "main_surgery";
+	id = "surg_privacy";
 	name = "privacy shutters control"
 	},
 /obj/effect/turf_decal/box/white,
@@ -41561,9 +41538,6 @@
 /obj/structure/table/wood,
 /obj/item/toy/plush/shark{
 	name = "Sharkmund F."
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
 	},
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/camera/directional/south{
@@ -49793,6 +49767,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/treatment_center)
 "ooR" = (
@@ -51857,16 +51834,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "oYn" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4
-	},
 /obj/machinery/plumbing/sender,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/box,
+/obj/effect/turf_decal/stripes/white/box{
+	color = "#EFB341"
+	},
 /turf/open/floor/plating,
 /area/station/medical/chemistry)
 "oYo" = (
@@ -52153,10 +52127,16 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/nt_rep)
 "pcI" = (
-/obj/effect/turf_decal/tile/green/opposingcorners,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/medical/virology)
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/camera/directional/east{
+	c_tag = "Medbay - Morgue";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "pcU" = (
 /obj/structure/railing/corner/end/flip{
 	dir = 8
@@ -53626,6 +53606,9 @@
 /area/station/science/xenobiology)
 "pzi" = (
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/open/floor/iron/white/side,
 /area/station/medical/paramedic)
 "pzk" = (
@@ -56012,14 +55995,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "qhL" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=lowhall2";
 	location = "lowhall1"
 	},
 /obj/effect/turf_decal/vg_decals/numbers/one,
+/obj/structure/railing/corner/end{
+	dir = 8
+	},
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -57057,18 +57040,12 @@
 /turf/open/floor/engine,
 /area/station/engineering/atmos)
 "qxE" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4
-	},
 /obj/machinery/plumbing/sender{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/box,
+/obj/effect/turf_decal/stripes/white/box{
+	color = "#EFB341"
 	},
 /turf/open/floor/plating,
 /area/station/medical/chemistry)
@@ -60110,7 +60087,7 @@
 	dir = 1
 	},
 /obj/machinery/button/door/directional/south{
-	id = "main_surgery";
+	id = "surg_privacy";
 	name = "privacy shutters control"
 	},
 /obj/effect/turf_decal/box/white,
@@ -62520,15 +62497,9 @@
 /area/station/hallway/secondary/command)
 "sgF" = (
 /obj/machinery/plumbing/receiver,
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4
+/obj/effect/turf_decal/stripes/box,
+/obj/effect/turf_decal/stripes/white/box{
+	color = "#EFB341"
 	},
 /turf/open/floor/plating,
 /area/station/medical/chemistry)
@@ -64561,9 +64532,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/structure/railing/corner/end{
-	dir = 4
-	},
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
@@ -66448,15 +66416,9 @@
 /obj/machinery/plumbing/receiver{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4
+/obj/effect/turf_decal/stripes/box,
+/obj/effect/turf_decal/stripes/white/box{
+	color = "#EFB341"
 	},
 /turf/open/floor/plating,
 /area/station/medical/chemistry)
@@ -77012,6 +76974,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/structure/railing/corner/end/flip{
+	dir = 4
+	},
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
@@ -80534,6 +80499,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/treatment_center)
 "xmp" = (
@@ -114427,8 +114395,8 @@ ooZ
 uMX
 xkw
 aBk
-dYf
 mPl
+dYf
 wwh
 nYA
 cfC
@@ -114941,8 +114909,8 @@ ooZ
 viw
 gpa
 aBk
-dYf
 mPl
+dYf
 ucY
 vaC
 cfC
@@ -121901,7 +121869,7 @@ rGm
 mfG
 iIq
 bKk
-bKk
+pcI
 jUX
 nMP
 cDG
@@ -122922,7 +122890,7 @@ xoA
 lQP
 vJN
 xoA
-bkT
+aMJ
 qHT
 wiV
 tRL
@@ -124725,10 +124693,10 @@ jKr
 qbd
 qsn
 uov
-jYP
-jYP
+uov
+uov
 jBL
-jYP
+uov
 uov
 uov
 iiJ
@@ -125252,7 +125220,7 @@ kTx
 aBj
 fsz
 aVQ
-pcI
+eCN
 kTx
 fWM
 dex
@@ -186397,8 +186365,8 @@ gzO
 vxo
 vxo
 qlP
-jMg
-asJ
+foq
+foq
 foq
 dha
 dha


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This greatly cleans up the Ouroboros medical department (+ a little elsewhere). All things that have been changed are listed under the proof of testing section.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Floating lights, broken buttons, and floor decals where they shouldn't be aren't exactly beneficial to the game's atmosphere.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
These shutters used to not work
https://github.com/user-attachments/assets/af596acd-efb5-44c4-8d76-0ed2292d0474

This staircase was just the floor version (meaning, you couldn't climb it)
https://github.com/user-attachments/assets/8a283233-369a-4a12-8994-faff97d1117e

This camera used to be floating.
![image](https://github.com/user-attachments/assets/c0dbd9fc-e181-4a99-9c27-e5cf12e70f7d)
Screenshot from camera monitor:
![image](https://github.com/user-attachments/assets/70128951-a417-4773-a00d-9e0f7ace8c81)

The yellow circled floor decal used to be where the blue circle was (Psychologist's office)
![image](https://github.com/user-attachments/assets/9472afe8-c06a-40dc-b9ad-8676de30f528)

This light used to be floating
![image](https://github.com/user-attachments/assets/13f0b032-45ae-497b-b900-4bad000f8d0a)

This floor tile used to not exist (Virology)
![image](https://github.com/user-attachments/assets/08f65bd4-f887-48f6-b114-fe0f7dad5f84)

There were floor decals in these walls (Chemistry)
![image](https://github.com/user-attachments/assets/ce43a3f5-62e6-457b-9999-ec40f837043b)

These railings used to use the corner pieces rather than the end pieces (Arrivals hallway)
![image](https://github.com/user-attachments/assets/48345a8e-e43b-4909-aed6-950239246515)

These lights used to be floating (Gateway)
![image](https://github.com/user-attachments/assets/d4bc48d2-3f82-48bb-883f-b722fd4004ec)

Mid_joiners were missing, circled in yellow, while the blue circled decal did not exist
![image](https://github.com/user-attachments/assets/d7cee14a-a5f8-4f3c-af55-0888e6b73fd6)

Chemical beacons and recipients had their bases modified to mesh better with the plating they were on (more or less a nitpick, I think it looks better but I would be willing to change it back if desired)
![image](https://github.com/user-attachments/assets/339b90dc-5951-4063-8bcd-da3db9845bd1)
![image](https://github.com/user-attachments/assets/3cdf17f8-9224-47c4-8aca-8755b1125872)

There used to be a floor decal in this wall too
![image](https://github.com/user-attachments/assets/eb09dd9d-191b-4b14-a487-9117c2bb18fd)


</details>


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
map: cleaned up the ouroboros medical department's floor decals and lights
fix: ouroboros surgery shutters are now linked to their buttons
fix: you can now climb the staircase to the paramedic dispatch room on ouroboros
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
