### PR TITLE
Surgery speed rebalance and changes

### DIFF
--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -79,7 +79,6 @@
 
 	return FALSE
 
-#define SURGERY_SPEEDUP_AREA 0.5 // NOVA EDIT Addition - reward for doing surgery in surgery
 #define SURGERY_SLOWDOWN_CAP_MULTIPLIER 2.5 //increase to make surgery slower but fail less, and decrease to make surgery faster but fail more
 ///Modifier given to surgery speed for dissected bodies.
 #define SURGERY_SPEED_DISSECTION_MODIFIER 0.8
@@ -87,6 +86,8 @@
 #define SURGERY_SPEED_MORBID_CURIOSITY 0.7
 ///Modifier given to patients with TRAIT_ANALGESIA
 #define SURGERY_SPEED_TRAIT_ANALGESIA 0.8
+
+#define SURGERY_SPEED_CALM_ENVIRONMENT 0.8 // NOVA EDIT ADDITION - Modifier given to surgery when done in calm areas (no other humans around)
 
 /datum/surgery_step/proc/initiate(mob/living/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
 	// Only followers of Asclepius have the ability to use Healing Touch and perform miracle feats of surgery.
@@ -122,6 +123,7 @@
 
 	if(HAS_TRAIT(target, TRAIT_ANALGESIA))
 		speed_mod *= SURGERY_SPEED_TRAIT_ANALGESIA
+		to_chat(user, span_notice("You are able to work faster due to the patient's calm attitude!")) // NOVA EDIT ADDITION - Better feedback for the use of analgesia
 
 	var/implement_speed_mod = 1
 	if(implement_type) //this means it isn't a require hand or any item step.
@@ -141,17 +143,14 @@
 
 	var/was_sleeping = (target.stat != DEAD && target.IsSleeping())
 
-	// NOVA EDIT ADDITION START - reward for doing surgery on calm patients, and for using surgery rooms(ie. surgerying alone)
-	if(was_sleeping || HAS_TRAIT(target, TRAIT_ANALGESIA) || target.stat == DEAD)
-		modded_time *= SURGERY_SPEEDUP_AREA
-		to_chat(user, span_notice("You are able to work faster due to the patient's calm attitude!"))
-	var/quiet_enviromnent = TRUE
+	// NOVA EDIT ADDITION START - reward for doing surgery on a calm environment (no other humans around)
+	var/quiet_environment = TRUE
 	for(var/mob/living/carbon/human/loud_people in view(3, target))
 		if(loud_people != user && loud_people != target)
-			quiet_enviromnent = FALSE
+			quiet_environment = FALSE
 			break
-	if(quiet_enviromnent)
-		modded_time *= SURGERY_SPEEDUP_AREA
+	if(quiet_environment)
+		modded_time *= SURGERY_SPEED_CALM_ENVIRONMENT
 		to_chat(user, span_notice("You are able to work faster due to the quiet environment!"))
 	// NOVA EDIT ADDITION END
 	if(do_after(user, modded_time, target = target, interaction_key = user.has_status_effect(/datum/status_effect/hippocratic_oath) ? target : DOAFTER_SOURCE_SURGERY)) //If we have the hippocratic oath, we can perform one surgery on each target, otherwise we can only do one surgery in total.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes Nova's (or rather, the older server's) old analgesic speed bonus in favor of TG's (https://github.com/NovaSector/NovaSector/pull/957) and turns the speedup modifier into a calm environment modifier, also reducing it's speed bonus from 50% down to 20%

Calm environment modifier itself is mostly left untouched aside from some wording changes in the code and making it a bit more clear to what it is.

Videos of how this impacts surgery speed are in proof of testing.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
Currently, surgeries are so fast that they nearly match alien tools with really little effort. This is mostly a result of our modular speedup bonus being faster than even TG's surgery speed modifiers, as well as Nova's and TG's analgesics bonus co-existing which results into them stacking into a boost of 70%.

For reference; Miner's salve boosts surgery speed by 10%, TG's analgesia, dissection and sterilizine all boost the surgery speed by 20% and can all be stacked together while our modular speedup just chops it down to 50% over very little effort just by being in an empty room and easily can be stacked into 100% (120% with TG analgesia modifier) speed boost if you drug your patient with painkillers or have them in a stasis bed (which would then be reduced down to 110% due to it having a debuff of 10%).

Medical players are meant to be awarded for the effort they spend into getting their patient numb and other things rather than a flat 50% speed bonus with very little effort, this should also discourage doctors from doing basic surgeries on a stasis bed.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
All of these are organ manipulation surgeries followed with cauterizing
No bonus


https://github.com/user-attachments/assets/033058a3-367c-48d7-9bb0-af9f45eb56ca


Calm environment bonus

https://github.com/user-attachments/assets/b61446c4-bffd-4472-8ff2-1efbc2d6101e

  
Numb and calm environment bonus

https://github.com/user-attachments/assets/f1a51084-d0ef-4c66-a7e1-e68518c5b6c9



</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Hardly
balance: Removes the 50% speedup surgery speed bonus from being in a calm environments and numb/dead patients
balance: Calm environment instead now boosts surgery speed by 20%
remove: Removed Nova's modular numb surgery speed boost due to it conflicting with TG's
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
