### PR TITLE
Reverts #1832 - Beepsky doesnt check weapons by default anymore.

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -53,8 +53,7 @@
 	var/last_found
 
 	///Flags SecBOTs use on what to check on targets when arresting, and whether they should announce it to security/handcuff their target
-	var/security_mode_flags = SECBOT_DECLARE_ARRESTS | SECBOT_CHECK_RECORDS | SECBOT_HANDCUFF_TARGET | SECBOT_CHECK_WEAPONS // NOVA EDIT CHANGE - Original: var/security_mode_flags = SECBOT_DECLARE_ARRESTS | SECBOT_CHECK_RECORDS | SECBOT_HANDCUFF_TARGET
-//	Selections: SECBOT_DECLARE_ARRESTS | SECBOT_CHECK_IDS | SECBOT_CHECK_WEAPONS | SECBOT_CHECK_RECORDS | SECBOT_HANDCUFF_TARGET
+	var/security_mode_flags = SECBOT_DECLARE_ARRESTS | SECBOT_CHECK_RECORDS | SECBOT_HANDCUFF_TARGET
 
 	///On arrest, charges the violator this much. If they don't have that much in their account, they will get beaten instead
 	var/fair_market_price_arrest = 25

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -54,6 +54,7 @@
 
 	///Flags SecBOTs use on what to check on targets when arresting, and whether they should announce it to security/handcuff their target
 	var/security_mode_flags = SECBOT_DECLARE_ARRESTS | SECBOT_CHECK_RECORDS | SECBOT_HANDCUFF_TARGET
+//	Selections: SECBOT_DECLARE_ARRESTS | SECBOT_CHECK_IDS | SECBOT_CHECK_WEAPONS | SECBOT_CHECK_RECORDS | SECBOT_HANDCUFF_TARGET
 
 	///On arrest, charges the violator this much. If they don't have that much in their account, they will get beaten instead
 	var/fair_market_price_arrest = 25


### PR DESCRIPTION

## About The Pull Request
Reverts the changes made on #1832 , using the original TG values for beepsky.

## How This Contributes To The Nova Sector Roleplay Experience
Beepsky no longer checks for people weapons by default, so its not either automatically hitting people for having weapons they are permited to use anyways, unless security goes out of their way to unlock it and use beepsky that way.

Most of our crew uses weapons, its weird for this setting to had been specifically changed.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/fb5c3544-1d91-4779-acb7-ec46103056c9)


</details>

## Changelog
:cl:
qol: Beepsky no longer starts with the check weaponry setting on (so no more evil beepsky by default) (TG default)
/:cl:
