### PR TITLE
Snowglobe Cryo - Fire Alarm

### DIFF
--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -27430,7 +27430,7 @@
 /obj/machinery/cryopod{
 	dir = 1
 	},
-/obj/machinery/status_display/ai/directional/east,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/corner{
 	dir = 1
 	},
@@ -62500,7 +62500,6 @@
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 9
 	},
-/obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron/corner,
 /area/station/hallway/secondary/entry)
 "qSz" = (
@@ -80735,6 +80734,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 8
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Swaps the display in cryo to a fire alarm to allow the area to be reset and not show on canary. 

Swaps the right display here from a west-mounted one to a north mounted one. Same effective x/y map position but gives better visual coverage (considering we just removed the display from croy.



## How This Contributes To The Nova Sector Roleplay Experience

Minor fix.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
Before - 

![image](https://github.com/user-attachments/assets/90f2c181-565a-42fa-a1b0-63dc77748b74)

After - 

![image](https://github.com/user-attachments/assets/f188056b-30a3-4f69-a18b-4dc298a37c98)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
map: snowglobe cryo - status display swapped to a fire alarm.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
