### PR TITLE
SerenityStation patches

### DIFF
--- a/_maps/map_files/SerenityStation/SerenityStation.dmm
+++ b/_maps/map_files/SerenityStation/SerenityStation.dmm
@@ -27070,7 +27070,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/dorms)
 "hKw" = (
-/obj/machinery/pdapainter/engineering,
 /obj/structure/cable,
 /obj/machinery/requests_console/directional/north{
 	department = "Head of Security's Desk";
@@ -27079,6 +27078,7 @@
 /obj/effect/mapping_helpers/requests_console/assistance,
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/announcement,
+/obj/machinery/pdapainter/security,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hos)
 "hKJ" = (
@@ -32272,7 +32272,6 @@
 /obj/machinery/door/airlock/mining{
 	name = "Drone Bay"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32283,6 +32282,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "jjl" = (
@@ -36000,6 +36000,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"klt" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "klu" = (
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 4
@@ -38714,7 +38721,6 @@
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Breakroom"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -38724,6 +38730,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "lct" = (
@@ -52525,12 +52532,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
-"plo" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 10
-	},
-/turf/closed/wall,
-/area/station/cargo/sorting)
 "plp" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/eva/abandoned)
@@ -65648,7 +65649,6 @@
 /obj/machinery/door/airlock/mining{
 	name = "Mining Dock"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65656,6 +65656,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "tfP" = (
@@ -77345,10 +77346,10 @@
 /obj/machinery/rnd/production/techfab/department/cargo,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "wuG" = (
@@ -81758,9 +81759,6 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/starboard/aft)
 "xNO" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
 /obj/machinery/camera/directional/south{
 	c_tag = "Supply - Customs Office";
 	network = list("ss13","prison")
@@ -81770,6 +81768,9 @@
 	name = "Markus's bed"
 	},
 /mob/living/basic/pet/dog/markus,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "xNU" = (
@@ -173690,7 +173691,7 @@ hAc
 aHS
 gII
 xNO
-plo
+mbf
 mbf
 mbf
 mbf
@@ -173946,7 +173947,7 @@ oWv
 hul
 hul
 rpL
-hul
+klt
 wuA
 tDh
 vMb


### PR DESCRIPTION
## About The Pull Request
This PR does the following:

1. Makes mining bay accessible to all of cargo so they can access drone bay
2. Fixes a decal in cargo noclipping it's way into the walls
3. Fixes HoS ID painter by giving them the correct one (fixes https://github.com/NovaSector/NovaSector/issues/4597)
## How This Contributes To The Nova Sector Roleplay Experience
Lets cargo technicians access drone bay which is to the side of the mining bay while fixing other minor issues with the map

## Proof of Testing
Compiled, should lint as well.
<details>
<summary>Screenshots/Videos</summary>

![StrongDMM_LH0lZUbomx](https://github.com/user-attachments/assets/71064f19-7b65-48e3-a85d-615d755027ca)

  
</details>

## Changelog
:cl: Hardly
fix: SerenityStation: Gave HoS the correct ID painter.
fix: SerenityStation: Fixed the decals in cargo creeping it's way into the walls.
map: Cargo Technicians can now access the drone bay without mining access.
/:cl:
