### PR TITLE
Med Technician Kit Balance Pass

### DIFF
--- a/modular_nova/modules/deforest_medical_items/code/storage_items.dm
+++ b/modular_nova/modules/deforest_medical_items/code/storage_items.dm
@@ -422,7 +422,7 @@
 		/obj/item/scalpel = 1,
 		/obj/item/hemostat = 1,
 		/obj/item/retractor = 1,
-		/obj/item/circular_saw/field_medic = 1,
+		/obj/item/circular_saw/field_medic/lowforce = 1,
 		/obj/item/bonesetter = 1,
 		/obj/item/cautery = 1,
 		/obj/item/surgical_drapes = 1,

--- a/modular_nova/modules/exp_corps/code/gear.dm
+++ b/modular_nova/modules/exp_corps/code/gear.dm
@@ -44,6 +44,9 @@
 	throw_range = 3
 	w_class = WEIGHT_CLASS_SMALL
 
+/obj/item/circular_saw/field_medic/lowforce
+	force = 9
+
 //Pointman's riot shield. Fixable with 1 plasteel, crafting recipe for broken shield
 /obj/item/shield/riot/pointman
 	name = "pointman shield"


### PR DESCRIPTION

## About The Pull Request

Right now this comes with the old vanguard ops field medic bonesaw. This is a `small` sized item with 20 force. This level of force is generally bulky+ size only. So let's tone that down a bit. 20 force -> 9 force via a new subtype.

## How This Contributes To The Nova Sector Roleplay Experience

Balancing.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: medical technician kit's bonesaw is significantly less lethal now.
/:cl:
