### PR TITLE
Fixes Felinid tail wagging

### DIFF
--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/tails.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/tails.dm
@@ -52,6 +52,8 @@
 	icon = 'modular_nova/master_files/icons/mob/sprite_accessory/tails.dmi'
 	icon_state = "cat"
 	color_src = USE_ONE_COLOR
+	recommended_species = list(SPECIES_HUMAN, SPECIES_SYNTH, SPECIES_FELINE, SPECIES_MAMMAL, SPECIES_GHOUL)
+	organ_type = /obj/item/organ/external/tail/cat
 
 /datum/sprite_accessory/tails/human/monkeyColorable
 	icon = 'modular_nova/master_files/icons/mob/sprite_accessory/tails.dmi'


### PR DESCRIPTION
## About The Pull Request
They can wag again. Turns out that we were specifying which tail to use previously by setting it on the `/human` subtype, which `/cat` used to be a subtype of, but that got missed during the repathing.

## How This Contributes To The Nova Sector Roleplay Experience
![image](https://github.com/user-attachments/assets/9ae286fc-e8b5-49a4-be31-7a447aabdfa7)

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/28ac7f59-dd94-46c4-9e22-1655952dead1)

</details>

## Changelog

:cl: GoldenAlpharex
fix: Felinids are no longer allergic to wagging their tails.
/:cl: