### PR TITLE
Removes the boobytrapped bluespace cell from Wawa's asteroid

### DIFF
--- a/_maps/nova/automapper/automapper_config.toml
+++ b/_maps/nova/automapper/automapper_config.toml
@@ -433,6 +433,14 @@ required_map = "wawastation.dmm"
 coordinates = [83, 92, 1]
 trait_name = "Station"
 
+# Wawastation TG-shenanigan removals.
+[templates.wawastation_asteroidbluecell]
+map_files = ["wawastation_asteroidbluecell.dmm"]
+directory = "_maps/nova/automapper/templates/wawastation/"
+required_map = "wawastation.dmm"
+coordinates = [142, 95, 2]
+trait_name = "Station"
+
 # SNOWGLOBE STATION MAP EDITS
 # Icecats Camp Lower Level - Snowglobe
 [templates.snowglobe_icecats_lower]

--- a/_maps/nova/automapper/templates/wawastation/wawastation_asteroidbluecell.dmm
+++ b/_maps/nova/automapper/templates/wawastation/wawastation_asteroidbluecell.dmm
@@ -1,0 +1,8 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/open/misc/asteroid,
+/area/station/asteroid)
+
+(1,1,1) = {"
+a
+"}


### PR DESCRIPTION
## About The Pull Request

Removes the rigged bluespace cell from wawa's asteroid area.

## How This Contributes To The Nova Sector Roleplay Experience

So I'm all for people not reading their surroundings and paying the consequences. The smokin' hot shower is a good example. There's a shower hooked up to a chem tank right next to a welding fuel tank, warning signs, etc.

![image](https://github.com/user-attachments/assets/51bf6a2e-df3b-4d51-9fec-40f9b6fd7f1b)

... This little shit is just bait though. 

![image](https://github.com/user-attachments/assets/8afa3c96-ed52-4ff6-a2f8-c9442b8178ee)

![image](https://github.com/user-attachments/assets/141f2f18-dbbc-42d3-8ada-e39e353605f8)

Automapper-ing it out.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/25ef51dc-254f-4fbf-bf80-a619ab945c0c)

</details>

## Changelog
:cl:
map: removed the trapped bluespace cell from wawa's asteroid area.
/:cl:
