### PR TITLE
Snowglobe - Disposals Stacker

### DIFF
--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -58602,10 +58602,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/service/chapel)
-"pIK" = (
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
-/turf/closed/wall/r_wall,
-/area/station/science/lab)
 "pIL" = (
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 1
@@ -267965,7 +267961,7 @@ xOk
 vYw
 sgG
 uSv
-pIK
+uSv
 uSv
 uSv
 uSv

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -781,6 +781,9 @@
 "ajP" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/mineral/stacking_unit_console{
+	pixel_x = 32
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "aka" = (
@@ -62812,7 +62815,9 @@
 /area/station/service/library)
 "qXv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/window/reinforced/tinted/spawner/directional/north,
+/obj/machinery/mineral/stacking_machine{
+	input_dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "qXH" = (


### PR DESCRIPTION

## About The Pull Request

Adds a stacking unit to Snowglobe's disposals. Somehow this has been missed repeatedly.

## How This Contributes To The Nova Sector Roleplay Experience

Missing. Fixed.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
map: Snowglobe - added stacking machine to disposals.
/:cl:
