### PR TITLE
Fix escape menu spacing

### DIFF
--- a/modular_nova/modules/escape_menu/code/escape_menu_nova.dm
+++ b/modular_nova/modules/escape_menu/code/escape_menu_nova.dm
@@ -6,7 +6,7 @@
 			/* hud_owner = */ src,
 			src,
 			"OPFOR",
-			/* offset = */ 3,
+			/* offset = */ 5,
 			CALLBACK(src, PROC_REF(home_opfor)),
 		)
 	)
@@ -17,7 +17,7 @@
 			/* hud_owner = */ src,
 			src,
 			"Ghost",
-			/* offset = */ 4,
+			/* offset = */ 6,
 			CALLBACK(src, PROC_REF(home_ghost)),
 		)
 	)
@@ -28,7 +28,7 @@
 			/* hud_owner = */ src,
 			src,
 			"Respawn",
-			/* offset = */ 5,
+			/* offset = */ 7,
 			CALLBACK(src, PROC_REF(home_respawn)),
 		)
 	)


### PR DESCRIPTION

## About The Pull Request
Fixes #4581 by moving our custom options down two notches
## How This Contributes To The Nova Sector Roleplay Experience
🖱️ 
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/a33275df-59dc-4789-addf-a93eec2b6e76)

</details>

## Changelog
:cl:
fix: The escape menu buttons no longer overlap
/:cl:
