### PR TITLE
[NON-MODULAR] Adds mag-fed turret limitations to pneumatic cannon

### DIFF
--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -143,6 +143,16 @@
 		if(user)
 			to_chat(user, span_warning("\The [I] is too large to fit into \the [src]!"))
 		return FALSE
+	//Nova Addition start
+	if(locate(/obj/item/storage/toolbox/emergency/turret/mag_fed) in src) //If loaded with a turret, stops more from being put in
+		if(user)
+			to_chat(user, span_warning("\The [I] is blocked from \the [src]'s loader!"))
+		return FALSE
+	if(istype(I, /obj/item/storage/toolbox/emergency/turret/mag_fed) && length(loadedItems) >= 1)
+		if(user)
+			to_chat(user, span_warning("\The [I] needs an empty cannon!"))
+		return FALSE
+	//Nova Addition end
 	return TRUE
 
 /obj/item/pneumatic_cannon/proc/load_item(obj/item/I, mob/user)
@@ -151,7 +161,12 @@
 	if(user) //Only use transfer proc if there's a user, otherwise just set loc.
 		if(!user.transferItemToLoc(I, src))
 			return FALSE
-		to_chat(user, span_notice("You load \the [I] into \the [src]."))
+	//	to_chat(user, span_notice("You load \the [I] into \the [src].")) << Original. Nova Addition start
+		if(istype(I, /obj/item/storage/toolbox/emergency/turret/mag_fed))
+			to_chat(user, span_warning("You load \the [I] into \the [src] before blocking the loader's opening."))
+		else
+			to_chat(user, span_notice("You load \the [I] into \the [src]."))
+	// Nova Addition End
 	else
 		I.forceMove(src)
 	loadedItems += I


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Pneumatic cannon now has unique interactions with mag-fed turret kits:

- Only one can fit into the pneumatic cannon
- You cannot load a turret into a pneumatic item with any other objects and vice versa

## How This Contributes To The Nova Sector Roleplay Experience

Loading more than one turret into a pneumatic cannon isn't good for balance, for several reasons:

1. While they can be/are sized small enough to be stored in backpacks easily, Having a tool dedicated to mass-distributing turrets should be separately designed with balance in mind. _Such an idea would also have to pass a desire outside of the deathmatch minigame for serious consideration_ 
2. Loading large amounts of turrets into the cannon creates a storage dilemma: They're designed as tools in addition or as a dedicated gimmick leaving little space left or taking key equipment slots. Having more than 5 rapidly deployed (again, outside of a dedicated tool) breaks balance in space economy
3. Finally, It basically becomes an easy way to line 1x1 hallways with layers of blockades that can EASILY take you out without preparations, annoying (often) security as they can become trapped in the right circumstances. Its good this was caught before easier ways to get lethal turrets were put in, let alone in this level of ease of deployment. 

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/6a5a7ca1-6a07-4384-bcaf-cedecd7f9d21

(note: i did decide that, "Hey, We're not just loading from the barrel, Why else does the pneumatic cannon have this second long tube?" and did some edits post-capture)
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Pneumatic cannons can now hold only one turret kit if loaded with one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
