### PR TITLE
Changes Nanotrasen Consultant and Blueshield's ID trims to be silver while preventing self-service AA

### DIFF
--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -59,6 +59,10 @@
 	for(var/access_as_text in managers)
 		var/list/info = managers[access_as_text]
 		var/access = access_as_text
+		// NOVA ADDITION BEGIN - Prevents those with captain access only from changing their own access (Blueshields and NTCs)
+		if(access == ACCESS_CAPTAIN)
+			continue
+		// NOVA ADDITION END
 		if((access in auth_card.access) && ((target_dept in info["regions"]) || !target_dept))
 			region_access |= info["regions"]
 			job_templates |= info["templates"]

--- a/modular_nova/master_files/code/datums/id_trim/jobs.dm
+++ b/modular_nova/master_files/code/datums/id_trim/jobs.dm
@@ -74,9 +74,6 @@
 		ACCESS_SCIENCE,
 		ACCESS_TELEPORTER,
 		ACCESS_WEAPONS,
-	)
-	minimal_wildcard_access = list(
-		ACCESS_CAPTAIN,
 		ACCESS_CENT_GENERAL,
 	)
 	template_access = list(
@@ -84,6 +81,13 @@
 		ACCESS_CHANGE_IDS,
 	)
 	job = /datum/job/blueshield
+
+// Gives the blueshield access to captain's quarters and comms console without having to upgrade into a centcom card.
+/datum/id_trim/job/blueshield/New()
+	.=..()
+	minimal_access |= list(
+		ACCESS_CAPTAIN,
+	)
 
 /datum/id_trim/job/nanotrasen_consultant
 	assignment = "Nanotrasen Consultant"
@@ -99,7 +103,6 @@
 		ACCESS_BAR,
 		ACCESS_BRIG_ENTRANCE,
 		ACCESS_CENT_GENERAL,
-		ACCESS_CHANGE_IDS,
 		ACCESS_CHAPEL_OFFICE,
 		ACCESS_COMMAND,
 		ACCESS_CONSTRUCTION,
@@ -132,16 +135,20 @@
 		ACCESS_THEATRE,
 		ACCESS_VAULT,
 		ACCESS_WEAPONS,
-	)
-	minimal_wildcard_access = list(
-		ACCESS_CAPTAIN,
-		ACCESS_CENT_GENERAL,
+		ACCESS_CENT_GENERAL
 	)
 	template_access = list(
 		ACCESS_CAPTAIN,
 		ACCESS_CHANGE_IDS,
 	)
 	job = /datum/job/nanotrasen_consultant
+
+// Gives the NTC access to captain's quarters and comms console without having to upgrade into a centcom card.
+/datum/id_trim/job/nanotrasen_consultant/New()
+	.=..()
+	minimal_access |= list(
+		ACCESS_CAPTAIN,
+	)
 
 /datum/id_trim/job/corrections_officer
 	assignment = "Corrections Officer"

--- a/modular_nova/modules/blueshield/code/blueshield.dm
+++ b/modular_nova/modules/blueshield/code/blueshield.dm
@@ -48,7 +48,7 @@
 	uniform = /obj/item/clothing/under/rank/blueshield
 	suit = /obj/item/clothing/suit/armor/vest/blueshield/jacket
 	gloves = /obj/item/clothing/gloves/tackler/security
-	id = /obj/item/card/id/advanced/centcom
+	id = /obj/item/card/id/advanced/silver
 	shoes = /obj/item/clothing/shoes/jackboots
 	ears = /obj/item/radio/headset/headset_bs/alt
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses

--- a/modular_nova/modules/nanotrasen_rep/code/nanotrasen_consultant.dm
+++ b/modular_nova/modules/nanotrasen_rep/code/nanotrasen_consultant.dm
@@ -69,7 +69,7 @@
 
 	chameleon_extras = list(/obj/item/gun/energy/e_gun, /obj/item/stamp/centcom)
 
-	id = /obj/item/card/id/advanced/centcom
+	id = /obj/item/card/id/advanced/silver
 	id_trim = /datum/id_trim/job/nanotrasen_consultant
 
 /obj/item/radio/headset/heads/nanotrasen_consultant


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Nanotrasen Consultant and Blueshield's ID trims have been changed to be Silver, meaning that the amount of access that can be given are as limited as a head's.

I've also removed the ID change access from the NTC since, well, that's HoP's job rather than an advisor's.

Additionally prevents those with captain access only (NTCs and Blueshields) from doing self-service AA by giving themselves HoP and then doing whatever they want with it.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Makes the game respect the game design behind the ID card trims where only captain's spare and captain's ID have the ability to be given all access as well as the following;

Command policy already states that blueshields already aren't meant to give themselves access, but that does not necessarily stop them if they know how to be sneaky enough and don't get ahelped. It's also hard to tell on whenever they have AA or not until an admin varedits their ID closely which is kind of annoying to do so. There are already many, many ways for them to break into places during emergencies and even then, they are still better off following the heads on emergencies like a bodyguard is meant to do.

NTCs in the other hand essentially have semi-AA already, which is enough to inspect every department well while doing their job on advising command. If they have a reason to require more access (eg. Departments breaking SoP) they should consult the HoP or Captain for it.

Additionally, the block encourages both roles to interact with the HoP or Captain in case they need access change rather than self-servicing AA for themselves, we're a roleplay server after all and veterans are meant to be a good representative of that, rather than just opening Plexagon Access Management on their PDA and ticking every single box just because the game allows that.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Hardly
balance: Nanotrasen Consultants and Blueshields now use silver IDs
balance: Blueshields and Nanotrasen Consultants can no longer change their own access
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
