### PR TITLE
Fixes floating lamp in Ouroboros maints

### DIFF
--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -16258,7 +16258,6 @@
 /area/station/security/courtroom)
 "eKl" = (
 /obj/effect/spawner/random/trash/moisture_trap,
-/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "eKm" = (
@@ -177912,7 +177911,7 @@ crh
 tPF
 aAm
 wUS
-jNS
+agJ
 gfP
 gfP
 gfP


### PR DESCRIPTION

## About The Pull Request

Before
![StrongDMM_rNApaiN01w](https://github.com/user-attachments/assets/782e80fd-cfcf-4162-99e5-bb72d7ce4f9e)

After
![StrongDMM_zODmXdcxmX](https://github.com/user-attachments/assets/71e9eaa2-dc5b-4127-acd2-723385b22bc9)

## How This Contributes To The Nova Sector Roleplay Experience
Lamps aren't meant to float

## Proof of Testing
<details>
It's a pretty simple change that has no reason to fail at linting
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl: Hardly
map: Ouroboros: Fixes a floating lamp in southern maintenance
/:cl:
