### PR TITLE
nerfs changeling to prepare for it being readded.

### DIFF
--- a/code/modules/antagonists/changeling/powers/strained_muscles.dm
+++ b/code/modules/antagonists/changeling/powers/strained_muscles.dm
@@ -21,7 +21,7 @@
 	else
 		user.remove_movespeed_modifier(/datum/movespeed_modifier/strained_muscles)
 		to_chat(user, span_notice("Our muscles relax."))
-		if(stacks >= 5) // NOVA EDIT: 5, instead of 10, means it only lasts half as long (instead of like, 50 seconds straight)
+		if(stacks >= 5) // NOVA EDIT CHANGE - 5, instead of 10, means it only lasts half as long (instead of like, 50 seconds straight) - ORIGINAL: if(stacks >= 10)
 			to_chat(user, span_danger("We collapse in exhaustion."))
 			user.Paralyze(60)
 			user.emote("gasp")

--- a/code/modules/antagonists/changeling/powers/strained_muscles.dm
+++ b/code/modules/antagonists/changeling/powers/strained_muscles.dm
@@ -21,7 +21,7 @@
 	else
 		user.remove_movespeed_modifier(/datum/movespeed_modifier/strained_muscles)
 		to_chat(user, span_notice("Our muscles relax."))
-		if(stacks >= 10)
+		if(stacks >= 5) // NOVA EDIT: 5, instead of 10, means it only lasts half as long (instead of like, 50 seconds straight)
 			to_chat(user, span_danger("We collapse in exhaustion."))
 			user.Paralyze(60)
 			user.emote("gasp")

--- a/code/modules/movespeed/modifiers/innate.dm
+++ b/code/modules/movespeed/modifiers/innate.dm
@@ -1,5 +1,5 @@
 /datum/movespeed_modifier/strained_muscles
-	multiplicative_slowdown = -0.1 // NOVA EDIT - Heavy nerf, because speedboosts are way-way more effective here
+	multiplicative_slowdown = -0.35// NOVA EDIT - Heavy nerf, because speedboosts are way-way more effective here
 	blacklisted_movetypes = (FLYING|FLOATING)
 
 /datum/movespeed_modifier/pai_spacewalk

--- a/code/modules/movespeed/modifiers/innate.dm
+++ b/code/modules/movespeed/modifiers/innate.dm
@@ -1,5 +1,5 @@
 /datum/movespeed_modifier/strained_muscles
-	multiplicative_slowdown = -0.35 // NOVA EDIT - Heavy nerf, because speedboosts are way-way more effective here - ORIGINAL: multiplicative_slowdown = -0.55
+	multiplicative_slowdown = -0.35 // NOVA EDIT CHANGE - Heavy nerf, because speedboosts are way-way more effective here - ORIGINAL: multiplicative_slowdown = -0.55
 	blacklisted_movetypes = (FLYING|FLOATING)
 
 /datum/movespeed_modifier/pai_spacewalk

--- a/code/modules/movespeed/modifiers/innate.dm
+++ b/code/modules/movespeed/modifiers/innate.dm
@@ -1,5 +1,5 @@
 /datum/movespeed_modifier/strained_muscles
-	multiplicative_slowdown = -0.55
+	multiplicative_slowdown = -0.1 // NOVA EDIT - Heavy nerf, because speedboosts are way-way more effective here
 	blacklisted_movetypes = (FLYING|FLOATING)
 
 /datum/movespeed_modifier/pai_spacewalk

--- a/code/modules/movespeed/modifiers/innate.dm
+++ b/code/modules/movespeed/modifiers/innate.dm
@@ -1,5 +1,5 @@
 /datum/movespeed_modifier/strained_muscles
-	multiplicative_slowdown = -0.35// NOVA EDIT - Heavy nerf, because speedboosts are way-way more effective here
+	multiplicative_slowdown = -0.35 // NOVA EDIT - Heavy nerf, because speedboosts are way-way more effective here - ORIGINAL: multiplicative_slowdown = -0.55
 	blacklisted_movetypes = (FLYING|FLOATING)
 
 /datum/movespeed_modifier/pai_spacewalk

--- a/modular_nova/master_files/code/modules/antagonists/changeling/changeling.dm
+++ b/modular_nova/master_files/code/modules/antagonists/changeling/changeling.dm
@@ -1,5 +1,6 @@
 /datum/antagonist/changeling
 	dna_max = 8 // changed from 6
+	chem_recharge_rate = 0.5
 	/// The time that the horror form died.
 	var/true_form_death
 	/// Any quirks that we don't want to be mimicked when transforming

--- a/modular_nova/master_files/code/modules/antagonists/changeling/changeling.dm
+++ b/modular_nova/master_files/code/modules/antagonists/changeling/changeling.dm
@@ -1,7 +1,5 @@
 /datum/antagonist/changeling
 	dna_max = 8 // changed from 6
-	genetic_points = 15 // changed from 10
-	total_genetic_points = 15 // changed from 10
 	/// The time that the horror form died.
 	var/true_form_death
 	/// Any quirks that we don't want to be mimicked when transforming


### PR DESCRIPTION


## About The Pull Request
- Removes bonus genetic points, and the raised cap
- Nerfs the legbooster, as we run a lower movespeed already and it makes you go way-to-fast for anyone to catch
- cuts chemical regen to 1 every 2 seconds, instead of 1 per second, to see how it settles in the balance since there's a-lot of new powers.
rest untouched
## How This Contributes To The Nova Sector Roleplay Experience

prepping them for being readded

## Proof of Testing
numbers change

## Changelog
:cl:
balance: Changeling has gone from 15 > 10 genetic points, had strained muscles heavily cutdown in the speedboost, and finally had it's chem-regen cut in half.
/:cl:
