### PR TITLE
Removes runed metal from the rare_materials drop table

### DIFF
--- a/code/game/objects/effects/spawners/random/engineering.dm
+++ b/code/game/objects/effects/spawners/random/engineering.dm
@@ -68,13 +68,11 @@
 	icon_state = "diamond"
 	spawn_loot_count = 3
 	loot = list( // Space loot spawner. Random selecton of a few rarer materials.
-		/obj/item/stack/sheet/runed_metal/ten = 20,
 		/obj/item/stack/sheet/mineral/diamond{amount = 15} = 15,
 		/obj/item/stack/sheet/mineral/uranium{amount = 15} = 15,
 		/obj/item/stack/sheet/mineral/plasma{amount = 15} = 15,
 		/obj/item/stack/sheet/mineral/gold{amount = 15} = 15,
 		/obj/item/stack/sheet/plastic/fifty = 5,
-		/obj/item/stack/sheet/runed_metal/fifty = 5,
 	)
 
 /obj/effect/spawner/random/engineering/toolbox


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Removes the Runed Metal as an option from the rare materials drop table

It has zero reason to be here. It is completely useless on our server except for aesthetics, especially given how we do not have any cult rounds ever. In ghost roles that rely on the resources from this, they are screwed out of diamond or other good ores and given this, potentially causing issues

If there is specific locations that would benefit lore wise or otherwise from having this, I would suggest its manually added.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Runed metal no longer spawns as a "Rare Material"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
