### PR TITLE
Restores Rapid Construction Fabricator spawn to Chief Engineer's Locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -23,6 +23,7 @@
 	new /obj/item/construction/plumbing/engineering(src) //NOVA EDIT ADDITION
 	new /obj/item/circuitboard/machine/rodstopper(src) //NOVA EDIT ADDITION
 	new /obj/item/card/id/departmental_budget/eng(src) //NOVA EDIT ADDITION
+	new /obj/item/flatpacked_machine(src) //NOVA EDIT ADDITION
 
 /obj/structure/closet/secure_closet/engineering_chief/populate_contents_immediate()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Restores the Rapid Construction Fabricator to the Chief Engineer's locker, as per #2441 .
## How This Contributes To The Nova Sector Roleplay Experience
Quicker access to better machines and tools in the correct hands moves things along and saves department resources.
The flatpacker is not even _close_ to a substitute for the benefits that a well managed RCF+Ore Silo provides to reducing Engineering's workload. 

The RCF was removed from the locker as part of #3160 .

In addition, with the changes presented in #4491 , the RCF is no longer a source of contraband. 

**tl;dr** ore silo + silo link + rcf = less walking and quicker repairs for the station, meaning we can get back to rp and away from mechanics.
## Proof of Testing
Prior PR code reversion.
Single line addition.
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:Moonridden
qol: Restores the Rapid Construction Fabricatory (RCF) to the Chief Engineer's locker.
/:cl:
