### PR TITLE
Snowglobe medical redo

### DIFF
--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -354,6 +354,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
+"aeu" = (
+/obj/effect/turf_decal/tile/blue/half,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/medbay/central)
 "aey" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Medbay Maintenance"
@@ -783,27 +788,11 @@
 /obj/structure/fence/cut/large,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"ajL" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/medbay/central)
 "ajP" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"ajT" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/medical/office)
 "aka" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_burn_chamber_input{
 	dir = 8
@@ -1126,15 +1115,6 @@
 /obj/effect/spawner/random/entertainment/toy,
 /turf/open/floor/iron,
 /area/station/service/theater/abandoned)
-"anO" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
 "aoc" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -1583,15 +1563,6 @@
 	dir = 1
 	},
 /area/station/engineering/atmospherics_engine)
-"ata" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "atg" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/warning{
@@ -2162,10 +2133,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Office"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/wood/tile,
 /area/station/medical/office)
 "azJ" = (
@@ -2406,6 +2377,11 @@
 /obj/item/storage/belt/mailbelt,
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
+"aCx" = (
+/obj/effect/turf_decal/tile/blue/half,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/treatment_center)
 "aCG" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/dark_red/filled/warning{
@@ -3657,14 +3633,6 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"aUU" = (
-/obj/effect/turf_decal/trimline/dark_red/warning{
-	dir = 10
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 4
-	},
-/area/station/medical/aslyum)
 "aUX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -4613,15 +4581,6 @@
 /obj/effect/turf_decal/siding/wood/end,
 /turf/open/floor/wood/tile,
 /area/station/medical/psychology)
-"biK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/station/medical/office)
 "biM" = (
 /obj/structure/cable,
 /obj/item/papercutter{
@@ -5629,6 +5588,7 @@
 "bwY" = (
 /obj/effect/turf_decal/tile/blue/half,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/treatment_center)
 "bxb" = (
@@ -6014,18 +5974,6 @@
 	dir = 4
 	},
 /area/station/security/office)
-"bCD" = (
-/obj/effect/turf_decal/trimline/blue/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/chemistry)
 "bCE" = (
 /turf/open/misc/dirt/icemoon,
 /area/icemoon/underground/explored/graveyard)
@@ -6249,6 +6197,13 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
+"bFI" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/full,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "bFS" = (
 /obj/structure/railing/wrestling{
 	dir = 4
@@ -6691,17 +6646,11 @@
 /turf/open/floor/carpet,
 /area/station/service/cafeteria)
 "bMn" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
+/obj/structure/sign/departments/virology/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/medbay/central)
 "bMx" = (
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
@@ -6766,6 +6715,10 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/fore)
+"bNS" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/large,
+/area/station/engineering/atmos/project)
 "bNT" = (
 /obj/machinery/camera/autoname/directional/north{
 	network = list("ss13","rd")
@@ -7358,26 +7311,12 @@
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/science/genetics)
 "bWW" = (
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_exterior";
-	name = "Virology Exterior Airlock"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door_buttons/access_button{
-	dir = 1;
-	idDoor = "virology_airlock_exterior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_y = 5;
-	req_access = list("virology");
-	pixel_x = 25
-	},
+/obj/machinery/door/airlock/virology,
 /turf/open/floor/iron/white/smooth_half,
 /area/station/medical/virology)
 "bXb" = (
@@ -7926,6 +7865,13 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms/room6)
+"cdx" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/station/medical/office)
 "cdy" = (
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 8
@@ -7969,6 +7915,17 @@
 /obj/effect/turf_decal/trimline/white/filled/line,
 /turf/open/floor/iron/edge,
 /area/station/hallway/secondary/entry)
+"cdR" = (
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 8
+	},
+/area/station/medical/medbay/central)
 "cdT" = (
 /obj/machinery/computer/security/qm{
 	dir = 1
@@ -8774,18 +8731,6 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/qm)
-"cpo" = (
-/obj/effect/turf_decal/tile/blue/anticorner{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/white/smooth_corner{
-	dir = 8
-	},
-/area/station/medical/medbay/central)
 "cpr" = (
 /obj/structure/rack,
 /obj/item/flashlight,
@@ -9014,16 +8959,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/nt_rep)
-"csZ" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/medbay/central)
 "ctd" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -9970,6 +9905,15 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"cHm" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "cHr" = (
 /obj/effect/spawner/random/entertainment/drugs{
 	pixel_x = -5;
@@ -10080,11 +10024,6 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
-"cIi" = (
-/obj/effect/turf_decal/tile/blue/half,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/medbay/central)
 "cIj" = (
 /mob/living/carbon/human/species/monkey,
 /obj/structure/flora/grass/jungle/b/style_4{
@@ -10458,15 +10397,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
-"cNg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "cNm" = (
 /turf/closed/wall,
 /area/station/hallway/primary)
@@ -10522,14 +10452,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
-"cOl" = (
-/obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/sign/departments/med/directional/south,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/treatment_center)
 "cOn" = (
 /obj/structure/closet/secure_closet/chemical,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -10730,15 +10652,6 @@
 	},
 /turf/open/floor/cult,
 /area/station/maintenance/condemnedroom)
-"cQG" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "cQI" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/eighties,
@@ -11461,6 +11374,15 @@
 	dir = 1
 	},
 /area/station/hallway/primary/starboard)
+"daP" = (
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 5
+	},
+/obj/machinery/digital_clock/directional/east,
+/turf/open/floor/iron/white/corner{
+	dir = 8
+	},
+/area/station/medical/aslyum)
 "daQ" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -12195,15 +12117,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark/side,
 /area/station/service/bar)
-"dmJ" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/obj/machinery/status_display/ai/directional/west,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/medbay/central)
 "dmS" = (
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/siding/wood,
@@ -12353,7 +12266,6 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "doX" = (
-/obj/structure/cable,
 /obj/item/defibrillator/loaded{
 	pixel_y = 6
 	},
@@ -12512,14 +12424,11 @@
 /turf/open/floor/iron/white/small,
 /area/station/common/pool)
 "drp" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
 	},
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
+/turf/open/floor/wood,
+/area/station/medical/office)
 "drx" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
 	dir = 1
@@ -12847,6 +12756,13 @@
 	},
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/primary/foreporthall)
+"dxn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "dxr" = (
 /obj/structure/sign/clock/directional/north,
 /obj/structure/cable,
@@ -13514,14 +13430,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"dGP" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Office"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/turf/open/floor/wood/tile,
-/area/station/medical/office)
 "dGR" = (
 /obj/effect/turf_decal/tile/brown/fourcorners,
 /obj/effect/turf_decal/siding/brown{
@@ -13818,15 +13726,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door_buttons/airlock_controller{
-	idExterior = "virology_airlock_exterior";
-	idInterior = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Console";
-	pixel_x = 25;
-	req_access = list("virology");
-	pixel_y = 24
-	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -14416,6 +14315,11 @@
 	dir = 1
 	},
 /area/station/command/bridge)
+"dSa" = (
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "dSr" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance{
@@ -14560,21 +14464,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/execution/transfer)
-"dUD" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "dUE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -15212,20 +15101,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms)
-"edy" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/cup/bottle/morphine{
-	pixel_x = -3;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/syringe,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "edB" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/steam_vent,
@@ -15429,20 +15304,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/foreporthall)
-"egl" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/warning{
-	dir = 4
-	},
-/obj/machinery/camera/autoname/directional/east{
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/chemistry)
 "egv" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
@@ -16219,7 +16080,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "erk" = (
 /obj/structure/rack/wooden,
 /obj/item/reagent_containers/cup/glass/coffee_cup{
@@ -16751,6 +16612,16 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_wrestle)
+"eyq" = (
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
+/area/station/medical/aslyum)
 "eyw" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
@@ -17043,6 +16914,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"eCA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "eCB" = (
 /obj/machinery/vending/sustenance/labor_camp,
 /turf/open/floor/iron/smooth_corner,
@@ -17192,13 +17070,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/warden)
-"eFA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/junction/flip,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "eFC" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 10
@@ -18169,6 +18040,17 @@
 /obj/item/pen,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
+"eTM" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "eTR" = (
 /obj/effect/landmark/start/botanist,
 /obj/effect/turf_decal/tile/dark_green/half,
@@ -19289,14 +19171,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/fore)
-"fjk" = (
-/obj/effect/turf_decal/trimline/blue/warning,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/chemistry)
 "fjl" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -19665,6 +19539,11 @@
 "foG" = (
 /turf/open/floor/iron/checker,
 /area/mine/laborcamp)
+"foO" = (
+/obj/effect/spawner/liquids_spawner,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/pool,
+/area/station/common/pool)
 "foU" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/lights/tubes{
@@ -21135,15 +21014,6 @@
 /obj/machinery/oven/range,
 /turf/open/floor/iron/kitchen,
 /area/station/maintenance/abandon_cafeteria)
-"fIx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "fII" = (
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
@@ -21852,7 +21722,6 @@
 /turf/open/floor/iron/large,
 /area/station/cargo/storage)
 "fTp" = (
-/obj/structure/cable,
 /obj/item/defibrillator/loaded{
 	pixel_y = 6
 	},
@@ -22143,15 +22012,12 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/west,
-/obj/machinery/newscaster/directional/north,
 /obj/structure/closet/secure_closet{
-	req_access = list("medical");
-	name = "Restraint Locker"
+	name = "Patient Restraints"
 	},
 /obj/item/clothing/suit/jacket/straight_jacket,
 /obj/item/clothing/glasses/blindfold,
 /obj/item/clothing/mask/muzzle,
-/obj/item/restraints/handcuffs,
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/medical/medbay/central)
 "fXm" = (
@@ -23050,15 +22916,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/sepia,
 /area/station/service/kitchen/diner)
-"gjv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "gjB" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/dark_green/opposingcorners,
@@ -23835,6 +23692,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/common/pool/sauna)
+"guy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "guB" = (
 /obj/machinery/door/airlock/bathroom{
 	name = "Restroom"
@@ -25291,8 +25155,9 @@
 /area/station/hallway/primary)
 "gNz" = (
 /obj/structure/table/wood,
-/obj/item/modular_computer/laptop{
-	pixel_x = -5;
+/obj/item/folder/white,
+/obj/item/paper_bin{
+	pixel_x = 4;
 	pixel_y = 6
 	},
 /turf/open/floor/carpet/blue,
@@ -25353,16 +25218,6 @@
 /obj/item/stack/sheet/iron/twenty,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engineering/engie_aft_starboard)
-"gOt" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/status_display/evac/directional/east,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/medbay/central)
 "gOv" = (
 /obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -25995,8 +25850,8 @@
 "gXm" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/obj/machinery/status_display/evac/directional/west,
-/obj/item/kirbyplants/random,
+/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/digital_clock/directional/west,
 /turf/open/floor/carpet/blue,
 /area/station/medical/office)
 "gXo" = (
@@ -26453,14 +26308,11 @@
 	},
 /area/station/engineering/atmos/hallway)
 "hdQ" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/medbay/central)
+/obj/structure/disposalpipe/segment,
+/obj/structure/hedge,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/grass,
+/area/station/medical/break_room)
 "hdR" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 8
@@ -26854,13 +26706,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"hjZ" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/station/medical/office)
 "hka" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/steam_vent,
@@ -26976,6 +26821,15 @@
 	dir = 4
 	},
 /area/station/command/heads_quarters/hos)
+"hlE" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/medbay/central)
 "hlK" = (
 /obj/machinery/computer/mech_bay_power_console,
 /turf/open/floor/iron/smooth_large,
@@ -27016,6 +26870,15 @@
 	dir = 8
 	},
 /area/station/medical/pharmacy)
+"hmg" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "hmn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27193,6 +27056,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chemistry)
+"hol" = (
+/obj/effect/turf_decal/tile/blue/half,
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/treatment_center)
 "hon" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27595,8 +27463,9 @@
 /obj/effect/turf_decal/tile/blue/anticorner,
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
-/obj/machinery/light_switch/directional/east,
-/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/obj/item/radio/intercom/directional/south,
+/obj/structure/curtain,
+/obj/machinery/digital_clock/directional/east,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 1
 	},
@@ -27902,27 +27771,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron/checker,
 /area/station/commons/lounge)
-"hxV" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/structure/rack/shelf,
-/obj/item/storage/box/gloves{
-	pixel_x = 0;
-	pixel_y = -4
-	},
-/obj/item/storage/box/gloves{
-	pixel_x = 0;
-	pixel_y = 3
-	},
-/obj/item/storage/box/rxglasses{
-	pixel_x = 0;
-	pixel_y = 10
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
 "hxX" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -28216,15 +28064,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/edge,
 /area/station/hallway/floor2)
-"hCw" = (
-/obj/effect/turf_decal/trimline/dark_red/warning{
-	dir = 5
+"hCt" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Patient Room A"
 	},
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/iron/white/corner{
-	dir = 8
-	},
-/area/station/medical/aslyum)
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_half,
+/area/station/medical/treatment_center)
 "hCx" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/table/reinforced,
@@ -28714,6 +28563,15 @@
 /obj/effect/spawner/random/structure/chair_flipped,
 /turf/open/floor/wood,
 /area/station/maintenance/abandon_office)
+"hJi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "hJr" = (
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
@@ -30015,6 +29873,7 @@
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 4
 	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 8
 	},
@@ -30115,6 +29974,7 @@
 "icj" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/landmark/start/bouncer,
+/obj/machinery/light/floor,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -30665,6 +30525,15 @@
 "ijA" = (
 /obj/effect/turf_decal/tile/blue/half,
 /obj/machinery/light/directional/south,
+/obj/structure/table,
+/obj/item/stack/medical/mesh{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/stack/medical/mesh{
+	pixel_x = 4;
+	pixel_y = 1
+	},
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/medbay/central)
 "ijC" = (
@@ -31301,15 +31170,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/primary)
-"isy" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/trimline/dark_red/warning{
-	dir = 8
-	},
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
-/area/station/medical/aslyum)
 "isz" = (
 /obj/effect/turf_decal/trimline/white/filled/line,
 /obj/machinery/camera/autoname/directional/south,
@@ -31897,6 +31757,23 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/gag_room)
+"iAL" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/cup/bottle/morphine{
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "iAS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31916,7 +31793,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Patient Exit"
+	name = "Medbay Employee Entrance"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
@@ -32021,12 +31898,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_arcade)
-"iDb" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/turf/open/floor/wood,
-/area/station/medical/office)
 "iDf" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/dark_green{
@@ -32297,6 +32168,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/side,
 /area/station/service/chapel)
+"iGZ" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/medbay/central)
 "iHa" = (
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 6
@@ -32895,6 +32775,14 @@
 /obj/structure/sign/warning/radiation/directional/south,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"iOk" = (
+/obj/effect/turf_decal/trimline/blue/warning,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/chemistry)
 "iOo" = (
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
@@ -32961,16 +32849,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/morgue)
-"iPi" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Patient Room B"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white/smooth_half,
-/area/station/medical/treatment_center)
 "iPl" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 8
@@ -33488,13 +33366,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/condemned_med)
-"iWK" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/trimline/dark_red/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/white/side,
-/area/station/medical/aslyum)
 "iWL" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -33610,15 +33481,6 @@
 	dir = 1
 	},
 /area/mine/laborcamp/security)
-"iXT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "iXY" = (
 /obj/structure/chair/sofa/right{
 	dir = 4
@@ -34298,12 +34160,12 @@
 /area/station/commons/dorms/room6)
 "jgG" = (
 /obj/effect/turf_decal/tile/blue,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box{
 	pixel_y = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
 	},
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/medical/break_room)
@@ -34608,13 +34470,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/mine/laborcamp)
-"jla" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "jlb" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 8;
@@ -34693,12 +34548,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/security/office)
-"jlE" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/station/medical/office)
 "jlI" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/light/directional/west,
@@ -36171,11 +36020,27 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/pharmacy)
+"jGo" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "jGD" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/freezer,
 /area/station/common/locker_room_shower)
+"jGE" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/station/medical/office)
 "jGH" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/moisture_trap,
@@ -36263,6 +36128,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
 /area/station/security/detectives_office)
+"jHZ" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/medbay/central)
 "jIk" = (
 /obj/effect/turf_decal/tile/dark_green/opposingcorners,
 /obj/structure/disposalpipe/segment,
@@ -36337,13 +36211,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/medical/virology)
-"jJg" = (
-/obj/machinery/camera/autoname/directional/north,
-/obj/effect/turf_decal/trimline/dark_red/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/white/side,
-/area/station/medical/aslyum)
 "jJm" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -36735,6 +36602,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/floor2)
+"jNw" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "jNz" = (
 /turf/open/floor/wood/large,
 /area/station/security/courtroom)
@@ -37623,6 +37495,15 @@
 	dir = 1
 	},
 /area/station/engineering/transit_tube)
+"kao" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "kap" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38244,6 +38125,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/commons/storage/art)
+"kiq" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/closet/secure_closet/medical1,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "kit" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners{
@@ -39402,7 +39294,7 @@
 /turf/open/floor/iron/white/smooth_half{
 	dir = 8
 	},
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "kxi" = (
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/dark/smooth_half,
@@ -39654,11 +39546,13 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
-/obj/structure/sign/departments/chemistry/directional/east,
-/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/blue/warning{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/east{
+	network = list("ss13","medbay")
+	},
+/obj/structure/sign/departments/chemistry/directional/east,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
@@ -40430,12 +40324,12 @@
 /area/station/security/warden)
 "kKl" = (
 /obj/item/kirbyplants/random,
+/obj/structure/sign/poster/official/help_others/directional/north,
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 1
 	},
-/obj/structure/sign/departments/exam_room/directional/north,
 /turf/open/floor/iron/white/smooth_corner,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "kKt" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/flora/bush/flowers_br/style_3,
@@ -40755,6 +40649,15 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"kOl" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "kOr" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 9
@@ -41244,11 +41147,15 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = -1;
-	pixel_y = 7
-	},
 /obj/structure/table/reinforced/rglass,
+/obj/item/reagent_containers/chem_pack{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/clipboard{
+	pixel_x = -2;
+	pixel_y = 2
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
 "kVC" = (
@@ -41865,6 +41772,14 @@
 	dir = 1
 	},
 /area/station/maintenance/abandon_cafeteria/hydro)
+"lfH" = (
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 10
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 4
+	},
+/area/station/medical/aslyum)
 "lfT" = (
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/camera/autoname/directional/north,
@@ -41970,16 +41885,6 @@
 	dir = 1
 	},
 /area/station/medical/chemistry)
-"lgN" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/north,
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
 "lgQ" = (
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
@@ -42072,15 +41977,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron/large,
 /area/station/engineering/atmos)
-"lib" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/light/directional/west,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/carpet/blue,
-/area/station/medical/office)
 "lie" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -42206,12 +42102,6 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
-"ljH" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/carpet/blue,
-/area/station/medical/office)
 "ljK" = (
 /obj/machinery/recharger{
 	pixel_y = 4
@@ -42279,8 +42169,14 @@
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms)
 "lkv" = (
-/turf/closed/wall,
-/area/station/medical/patients_rooms/room_a)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "lkx" = (
 /obj/effect/turf_decal/trimline/yellow/line,
 /obj/machinery/firealarm/directional/south,
@@ -42654,6 +42550,20 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"lqB" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "lqM" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -42759,6 +42669,14 @@
 	dir = 4
 	},
 /area/station/service/hydroponics)
+"lrU" = (
+/obj/effect/turf_decal/tile/blue/half,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/treatment_center)
 "lrV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -43052,7 +42970,8 @@
 /area/station/maintenance/abandon_cafeteria)
 "lwa" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/closed/wall,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/plating,
 /area/station/medical/chemistry)
 "lwn" = (
 /obj/machinery/shower/directional/east,
@@ -43607,10 +43526,6 @@
 	dir = 1
 	},
 /area/station/command/gateway)
-"lDU" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "lEd" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 1
@@ -46015,6 +45930,7 @@
 /obj/item/bedsheet/medical{
 	dir = 1
 	},
+/obj/structure/curtain,
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/medical/patients_rooms/room_a)
 "mnZ" = (
@@ -46600,11 +46516,6 @@
 	dir = 1
 	},
 /area/station/service/bar)
-"mwZ" = (
-/obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/status_display/ai/directional/south,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/treatment_center)
 "mxc" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -46953,15 +46864,6 @@
 	dir = 8
 	},
 /area/station/security/prison)
-"mBO" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/treatment_center)
 "mBP" = (
 /obj/structure/curtain/cloth/fancy/mechanical{
 	name = "curtain";
@@ -48482,6 +48384,15 @@
 	},
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/security/prison/work)
+"mYm" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/light/directional/west,
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "mYu" = (
 /obj/structure/cable,
 /obj/machinery/light_switch/directional/west,
@@ -48579,8 +48490,8 @@
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/starboard)
 "mZZ" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/machinery/camera/autoname/directional/east,
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/carpet/blue,
 /area/station/medical/office)
 "nah" = (
@@ -48706,13 +48617,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/open/floor/wood,
 /area/station/maintenance/fore/greater)
-"nck" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/break_room)
 "ncF" = (
 /obj/structure/chair/pew/left{
 	dir = 1
@@ -49234,6 +49138,15 @@
 /obj/machinery/computer/crew,
 /turf/open/floor/carpet/blue,
 /area/station/medical/office)
+"nlG" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/medbay/central)
 "nlO" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
@@ -49311,12 +49224,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/starboard)
-"nmY" = (
-/obj/effect/turf_decal/trimline/dark_red/warning,
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/station/medical/aslyum)
 "nna" = (
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance_storage,
 /obj/structure/disposalpipe/segment{
@@ -49655,6 +49562,7 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/storage)
 "nqU" = (
@@ -49746,6 +49654,28 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/abandon_cafeteria)
+"nrM" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/structure/rack/shelf,
+/obj/structure/bed/medical/emergency{
+	dir = 4
+	},
+/obj/structure/bed/medical/emergency{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 5
+	},
+/obj/structure/bed/medical/emergency{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 10
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "nrP" = (
 /obj/structure/cable,
 /obj/machinery/status_display/evac/directional/north,
@@ -50543,17 +50473,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/aft)
-"nCi" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/closet/secure_closet/medical1,
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
 "nCl" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -50664,15 +50583,6 @@
 /obj/effect/spawner/random/structure/chair_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/law)
-"nDh" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/medbay/central)
 "nDl" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/dark,
@@ -51708,7 +51618,7 @@
 /turf/open/floor/iron/white/smooth_half{
 	dir = 8
 	},
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "nPY" = (
 /obj/structure/cable,
 /obj/machinery/light_switch/directional/south,
@@ -52584,7 +52494,7 @@
 /area/icemoon/underground/explored/graveyard)
 "obD" = (
 /obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/treatment_center)
 "obL" = (
@@ -52918,16 +52828,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
-"ogQ" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "ogS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -52940,7 +52840,11 @@
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "ohb" = (
 /obj/effect/turf_decal/tile/blue/anticorner,
-/obj/machinery/camera/autoname/directional/east,
+/obj/item/storage/box/rxglasses{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/structure/table,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 1
 	},
@@ -53413,15 +53317,14 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmospherics_engine)
 "omc" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light/floor,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id = "Barshutters"
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/station/service/bar)
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "omj" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
@@ -53733,7 +53636,7 @@
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "osb" = (
 /obj/structure/closet/emcloset,
 /obj/item/flashlight,
@@ -54325,11 +54228,11 @@
 /area/station/hallway/primary)
 "oBf" = (
 /obj/structure/cable,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "oBi" = (
@@ -54809,6 +54712,7 @@
 /obj/effect/turf_decal/tile/blue/full,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/storage)
 "oIe" = (
@@ -54956,7 +54860,9 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/cryo)
 "oKq" = (
@@ -55541,17 +55447,10 @@
 	},
 /area/station/science/robotics/lab)
 "oRV" = (
-/obj/structure/table/wood,
-/obj/item/folder/white{
-	pixel_x = -2;
-	pixel_y = 0
-	},
-/obj/item/paper_bin{
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/turf/open/floor/carpet/blue,
-/area/station/medical/office)
+/obj/effect/turf_decal/tile/blue/half,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/medbay/central)
 "oRX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/newscaster/directional/south,
@@ -57043,6 +56942,18 @@
 	},
 /turf/open/floor/iron/corner,
 /area/station/tcommsat/computer)
+"plK" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "plL" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/yellow/line,
@@ -57073,18 +56984,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/aft)
-"plT" = (
-/obj/structure/rack/shelf,
-/obj/item/storage/box/syringes{
-	pixel_x = 0;
-	pixel_y = -4
-	},
-/obj/item/storage/box/syringes{
-	pixel_x = 0;
-	pixel_y = 3
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "plV" = (
 /obj/structure/railing/wooden_fence,
 /turf/open/misc/hay/icemoon,
@@ -58537,6 +58436,15 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
+"pJU" = (
+/obj/structure/table,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 6
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/medical/aslyum)
 "pKd" = (
 /obj/structure/weightmachine,
 /turf/open/floor/iron/checker,
@@ -59145,7 +59053,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/white,
 /area/station/medical/aslyum)
 "pTg" = (
@@ -59314,6 +59221,13 @@
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"pWg" = (
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white/side,
+/area/station/medical/aslyum)
 "pWh" = (
 /obj/effect/turf_decal/tile/dark_green/opposingcorners,
 /obj/effect/landmark/start/virologist,
@@ -59614,7 +59528,7 @@
 /area/station/maintenance/department/security/brig)
 "qan" = (
 /obj/machinery/door/airlock/medical/glass{
-	name = "Patient Room A"
+	name = "Patient Room B"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60523,11 +60437,10 @@
 "qoy" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Office"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/wood/tile,
 /area/station/medical/office)
 "qoB" = (
@@ -60792,15 +60705,6 @@
 	dir = 6
 	},
 /area/station/service/chapel)
-"qrQ" = (
-/obj/effect/turf_decal/trimline/dark_red/warning{
-	dir = 9
-	},
-/obj/structure/bed{
-	dir = 1
-	},
-/turf/open/floor/iron/white/corner,
-/area/station/medical/aslyum)
 "qrR" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -60852,22 +60756,6 @@
 "qsH" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/science/central)
-"qsJ" = (
-/obj/effect/turf_decal/trimline/blue/warning{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/item/reagent_containers/chem_pack{
-	pixel_x = 3;
-	pixel_y = 7
-	},
-/obj/item/stack/medical/bone_gel{
-	pixel_x = -6;
-	pixel_y = 0
-	},
-/obj/structure/table/reinforced/rglass,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
 "qsK" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -60951,9 +60839,6 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/orderly,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -61041,6 +60926,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/secondary/recreation)
+"quI" = (
+/obj/machinery/status_display/ai/directional/north,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white/side,
+/area/station/medical/aslyum)
 "quL" = (
 /obj/structure/closet/secure_closet/security/cargo,
 /obj/structure/cable,
@@ -61339,21 +61231,17 @@
 	},
 /obj/structure/table,
 /obj/item/stack/medical/mesh{
-	pixel_x = -4;
+	pixel_x = -3;
 	pixel_y = 6
 	},
 /obj/item/stack/medical/suture{
-	pixel_x = 6;
-	pixel_y = 0
-	},
-/obj/item/reagent_containers/hypospray/medipen{
-	pixel_x = -3;
-	pixel_y = -4
+	pixel_x = 5;
+	pixel_y = 1
 	},
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 4
 	},
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "qzx" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -62184,6 +62072,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"qKN" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 9
+	},
+/turf/open/floor/iron/white/corner,
+/area/station/medical/aslyum)
 "qKZ" = (
 /obj/effect/spawner/random/structure/tank_holder,
 /turf/open/floor/iron/white/smooth_edge{
@@ -63646,7 +63543,8 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
-/obj/machinery/light_switch/directional/west,
+/obj/item/radio/intercom/directional/west,
+/obj/structure/curtain,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -63844,6 +63742,12 @@
 /obj/item/storage/box/fountainpens,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"rkd" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/turf/open/floor/plating,
+/area/station/medical/break_room)
 "rke" = (
 /obj/effect/landmark/start/security_officer,
 /obj/structure/chair/office/light{
@@ -64291,12 +64195,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
-"rrF" = (
-/obj/effect/turf_decal/siding/wood/end{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/medical/office)
 "rrG" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -64531,6 +64429,12 @@
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/rec)
+"rwh" = (
+/obj/effect/turf_decal/trimline/dark_red/warning,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/station/medical/aslyum)
 "rwq" = (
 /obj/effect/spawner/random/trash/graffiti,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -64676,12 +64580,12 @@
 "ryh" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
-	pixel_y = 11;
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/hypospray/medipen{
 	pixel_x = -5;
-	pixel_y = -3
+	pixel_y = 10
+	},
+/obj/machinery/computer/records/medical/laptop{
+	pixel_x = 11;
+	pixel_y = 2
 	},
 /turf/open/floor/carpet/blue,
 /area/station/medical/office)
@@ -65537,8 +65441,8 @@
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
 	frequency = 1449;
-	id_tag = "virology_airlock_interior2"s";
-	name = "Public Virology Interior Airlock"
+	id_tag = "virology_airlock_interior";
+	name = "Virology Interior Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /obj/machinery/door/firedoor,
@@ -65546,13 +65450,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door_buttons/access_button{
-	dir = 1;
-	idDoor = "virology_airlock_interior2";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
+	pixel_x = 0;
 	pixel_y = -21;
+	idSelf = "viro_public_control";
 	req_access = list("virology");
-	pixel_x = -5
+	idDoor = "virology_airlock_interior"
 	},
 /turf/open/floor/iron/white/smooth_half{
 	dir = 8
@@ -65730,18 +65632,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/secondary/recreation)
-"rOW" = (
-/obj/structure/table/wood,
-/obj/item/folder/white{
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/obj/item/storage/pill_bottle/iron{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/turf/open/floor/carpet/blue,
-/area/station/medical/office)
 "rPg" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -66093,14 +65983,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"rSI" = (
-/obj/effect/turf_decal/trimline/blue/warning,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/chemistry)
 "rSL" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -66955,6 +66837,22 @@
 	dir = 4
 	},
 /area/station/hallway/primary/aftporthall)
+"sbI" = (
+/obj/structure/rack/shelf,
+/obj/item/storage/box/masks{
+	pixel_x = -6;
+	pixel_y = -5
+	},
+/obj/item/storage/box/syringes{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/cup/bottle/epinephrine{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "sbP" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
@@ -67023,6 +66921,13 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/security/medical)
+"scQ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/medical/office)
 "scS" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
@@ -67420,12 +67325,6 @@
 	},
 /turf/open/floor/cult,
 /area/station/maintenance/condemnedroom)
-"sis" = (
-/obj/effect/turf_decal/tile/blue/half,
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/treatment_center)
 "six" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -67635,7 +67534,6 @@
 /area/station/maintenance/fore)
 "slq" = (
 /obj/effect/turf_decal/tile/dark_green,
-/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -68219,8 +68117,8 @@
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
 	frequency = 1449;
-	id_tag = "virology_airlock_exterior2";
-	name = "Public Virology Exterior Airlock"
+	id_tag = "virology_airlock_exterior";
+	name = "Virology Exterior Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /obj/machinery/door/firedoor,
@@ -68228,13 +68126,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door_buttons/access_button{
-	dir = 1;
-	idDoor = "virology_airlock_exterior2";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_y = -22;
+	pixel_x = 0;
+	pixel_y = -21;
+	idSelf = "viro_public_control";
 	req_access = list("virology");
-	pixel_x = 0
+	idDoor = "virology_airlock_exterior"
 	},
 /turf/open/floor/iron/white/smooth_half{
 	dir = 8
@@ -68408,6 +68304,11 @@
 	dir = 1
 	},
 /area/station/cargo/storage)
+"svb" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/full,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "svg" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
@@ -69017,6 +68918,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/floor2)
+"sCv" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/treatment_center)
 "sCB" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/wood/parquet,
@@ -69304,6 +69214,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"sGO" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/east,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/camera/autoname/directional/east,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/medbay/central)
 "sGQ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -69496,7 +69417,6 @@
 	pixel_x = 7;
 	pixel_y = -5
 	},
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -69596,7 +69516,6 @@
 /obj/effect/turf_decal/tile/blue/half,
 /obj/machinery/iv_drip,
 /obj/structure/cable,
-/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/patients_rooms/room_a)
 "sJR" = (
@@ -70380,6 +70299,10 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron,
 /area/station/maintenance/dorm_room)
+"sWq" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "sWv" = (
 /obj/structure/table,
 /obj/item/folder/yellow{
@@ -72184,15 +72107,6 @@
 	},
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/primary/forestarboardhall)
-"tvT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/turf/open/floor/wood,
-/area/station/medical/office)
 "tvW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -72390,6 +72304,15 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood/tile,
 /area/station/service/theater)
+"tzt" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "tzD" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -72438,6 +72361,7 @@
 /obj/item/bedsheet/medical{
 	dir = 1
 	},
+/obj/structure/curtain,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 4
 	},
@@ -72521,6 +72445,15 @@
 	dir = 4
 	},
 /area/station/engineering/transit_tube)
+"tAW" = (
+/obj/effect/turf_decal/tile/blue/half,
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/medbay/central)
 "tBr" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -72880,7 +72813,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/structure/sign/departments/exam_room/directional/east,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 1
 	},
@@ -73134,11 +73066,11 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Employee Entrance"
+	},
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 1
-	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Patient Exit"
 	},
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/medical/treatment_center)
@@ -73782,6 +73714,13 @@
 /obj/effect/turf_decal/tile/dark_green/diagonal_edge,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"tPI" = (
+/obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white/side,
+/area/station/medical/aslyum)
 "tPW" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
@@ -73935,6 +73874,14 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/ordnance_maint)
+"tRW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/full,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "tRY" = (
 /turf/closed/wall,
 /area/station/maintenance/abandon_exam)
@@ -74267,15 +74214,6 @@
 	dir = 5
 	},
 /area/station/cargo/miningfoundry)
-"tWW" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/medbay/central)
 "tXf" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/flora/bush/fullgrass,
@@ -74516,6 +74454,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/morgue)
+"uaB" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/white/side{
+	dir = 8
+	},
+/area/station/medical/aslyum)
 "uaH" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -75098,6 +75045,12 @@
 	dir = 4
 	},
 /area/station/hallway/primary/forestarboardhall)
+"uim" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/medical/office)
 "uiq" = (
 /obj/machinery/light/directional/north,
 /obj/structure/closet/emcloset,
@@ -75727,7 +75680,6 @@
 	},
 /area/station/engineering/atmos/project)
 "usB" = (
-/obj/structure/cable,
 /obj/machinery/rnd/production/techfab/department/medical,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/smooth_large,
@@ -75989,16 +75941,21 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "uwM" = (
-/obj/effect/turf_decal/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/warning{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/table/reinforced/rglass,
+/obj/item/stack/medical/bone_gel{
+	pixel_x = 4;
+	pixel_y = 13
 	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
+/obj/item/clothing/neck/stethoscope{
+	pixel_x = -5;
+	pixel_y = 4
 	},
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/treatment_center)
 "uwN" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -76455,6 +76412,15 @@
 	dir = 4
 	},
 /area/station/science/explab)
+"uDt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/station/medical/office)
 "uDv" = (
 /obj/structure/table/wood,
 /obj/item/toy/foamfinger{
@@ -76560,6 +76526,15 @@
 	dir = 1
 	},
 /area/station/command/bridge)
+"uFo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "uFp" = (
 /turf/open/floor/wood/tile,
 /area/station/service/lawoffice)
@@ -77146,6 +77121,28 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/service)
+"uNq" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/structure/rack/shelf,
+/obj/machinery/light/directional/north,
+/obj/item/storage/box/gloves{
+	pixel_x = -6;
+	pixel_y = -4
+	},
+/obj/item/storage/box/bodybags{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/cup/bottle/multiver{
+	pixel_x = 7;
+	pixel_y = -1
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "uNs" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -78031,6 +78028,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/edge,
 /area/station/ai_monitored/command/storage/eva)
+"vac" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/status_display/ai/directional/north,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "vae" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -78700,6 +78703,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_cafeteria/hydro)
+"viN" = (
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "viY" = (
 /obj/machinery/vending/wardrobe/det_wardrobe,
 /obj/item/radio/intercom/directional/south,
@@ -78748,14 +78755,6 @@
 	},
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/fore)
-"vjA" = (
-/obj/effect/turf_decal/trimline/blue/warning,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/status_display/ai/directional/south,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/chemistry)
 "vjF" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -78787,6 +78786,28 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/cargo/miningoffice)
+"vjW" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -8;
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_x = 8;
+	pixel_y = 10
+	},
+/obj/item/stack/medical/gauze/twelve{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "vjY" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -78849,15 +78870,6 @@
 	},
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary)
-"vlF" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "vlO" = (
 /obj/structure/cable,
 /obj/structure/chair/comfy{
@@ -79170,13 +79182,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
-"voS" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/carpet/blue,
-/area/station/medical/office)
 "voV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -79253,10 +79258,10 @@
 /area/station/service/library/private)
 "vpy" = (
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Office"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/wood/tile,
 /area/station/medical/office)
 "vpz" = (
@@ -79572,15 +79577,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp/security)
-"vui" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "vut" = (
 /turf/open/floor/iron/stairs/left,
 /area/station/hallway/primary)
@@ -79597,7 +79593,6 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/machinery/camera/autoname/directional/south,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 4
@@ -79749,13 +79744,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/port)
-"vxj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "vxk" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/structure/disposalpipe/segment{
@@ -79862,6 +79850,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/miningoffice)
+"vyn" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/medbay/central)
 "vyv" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron,
@@ -80009,6 +80006,16 @@
 	},
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"vAM" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/medbay/central)
 "vAP" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron/dark,
@@ -80505,6 +80512,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/large,
 /area/station/engineering/lobby)
+"vHv" = (
+/obj/effect/turf_decal/trimline/blue/warning,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/chemistry)
 "vHD" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/entertainment/musical_instrument{
@@ -80613,12 +80628,14 @@
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms/room7)
 "vIG" = (
-/obj/effect/turf_decal/trimline/dark_red/warning{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/folder/white,
+/obj/item/reagent_containers/dropper{
+	pixel_x = -10;
+	pixel_y = 11
 	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/white/side,
-/area/station/medical/aslyum)
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "vIO" = (
 /turf/closed/wall/r_wall,
 /area/station/security/office)
@@ -80761,6 +80778,15 @@
 /obj/effect/spawner/random/trash/graffiti,
 /turf/closed/wall,
 /area/station/common/night_club)
+"vJQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "vJY" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -80938,15 +80964,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
-"vMg" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "vMu" = (
 /turf/open/openspace/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
@@ -81132,7 +81149,7 @@
 	},
 /obj/structure/table/glass,
 /obj/effect/spawner/random/medical/medkit,
-/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 8
 	},
@@ -82675,26 +82692,6 @@
 	dir = 1
 	},
 /area/station/service/hydroponics)
-"wlb" = (
-/obj/structure/table,
-/obj/item/storage/box/masks{
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/cup/bottle/epinephrine{
-	pixel_x = 7;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/cup/bottle/multiver{
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/syringe{
-	pixel_x = 2;
-	pixel_y = -3
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "wle" = (
 /obj/machinery/computer/monitor{
 	name = "Bridge Power Monitoring Console"
@@ -83443,6 +83440,12 @@
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/carpet/green,
 /area/station/command/heads_quarters/nt_rep)
+"wwq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/storage)
 "wwr" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/box/red/corners{
@@ -83644,11 +83647,6 @@
 	dir = 4
 	},
 /area/station/service/hydroponics/garden)
-"wym" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
-/turf/open/floor/plating,
-/area/station/medical/break_room)
 "wyn" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -83700,7 +83698,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "wza" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/full,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -84353,24 +84350,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white/small,
 /area/station/common/pool)
-"wGV" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -4;
-	pixel_y = 14
-	},
-/obj/item/clothing/glasses/hud/health{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/item/clothing/glasses/hud/health,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "wHa" = (
 /turf/open/floor/iron/edge{
 	dir = 4
@@ -84512,6 +84491,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/newsroom)
+"wJC" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/medical/office)
 "wJF" = (
 /obj/structure/rack/shelf,
 /obj/item/clothing/suit/hooded/wintercoat/eva{
@@ -84953,7 +84938,7 @@
 /area/station/hallway/primary/foreporthall)
 "wOX" = (
 /obj/effect/turf_decal/siding/wood/end{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/station/medical/office)
@@ -85011,15 +84996,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
-"wPm" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/trimline/dark_red/warning{
-	dir = 4
-	},
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
-/area/station/medical/aslyum)
 "wPq" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/door/window/right/directional/south{
@@ -85201,15 +85177,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/science/robotics/lab)
-"wRV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "wRX" = (
 /obj/structure/table,
 /obj/item/poster/random_official{
@@ -86201,7 +86168,6 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 1
 	},
@@ -86983,6 +86949,7 @@
 	pixel_x = 6;
 	pixel_y = 9
 	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 8
 	},
@@ -88330,6 +88297,7 @@
 /obj/effect/turf_decal/trimline/blue/warning{
 	dir = 8
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -88393,6 +88361,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "xHu" = (
@@ -88480,11 +88449,8 @@
 /obj/effect/turf_decal/tile/dark_green/half{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/effect/mapping_helpers/requests_console/supplies,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/requests_console/auto_name/directional/west,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -89349,11 +89315,6 @@
 	dir = 1
 	},
 /area/station/medical/chemistry)
-"xUl" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/carpet/blue,
-/area/station/medical/office)
 "xUz" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
@@ -89452,6 +89413,18 @@
 	dir = 1
 	},
 /area/station/service/hydroponics)
+"xVQ" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/chemistry)
 "xVZ" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/abandon_cafeteria/hydro)
@@ -89461,13 +89434,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door_buttons/airlock_controller{
-	idExterior = "virology_airlock_exterior2";
-	idInterior = "virology_airlock_interior2";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Console";
-	pixel_x = -23;
+	pixel_x = -25;
+	pixel_y = 24;
+	idSelf = "viro_public_control";
+	idInterior = "virology_airlock_interior";
+	idExterior = "virology_airlock_exterior";
 	req_access = list("virology");
-	pixel_y = -22
+	name = "Virology Public Access Console"
 	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
@@ -89844,24 +89817,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
-"yaY" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/structure/rack/shelf,
-/obj/structure/bed/medical/emergency,
-/obj/structure/bed/medical/emergency{
-	pixel_x = 0;
-	pixel_y = 4
-	},
-/obj/structure/bed/medical/emergency{
-	pixel_x = 0;
-	pixel_y = 9
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
 "ybh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -90089,6 +90044,15 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/station/service/theater)
+"ydZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "yed" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 8
@@ -90105,26 +90069,14 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/auxiliary)
 "yep" = (
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_interior";
-	name = "Virology Interior Airlock"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door_buttons/access_button{
-	dir = 1;
-	idDoor = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_y = 7;
-	req_access = list("virology");
-	pixel_x = 24
-	},
+/obj/machinery/door/airlock/virology,
 /turf/open/floor/iron/white/smooth_half,
 /area/station/medical/virology)
 "yeq" = (
@@ -90149,19 +90101,6 @@
 	dir = 4
 	},
 /area/station/security/prison)
-"yeC" = (
-/obj/effect/turf_decal/trimline/dark_red/warning{
-	dir = 6
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/pill_bottle/psicodine{
-	pixel_x = -4;
-	pixel_y = 7
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/station/medical/aslyum)
 "yeR" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/blueshield)
@@ -184378,7 +184317,7 @@ wRH
 eUA
 eUA
 eUA
-eUA
+bNS
 eUA
 eUA
 upM
@@ -191295,7 +191234,7 @@ bmo
 bmo
 bmo
 bmo
-bmo
+foO
 bmo
 hFa
 lnZ
@@ -200511,7 +200450,7 @@ vUe
 win
 uXb
 pdp
-naP
+bMn
 lGE
 ldV
 xcB
@@ -203651,7 +203590,7 @@ ozU
 lRo
 pKi
 pKi
-pKi
+dSa
 bBY
 uEF
 aqq
@@ -206202,7 +206141,7 @@ uXn
 vss
 cMe
 cMe
-cMe
+sWq
 iqv
 aVA
 kur
@@ -253538,9 +253477,9 @@ kuu
 cDJ
 uTc
 mFr
-tSl
-usK
-bvd
+tRW
+bFI
+svb
 pGR
 iyb
 eoO
@@ -255541,7 +255480,7 @@ vYJ
 jGK
 qHr
 mfL
-omc
+fqg
 icj
 nmp
 rwv
@@ -263490,7 +263429,7 @@ ere
 nPO
 kxd
 orY
-hDc
+weS
 lQx
 czw
 xaA
@@ -263744,20 +263683,20 @@ hlZ
 nhH
 lyF
 kKl
-qpU
-qpU
+nLr
+nLr
 qzu
-hDc
+weS
 wFk
 mQv
-yaY
+nrM
 ycV
-sis
+bwY
 ePv
 tIi
 iAV
 ePv
-lkv
+hpZ
 hpZ
 hpZ
 hpZ
@@ -263994,17 +263933,17 @@ lta
 xit
 okM
 xGM
-bCD
+mxx
 mxx
 mxx
 ohW
 mvc
 cTi
-anO
+hmg
 aRV
 aRV
 mAh
-mBO
+sCv
 qpU
 qpU
 qgq
@@ -264012,7 +263951,7 @@ ycV
 obD
 hDc
 sAq
-cOl
+lrU
 hDc
 mnT
 rhc
@@ -264268,9 +264207,9 @@ ycV
 ycV
 mxg
 hDc
-bMn
+plK
 pIZ
-qan
+hCt
 nVz
 upZ
 sJQ
@@ -264769,9 +264708,9 @@ cJm
 dVD
 oya
 dVD
-rSI
+aaZ
 cTi
-lgN
+kOl
 akw
 bGX
 ala
@@ -265026,22 +264965,22 @@ lta
 uwY
 lta
 oya
-fjk
+aaZ
 cTi
-nCi
+kiq
 npG
-kVz
+uwM
 ygF
 gZF
 pzG
-qsJ
+kVz
 iJa
 lDn
 mGx
 fsa
 qlB
 hGQ
-iPi
+qan
 rPm
 sLD
 vuS
@@ -265283,18 +265222,18 @@ uwY
 lta
 uwY
 dVD
-vjA
+vHv
 cTi
-hxV
-plT
-wlb
+uNq
+sbI
+viN
 aRV
 saK
 kJu
 qca
 xOS
 lDn
-bwY
+hol
 hDc
 iaZ
 ohb
@@ -265540,7 +265479,7 @@ lta
 uwY
 lta
 oya
-aaZ
+iOk
 cTi
 eZJ
 qjP
@@ -265551,7 +265490,7 @@ oKp
 iCQ
 vQr
 lDn
-mwZ
+aCx
 abi
 abi
 abi
@@ -265806,8 +265745,8 @@ qjP
 pKu
 myb
 iCQ
-ogQ
-fIx
+cHm
+lkv
 bwA
 abi
 slB
@@ -266044,14 +265983,14 @@ vwH
 kLB
 spm
 pxC
-egl
+xVQ
 kAk
 oCK
 bOv
 pxC
 iXK
 spm
-bOv
+spm
 hjy
 spm
 wyn
@@ -266063,8 +266002,8 @@ lyb
 qVd
 xfa
 iCQ
-wGV
-cNg
+eTM
+uFo
 bwA
 qNq
 fhK
@@ -266315,13 +266254,13 @@ cTi
 cTi
 nuP
 vmu
-dGP
+vpy
 vmu
 nuP
 nuP
 nuP
-dUD
-cNg
+vjW
+lkv
 aTe
 dnR
 xxq
@@ -266570,15 +266509,15 @@ szn
 hNV
 nuP
 gXm
-lib
+mYm
 lyV
-rrF
+wOX
 bvN
 aYX
-ljH
+mZZ
 nuP
-cQG
-cNg
+lqB
+lkv
 bwA
 qNq
 hCC
@@ -266822,20 +266761,20 @@ lpH
 lpH
 uXb
 uXb
-vMg
+jGo
 mXj
 bwA
 vmu
 hjO
-oRV
+gNz
 hZe
-hjZ
-rOW
+cdx
+vIG
 lyV
 bAu
 vmu
-ldD
-cNg
+tzt
+lkv
 bwA
 cQk
 moL
@@ -267073,26 +267012,26 @@ fUa
 aUT
 amw
 lpH
-qrQ
-isy
-aUU
+qKN
+eyq
+lfH
 lpH
 fWZ
-nDh
+nLr
 qxC
 mXj
 ngA
 vpy
 slK
-ajT
-ajT
+scQ
+scQ
 xFc
 oLY
 oLY
-biK
+uDt
 azI
 mXj
-cNg
+lkv
 bwA
 woW
 egP
@@ -267330,26 +267269,26 @@ nHR
 ssM
 rYa
 lpH
-iWK
+pWg
 ykr
-nmY
+rwh
 nNB
-edy
+iAL
 ngA
 oxG
 mXj
 ngA
 vpy
-iDb
-jlE
-jlE
+drp
+wJC
+wJC
 wjK
-jlE
-jlE
-tvT
+wJC
+wJC
+jGE
 qoy
-lDU
-fIx
+ngA
+lkv
 aTe
 uyh
 elN
@@ -267587,7 +267526,7 @@ pBD
 rYa
 rVe
 lpH
-jJg
+quI
 hLC
 biC
 pTd
@@ -267600,13 +267539,13 @@ vmu
 bAu
 lyV
 nlE
-hjZ
+cdx
 ryh
 lyV
-voS
+bAu
 vmu
 ldD
-cNg
+lkv
 bwA
 woW
 wUm
@@ -267844,27 +267783,27 @@ wHN
 ohd
 wHN
 lpH
-vIG
+tPI
 bkw
-nmY
+rwh
 nNB
 ldD
 ngA
 hil
 mXj
-cIi
+bwA
 nuP
-xUl
+vac
 vFO
 lyV
-wOX
+uim
 gNz
 sDv
-mZZ
+jNw
 nuP
-drp
-cNg
-bwA
+ldD
+lkv
+tAW
 tpX
 udA
 hcA
@@ -268103,13 +268042,13 @@ rYa
 lpH
 psk
 ezN
-nmY
+rwh
 lpH
-cpo
-gOt
+cdR
+sGO
 huv
-wRV
-bwA
+vJQ
+aeu
 nuP
 nuP
 nuP
@@ -268119,8 +268058,8 @@ vmu
 nuP
 nuP
 nuP
-ata
-cNg
+omc
+lkv
 ijA
 vJH
 vJH
@@ -268358,26 +268297,26 @@ ojn
 rYa
 rYa
 lpH
-hCw
-wPm
-yeC
+daP
+uaB
+pJU
 lpH
 weS
 weS
-drp
-iXT
+ldD
+hJi
 pWo
-dmJ
+hlE
 hbh
-ajL
+vyn
 nLr
 ngA
 nLr
-tWW
-hdQ
+vAM
+nlG
 nLr
 qxC
-cNg
+lkv
 bwA
 pIY
 rRJ
@@ -268622,19 +268561,19 @@ lpH
 kHD
 tHv
 ldD
-vui
-jla
-jla
-jla
-jla
-jla
-eFA
-vxj
-vxj
-vxj
-eFA
-vxj
-gjv
+kao
+dxn
+dxn
+dxn
+dxn
+dxn
+guy
+eCA
+eCA
+eCA
+eCA
+eCA
+ydZ
 bwA
 hqv
 ylM
@@ -268882,14 +268821,14 @@ ava
 aSp
 cSu
 aSp
-csZ
-aSp
+jHZ
+iGZ
 uVZ
-cNg
+lkv
 qvo
 gSO
 aSp
-uwM
+aSp
 aSp
 tBy
 fGp
@@ -269141,12 +269080,12 @@ mSU
 xqS
 xqS
 xqS
-vlF
+ldD
 ccH
 wfu
 caz
 wWB
-nck
+tUX
 tUX
 mKJ
 wWB
@@ -269400,8 +269339,8 @@ fTq
 xqS
 qcN
 oBf
-bwA
-lky
+oRV
+hdQ
 jgG
 qtG
 cEv
@@ -270680,7 +270619,7 @@ bvC
 cQV
 nDp
 wza
-aCd
+wwq
 fPl
 oVi
 gcB
@@ -270691,7 +270630,7 @@ tyN
 syS
 syS
 syS
-wym
+rkd
 syS
 syS
 syS

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -81,31 +81,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_wrestle)
 "aaZ" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/warning,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
 	},
-/obj/machinery/firealarm/directional/east,
-/obj/machinery/cell_charger{
-	pixel_y = 5
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/chemistry)
 "abd" = (
 /turf/closed/wall,
 /area/station/common/arcade)
 "abi" = (
-/obj/structure/curtain/cloth/fancy/mechanical{
-	icon_state = "bounty-open";
-	icon_type = "bounty";
-	id = "SurgeryAcurtains";
-	name = "curtain"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/medical/patients_rooms/room_a)
+/turf/closed/wall,
+/area/station/medical/surgery)
 "abl" = (
 /obj/machinery/turretid{
 	pixel_x = 28;
@@ -118,14 +105,6 @@
 	dir = 4
 	},
 /area/station/ai_monitored/turret_protected/aisat/foyer)
-"abC" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
 "abO" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -578,12 +557,6 @@
 	dir = 1
 	},
 /area/station/engineering/atmos)
-"agI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
 "agU" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -849,10 +822,10 @@
 	},
 /area/station/hallway/floor2)
 "akw" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/smooth_half{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 1
 	},
+/turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
 "aky" = (
 /obj/effect/turf_decal/siding/dark{
@@ -878,11 +851,8 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "ala" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/turf/open/floor/iron/white/smooth_half{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/warning,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
 "alb" = (
 /obj/machinery/space_heater,
@@ -1290,25 +1260,18 @@
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/primary/aftstarboardhall)
 "apG" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/dark_blue/half{
+/obj/effect/turf_decal/tile/blue/half{
 	dir = 4
 	},
+/obj/machinery/iv_drip,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
-/area/station/medical/paramedic)
+/area/station/medical/patients_rooms/room_b)
 "apP" = (
 /obj/structure/curtain/cloth/fancy/mechanical{
 	icon_state = "bounty-open";
@@ -1348,16 +1311,6 @@
 	dir = 8
 	},
 /area/station/science/xenobiology)
-"aqu" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/paramedic)
 "aqw" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/machinery/vending/hydroseeds,
@@ -1775,21 +1728,14 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmospherics_engine)
 "ava" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 4
 	},
-/obj/item/storage/pill_bottle/mannitol{
-	pixel_y = 10;
-	pixel_x = -5
-	},
-/obj/item/analyzer{
-	pixel_x = 2
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white/smooth_corner{
-	dir = 1
+	dir = 8
 	},
-/area/station/medical/cryo)
+/area/station/medical/medbay/central)
 "avb" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/dark_blue,
@@ -2178,12 +2124,13 @@
 	},
 /area/station/hallway/primary/aftporthall)
 "azI" = (
+/obj/machinery/door/airlock/medical/glass,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/wood/tile,
+/area/station/medical/office)
 "azJ" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
@@ -3191,13 +3138,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison/work)
-"aOx" = (
-/obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/medbay/central)
 "aOD" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -3420,13 +3360,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/abandon_wrestle)
 "aRy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aRA" = (
@@ -3460,12 +3396,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos/lesser)
 "aRV" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/treatment_center)
 "aRY" = (
 /turf/closed/wall/r_wall,
 /area/station/command/meeting_room/council)
@@ -3558,14 +3490,10 @@
 /turf/open/floor/grass,
 /area/station/hallway/primary/fore)
 "aTe" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/blue/half,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/medbay/central)
 "aTf" = (
 /obj/machinery/light/directional/north,
@@ -4033,9 +3961,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/rec)
 "aYX" = (
-/obj/effect/landmark/start/chief_medical_officer,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "aZb" = (
 /turf/closed/wall/r_wall,
 /area/station/science/circuits)
@@ -4612,14 +4543,11 @@
 /turf/closed/wall,
 /area/station/maintenance/abandon_kitchen_upper)
 "biC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/area/station/medical/aslyum)
 "biE" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/green/filled/warning{
@@ -4736,12 +4664,12 @@
 /turf/open/floor/iron/diagonal,
 /area/station/commons/locker)
 "bkw" = (
-/obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/camera/autoname/directional/south{
-	network = list("ss13","medbay")
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/medbay/central)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/aslyum)
 "bkC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5065,7 +4993,7 @@
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/blue/half,
 /turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/patients_rooms/room_a)
+/area/station/medical/surgery)
 "boB" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/trimline/yellow/corner{
@@ -5584,14 +5512,14 @@
 	},
 /area/station/engineering/engine_smes)
 "bvN" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -4;
+	pixel_y = 5
 	},
-/obj/structure/noticeboard/directional/north,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
+/obj/item/folder/white,
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "bvR" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/effect/mapping_helpers/broken_floor,
@@ -5643,10 +5571,9 @@
 /area/station/hallway/floor2)
 "bwY" = (
 /obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/light/directional/south,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/medbay/central)
+/area/station/medical/treatment_center)
 "bxb" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/dark{
@@ -5688,7 +5615,7 @@
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 4
 	},
-/area/station/medical/patients_rooms/room_b)
+/area/station/medical/surgery/theatre)
 "bxW" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/door/window/right/directional/north{
@@ -5860,13 +5787,9 @@
 /turf/open/floor/wood,
 /area/station/service/newsroom)
 "bAu" = (
-/obj/machinery/defibrillator_mount/directional/south,
-/obj/effect/turf_decal/tile/blue/half,
-/obj/structure/bed/medical{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/treatment_center)
+/obj/structure/closet/secure_closet/personal,
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "bAy" = (
 /turf/open/floor/iron,
 /area/station/maintenance/department/engineering/engie_aft_starboard)
@@ -6323,13 +6246,8 @@
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms/room3)
 "bGX" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_half{
-	dir = 8
-	},
+/obj/machinery/stasis,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
 "bHa" = (
 /obj/structure/table,
@@ -7264,13 +7182,10 @@
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners{
 	dir = 1
 	},
-/obj/item/clothing/mask/surgical{
-	pixel_y = 17
-	},
-/obj/item/storage/fancy/donut_box{
-	pixel_y = 6
-	},
 /obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_y = 7
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "bVj" = (
@@ -7387,7 +7302,7 @@
 /obj/effect/turf_decal/tile/blue/half,
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/patients_rooms/room_a)
+/area/station/medical/surgery)
 "bXc" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "Dorm5shutters";
@@ -8194,26 +8109,13 @@
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "cgN" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/obj/item/reagent_containers/dropper{
-	pixel_y = -4
-	},
-/obj/item/reagent_containers/dropper{
-	pixel_y = -2
-	},
-/obj/item/book/manual/wiki/surgery{
-	pixel_y = 4;
-	pixel_x = -15
-	},
-/obj/machinery/recharger{
-	pixel_y = 7
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "cgQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
@@ -9453,7 +9355,7 @@
 /obj/structure/railing,
 /obj/item/radio/intercom/directional/west,
 /turf/open/openspace,
-/area/station/medical/medbay/central)
+/area/station/medical/treatment_center)
 "czH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9497,15 +9399,6 @@
 /obj/machinery/mining_weather_monitor/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"cAx" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/medbay/central)
 "cAA" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -9745,15 +9638,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/newsroom)
-"cEm" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "cEo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9839,14 +9723,6 @@
 "cFd" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/cargo)
-"cFi" = (
-/obj/machinery/cryo_cell,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/box/blue,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/cryo)
 "cFn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -10201,21 +10077,10 @@
 /turf/closed/wall,
 /area/station/maintenance/law)
 "cJm" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/yellow/half,
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
-/obj/machinery/door/airlock/research/glass{
-	name = "Chemistry Lab"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/smooth_half,
+/obj/effect/turf_decal/tile/yellow/full,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chemistry)
 "cJt" = (
 /turf/closed/wall/r_wall,
@@ -11254,7 +11119,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
-/area/station/medical/patients_rooms/room_b)
+/area/station/medical/surgery/theatre)
 "cYj" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -11803,20 +11668,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/condemned_med)
 "dhO" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/dark_blue/half{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/paramedic)
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "dhP" = (
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/carpet,
@@ -12287,7 +12149,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/smooth_half,
-/area/station/medical/patients_rooms/room_a)
+/area/station/medical/surgery)
 "dob" = (
 /obj/structure/cable,
 /obj/item/kirbyplants/random,
@@ -12581,15 +12443,6 @@
 /obj/structure/flora/rock/icy/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"dsy" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "dsD" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable,
@@ -12704,15 +12557,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"dul" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "duo" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -13234,15 +13078,6 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"dBO" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/obj/machinery/digital_clock/directional/west,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/medbay/central)
 "dCb" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -13260,10 +13095,11 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 8
 	},
+/obj/machinery/anesthetic_machine,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
-/area/station/medical/patients_rooms/room_a)
+/area/station/medical/surgery)
 "dCO" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
@@ -14660,10 +14496,10 @@
 	},
 /area/station/engineering/atmos)
 "dVD" = (
-/obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chemistry)
 "dVG" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -15458,7 +15294,7 @@
 	name = "curtain"
 	},
 /turf/open/floor/iron/white/smooth_corner,
-/area/station/medical/patients_rooms/room_b)
+/area/station/medical/surgery/theatre)
 "egT" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -15746,7 +15582,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
-/area/station/medical/patients_rooms/room_b)
+/area/station/medical/surgery/theatre)
 "elS" = (
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
@@ -16177,13 +16013,9 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/mining)
 "ere" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
+/turf/open/floor/plating,
 /area/station/medical/medbay/central)
 "erk" = (
 /obj/structure/rack/wooden,
@@ -16790,19 +16622,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood/tile,
 /area/station/maintenance/abandon_psych)
-"eze" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/structure/sign/poster/official/cleanliness/directional/north,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "ezi" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/disposalpipe/segment{
@@ -16855,10 +16674,9 @@
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/science/robotics)
 "ezN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/area/station/medical/aslyum)
 "ezY" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/tile,
@@ -17887,7 +17705,7 @@
 /area/station/security/prison/shower)
 "ePv" = (
 /turf/closed/wall/r_wall,
-/area/station/medical/paramedic)
+/area/station/medical/treatment_center)
 "ePP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -18560,8 +18378,14 @@
 /turf/closed/wall/r_wall,
 /area/station/commons/storage/mining)
 "eZJ" = (
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/machinery/cryo_cell,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/cryo)
 "eZP" = (
 /obj/structure/railing{
 	dir = 10
@@ -19099,7 +18923,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
-/area/station/medical/patients_rooms/room_a)
+/area/station/medical/surgery)
 "fhO" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes{
@@ -19784,29 +19608,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"fqS" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/structure/rack/shelf,
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/dropper{
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone,
-/turf/open/floor/iron/white/smooth_corner{
-	dir = 1
-	},
-/area/station/medical/cryo)
 "fqU" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 4
@@ -19852,13 +19653,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "fsa" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
-	dir = 1
-	},
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/station/medical/paramedic)
+/obj/structure/hedge,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/grass,
+/area/station/medical/treatment_center)
 "fsb" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -21014,10 +20812,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"fHb" = (
-/obj/machinery/button/polarizer,
-/turf/closed/wall,
-/area/station/medical/treatment_center)
 "fHc" = (
 /obj/item/flashlight/lamp{
 	pixel_x = -4;
@@ -21061,12 +20855,13 @@
 	},
 /area/station/security/medical)
 "fHt" = (
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/smooth_half{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/station/medical/treatment_center)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chemistry)
 "fHC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -21443,13 +21238,22 @@
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/security/office)
 "fMQ" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
 	},
-/obj/structure/chair/sofa/right,
-/turf/open/floor/iron/white,
-/area/station/medical/paramedic)
+/obj/structure/table/glass,
+/obj/item/reagent_containers/medigel/aiuri{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/pill/amollin{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/patients_rooms/room_a)
 "fNe" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -22107,11 +21911,12 @@
 	},
 /area/station/hallway/primary)
 "fWZ" = (
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron/white/smooth_corner{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 1
 	},
-/area/station/medical/cryo)
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white/smooth_corner,
+/area/station/medical/medbay/central)
 "fXm" = (
 /turf/open/floor/plating,
 /area/station/maintenance/condemned_med)
@@ -22360,13 +22165,6 @@
 /obj/effect/spawner/random/structure/shipping_container,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"gaE" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
 "gaF" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -22430,15 +22228,6 @@
 	dir = 6
 	},
 /area/station/security/prison/rec)
-"gbx" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/cryo)
 "gby" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22544,13 +22333,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/eighties/red,
 /area/station/commons/fitness/recreation)
-"gcQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
 "gcT" = (
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/service/theater)
@@ -22834,8 +22616,13 @@
 /turf/open/floor/iron/checker,
 /area/station/commons/lounge)
 "ggF" = (
-/turf/closed/wall/r_wall,
-/area/station/medical/cryo)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "ggO" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -22924,21 +22711,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/ordnance_maint_lesser)
 "ghR" = (
-/obj/effect/turf_decal/tile/dark_blue/half,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/blue/anticorner,
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/recharger{
-	pixel_y = 8;
-	pixel_x = 5
-	},
-/obj/structure/sign/poster/official/help_others/directional/south,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/paramedic)
+/area/station/medical/patients_rooms/room_a)
 "ghX" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/herringbone,
@@ -24178,10 +23958,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/science/robotics/lab)
-"gzJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "gzL" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/effect/turf_decal/siding/yellow{
@@ -24555,17 +24331,13 @@
 /area/station/maintenance/solars/starboard/fore)
 "gDJ" = (
 /obj/effect/turf_decal/tile/blue/half{
-	dir = 4
+	dir = 1
 	},
-/obj/effect/landmark/start/orderly,
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/effect/mapping_helpers/requests_console/supplies,
-/obj/machinery/requests_console/auto_name/directional/east,
 /turf/open/floor/iron/white/smooth_edge{
-	dir = 4
+	dir = 1
 	},
-/area/station/medical/medbay/central)
+/area/station/medical/treatment_center)
 "gDK" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/machinery/status_display/ai/directional/south,
@@ -25271,14 +25043,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary)
 "gNz" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = 4;
+	pixel_y = 6
 	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/treatment_center)
+/obj/item/folder/white,
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "gND" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/edge{
@@ -25965,13 +25737,10 @@
 /turf/open/floor/iron/white/smooth_half,
 /area/station/engineering/main)
 "gXm" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/warning,
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/chemistry)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "gXo" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -26131,19 +25900,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/ordnance_maint_lesser)
 "gZF" = (
-/obj/effect/turf_decal/tile/blue/half{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/item/stack/medical/gauze,
-/obj/structure/towel_bin{
-	pixel_y = 7;
-	pixel_x = -5
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "gZK" = (
 /obj/structure/disposalpipe/segment,
@@ -26243,7 +26003,10 @@
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms/room7)
 "hbh" = (
-/obj/structure/sign/departments/exam_room/directional/west,
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -26333,10 +26096,11 @@
 	dir = 4
 	},
 /obj/machinery/newscaster/directional/east,
+/obj/machinery/anesthetic_machine,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
-/area/station/medical/patients_rooms/room_b)
+/area/station/medical/surgery/theatre)
 "hcH" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/effect/turf_decal/siding/dark{
@@ -26432,8 +26196,8 @@
 /area/station/engineering/atmos/hallway)
 "hdQ" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/window/reinforced/fulltile,
 /obj/structure/hedge,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/medical/break_room)
 "hdR" = (
@@ -26657,13 +26421,11 @@
 	},
 /area/station/engineering/storage/tech)
 "hil" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/structure/chair/sofa/middle,
 /turf/open/floor/iron/white,
-/area/station/medical/paramedic)
+/area/station/medical/medbay/central)
 "hin" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/steam_vent,
@@ -26741,16 +26503,15 @@
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/primary)
 "hjy" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/smooth_edge{
-	dir = 1
+	dir = 4
 	},
-/area/station/medical/medbay/central)
+/area/station/medical/chemistry)
 "hjz" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
@@ -26819,11 +26580,8 @@
 /area/station/engineering/atmos)
 "hjO" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/full,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "hjR" = (
 /obj/structure/table_frame,
 /obj/item/wrench{
@@ -26973,16 +26731,16 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "hlZ" = (
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research/glass{
 	name = "Pharmacy"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
 /turf/open/floor/iron/white/smooth_half{
 	dir = 8
 	},
@@ -27563,10 +27321,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos/lesser)
 "htB" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
+/obj/effect/turf_decal/tile/blue/anticorner,
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 1
+	},
+/area/station/medical/patients_rooms/room_b)
 "htC" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/landmark/start/hangover,
@@ -27620,18 +27381,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/forestarboardhall)
-"hui" = (
-/obj/machinery/defibrillator_mount/directional/north,
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/structure/bed/medical{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
 "hul" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
@@ -27995,20 +27744,6 @@
 /obj/item/clipboard,
 /turf/open/floor/iron/edge,
 /area/station/commons/locker)
-"hAb" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/medbay/central)
 "hAd" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -28230,7 +27965,7 @@
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 8
 	},
-/area/station/medical/patients_rooms/room_a)
+/area/station/medical/surgery)
 "hCJ" = (
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/structure/flora/tree/jungle/small{
@@ -28534,15 +28269,12 @@
 	},
 /area/mine/laborcamp)
 "hGQ" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue/half,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/paramedic)
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/treatment_center)
 "hHb" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -28826,12 +28558,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "hLC" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/area/station/medical/aslyum)
 "hLE" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/sign/poster/random/directional/south,
@@ -28985,14 +28716,13 @@
 /turf/open/floor/iron/dark/textured_edge,
 /area/station/command/heads_quarters/hos)
 "hNV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/navbeacon{
-	location = "PMed1";
-	codes_txt = "patrol;next_patrol=PMed2"
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 4
+	},
 /area/station/medical/medbay/central)
 "hOc" = (
 /turf/open/floor/iron/white/smooth_large,
@@ -29825,11 +29555,11 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "hZe" = (
-/obj/machinery/computer/crew{
-	dir = 1
+/obj/machinery/computer/records/medical{
+	dir = 8
 	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "hZi" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 4
@@ -29978,22 +29708,13 @@
 /turf/open/floor/iron/white/smooth_half,
 /area/station/science/xenobiology)
 "iaZ" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 8
-	},
-/obj/machinery/suit_storage_unit/medical,
-/obj/effect/turf_decal/tile/dark_blue/anticorner{
+/obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/box/blue,
-/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 8
 	},
-/area/station/medical/paramedic)
+/area/station/medical/treatment_center)
 "ibe" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31413,14 +31134,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
-"itD" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white/smooth_half,
-/area/station/medical/cryo)
 "itP" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix,
 /turf/open/floor/engine,
@@ -31449,18 +31162,15 @@
 /turf/open/floor/carpet/black,
 /area/station/service/greenroom)
 "iut" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
+/obj/effect/turf_decal/caution/stand_clear/blue{
+	dir = 8
 	},
-/obj/item/hemostat{
-	pixel_x = 2;
-	pixel_y = 11
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 8
 	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/medbay/central)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/treatment_center)
 "iuv" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/effect/turf_decal/siding/dark{
@@ -31594,7 +31304,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/patients_rooms/room_b)
+/area/station/medical/surgery/theatre)
 "iwl" = (
 /obj/machinery/shower/directional/north,
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
@@ -31901,10 +31611,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/white/smooth_half{
+/obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 8
 	},
-/area/station/medical/paramedic)
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 4
+	},
+/area/station/medical/treatment_center)
 "iBg" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -32130,10 +31843,6 @@
 "iEL" = (
 /turf/open/floor/iron/dark/side,
 /area/station/commons/fitness)
-"iEO" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
 "iEX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -32219,17 +31928,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
-"iGg" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/directional/west{
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/medbay/central)
 "iGq" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -32442,14 +32140,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "iJa" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 6
 	},
-/obj/machinery/digital_clock/directional/north,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/treatment_center)
 "iJc" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
@@ -32583,15 +32279,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/foreporthall)
-"iKF" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/warning,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/chemistry)
 "iKJ" = (
 /obj/effect/landmark/start/bartender,
 /obj/effect/turf_decal/tile/bar,
@@ -33182,10 +32869,11 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/theater)
 "iSJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 2
-	},
-/turf/open/floor/iron/white/smooth_large,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "iSK" = (
 /obj/structure/cable,
@@ -33566,15 +33254,12 @@
 	},
 /area/station/engineering/atmos)
 "iXK" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/warning{
-	dir = 6
-	},
 /obj/structure/sign/poster/official/periodic_table/directional/east,
-/turf/open/floor/iron/white/smooth_corner{
-	dir = 1
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
 	},
 /area/station/medical/chemistry)
 "iXP" = (
@@ -34266,15 +33951,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/coffeemaker{
-	pixel_y = 19
-	},
-/obj/item/coffee_cartridge/fancy,
-/obj/item/coffee_cartridge/decaf{
-	pixel_x = 2;
-	pixel_y = 3
-	},
 /obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box{
+	pixel_y = 6
+	},
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/medical/break_room)
 "jgL" = (
@@ -35985,19 +35665,17 @@
 /turf/open/floor/wood/parquet,
 /area/station/commons/dorms/room4)
 "jEC" = (
+/obj/machinery/door/airlock/medical/glass,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Employee Entrance"
-	},
-/turf/open/floor/iron/white/smooth_half,
-/area/station/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "jET" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
@@ -36875,16 +36553,6 @@
 	dir = 8
 	},
 /area/station/medical/storage)
-"jQa" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/machinery/newscaster/directional/north,
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "jQg" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -37378,16 +37046,18 @@
 /turf/open/floor/iron,
 /area/station/maintenance/fore/greater)
 "jWG" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
+/obj/machinery/door/airlock/research/glass{
+	name = "Pharmacy"
 	},
-/obj/machinery/light/small/directional/east,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/departments/exam_room/directional/east,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
 	},
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "jWH" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/machinery/newscaster/directional/north,
@@ -37774,11 +37444,14 @@
 	},
 /area/station/hallway/primary/aftporthall)
 "kcR" = (
-/obj/machinery/shower/directional/west,
-/obj/effect/turf_decal/tile/blue/full,
-/obj/structure/drain,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/cryo)
 "kde" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/closed/wall/r_wall,
@@ -37817,13 +37490,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/freezer,
 /area/station/commons/dorms/room4)
-"kdx" = (
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/smooth_half,
-/area/station/medical/treatment_center)
 "kdz" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/light/directional/north,
@@ -39196,7 +38862,7 @@
 /obj/effect/turf_decal/tile/blue/half,
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/patients_rooms/room_b)
+/area/station/medical/surgery/theatre)
 "kvk" = (
 /obj/structure/cable,
 /turf/closed/wall,
@@ -39359,6 +39025,7 @@
 	id_tag = "MedbayFoyer";
 	name = "Medbay"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_half{
 	dir = 8
 	},
@@ -39571,11 +39238,6 @@
 "kzI" = (
 /turf/open/floor/iron/dark/diagonal,
 /area/station/commons/vacant_room/commissary)
-"kzV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "kzX" = (
 /turf/open/floor/iron/corner{
 	dir = 8
@@ -39807,7 +39469,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/patients_rooms/room_a)
+/area/station/medical/surgery)
 "kCV" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/circuit,
@@ -40353,15 +40015,9 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/library)
 "kJu" = (
-/obj/machinery/stasis{
-	dir = 4
-	},
-/obj/machinery/defibrillator_mount/directional/south,
-/obj/effect/turf_decal/tile/blue/half,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron/white/smooth_edge,
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "kJB" = (
 /obj/structure/falsewall,
@@ -40404,7 +40060,10 @@
 "kKl" = (
 /obj/item/kirbyplants/random,
 /obj/structure/sign/poster/official/help_others/directional/north,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 1
+	},
+/turf/open/floor/iron/white/smooth_corner,
 /area/station/medical/medbay/central)
 "kKt" = (
 /obj/structure/window/reinforced/fulltile,
@@ -40782,18 +40441,6 @@
 "kPh" = (
 /turf/open/floor/iron/corner,
 /area/station/hallway/primary/port)
-"kPn" = (
-/obj/structure/table/glass,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/item/book/manual/wiki/medicine{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/healthanalyzer,
-/turf/open/floor/iron/white/smooth_corner{
-	dir = 8
-	},
-/area/station/medical/cryo)
 "kPp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40898,19 +40545,17 @@
 /turf/open/floor/iron/large,
 /area/station/cargo/sorting)
 "kQL" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/door/airlock/research/glass{
+	name = "Pharmacy"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
-/obj/machinery/light/directional/east,
-/obj/item/wrench/medical{
-	pixel_y = 6
-	},
-/obj/item/storage/box/masks,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/cryo)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "kQP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -41224,15 +40869,11 @@
 /turf/open/openspace,
 /area/station/hallway/primary/aft)
 "kVz" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/blue/warning{
 	dir = 4
 	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
+/turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
 "kVC" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
@@ -41504,7 +41145,7 @@
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 4
 	},
-/area/station/medical/medbay/central)
+/area/station/medical/treatment_center)
 "kZS" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/corner,
@@ -42248,16 +41889,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/floor2)
 "lky" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/treatment_center)
+/obj/structure/hedge,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/grass,
+/area/station/medical/break_room)
 "lkA" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
@@ -42487,12 +42122,8 @@
 /turf/open/floor/stone,
 /area/station/commons/dorms/room2)
 "lpH" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/digital_clock/directional/west,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/cryo)
+/turf/closed/wall/r_wall,
+/area/station/medical/aslyum)
 "lpJ" = (
 /obj/structure/table,
 /obj/item/pushbroom,
@@ -42886,6 +42517,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/east,
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
@@ -43018,20 +42650,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_cafeteria)
 "lwa" = (
-/obj/structure/rack/shelf,
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/machinery/digital_clock/directional/north,
-/obj/machinery/camera/autoname/directional/north,
-/obj/item/storage/box/masks,
-/obj/item/storage/box/gloves,
-/obj/item/soap,
-/obj/effect/turf_decal/bot_blue,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/closed/wall,
+/area/station/medical/chemistry)
 "lwn" = (
 /obj/machinery/shower/directional/east,
 /obj/structure/drain,
@@ -43133,10 +42754,14 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/aft)
 "lyb" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/full,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/obj/effect/landmark/start/orderly,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/cryo)
 "lyh" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet,
@@ -43159,13 +42784,8 @@
 /turf/closed/wall,
 /area/station/medical/pharmacy)
 "lyV" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/treatment_center)
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "lze" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -43527,12 +43147,11 @@
 /turf/open/floor/iron/white/small,
 /area/station/common/pool)
 "lDn" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/treatment_center)
 "lDr" = (
 /turf/open/floor/carpet/red,
 /area/station/service/lawoffice)
@@ -43947,11 +43566,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"lJT" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white/smooth_half,
-/area/station/medical/treatment_center)
 "lKd" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -43973,17 +43587,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/hallway/primary/aftporthall)
-"lKK" = (
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
 "lKM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -44339,14 +43942,8 @@
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/medical/morgue)
 "lQx" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
+/turf/open/openspace,
+/area/station/medical/treatment_center)
 "lQA" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -44821,15 +44418,6 @@
 	dir = 10
 	},
 /area/station/security/prison)
-"lXp" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "lXq" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -45850,16 +45438,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
-"mlR" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/machinery/vending/wallmed/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "mlV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -45963,11 +45541,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/foreporthall)
-"mmK" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/iron/white/smooth_half,
-/area/station/medical/medbay/central)
 "mnb" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -46025,19 +45598,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aftporthall)
 "mnT" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
+/obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/spawner/random/food_or_drink/donkpockets{
-	pixel_x = 6;
-	pixel_y = 7
+/obj/structure/bed{
+	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/west,
+/obj/item/bedsheet/medical{
+	dir = 1
+	},
 /turf/open/floor/iron/white/smooth_corner,
-/area/station/medical/paramedic)
+/area/station/medical/patients_rooms/room_a)
 "mnZ" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/toilet,
@@ -46078,7 +45649,7 @@
 /turf/open/floor/iron/white/smooth_half{
 	dir = 8
 	},
-/area/station/medical/patients_rooms/room_a)
+/area/station/medical/surgery/theatre)
 "moP" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -46458,10 +46029,16 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/miningfoyer)
 "mvc" = (
-/obj/effect/turf_decal/tile/blue/full,
-/obj/structure/disposalpipe/junction/yjunction,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 4
+	},
+/area/station/medical/chemistry)
 "mvg" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/corner{
@@ -46626,14 +46203,10 @@
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
 "mxg" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/camera/autoname/directional/south{
-	network = list("ss13","medbay")
-	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/medbay/central)
+/area/station/medical/treatment_center)
 "mxn" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -46654,14 +46227,16 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/ce)
 "mxx" = (
-/obj/effect/turf_decal/tile/blue/anticorner{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 8
 	},
-/obj/item/clipboard,
-/obj/item/flashlight/pen,
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white/smooth_corner,
-/area/station/medical/medbay/central)
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/chemistry)
 "mxI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46740,24 +46315,13 @@
 /turf/open/floor/wood/parquet,
 /area/station/common/night_club/back_stage)
 "myb" = (
-/obj/structure/rack/shelf,
 /obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/newscaster/directional/south,
-/obj/machinery/camera/autoname/directional/south,
-/obj/item/storage/box/syringes{
-	pixel_x = 2;
-	pixel_y = -5
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
 	},
-/obj/item/clothing/glasses/hud/health{
-	pixel_y = 7;
-	pixel_x = -2
-	},
-/obj/effect/turf_decal/bot_blue,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/treatment_center)
+/area/station/medical/cryo)
 "myd" = (
 /turf/open/floor/iron/dark/corner,
 /area/station/commons/fitness)
@@ -46905,14 +46469,11 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/blueshield)
 "mAh" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "mAi" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/cable,
@@ -47323,12 +46884,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "mGx" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/medbay/central)
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "mGy" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo/miningoffice)
@@ -47931,16 +47489,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/large,
 /area/station/engineering/atmospherics_engine)
-"mPR" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/cryo)
 "mPT" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -47988,7 +47536,7 @@
 /turf/open/floor/iron/stairs/right{
 	dir = 8
 	},
-/area/station/medical/medbay/central)
+/area/station/medical/treatment_center)
 "mQF" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_red/filled/line{
@@ -48414,13 +47962,9 @@
 	},
 /area/station/medical/pharmacy)
 "mXj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/navbeacon{
-	location = "PMed4";
-	codes_txt = "patrol;next_patrol=PMed1"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "mXk" = (
@@ -48612,25 +48156,9 @@
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/starboard)
 "mZZ" = (
-/obj/effect/turf_decal/tile/blue/anticorner,
-/obj/item/book/manual/wiki/medicine{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/toy/figure/md{
-	pixel_x = 7;
-	pixel_y = 19
-	},
-/obj/item/storage/pill_bottle/mannitol{
-	pixel_x = 7;
-	pixel_y = 4
-	},
-/obj/machinery/firealarm/directional/south,
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white/smooth_corner{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "nah" = (
 /obj/item/flashlight/glowstick/yellow,
 /turf/open/floor/plating,
@@ -48719,12 +48247,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/security/courtroom)
-"nbd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
 "nbq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49046,14 +48568,8 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "nhH" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
-/obj/machinery/door/airlock/research/glass{
-	name = "Pharmacy"
-	},
-/turf/open/floor/iron/white/smooth_half{
-	dir = 8
-	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "nhI" = (
 /obj/effect/turf_decal/siding/dark{
@@ -49284,16 +48800,9 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "nlE" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
+/obj/machinery/computer/crew,
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "nlO" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
@@ -49618,14 +49127,12 @@
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp)
 "npG" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 5
 	},
-/obj/structure/sign/poster/official/periodic_table/directional/east,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/treatment_center)
 "npI" = (
 /obj/item/radio/intercom/directional/north{
 	freerange = 1;
@@ -50005,9 +49512,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "nuP" = (
-/obj/effect/turf_decal/tile/blue/full,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
+/turf/closed/wall,
+/area/station/medical/office)
 "nuX" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/steam_vent,
@@ -51325,7 +50831,7 @@
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 4
 	},
-/area/station/medical/patients_rooms/room_a)
+/area/station/medical/surgery)
 "nLq" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 4
@@ -51517,9 +51023,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "nNB" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/medical/aslyum)
 "nNN" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/green,
@@ -51628,15 +51134,6 @@
 	dir = 4
 	},
 /area/station/command/heads_quarters/ce)
-"nOR" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/medbay/central)
 "nOS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -51749,6 +51246,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_half{
 	dir = 8
 	},
@@ -51931,17 +51429,6 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/common/pool)
-"nRI" = (
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
 "nRR" = (
 /obj/item/weldingtool{
 	pixel_x = 12;
@@ -52176,15 +51663,16 @@
 /turf/open/floor/carpet/purple,
 /area/station/science/lab)
 "nVz" = (
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/navbeacon{
-	location = "PMed3";
-	codes_txt = "patrol;next_patrol=PMed4"
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/patients_rooms/room_a)
 "nVA" = (
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating,
@@ -52982,22 +52470,11 @@
 /turf/open/floor/iron/dark/side,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "ohb" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/suit_storage_unit/medical,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/blue/anticorner,
+/turf/open/floor/iron/white/smooth_corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/dark_blue/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/box/blue,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/paramedic)
+/area/station/medical/treatment_center)
 "ohd" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -53074,8 +52551,11 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/fore/greater)
 "ohW" = (
-/obj/effect/turf_decal/tile/blue/half{
+/obj/effect/turf_decal/trimline/blue/warning{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53085,7 +52565,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
-/area/station/medical/medbay/central)
+/area/station/medical/chemistry)
 "ohY" = (
 /obj/effect/turf_decal/stripes,
 /obj/machinery/exodrone_launcher,
@@ -53364,14 +52844,12 @@
 /turf/open/floor/wood/tile,
 /area/station/medical/psychology)
 "okR" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 10
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/medbay/central)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/treatment_center)
 "okS" = (
 /obj/structure/cable,
 /obj/item/flashlight/glowstick/yellow,
@@ -53480,13 +52958,6 @@
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engineering/engie_aft_starboard)
-"omv" = (
-/obj/effect/turf_decal/tile/blue/half,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/treatment_center)
 "omI" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53787,7 +53258,7 @@
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 1
 	},
-/area/station/medical/patients_rooms/room_b)
+/area/station/medical/surgery/theatre)
 "orY" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -54122,23 +53593,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "oxG" = (
-/obj/effect/turf_decal/tile/blue/anticorner{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/item/clipboard{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/chem_pack,
-/obj/item/reagent_containers/chem_pack{
-	pixel_y = 5;
-	pixel_x = 5
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white/smooth_corner{
-	dir = 8
-	},
-/area/station/medical/treatment_center)
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "oxO" = (
 /obj/structure/railing/wooden_fencing,
 /turf/open/floor/iron/stairs{
@@ -54152,11 +53611,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/aft)
 "oya" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow/full,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chemistry)
 "oys" = (
 /obj/effect/turf_decal/trimline/white/line,
 /turf/open/floor/iron/dark/smooth_edge,
@@ -54399,6 +53858,8 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "oBi" = (
@@ -54417,14 +53878,12 @@
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/primary/port)
 "oBo" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/treatment_center)
 "oBz" = (
 /obj/effect/landmark/navigate_destination{
 	location = "Holodeck"
@@ -54659,12 +54118,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/commons/locker)
-"oFn" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/cryo)
 "oFo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55028,14 +54481,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "oKp" = (
-/obj/machinery/iv_drip,
 /obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/light/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
 /turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/treatment_center)
+/area/station/medical/cryo)
 "oKq" = (
 /obj/effect/turf_decal/caution,
 /obj/structure/cable,
@@ -55176,20 +54627,11 @@
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "oLY" = (
-/obj/structure/rack/shelf,
-/obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/newscaster/directional/south,
-/obj/machinery/camera/autoname/directional/south,
-/obj/item/storage/box/bodybags{
-	pixel_y = -6
-	},
-/obj/item/emergency_bed{
-	pixel_y = 6;
-	pixel_x = 5
-	},
-/obj/effect/turf_decal/bot_blue,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/treatment_center)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/medical/office)
 "oMn" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 1
@@ -56212,26 +55654,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/common/night_club)
-"oZD" = (
-/obj/machinery/light/directional/north,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/dark_blue/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/paramedic)
 "oZE" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -56604,16 +56026,6 @@
 	dir = 1
 	},
 /area/station/security/office)
-"peB" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/machinery/status_display/ai/directional/north,
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "peD" = (
 /obj/structure/rack/wooden,
 /obj/item/folder/red{
@@ -56646,14 +56058,6 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/wood/large,
 /area/station/security/detectives_office)
-"peE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/cryo)
 "peI" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -56673,15 +56077,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/morgue)
 "peU" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/warning,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
 	},
-/obj/machinery/digital_clock/directional/east,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/chemistry)
 "pfb" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -56980,7 +56382,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/patients_rooms/room_b)
+/area/station/medical/surgery/theatre)
 "pjq" = (
 /obj/machinery/computer/operating{
 	name = "Robotics Operating Computer"
@@ -57226,16 +56628,6 @@
 "pmm" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/entry)
-"pmr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/shower/directional/west,
-/obj/structure/drain,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
 "pmt" = (
 /obj/effect/landmark/start/prisoner,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -57616,14 +57008,10 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "psk" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/cryo)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/aslyum)
 "psn" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
@@ -57985,10 +57373,12 @@
 	},
 /area/mine/laborcamp)
 "pze" = (
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/blue/full,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/iron/white/smooth_large,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "pzi" = (
 /obj/machinery/computer/records/medical{
@@ -58012,19 +57402,11 @@
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/primary)
 "pzG" = (
-/obj/effect/turf_decal/tile/blue/anticorner{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 5
 	},
-/obj/item/clothing/neck/stethoscope{
-	pixel_y = 7
-	},
-/obj/item/clothing/glasses/regular{
-	pixel_y = 12
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white/smooth_corner{
-	dir = 4
-	},
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
 "pzI" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -58082,18 +57464,19 @@
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners{
 	dir = 1
 	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_y = 1;
-	pixel_x = -7
-	},
-/obj/machinery/recharger{
-	pixel_y = 7
-	},
-/obj/item/healthanalyzer{
-	pixel_y = -5;
-	pixel_x = 6
-	},
 /obj/structure/table/reinforced,
+/obj/machinery/coffeemaker{
+	pixel_x = 0;
+	pixel_y = 11
+	},
+/obj/item/coffee_cartridge/decaf{
+	pixel_x = 5;
+	pixel_y = -6
+	},
+/obj/item/coffee_cartridge/fancy{
+	pixel_x = -6;
+	pixel_y = -6
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "pAx" = (
@@ -58622,16 +58005,12 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/medical)
 "pIZ" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
-	dir = 1
-	},
-/obj/effect/landmark/start/paramedic,
+/obj/effect/turf_decal/tile/blue/half,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/paramedic)
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/treatment_center)
 "pJb" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes{
@@ -58712,18 +58091,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/central/lesser)
 "pKu" = (
-/obj/effect/turf_decal/tile/blue/anticorner{
-	dir = 1
-	},
-/obj/item/clipboard{
-	pixel_x = -2;
-	pixel_y = -15
-	},
-/obj/item/healthanalyzer,
-/obj/machinery/firealarm/directional/north,
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white/smooth_corner,
-/area/station/medical/treatment_center)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "pKw" = (
 /obj/structure/spirit_board,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58812,14 +58183,12 @@
 /turf/open/floor/plating,
 /area/station/commons/vacant_room)
 "pMi" = (
-/obj/effect/turf_decal/tile/blue/full,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue/half,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/computer/records/medical,
-/turf/open/floor/iron/white/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/treatment_center)
 "pMk" = (
 /obj/structure/table,
@@ -58997,7 +58366,7 @@
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/blue/half,
 /turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/patients_rooms/room_b)
+/area/station/medical/surgery/theatre)
 "pOs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59272,12 +58641,13 @@
 /turf/open/floor/grass,
 /area/station/hallway/secondary/entry)
 "pTd" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/machinery/door/airlock/medical/glass,
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/area/station/medical/aslyum)
 "pTg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -59743,15 +59113,13 @@
 /turf/closed/wall,
 /area/station/maintenance/department/security/brig)
 "qan" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/paramedic)
+/obj/machinery/door/airlock/medical/glass,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_half,
+/area/station/medical/treatment_center)
 "qat" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/white/filled/warning{
@@ -59864,15 +59232,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "qca" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/warning,
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/blue/half{
 	dir = 4
 	},
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/chemistry)
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/treatment_center)
 "qcg" = (
 /obj/structure/railing/wooden_fence{
 	dir = 6
@@ -60105,18 +59473,11 @@
 /turf/open/floor/iron/diagonal,
 /area/station/service/hydroponics)
 "qgq" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/box/blue,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/cryo)
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "qgx" = (
 /obj/structure/table,
 /obj/machinery/camera/autoname/directional/south{
@@ -60285,10 +59646,9 @@
 	},
 /area/station/commons/fitness)
 "qjP" = (
-/obj/effect/turf_decal/tile/blue/full,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "qjZ" = (
 /obj/machinery/door/window/left/directional/north{
 	req_access = list("genetics");
@@ -60387,23 +59747,14 @@
 /turf/open/floor/iron/edge,
 /area/station/engineering/atmos/office)
 "qlB" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/dark_blue/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/paramedic)
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "qlG" = (
 /obj/structure/sink/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -60536,9 +59887,11 @@
 	},
 /area/station/hallway/primary/starboard)
 "qmW" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "qmY" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -60666,20 +60019,11 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/lab)
 "qoy" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/item/radio/intercom/directional/north,
-/obj/item/flashlight/pen,
-/obj/item/book/manual/wiki/surgery{
-	pixel_x = 9;
-	pixel_y = 9
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
+/obj/machinery/door/airlock/medical/glass,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/tile,
+/area/station/medical/office)
 "qoB" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/landmark/start/scientist,
@@ -61191,6 +60535,9 @@
 /area/station/service/kitchen)
 "qvo" = (
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qvy" = (
@@ -61452,10 +60799,13 @@
 	},
 /area/station/hallway/primary/foreporthall)
 "qzu" = (
-/obj/structure/cable,
 /obj/machinery/light/directional/south,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 4
+	},
 /area/station/medical/medbay/central)
 "qzx" = (
 /obj/machinery/door/airlock/external,
@@ -62118,17 +61468,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
-"qIR" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/item/clipboard,
-/obj/item/hand_labeler,
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "qIW" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/dark/corner{
@@ -62494,10 +61833,15 @@
 	},
 /area/station/security/warden)
 "qNq" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	icon_state = "bounty-open";
+	icon_type = "bounty";
+	id = "SurgeryAcurtains";
+	name = "curtain"
+	},
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/iron/white/smooth_half,
-/area/station/medical/chemistry)
+/turf/open/floor/plating,
+/area/station/medical/surgery)
 "qNJ" = (
 /turf/open/floor/iron/stairs/right{
 	dir = 4
@@ -62940,22 +62284,16 @@
 	},
 /area/station/engineering/lobby)
 "qVd" = (
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue/half{
-	dir = 1
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
 	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Employee Entrance"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/smooth_half,
-/area/station/medical/medbay/central)
+/area/station/medical/cryo)
 "qVh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -63690,14 +63028,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "rfU" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/warning,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/iron/white/smooth_edge,
+/obj/effect/turf_decal/tile/yellow/full,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chemistry)
 "rgr" = (
 /obj/effect/turf_decal/trimline/blue/line{
@@ -63751,36 +63086,23 @@
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/primary/starboard)
 "rhc" = (
-/obj/effect/turf_decal/tile/dark_blue/half{
+/obj/effect/turf_decal/tile/blue/half{
 	dir = 8
 	},
-/obj/machinery/newscaster/directional/west,
-/obj/structure/table/reinforced,
-/obj/item/emergency_bed{
-	pixel_x = -7;
-	pixel_y = 15
+/obj/structure/bed{
+	dir = 1
 	},
-/obj/item/emergency_bed{
-	pixel_x = 7;
-	pixel_y = 15
+/obj/item/bedsheet/medical{
+	dir = 1
 	},
-/obj/item/wheelchair,
-/obj/item/climbing_hook{
-	pixel_y = 14;
-	pixel_x = 3
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/item/climbing_hook{
-	pixel_y = 14;
-	pixel_x = -3
-	},
-/obj/item/wheelchair{
-	pixel_y = 5
-	},
-/obj/machinery/light/small/directional/west,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
-/area/station/medical/paramedic)
+/area/station/medical/patients_rooms/room_a)
 "rhd" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -64798,11 +64120,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/forestarboardhall)
 "ryh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
+/obj/structure/table/wood,
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "rym" = (
 /obj/structure/closet/secure_closet/contraband/heads,
 /obj/machinery/airalarm/directional/east,
@@ -65419,18 +64739,6 @@
 /obj/machinery/digital_clock/directional/east,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/nt_rep)
-"rHB" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/microwave{
-	pixel_y = 8
-	},
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron/white,
-/area/station/medical/paramedic)
 "rHD" = (
 /obj/machinery/light/directional/north,
 /obj/structure/secure_safe/directional/north,
@@ -65701,18 +65009,6 @@
 /obj/structure/railing/wooden_fence,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"rMo" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = -4;
-	pixel_y = 1
-	},
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/ordnance_maint)
 "rMp" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -65879,12 +65175,14 @@
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms)
 "rPm" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
+/obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/paramedic)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_corner,
+/area/station/medical/patients_rooms/room_b)
 "rPr" = (
 /obj/effect/spawner/random/structure/chair_maintenance,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -66950,16 +66248,14 @@
 /turf/open/floor/grass,
 /area/station/hallway/primary)
 "saB" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 4
 	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
+/obj/machinery/cryo_cell,
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 8
 	},
-/area/station/medical/medbay/central)
+/area/station/medical/cryo)
 "saC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66970,9 +66266,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "saK" = (
-/obj/effect/turf_decal/tile/blue/full,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white/smooth_large,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "saS" = (
 /obj/machinery/brm,
@@ -67775,7 +67070,7 @@
 	},
 /obj/structure/drain,
 /turf/open/floor/iron/white/smooth_corner,
-/area/station/medical/patients_rooms/room_a)
+/area/station/medical/surgery)
 "slJ" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 10
@@ -67786,18 +67081,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/foreporthall)
 "slK" = (
-/obj/machinery/vending/wallmed/directional/north,
-/obj/structure/rack/shelf,
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/machinery/camera/autoname/directional/north,
-/obj/item/storage/box/rxglasses,
-/obj/effect/turf_decal/bot_blue,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/treatment_center)
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/medical/office)
 "slN" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -67900,19 +67186,6 @@
 "smX" = (
 /turf/open/floor/iron/diagonal,
 /area/station/command/bridge)
-"snk" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/obj/item/stack/medical/gauze{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/treatment_center)
 "snn" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -68081,12 +67354,10 @@
 /area/station/medical/chemistry)
 "spo" = (
 /obj/effect/turf_decal/tile/blue/anticorner{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/white/smooth_corner{
-	dir = 8
-	},
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_corner,
 /area/station/medical/medbay/central)
 "spp" = (
 /turf/open/openspace,
@@ -68859,14 +68130,15 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "szn" = (
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/navbeacon{
-	location = "PMed2";
-	codes_txt = "patrol;next_patrol=PMed3"
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "szq" = (
 /obj/structure/cable,
@@ -68927,21 +68199,16 @@
 	},
 /area/station/cargo/miningfoyer)
 "sAq" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/dark_blue/half{
-	dir = 1
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
-/area/station/medical/paramedic)
+/area/station/medical/treatment_center)
 "sAv" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 1
@@ -69138,7 +68405,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/patients_rooms/room_a)
+/area/station/medical/surgery)
 "sCu" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
@@ -69243,26 +68510,23 @@
 /turf/open/floor/wood,
 /area/station/maintenance/hiddenlibrary)
 "sDo" = (
-/obj/structure/cable,
-/obj/machinery/holopad,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
+/obj/effect/turf_decal/trimline/blue/warning,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/chemistry)
 "sDp" = (
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
 "sDv" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
+/obj/structure/chair/office{
+	dir = 8
 	},
-/obj/item/stack/medical/gauze{
-	pixel_y = 3;
-	pixel_x = -2
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/treatment_center)
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "sDw" = (
 /obj/structure/closet/crate/large,
 /obj/effect/turf_decal/delivery,
@@ -69605,17 +68869,32 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/service/hydroponics)
 "sIP" = (
-/obj/machinery/defibrillator_mount/directional/north,
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 1
 	},
-/obj/machinery/stasis{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/structure/table,
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 12
 	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = 7;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = 0;
+	pixel_y = 5
+	},
+/obj/item/wrench/medical{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
-/area/station/medical/treatment_center)
+/area/station/medical/cryo)
 "sIQ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -69708,17 +68987,11 @@
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/security/warden)
 "sJQ" = (
-/obj/effect/turf_decal/tile/dark_blue/anticorner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/medical1,
-/turf/open/floor/iron/white/smooth_corner{
-	dir = 4
-	},
-/area/station/medical/paramedic)
+/obj/effect/turf_decal/tile/blue/half,
+/obj/machinery/iv_drip,
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/patients_rooms/room_a)
 "sJR" = (
 /obj/structure/rack,
 /turf/open/floor/plating,
@@ -69815,18 +69088,19 @@
 /turf/open/floor/iron/edge,
 /area/station/hallway/floor2)
 "sLD" = (
-/obj/effect/turf_decal/tile/dark_blue/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/blue/half{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/chair/sofa/left,
-/turf/open/floor/iron/white,
-/area/station/medical/paramedic)
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/patients_rooms/room_b)
 "sLG" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -69969,20 +69243,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"sOc" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/medbay/central)
 "sOf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70691,16 +69951,8 @@
 	},
 /area/station/security/brig)
 "sZc" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/medbay/central)
+/turf/closed/wall/r_wall,
+/area/station/medical/surgery)
 "sZd" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/toy_figure{
@@ -71924,10 +71176,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/wrestle)
 "tpX" = (
-/obj/effect/turf_decal/tile/blue/half,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/medbay/central)
+/turf/closed/wall,
+/area/station/medical/surgery/theatre)
 "tpY" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72563,10 +71813,19 @@
 /turf/open/floor/stone,
 /area/station/service/forge)
 "tAc" = (
-/obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/medbay/central)
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 8
+	},
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/medical{
+	dir = 1
+	},
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 4
+	},
+/area/station/medical/patients_rooms/room_a)
 "tAh" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/caution/white{
@@ -72673,12 +71932,12 @@
 	},
 /area/station/security/breakroom)
 "tBy" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
@@ -73252,23 +72511,21 @@
 /area/station/maintenance/abandon_kitchen_upper)
 "tIi" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1
-	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Employee Entrance"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 1
 	},
-/turf/open/floor/iron/white/smooth_half{
-	dir = 8
-	},
-/area/station/medical/paramedic)
+/turf/open/floor/iron/white/smooth_corner,
+/area/station/medical/treatment_center)
 "tIm" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/structure/chair{
@@ -74600,11 +73857,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/foreporthall)
-"tZT" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/medbay/central)
 "tZV" = (
 /obj/structure/stairs/south,
 /turf/open/floor/plating/snowed/icemoon,
@@ -74882,7 +74134,7 @@
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 8
 	},
-/area/station/medical/patients_rooms/room_b)
+/area/station/medical/surgery/theatre)
 "udB" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/white/line{
@@ -75041,15 +74293,6 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
-"ufP" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "ufR" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/holopad,
@@ -75621,12 +74864,13 @@
 /turf/open/floor/carpet,
 /area/station/service/greenroom)
 "upZ" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/paramedic)
+/area/station/medical/patients_rooms/room_a)
 "uqa" = (
 /obj/item/flashlight/glowstick/yellow,
 /turf/open/floor/plating,
@@ -75949,40 +75193,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/ordnance_maint_lesser)
 "utH" = (
-/obj/structure/rack/shelf,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/dark_blue/half{
-	dir = 4
-	},
-/obj/item/storage/box/syringes{
-	pixel_y = -3;
-	pixel_x = 2
-	},
-/obj/item/holosign_creator/medical/treatment_zone{
-	pixel_y = 6;
-	pixel_x = 4
-	},
-/obj/item/holosign_creator/medical/treatment_zone{
-	pixel_y = 3;
-	pixel_x = 6
-	},
-/obj/item/clothing/glasses/hud/health{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/item/clothing/glasses/hud/health{
-	pixel_x = -7
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/paramedic)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "utI" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /obj/effect/turf_decal/trimline/purple/filled/warning{
@@ -76266,7 +75479,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/smooth_half,
-/area/station/medical/patients_rooms/room_b)
+/area/station/medical/surgery/theatre)
 "uyi" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
@@ -77093,7 +76306,7 @@
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 1
 	},
-/area/station/medical/patients_rooms/room_a)
+/area/station/medical/surgery)
 "uJM" = (
 /obj/structure/chair/office/light,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -77754,9 +76967,14 @@
 	},
 /area/station/engineering/atmos)
 "uUJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/iron/white/smooth_half,
-/area/station/medical/chemistry)
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "uUK" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable,
@@ -77897,13 +77115,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "uVZ" = (
-/obj/effect/landmark/start/medical_doctor,
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
-/area/station/medical/break_room)
+/area/station/medical/medbay/central)
 "uWb" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/effect/turf_decal/bot_white{
@@ -77978,9 +77195,6 @@
 /obj/structure/ladder,
 /turf/open/floor/plating,
 /area/station/service/hydroponics)
-"uWS" = (
-/turf/closed/wall,
-/area/station/medical/paramedic)
 "uWZ" = (
 /obj/effect/spawner/random/trash/box,
 /turf/open/floor/plating,
@@ -78241,10 +77455,12 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/cargo/sorting)
 "vaK" = (
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/yellow/full,
 /obj/structure/disposalpipe/junction,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chemistry)
 "vaR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -79051,11 +78267,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/wrestle)
 "vmu" = (
-/obj/structure/closet/secure_closet/medical1,
-/obj/structure/window/spawner/directional/west,
-/obj/effect/turf_decal/bot_blue,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
+/obj/structure/hedge,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/grass,
+/area/station/medical/office)
 "vmv" = (
 /obj/structure/railing{
 	dir = 8
@@ -79389,25 +78604,10 @@
 /turf/open/floor/carpet,
 /area/station/service/library/private)
 "vpy" = (
-/obj/effect/turf_decal/tile/blue/full,
-/obj/machinery/light/floor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/window/spawner/directional/west,
-/obj/item/reagent_containers/syringe{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/syringe{
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/syringe,
-/obj/item/flashlight/pen,
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
+/obj/machinery/door/airlock/medical/glass,
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood/tile,
+/area/station/medical/office)
 "vpz" = (
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 8
@@ -79556,13 +78756,25 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/transit_tube)
 "vrI" = (
-/obj/effect/landmark/start/medical_doctor,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/mask/surgical{
+	pixel_y = -1;
+	pixel_x = 2
+	},
+/obj/item/healthanalyzer{
+	pixel_y = 8;
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_y = 10;
+	pixel_x = -10
 	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
@@ -79721,17 +78933,14 @@
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "vuS" = (
-/obj/effect/turf_decal/tile/dark_blue/anticorner,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 8
 	},
-/obj/machinery/computer/records/medical{
-	dir = 1
-	},
+/obj/structure/closet/secure_closet/personal/patient,
 /turf/open/floor/iron/white/smooth_corner{
-	dir = 1
+	dir = 4
 	},
-/area/station/medical/paramedic)
+/area/station/medical/patients_rooms/room_b)
 "vuT" = (
 /obj/structure/ladder,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -79740,11 +78949,6 @@
 "vvd" = (
 /turf/closed/wall,
 /area/station/maintenance/gamer_lair)
-"vvi" = (
-/obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/digital_clock/directional/south,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/medbay/central)
 "vvm" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/disposalpipe/segment{
@@ -80314,12 +79518,13 @@
 	},
 /area/station/hallway/primary/aftstarboardhall)
 "vDa" = (
-/obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/door/airlock/research/glass{
+	name = "Pharmacy"
 	},
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/medbay/central)
+/obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "vDf" = (
 /obj/effect/turf_decal/trimline/white/line,
 /turf/open/floor/iron/dark/smooth_edge,
@@ -80531,26 +79736,9 @@
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/primary/aft)
 "vFO" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
-	},
-/obj/item/stack/medical/gauze{
-	pixel_x = 0;
-	pixel_y = 4
-	},
-/obj/item/clothing/neck/stethoscope{
-	pixel_y = 20;
-	pixel_x = -5
-	},
-/obj/item/clothing/glasses/hud/health{
-	pixel_y = 11;
-	pixel_x = 6
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/treatment_center)
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "vFP" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/moisture_trap,
@@ -80755,14 +79943,13 @@
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms/room7)
 "vIG" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
 	},
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white/smooth_edge{
-	dir = 1
+	dir = 4
 	},
-/area/station/medical/medbay/central)
+/area/station/medical/chemistry)
 "vIO" = (
 /turf/closed/wall/r_wall,
 /area/station/security/office)
@@ -80893,11 +80080,8 @@
 	},
 /area/station/engineering/atmos/project)
 "vJH" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white/smooth_corner,
-/area/station/medical/cryo)
+/turf/closed/wall/r_wall,
+/area/station/medical/surgery/theatre)
 "vJM" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/cable,
@@ -80948,7 +80132,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
-/area/station/medical/medbay/central)
+/area/station/medical/treatment_center)
 "vKv" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 1
@@ -81265,13 +80449,15 @@
 	},
 /area/station/service/bar)
 "vOs" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 4
 	},
-/obj/machinery/holopad,
-/turf/open/floor/iron/white,
-/area/station/medical/paramedic)
+/obj/structure/table/glass,
+/obj/effect/spawner/random/medical/medkit,
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 8
+	},
+/area/station/medical/patients_rooms/room_a)
 "vOx" = (
 /obj/structure/table,
 /obj/item/storage/box/fireworks{
@@ -82690,14 +81876,11 @@
 /turf/open/floor/iron/checker,
 /area/station/security/prison/mess)
 "wjK" = (
-/obj/effect/turf_decal/tile/blue/full,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
+/turf/open/floor/wood,
+/area/station/medical/office)
 "wjP" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -83043,7 +82226,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/medical/patients_rooms/room_b)
+/area/station/medical/surgery/theatre)
 "woZ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -83759,9 +82942,16 @@
 	},
 /area/station/service/hydroponics/garden)
 "wyn" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/smooth_half,
-/area/station/medical/treatment_center)
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 6
+	},
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 1
+	},
+/area/station/medical/chemistry)
 "wys" = (
 /turf/open/floor/iron/stairs/right,
 /area/station/science/research)
@@ -84016,7 +83206,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
-/area/station/medical/patients_rooms/room_a)
+/area/station/medical/surgery)
 "wBd" = (
 /obj/structure/table,
 /obj/item/stack/sheet/cardboard{
@@ -84337,7 +83527,7 @@
 /turf/open/floor/iron/stairs/left{
 	dir = 8
 	},
-/area/station/medical/medbay/central)
+/area/station/medical/treatment_center)
 "wFr" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
@@ -85005,13 +84195,8 @@
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/secondary/recreation)
 "wOt" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/full,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "wOu" = (
 /turf/closed/wall,
 /area/station/commons/dorms/room4)
@@ -85041,13 +84226,8 @@
 	},
 /area/station/hallway/primary/foreporthall)
 "wOX" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/blue/half,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/treatment_center)
+/turf/open/floor/wood,
+/area/station/medical/office)
 "wOZ" = (
 /obj/effect/turf_decal/stripes{
 	dir = 9
@@ -85082,10 +84262,15 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "wPf" = (
+/obj/machinery/door/airlock/research/glass{
+	name = "Pharmacy"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue/half,
-/turf/open/floor/iron/white/smooth_half,
-/area/station/medical/cryo)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "wPi" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -85285,15 +84470,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
-"wSe" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/station/medical/medbay/central)
 "wSi" = (
 /obj/machinery/computer/exodrone_control_console{
 	dir = 8
@@ -85452,7 +84628,7 @@
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
-/area/station/medical/patients_rooms/room_b)
+/area/station/medical/surgery/theatre)
 "wUr" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -85951,7 +85127,7 @@
 	},
 /obj/machinery/photocopier,
 /turf/open/floor/iron/white/smooth_corner,
-/area/station/medical/medbay/central)
+/area/station/medical/treatment_center)
 "xaE" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -86273,12 +85449,14 @@
 /turf/open/floor/iron/corner,
 /area/station/command/teleporter)
 "xfa" = (
-/obj/effect/turf_decal/tile/blue/half,
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/effect/turf_decal/tile/blue/anticorner,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/treatment_center)
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 1
+	},
+/area/station/medical/cryo)
 "xfb" = (
 /obj/structure/trash_pile,
 /turf/open/floor/iron/corner{
@@ -86502,6 +85680,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 8
 	},
@@ -86516,16 +85697,6 @@
 "xiy" = (
 /turf/closed/wall,
 /area/station/commons/toilet/auxiliary)
-"xiz" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "xiD" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes{
@@ -86803,16 +85974,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/fore)
-"xlA" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/warning,
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/chemistry)
 "xlK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -86856,19 +86017,6 @@
 	dir = 8
 	},
 /area/station/service/theater)
-"xmw" = (
-/obj/effect/turf_decal/tile/dark_blue/half,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 4
-	},
-/obj/machinery/computer/crew{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/paramedic)
 "xmz" = (
 /obj/machinery/light/floor,
 /obj/effect/turf_decal/stripes,
@@ -87078,23 +86226,18 @@
 	},
 /area/station/cargo/miningfoyer)
 "xoO" = (
-/obj/machinery/status_display/evac/directional/east,
-/obj/machinery/recharge_station,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/dark_blue{
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/medigel/libital{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/open/floor/iron/white/smooth_corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/dark_blue/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot_blue,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/paramedic)
+/area/station/medical/patients_rooms/room_b)
 "xoT" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -87721,7 +86864,7 @@
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 8
 	},
-/area/station/medical/patients_rooms/room_a)
+/area/station/medical/surgery)
 "xxx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -88317,14 +87460,11 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/xenobiology)
 "xFc" = (
-/obj/effect/landmark/start/medical_doctor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/treatment_center)
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/medical/office)
 "xFd" = (
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
@@ -88425,19 +87565,18 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "xGM" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/warning{
-	dir = 10
-	},
-/obj/machinery/newscaster/directional/south,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/iron/white/smooth_corner{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
 	},
 /area/station/medical/chemistry)
 "xGP" = (
@@ -89020,16 +88159,12 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "xOS" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "xOV" = (
 /obj/effect/turf_decal/trimline/white/line,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -89488,7 +88623,6 @@
 	dir = 1
 	},
 /obj/effect/landmark/event_spawn,
-/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -90092,11 +89226,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary)
 "ycV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/treatment_center)
 "ycX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
@@ -90387,13 +89520,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "ygF" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 6
 	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
 "ygH" = (
 /obj/structure/cable,
@@ -90614,14 +89745,8 @@
 /turf/open/floor/iron/checker,
 /area/station/commons/fitness/recreation)
 "ykr" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
-/obj/machinery/camera/autoname/directional/north,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 1
-	},
-/area/station/medical/cryo)
+/turf/open/floor/iron/white,
+/area/station/medical/aslyum)
 "yks" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_red/filled/line,
@@ -263554,17 +262679,17 @@ iEo
 rXK
 sOq
 lyF
-rCh
+ere
 nPO
 kxd
 orY
 weS
-kHD
+lQx
 czw
 xaA
 vKo
 kZR
-uXb
+ePv
 mOm
 lbr
 vAl
@@ -263803,32 +262928,32 @@ xZx
 sfo
 xZx
 fPE
-cTi
-cTi
-cTi
+lyF
+lyF
+lyF
 lyF
 lyF
 hlZ
 nhH
 lyF
 kKl
-ngA
-ngA
+nLr
+nLr
 qzu
 weS
 wFk
 mQv
-ldD
-kzV
+vQr
+ycV
 bwY
-uXb
+ePv
 tIi
 iAV
 ePv
-uWS
-ePv
-ePv
-ePv
+lkv
+hpZ
+hpZ
+hpZ
 cKA
 kOj
 sUr
@@ -264062,30 +263187,30 @@ lta
 xit
 okM
 xGM
-cTi
 mxx
-nLr
+mxx
+mxx
 ohW
-nLr
-iGg
-nLr
-nLr
-sZc
+mvc
+cTi
+vQr
+aRV
+aRV
 mAh
-nOR
-nLr
-nLr
-qxC
-kzV
-bwA
-weS
+qpU
+qpU
+qpU
+qgq
+ycV
+obD
+hDc
 sAq
-hGQ
-rHB
+pIZ
+hDc
 mnT
 rhc
-ePv
-ePv
+tAc
+hpZ
 cdz
 xqo
 tnr
@@ -264318,31 +263443,31 @@ dKX
 uwY
 lta
 uwY
-qca
-cTi
-peB
-hNV
-ccH
-oya
-oya
-oya
-oya
+por
+uwY
+lta
+uwY
+fHt
+aaZ
+kQL
+vQr
 aRV
-oya
+aRV
+aRV
 ycV
 ycV
 ycV
 ycV
-szn
+ycV
 mxg
-weS
-oZD
+hDc
+sAq
 pIZ
-aqu
-rPm
+qan
+nVz
 upZ
 sJQ
-ePv
+hpZ
 siL
 iEX
 kQF
@@ -264576,30 +263701,30 @@ lta
 uwY
 lta
 rfU
-qNq
-ufP
-lDn
+sfo
+xZx
+sfo
 vaK
 peU
 jWG
 gDJ
 oBo
-hAb
-okR
-aSp
-aaZ
 iut
-huv
-ycV
-bwA
-gzJ
-dhO
-hGQ
+okR
+ggF
+oBo
+iut
+okR
+pze
+mAh
 fsa
-rPm
+dhO
+pIZ
+fsa
+vOs
 fMQ
 ghR
-ePv
+hpZ
 acy
 evB
 cYn
@@ -264832,31 +263957,31 @@ kGC
 feO
 lta
 uwY
-iKF
+dVD
 cJm
-xiz
+dVD
 oya
-ijA
-hDc
-hDc
-hDc
+dVD
+aaZ
+cTi
+vQr
 akw
 bGX
 ala
-hDc
-hDc
-hDc
-lXp
-ycV
-bwA
+utH
+akw
+bGX
+ala
+cgN
+iSJ
 jEC
-dhO
-pIZ
-vOs
-rPm
-hil
-xmw
-ePv
+uUJ
+pMi
+hDc
+aLZ
+aLZ
+aLZ
+xaX
 pFF
 tRV
 pFF
@@ -265089,31 +264214,31 @@ uwY
 lta
 uwY
 lta
-iKF
-uUJ
-ldD
+cJm
+lta
+uwY
+lta
 oya
-bwA
-hDc
-pKu
-snk
-qpU
+aaZ
+cTi
+vQr
+npG
 kVz
 ygF
 gZF
 pzG
-fHb
+kVz
 iJa
-ycV
+lDn
 mGx
-qVd
+fsa
 qlB
 hGQ
 qan
 rPm
 sLD
 vuS
-ePv
+xaX
 pNh
 wtQ
 wtQ
@@ -265346,31 +264471,31 @@ lta
 uwY
 lta
 uwY
-iKF
-cTi
-bvN
-oya
 dVD
-hDc
-sIP
-nuP
-eZJ
-mvc
-htB
+uwY
+lta
+uwY
+dVD
+aaZ
+cTi
+vQr
+aRV
+aRV
+aRV
 saK
 kJu
-hDc
+qca
 xOS
 lDn
-oRV
-mmK
+obD
+hDc
 iaZ
 ohb
-utH
+fsa
 xoO
 apG
-ePv
-ePv
+htB
+xaX
 pNh
 mmd
 pFF
@@ -265603,31 +264728,31 @@ fKJ
 xqp
 lOq
 rSr
-xlA
-cTi
-qcN
+cJm
+lta
+uwY
+lta
 oya
-bwA
-hDc
-nRI
+aaZ
+cTi
 eZJ
 qjP
-xFc
+qjP
 wOt
-eZJ
+pKu
 oKp
-hDc
-eze
-oya
-wfu
-lkv
-lkv
+iCQ
+vQr
+lDn
+obD
 abi
 abi
-hpZ
-ePv
-ePv
-rMo
+abi
+abi
+xaX
+xaX
+xaX
+xaX
 pNh
 mmd
 pFF
@@ -265860,28 +264985,28 @@ lta
 uwY
 lta
 uwY
-gXm
-cTi
-ldD
+lta
+uwY
+lta
 oya
-bwA
-hDc
+dVD
+sDo
 lwa
-nuP
+sIP
 qmW
-wjK
-iEO
-nuP
+qjP
+qjP
+pKu
 myb
-hDc
-saB
-oya
+iCQ
+ldD
+aRy
 bwA
-lkv
+abi
 slB
 dCC
 nLo
-hpZ
+sZc
 ejQ
 aVD
 pNh
@@ -266118,27 +265243,27 @@ oCK
 bOv
 pxC
 iXK
-cTi
 vIG
-oya
-bwA
-wyn
-vQr
-eZJ
-kcR
-pmr
-lyb
-eZJ
-xfa
-lJT
+vIG
 hjy
-oya
+vIG
+wyn
+cTi
+saB
+kcR
+qjP
+lyb
+qVd
+xfa
+iCQ
+ldD
+aRy
 bwA
-abi
+qNq
 fhK
 sCr
 bXb
-hpZ
+sZc
 pNh
 wtQ
 wtQ
@@ -266376,26 +265501,26 @@ jXx
 jXx
 jXx
 jXx
-mlR
-oya
+cTi
+wPf
 vDa
-wyn
-vQr
+cTi
+cTi
 nuP
 vmu
 vpy
-sDo
+vmu
 nuP
-obD
-wyn
+nuP
+nuP
 ldD
-oya
-mGx
+aRy
+aTe
 dnR
 xxq
 kCI
 box
-hpZ
+sZc
 pNh
 wtQ
 lYe
@@ -266633,26 +265758,26 @@ hHk
 owU
 owU
 bSq
-ldD
-oya
-bwA
-wyn
-vQr
+spo
+szn
+hNV
+nuP
+gXm
 aYX
-pze
-cgN
-lyb
-eZJ
-obD
-wyn
+lyV
+wOX
+bvN
+aYX
+mZZ
+nuP
 ldD
-oya
+aRy
 bwA
-abi
+qNq
 hCC
 wAV
 uJJ
-hpZ
+sZc
 igW
 sIs
 gHN
@@ -266883,33 +266008,33 @@ szj
 rYa
 uOx
 jVV
-ggF
-ggF
-ggF
-ggF
-ggF
-ggF
-ggF
-aTe
-oya
+lpH
+lpH
+lpH
+lpH
+lpH
+uXb
+uXb
+ldD
+mXj
 bwA
-wyn
-vQr
-nuP
-hZe
-pMi
-ryh
+vmu
 hjO
-omv
-kdx
-nlE
-oya
+gNz
+hZe
+wOX
+ryh
+lyV
+bAu
+vmu
+ldD
+aRy
 bwA
 cQk
 moL
-lkv
-lkv
-hpZ
+tpX
+tpX
+vJH
 aPD
 wtQ
 gHN
@@ -267140,33 +266265,33 @@ cns
 fUa
 aUT
 amw
-ggF
-vJH
-peE
-mPR
+lpH
+ykr
+ykr
+ykr
 lpH
 fWZ
-wPf
-ldD
-oya
-bwA
-hDc
+nLr
+qxC
+mXj
+ngA
+vpy
 slK
-eZJ
-nuP
+slK
+slK
 xFc
-lyb
-eZJ
 oLY
-hDc
-lQx
-oya
-aOx
+oLY
+oLY
+azI
+mXj
+aRy
+bwA
 woW
 egP
 cYg
 bxV
-xaX
+vJH
 pgR
 wAP
 gHN
@@ -267397,33 +266522,33 @@ cns
 nHR
 ssM
 rYa
-ggF
-cFi
-ezN
-agI
+lpH
+ykr
+ykr
+ykr
 nNB
-oFn
-wPf
 ldD
-oya
-bwA
-hDc
-lKK
-nuP
-iSJ
-wjK
-gaE
-lyb
+ngA
+oxG
+mXj
+ngA
+vpy
 wOX
-hDc
+wOX
+wOX
+wjK
+wOX
+wOX
+wOX
 qoy
-ycV
-mGx
+ngA
+aRy
+aTe
 uyh
 elN
 iwj
 pOn
-xaX
+vJH
 pgR
 jeo
 gHN
@@ -267654,33 +266779,33 @@ cns
 pBD
 rYa
 rVe
-ggF
+lpH
 ykr
 hLC
 biC
 pTd
-gbx
-itD
 wnB
-oya
+aRy
+aRy
+mXj
 bwA
-hDc
-hui
-eZJ
-nuP
-nbd
-lyb
-eZJ
+vmu
 bAu
-hDc
-qIR
-oya
+lyV
+nlE
+wOX
+ryh
+lyV
+bAu
+vmu
+ldD
+aRy
 bwA
 woW
 wUm
 pjf
 kvj
-xaX
+vJH
 pAt
 wtQ
 gHN
@@ -267911,33 +267036,33 @@ cns
 wHN
 ohd
 wHN
-ggF
-cFi
-ezN
-gcQ
-ezN
-oFn
-wPf
+lpH
+ykr
+bkw
+ykr
+nNB
 ldD
-oya
-vvi
-hDc
-oxG
+ngA
+hil
+mXj
+bwA
+nuP
+bAu
 vFO
 lyV
-lky
+wOX
 gNz
 sDv
 mZZ
-hDc
-dul
-oya
-bkw
-aLZ
+nuP
+ldD
+aRy
+bwA
+tpX
 udA
 hcA
 orH
-xaX
+vJH
 xXO
 wtQ
 uAF
@@ -268168,33 +267293,33 @@ cns
 mCN
 rYa
 rYa
-ggF
+lpH
 psk
 ezN
-abC
-qgq
+ykr
+lpH
 ava
-iCQ
-jQa
-oya
-dVD
-hDc
-hDc
-hDc
-akw
-bGX
-fHt
-hDc
-hDc
-hDc
-cEm
-oya
-tAc
-xaX
-xaX
-xaX
-xaX
-xaX
+aSp
+huv
+mXj
+bwA
+nuP
+nuP
+nuP
+vmu
+vpy
+vmu
+nuP
+nuP
+nuP
+ldD
+aRy
+ijA
+vJH
+vJH
+vJH
+vJH
+vJH
 lYe
 cnS
 gHN
@@ -268425,28 +267550,28 @@ cns
 ojn
 rYa
 rYa
-ggF
-kPn
-kQL
-fqS
-iCQ
-iCQ
-iCQ
-dsy
-oya
+lpH
+ykr
+ykr
+ykr
+lpH
+weS
+weS
+ldD
+mXj
 pWo
-nOR
-hbh
-wSe
 nLr
-sOc
-ere
-wSe
-dBO
+hbh
+nLr
+nLr
+ngA
+nLr
+nLr
+nLr
 nLr
 qxC
-oya
-tpX
+aRy
+bwA
 pIY
 rRJ
 yiU
@@ -268682,28 +267807,28 @@ cns
 wHN
 its
 wHN
-ggF
-ggF
-ggF
-ggF
-ggF
+lpH
+lpH
+lpH
+lpH
+lpH
 kHD
 tHv
 ldD
 mXj
-oya
-oya
-oya
-oya
-oya
-ccH
-oya
-oya
-oya
-oya
-oya
-nVz
-tZT
+mXj
+mXj
+mXj
+mXj
+mXj
+aRy
+aRy
+aRy
+aRy
+aRy
+aRy
+aRy
+bwA
 hqv
 ylM
 tYe
@@ -268946,13 +268071,13 @@ nZN
 uXb
 kHD
 euE
-spo
-cAx
+ava
+aSp
 cSu
 aSp
-npG
 aSp
-huv
+aSp
+uVZ
 aRy
 qvo
 gSO
@@ -269210,7 +268335,7 @@ xqS
 xqS
 xqS
 ldD
-azI
+ccH
 wfu
 caz
 wWB
@@ -269724,12 +268849,12 @@ aCd
 dVQ
 xqS
 chZ
-azI
+ccH
 bwA
-tUX
+lky
 vrI
 vGa
-uVZ
+vGa
 lPD
 gUR
 gFj

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -6197,13 +6197,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
-"bFI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/full,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "bFS" = (
 /obj/structure/railing/wrestling{
 	dir = 4
@@ -6646,11 +6639,10 @@
 /turf/open/floor/carpet,
 /area/station/service/cafeteria)
 "bMn" = (
-/obj/structure/sign/departments/virology/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/medbay/central)
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/full,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "bMx" = (
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
@@ -7316,7 +7308,19 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/virology,
+/obj/machinery/door/airlock/virology{
+	frequency = 1449;
+	autoclose = 0;
+	id_tag = "viro_med_external";
+	name = "Virology Exterior Airlock"
+	},
+/obj/machinery/door_buttons/access_button{
+	pixel_x = 25;
+	pixel_y = 0;
+	idSelf = "viro_med_control";
+	idDoor = "viro_med_external";
+	req_access = list("virology")
+	},
 /turf/open/floor/iron/white/smooth_half,
 /area/station/medical/virology)
 "bXb" = (
@@ -11378,7 +11382,7 @@
 /obj/effect/turf_decal/trimline/dark_red/warning{
 	dir = 5
 	},
-/obj/machinery/digital_clock/directional/east,
+/obj/structure/sign/clock/directional/east,
 /turf/open/floor/iron/white/corner{
 	dir = 8
 	},
@@ -31793,7 +31797,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Employee Entrance"
+	name = "Medbay Patient Exit"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
@@ -33729,6 +33733,13 @@
 /obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/security/courtroom)
+"jbi" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/full,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "jbq" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/item/radio/intercom/directional/south,
@@ -42778,6 +42789,14 @@
 	dir = 1
 	},
 /area/station/engineering/atmos)
+"lsY" = (
+/obj/effect/turf_decal/trimline/blue/warning,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/chemistry)
 "lta" = (
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chemistry)
@@ -66237,6 +66256,14 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/iron/dark/airless,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
+"rVn" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/full,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "rVp" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
@@ -67534,6 +67561,15 @@
 /area/station/maintenance/fore)
 "slq" = (
 /obj/effect/turf_decal/tile/dark_green,
+/obj/machinery/door_buttons/airlock_controller{
+	pixel_x = 0;
+	pixel_y = 24;
+	idSelf = "viro_med_control";
+	name = "Virology Medical Access Control";
+	idInterior = "viro_med_internal";
+	idExterior = "viro_med_external";
+	req_access = list("virology")
+	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -68304,11 +68340,6 @@
 	dir = 1
 	},
 /area/station/cargo/storage)
-"svb" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/full,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "svg" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
@@ -73067,7 +73098,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Employee Entrance"
+	name = "Medbay Patient Exit"
 	},
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 1
@@ -73874,14 +73905,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/ordnance_maint)
-"tRW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/full,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "tRY" = (
 /turf/closed/wall,
 /area/station/maintenance/abandon_exam)
@@ -90076,7 +90099,19 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/virology,
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "viro_med_internal";
+	name = "Virology Interior Airlock"
+	},
+/obj/machinery/door_buttons/access_button{
+	pixel_x = 25;
+	pixel_y = 0;
+	idSelf = "viro_med_control";
+	idDoor = "viro_med_internal";
+	req_access = list("virology")
+	},
 /turf/open/floor/iron/white/smooth_half,
 /area/station/medical/virology)
 "yeq" = (
@@ -200450,7 +200485,7 @@ vUe
 win
 uXb
 pdp
-bMn
+naP
 lGE
 ldV
 xcB
@@ -253477,9 +253512,9 @@ kuu
 cDJ
 uTc
 mFr
-tRW
-bFI
-svb
+rVn
+jbi
+bMn
 pGR
 iyb
 eoO
@@ -264965,7 +265000,7 @@ lta
 uwY
 lta
 oya
-aaZ
+lsY
 cTi
 kiq
 npG

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -783,11 +783,27 @@
 /obj/structure/fence/cut/large,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"ajL" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/medbay/central)
 "ajP" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"ajT" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/medical/office)
 "aka" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_burn_chamber_input{
 	dir = 8
@@ -1110,6 +1126,15 @@
 /obj/effect/spawner/random/entertainment/toy,
 /turf/open/floor/iron,
 /area/station/service/theater/abandoned)
+"anO" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "aoc" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -1558,6 +1583,15 @@
 	dir = 1
 	},
 /area/station/engineering/atmospherics_engine)
+"ata" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "atg" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/warning{
@@ -2124,11 +2158,14 @@
 	},
 /area/station/hallway/primary/aftporthall)
 "azI" = (
-/obj/machinery/door/airlock/medical/glass,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Office"
+	},
 /turf/open/floor/wood/tile,
 /area/station/medical/office)
 "azJ" = (
@@ -3620,6 +3657,14 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"aUU" = (
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 10
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 4
+	},
+/area/station/medical/aslyum)
 "aUX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -3965,6 +4010,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/medical_doctor,
+/obj/machinery/light/directional/west,
 /turf/open/floor/carpet/blue,
 /area/station/medical/office)
 "aZb" = (
@@ -4546,7 +4592,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/trimline/dark_red/warning,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
 /area/station/medical/aslyum)
 "biE" = (
 /obj/machinery/light/directional/north,
@@ -4564,6 +4613,15 @@
 /obj/effect/turf_decal/siding/wood/end,
 /turf/open/floor/wood/tile,
 /area/station/medical/psychology)
+"biK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/station/medical/office)
 "biM" = (
 /obj/structure/cable,
 /obj/item/papercutter{
@@ -5517,7 +5575,6 @@
 	pixel_x = -4;
 	pixel_y = 5
 	},
-/obj/item/folder/white,
 /turf/open/floor/carpet/blue,
 /area/station/medical/office)
 "bvR" = (
@@ -5957,6 +6014,18 @@
 	dir = 4
 	},
 /area/station/security/office)
+"bCD" = (
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/chemistry)
 "bCE" = (
 /turf/open/misc/dirt/icemoon,
 /area/icemoon/underground/explored/graveyard)
@@ -6622,11 +6691,17 @@
 /turf/open/floor/carpet,
 /area/station/service/cafeteria)
 "bMn" = (
-/obj/structure/sign/departments/virology/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/medbay/central)
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "bMx" = (
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
@@ -7291,9 +7366,18 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door_buttons/access_button{
+	dir = 1;
+	idDoor = "virology_airlock_exterior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_y = 5;
+	req_access = list("virology");
+	pixel_x = 25
+	},
 /turf/open/floor/iron/white/smooth_half,
 /area/station/medical/virology)
 "bXb" = (
@@ -8109,12 +8193,10 @@
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "cgN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/disposalpipe/junction/yjunction,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "cgQ" = (
@@ -8311,14 +8393,9 @@
 /turf/open/floor/wood/parquet,
 /area/station/commons/dorms/room6)
 "ckr" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8;
-	pixel_x = 7
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 1
 	},
@@ -8697,6 +8774,18 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/qm)
+"cpo" = (
+/obj/effect/turf_decal/tile/blue/anticorner{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 8
+	},
+/area/station/medical/medbay/central)
 "cpr" = (
 /obj/structure/rack,
 /obj/item/flashlight,
@@ -8925,6 +9014,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/nt_rep)
+"csZ" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/medbay/central)
 "ctd" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -9981,6 +10080,11 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
+"cIi" = (
+/obj/effect/turf_decal/tile/blue/half,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/medbay/central)
 "cIj" = (
 /mob/living/carbon/human/species/monkey,
 /obj/structure/flora/grass/jungle/b/style_4{
@@ -10354,6 +10458,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
+"cNg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "cNm" = (
 /turf/closed/wall,
 /area/station/hallway/primary)
@@ -10409,6 +10522,14 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
+"cOl" = (
+/obj/effect/turf_decal/tile/blue/half,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/sign/departments/med/directional/south,
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/treatment_center)
 "cOn" = (
 /obj/structure/closet/secure_closet/chemical,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -10609,6 +10730,15 @@
 	},
 /turf/open/floor/cult,
 /area/station/maintenance/condemnedroom)
+"cQG" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "cQI" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/eighties,
@@ -12065,6 +12195,15 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark/side,
 /area/station/service/bar)
+"dmJ" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/obj/machinery/status_display/ai/directional/west,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/medbay/central)
 "dmS" = (
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/siding/wood,
@@ -12373,10 +12512,14 @@
 /turf/open/floor/iron/white/small,
 /area/station/common/pool)
 "drp" = (
-/obj/machinery/newscaster/directional/east,
-/obj/effect/turf_decal/tile/dark_green/opposingcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "drx" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
 	dir = 1
@@ -13371,6 +13514,14 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"dGP" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Office"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/turf/open/floor/wood/tile,
+/area/station/medical/office)
 "dGR" = (
 /obj/effect/turf_decal/tile/brown/fourcorners,
 /obj/effect/turf_decal/siding/brown{
@@ -13667,6 +13818,15 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "virology_airlock_exterior";
+	idInterior = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Console";
+	pixel_x = 25;
+	req_access = list("virology");
+	pixel_y = 24
+	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -14400,6 +14560,21 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/execution/transfer)
+"dUD" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "dUE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -15037,6 +15212,20 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms)
+"edy" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/cup/bottle/morphine{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/syringe,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "edB" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/steam_vent,
@@ -15240,6 +15429,20 @@
 	dir = 8
 	},
 /area/station/hallway/primary/foreporthall)
+"egl" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/directional/east{
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/chemistry)
 "egv" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
@@ -16016,7 +16219,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/medical/medbay/central)
+/area/station/medical/treatment_center)
 "erk" = (
 /obj/structure/rack/wooden,
 /obj/item/reagent_containers/cup/glass/coffee_cup{
@@ -16989,6 +17192,13 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/warden)
+"eFA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "eFC" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 10
@@ -19079,6 +19289,14 @@
 	dir = 1
 	},
 /area/station/hallway/primary/fore)
+"fjk" = (
+/obj/effect/turf_decal/trimline/blue/warning,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/chemistry)
 "fjl" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -20772,6 +20990,7 @@
 /area/station/science/lab)
 "fGp" = (
 /obj/effect/turf_decal/tile/blue/anticorner,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 1
 	},
@@ -20916,6 +21135,15 @@
 /obj/machinery/oven/range,
 /turf/open/floor/iron/kitchen,
 /area/station/maintenance/abandon_cafeteria)
+"fIx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "fII" = (
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
@@ -21915,6 +22143,15 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/west,
+/obj/machinery/newscaster/directional/north,
+/obj/structure/closet/secure_closet{
+	req_access = list("medical");
+	name = "Restraint Locker"
+	},
+/obj/item/clothing/suit/jacket/straight_jacket,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/mask/muzzle,
+/obj/item/restraints/handcuffs,
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/medical/medbay/central)
 "fXm" = (
@@ -22715,6 +22952,7 @@
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 1
 	},
@@ -22812,6 +23050,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/sepia,
 /area/station/service/kitchen/diner)
+"gjv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "gjB" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/dark_green/opposingcorners,
@@ -25044,11 +25291,10 @@
 /area/station/hallway/primary)
 "gNz" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = 4;
+/obj/item/modular_computer/laptop{
+	pixel_x = -5;
 	pixel_y = 6
 	},
-/obj/item/folder/white,
 /turf/open/floor/carpet/blue,
 /area/station/medical/office)
 "gND" = (
@@ -25107,6 +25353,16 @@
 /obj/item/stack/sheet/iron/twenty,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engineering/engie_aft_starboard)
+"gOt" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/station/medical/medbay/central)
 "gOv" = (
 /obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -25739,6 +25995,8 @@
 "gXm" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/machinery/status_display/evac/directional/west,
+/obj/item/kirbyplants/random,
 /turf/open/floor/carpet/blue,
 /area/station/medical/office)
 "gXo" = (
@@ -26195,11 +26453,14 @@
 	},
 /area/station/engineering/atmos/hallway)
 "hdQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/hedge,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/grass,
-/area/station/medical/break_room)
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/medbay/central)
 "hdR" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 8
@@ -26508,6 +26769,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 4
+	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
@@ -26590,6 +26854,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"hjZ" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/station/medical/office)
 "hka" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/steam_vent,
@@ -27324,6 +27595,8 @@
 /obj/effect/turf_decal/tile/blue/anticorner,
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
+/obj/machinery/light_switch/directional/east,
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 1
 	},
@@ -27427,6 +27700,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "huw" = (
@@ -27628,6 +27902,27 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron/checker,
 /area/station/commons/lounge)
+"hxV" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/structure/rack/shelf,
+/obj/item/storage/box/gloves{
+	pixel_x = 0;
+	pixel_y = -4
+	},
+/obj/item/storage/box/gloves{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/item/storage/box/rxglasses{
+	pixel_x = 0;
+	pixel_y = 10
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "hxX" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -27921,6 +28216,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/edge,
 /area/station/hallway/floor2)
+"hCw" = (
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 5
+	},
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/iron/white/corner{
+	dir = 8
+	},
+/area/station/medical/aslyum)
 "hCx" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/table/reinforced,
@@ -30997,6 +31301,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/primary)
+"isy" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
+/area/station/medical/aslyum)
 "isz" = (
 /obj/effect/turf_decal/trimline/white/filled/line,
 /obj/machinery/camera/autoname/directional/south,
@@ -31603,7 +31916,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Employee Entrance"
+	name = "Medbay Patient Exit"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
@@ -31708,6 +32021,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_arcade)
+"iDb" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/wood,
+/area/station/medical/office)
 "iDf" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/dark_green{
@@ -32140,10 +32459,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "iJa" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/blue/warning{
 	dir = 6
 	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/defibrillator_mount/mobile,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
 "iJc" = (
@@ -32640,6 +32961,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/morgue)
+"iPi" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Patient Room B"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white/smooth_half,
+/area/station/medical/treatment_center)
 "iPl" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 8
@@ -33157,6 +33488,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/condemned_med)
+"iWK" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white/side,
+/area/station/medical/aslyum)
 "iWL" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -33258,6 +33596,9 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 4
+	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
@@ -33269,6 +33610,15 @@
 	dir = 1
 	},
 /area/mine/laborcamp/security)
+"iXT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "iXY" = (
 /obj/structure/chair/sofa/right{
 	dir = 4
@@ -33948,12 +34298,12 @@
 /area/station/commons/dorms/room6)
 "jgG" = (
 /obj/effect/turf_decal/tile/blue,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box{
 	pixel_y = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/medical/break_room)
@@ -34258,6 +34608,13 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/mine/laborcamp)
+"jla" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "jlb" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 8;
@@ -34336,6 +34693,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/security/office)
+"jlE" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/medical/office)
 "jlI" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/light/directional/west,
@@ -35665,7 +36028,9 @@
 /turf/open/floor/wood/parquet,
 /area/station/commons/dorms/room4)
 "jEC" = (
-/obj/machinery/door/airlock/medical/glass,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Patient Rooms"
+	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/unres{
@@ -35674,6 +36039,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "jET" = (
@@ -35971,6 +36337,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/medical/virology)
+"jJg" = (
+/obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white/side,
+/area/station/medical/aslyum)
 "jJm" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -39029,7 +39402,7 @@
 /turf/open/floor/iron/white/smooth_half{
 	dir = 8
 	},
-/area/station/medical/medbay/central)
+/area/station/medical/treatment_center)
 "kxi" = (
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/dark/smooth_half,
@@ -39281,13 +39654,11 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
+/obj/structure/sign/departments/chemistry/directional/east,
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/blue/warning{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/east{
-	network = list("ss13","medbay")
-	},
-/obj/structure/sign/departments/chemistry/directional/east,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
@@ -40059,12 +40430,12 @@
 /area/station/security/warden)
 "kKl" = (
 /obj/item/kirbyplants/random,
-/obj/structure/sign/poster/official/help_others/directional/north,
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 1
 	},
+/obj/structure/sign/departments/exam_room/directional/north,
 /turf/open/floor/iron/white/smooth_corner,
-/area/station/medical/medbay/central)
+/area/station/medical/treatment_center)
 "kKt" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/flora/bush/flowers_br/style_3,
@@ -40869,10 +41240,15 @@
 /turf/open/openspace,
 /area/station/hallway/primary/aft)
 "kVz" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/blue/warning{
 	dir = 4
 	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/item/clothing/neck/stethoscope{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
 "kVC" = (
@@ -41594,6 +41970,16 @@
 	dir = 1
 	},
 /area/station/medical/chemistry)
+"lgN" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "lgQ" = (
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
@@ -41686,6 +42072,15 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron/large,
 /area/station/engineering/atmos)
+"lib" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/light/directional/west,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "lie" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -41811,6 +42206,12 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
+"ljH" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "ljK" = (
 /obj/machinery/recharger{
 	pixel_y = 4
@@ -42506,10 +42907,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
 "lud" = (
-/obj/structure/chair/sofa/corp{
-	dir = 8;
-	pixel_x = 7
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -42518,6 +42915,10 @@
 	},
 /obj/item/radio/intercom/directional/east,
 /obj/effect/landmark/start/medical_doctor,
+/obj/structure/chair/sofa/corp/left{
+	dir = 8;
+	pixel_x = 7
+	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
@@ -43150,6 +43551,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "lDr" = (
@@ -43203,6 +43607,10 @@
 	dir = 1
 	},
 /area/station/command/gateway)
+"lDU" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "lEd" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 1
@@ -46192,6 +46600,11 @@
 	dir = 1
 	},
 /area/station/service/bar)
+"mwZ" = (
+/obj/effect/turf_decal/tile/blue/half,
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/treatment_center)
 "mxc" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -46320,6 +46733,7 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/cryo)
 "myd" = (
@@ -46539,6 +46953,15 @@
 	dir = 8
 	},
 /area/station/security/prison)
+"mBO" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/treatment_center)
 "mBP" = (
 /obj/structure/curtain/cloth/fancy/mechanical{
 	name = "curtain";
@@ -48156,7 +48579,8 @@
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/starboard)
 "mZZ" = (
-/obj/structure/filingcabinet/chestdrawer,
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/carpet/blue,
 /area/station/medical/office)
 "nah" = (
@@ -48282,6 +48706,13 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/open/floor/wood,
 /area/station/maintenance/fore/greater)
+"nck" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/break_room)
 "ncF" = (
 /obj/structure/chair/pew/left{
 	dir = 1
@@ -48880,6 +49311,12 @@
 	dir = 8
 	},
 /area/station/hallway/primary/starboard)
+"nmY" = (
+/obj/effect/turf_decal/trimline/dark_red/warning,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/station/medical/aslyum)
 "nna" = (
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance_storage,
 /obj/structure/disposalpipe/segment{
@@ -49127,10 +49564,11 @@
 /turf/open/floor/iron/smooth,
 /area/mine/laborcamp)
 "npG" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/blue/warning{
 	dir = 5
 	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/defibrillator_mount/mobile,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
 "npI" = (
@@ -50105,6 +50543,17 @@
 	dir = 8
 	},
 /area/station/hallway/primary/aft)
+"nCi" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/closet/secure_closet/medical1,
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "nCl" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -50215,6 +50664,15 @@
 /obj/effect/spawner/random/structure/chair_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/law)
+"nDh" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/medbay/central)
 "nDl" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/dark,
@@ -51250,7 +51708,7 @@
 /turf/open/floor/iron/white/smooth_half{
 	dir = 8
 	},
-/area/station/medical/medbay/central)
+/area/station/medical/treatment_center)
 "nPY" = (
 /obj/structure/cable,
 /obj/machinery/light_switch/directional/south,
@@ -52126,6 +52584,7 @@
 /area/icemoon/underground/explored/graveyard)
 "obD" = (
 /obj/effect/turf_decal/tile/blue/half,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/treatment_center)
 "obL" = (
@@ -52459,6 +52918,16 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
+"ogQ" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "ogS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -52471,6 +52940,7 @@
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "ohb" = (
 /obj/effect/turf_decal/tile/blue/anticorner,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 1
 	},
@@ -53263,7 +53733,7 @@
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/medical/medbay/central)
+/area/station/medical/treatment_center)
 "osb" = (
 /obj/structure/closet/emcloset,
 /obj/item/flashlight,
@@ -53855,11 +54325,11 @@
 /area/station/hallway/primary)
 "oBf" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "oBi" = (
@@ -54485,6 +54955,8 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/cryo)
 "oKq" = (
@@ -54630,6 +55102,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/station/medical/office)
 "oMn" = (
@@ -55066,10 +55541,17 @@
 	},
 /area/station/science/robotics/lab)
 "oRV" = (
-/obj/effect/turf_decal/tile/blue/half,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white/smooth_edge,
-/area/station/medical/medbay/central)
+/obj/structure/table/wood,
+/obj/item/folder/white{
+	pixel_x = -2;
+	pixel_y = 0
+	},
+/obj/item/paper_bin{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "oRX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/newscaster/directional/south,
@@ -56591,6 +57073,18 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/aft)
+"plT" = (
+/obj/structure/rack/shelf,
+/obj/item/storage/box/syringes{
+	pixel_x = 0;
+	pixel_y = -4
+	},
+/obj/item/storage/box/syringes{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "plV" = (
 /obj/structure/railing/wooden_fence,
 /turf/open/misc/hay/icemoon,
@@ -57010,7 +57504,10 @@
 "psk" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white/side,
 /area/station/medical/aslyum)
 "psn" = (
 /obj/structure/closet/firecloset,
@@ -58641,11 +59138,14 @@
 /turf/open/floor/grass,
 /area/station/hallway/secondary/entry)
 "pTd" = (
-/obj/machinery/door/airlock/medical/glass,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Asylum"
+	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/white,
 /area/station/medical/aslyum)
 "pTg" = (
@@ -59113,7 +59613,9 @@
 /turf/closed/wall,
 /area/station/maintenance/department/security/brig)
 "qan" = (
-/obj/machinery/door/airlock/medical/glass,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Patient Room A"
+	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -60019,9 +60521,13 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/lab)
 "qoy" = (
-/obj/machinery/door/airlock/medical/glass,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Office"
+	},
 /turf/open/floor/wood/tile,
 /area/station/medical/office)
 "qoB" = (
@@ -60286,6 +60792,15 @@
 	dir = 6
 	},
 /area/station/service/chapel)
+"qrQ" = (
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 9
+	},
+/obj/structure/bed{
+	dir = 1
+	},
+/turf/open/floor/iron/white/corner,
+/area/station/medical/aslyum)
 "qrR" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -60337,6 +60852,22 @@
 "qsH" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/science/central)
+"qsJ" = (
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/item/reagent_containers/chem_pack{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/item/stack/medical/bone_gel{
+	pixel_x = -6;
+	pixel_y = 0
+	},
+/obj/structure/table/reinforced/rglass,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/treatment_center)
 "qsK" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -60420,6 +60951,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/orderly,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -60803,10 +61337,23 @@
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 8
 	},
+/obj/structure/table,
+/obj/item/stack/medical/mesh{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/stack/medical/suture{
+	pixel_x = 6;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/hypospray/medipen{
+	pixel_x = -3;
+	pixel_y = -4
+	},
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 4
 	},
-/area/station/medical/medbay/central)
+/area/station/medical/treatment_center)
 "qzx" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -63099,6 +63646,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -63743,6 +64291,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
+"rrF" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/medical/office)
 "rrG" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -64121,6 +64675,14 @@
 /area/station/hallway/primary/forestarboardhall)
 "ryh" = (
 /obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 11;
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/hypospray/medipen{
+	pixel_x = -5;
+	pixel_y = -3
+	},
 /turf/open/floor/carpet/blue,
 /area/station/medical/office)
 "rym" = (
@@ -64975,16 +65537,23 @@
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
 	frequency = 1449;
-	id_tag = "virology_airlock_interior";
-	name = "Virology Interior Airlock"
+	id_tag = "virology_airlock_interior2"s";
+	name = "Public Virology Interior Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door_buttons/access_button{
+	dir = 1;
+	idDoor = "virology_airlock_interior2";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_y = -21;
+	req_access = list("virology");
+	pixel_x = -5
+	},
 /turf/open/floor/iron/white/smooth_half{
 	dir = 8
 	},
@@ -65161,6 +65730,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/secondary/recreation)
+"rOW" = (
+/obj/structure/table/wood,
+/obj/item/folder/white{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/obj/item/storage/pill_bottle/iron{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "rPg" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -65512,6 +66093,14 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"rSI" = (
+/obj/effect/turf_decal/trimline/blue/warning,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/chemistry)
 "rSL" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -66831,6 +67420,12 @@
 	},
 /turf/open/floor/cult,
 /area/station/maintenance/condemnedroom)
+"sis" = (
+/obj/effect/turf_decal/tile/blue/half,
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/treatment_center)
 "six" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -67082,6 +67677,9 @@
 /area/station/hallway/primary/foreporthall)
 "slK" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
 /turf/open/floor/wood,
 /area/station/medical/office)
 "slN" = (
@@ -67621,16 +68219,23 @@
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
 	frequency = 1449;
-	id_tag = "virology_airlock_exterior";
-	name = "Virology Exterior Airlock"
+	id_tag = "virology_airlock_exterior2";
+	name = "Public Virology Exterior Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door_buttons/access_button{
+	dir = 1;
+	idDoor = "virology_airlock_exterior2";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_y = -22;
+	req_access = list("virology");
+	pixel_x = 0
+	},
 /turf/open/floor/iron/white/smooth_half{
 	dir = 8
 	},
@@ -68525,6 +69130,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/medical_doctor,
+/obj/machinery/light/directional/east,
 /turf/open/floor/carpet/blue,
 /area/station/medical/office)
 "sDw" = (
@@ -68916,7 +69522,7 @@
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 8
 	},
-/obj/structure/noticeboard/directional/east,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
@@ -68990,6 +69596,7 @@
 /obj/effect/turf_decal/tile/blue/half,
 /obj/machinery/iv_drip,
 /obj/structure/cable,
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/patients_rooms/room_a)
 "sJR" = (
@@ -71577,6 +72184,15 @@
 	},
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/primary/forestarboardhall)
+"tvT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/station/medical/office)
 "tvW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -72264,7 +72880,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/light_switch/directional/east,
+/obj/structure/sign/departments/exam_room/directional/east,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 1
 	},
@@ -72518,11 +73134,11 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Employee Entrance"
-	},
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 1
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Patient Exit"
 	},
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/medical/treatment_center)
@@ -73651,6 +74267,15 @@
 	dir = 5
 	},
 /area/station/cargo/miningfoundry)
+"tWW" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 8
+	},
+/area/station/medical/medbay/central)
 "tXf" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/flora/bush/fullgrass,
@@ -75364,18 +75989,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "uwM" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/warning{
+/obj/effect/turf_decal/tile/blue/half{
 	dir = 4
 	},
-/obj/machinery/light/directional/east,
-/obj/machinery/status_display/evac/directional/east,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
-/area/station/medical/chemistry)
+/area/station/medical/medbay/central)
 "uwN" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -75706,6 +76329,7 @@
 "uBC" = (
 /obj/effect/turf_decal/tile/blue/anticorner,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 1
 	},
@@ -78124,6 +78748,14 @@
 	},
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/fore)
+"vjA" = (
+/obj/effect/turf_decal/trimline/blue/warning,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/medical/chemistry)
 "vjF" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -78217,6 +78849,15 @@
 	},
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary)
+"vlF" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "vlO" = (
 /obj/structure/cable,
 /obj/structure/chair/comfy{
@@ -78529,6 +79170,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"voS" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "voV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -78604,8 +79252,11 @@
 /turf/open/floor/carpet,
 /area/station/service/library/private)
 "vpy" = (
-/obj/machinery/door/airlock/medical/glass,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Office"
+	},
 /turf/open/floor/wood/tile,
 /area/station/medical/office)
 "vpz" = (
@@ -78921,6 +79572,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp/security)
+"vui" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "vut" = (
 /turf/open/floor/iron/stairs/left,
 /area/station/hallway/primary)
@@ -78937,6 +79597,8 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 4
 	},
@@ -79087,6 +79749,13 @@
 	dir = 4
 	},
 /area/station/hallway/primary/port)
+"vxj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "vxk" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/structure/disposalpipe/segment{
@@ -79737,6 +80406,7 @@
 /area/station/hallway/primary/aft)
 "vFO" = (
 /obj/effect/landmark/start/medical_doctor,
+/obj/machinery/light/directional/east,
 /turf/open/floor/carpet/blue,
 /area/station/medical/office)
 "vFP" = (
@@ -79943,13 +80613,12 @@
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms/room7)
 "vIG" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 1
 	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 4
-	},
-/area/station/medical/chemistry)
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/white/side,
+/area/station/medical/aslyum)
 "vIO" = (
 /turf/closed/wall/r_wall,
 /area/station/security/office)
@@ -80269,6 +80938,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
+"vMg" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "vMu" = (
 /turf/open/openspace/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
@@ -80454,6 +81132,7 @@
 	},
 /obj/structure/table/glass,
 /obj/effect/spawner/random/medical/medkit,
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 8
 	},
@@ -81879,6 +82558,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/station/medical/office)
 "wjP" = (
@@ -81992,6 +82675,26 @@
 	dir = 1
 	},
 /area/station/service/hydroponics)
+"wlb" = (
+/obj/structure/table,
+/obj/item/storage/box/masks{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/bottle/epinephrine{
+	pixel_x = 7;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/bottle/multiver{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "wle" = (
 /obj/machinery/computer/monitor{
 	name = "Bridge Power Monitoring Console"
@@ -82941,6 +83644,11 @@
 	dir = 4
 	},
 /area/station/service/hydroponics/garden)
+"wym" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/turf/open/floor/plating,
+/area/station/medical/break_room)
 "wyn" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -83645,6 +84353,24 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white/small,
 /area/station/common/pool)
+"wGV" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -4;
+	pixel_y = 14
+	},
+/obj/item/clothing/glasses/hud/health{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/hud/health,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/medbay/central)
 "wHa" = (
 /turf/open/floor/iron/edge{
 	dir = 4
@@ -84226,6 +84952,9 @@
 	},
 /area/station/hallway/primary/foreporthall)
 "wOX" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/station/medical/office)
 "wOZ" = (
@@ -84282,6 +85011,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
+"wPm" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/white/side{
+	dir = 8
+	},
+/area/station/medical/aslyum)
 "wPq" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/door/window/right/directional/south{
@@ -84463,6 +85201,15 @@
 	},
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/science/robotics/lab)
+"wRV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "wRX" = (
 /obj/structure/table,
 /obj/item/poster/random_official{
@@ -85453,6 +86200,8 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 1
 	},
@@ -87463,6 +88212,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/station/medical/office)
 "xFd" = (
@@ -88594,6 +89349,11 @@
 	dir = 1
 	},
 /area/station/medical/chemistry)
+"xUl" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/carpet/blue,
+/area/station/medical/office)
 "xUz" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
@@ -88700,6 +89460,15 @@
 /obj/effect/turf_decal/tile/dark_green,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "virology_airlock_exterior2";
+	idInterior = "virology_airlock_interior2";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Console";
+	pixel_x = -23;
+	req_access = list("virology");
+	pixel_y = -22
+	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -89075,6 +89844,24 @@
 	},
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
+"yaY" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/structure/rack/shelf,
+/obj/structure/bed/medical/emergency,
+/obj/structure/bed/medical/emergency{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/obj/structure/bed/medical/emergency{
+	pixel_x = 0;
+	pixel_y = 9
+	},
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/medical/treatment_center)
 "ybh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -89326,11 +90113,18 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door_buttons/access_button{
+	dir = 1;
+	idDoor = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_y = 7;
+	req_access = list("virology");
+	pixel_x = 24
+	},
 /turf/open/floor/iron/white/smooth_half,
 /area/station/medical/virology)
 "yeq" = (
@@ -89355,6 +90149,19 @@
 	dir = 4
 	},
 /area/station/security/prison)
+"yeC" = (
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 6
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/pill_bottle/psicodine{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/medical/aslyum)
 "yeR" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/blueshield)
@@ -196632,7 +197439,7 @@ qBj
 lGE
 tAP
 pNf
-drp
+mJl
 jOO
 mJl
 mJl
@@ -199704,7 +200511,7 @@ vUe
 win
 uXb
 pdp
-bMn
+naP
 lGE
 ldV
 xcB
@@ -262683,7 +263490,7 @@ ere
 nPO
 kxd
 orY
-weS
+hDc
 lQx
 czw
 xaA
@@ -262937,15 +263744,15 @@ hlZ
 nhH
 lyF
 kKl
-nLr
-nLr
+qpU
+qpU
 qzu
-weS
+hDc
 wFk
 mQv
-vQr
+yaY
 ycV
-bwY
+sis
 ePv
 tIi
 iAV
@@ -263187,17 +263994,17 @@ lta
 xit
 okM
 xGM
-mxx
+bCD
 mxx
 mxx
 ohW
 mvc
 cTi
-vQr
+anO
 aRV
 aRV
 mAh
-qpU
+mBO
 qpU
 qpU
 qgq
@@ -263205,7 +264012,7 @@ ycV
 obD
 hDc
 sAq
-pIZ
+cOl
 hDc
 mnT
 rhc
@@ -263461,7 +264268,7 @@ ycV
 ycV
 mxg
 hDc
-sAq
+bMn
 pIZ
 qan
 nVz
@@ -263962,9 +264769,9 @@ cJm
 dVD
 oya
 dVD
-aaZ
+rSI
 cTi
-vQr
+lgN
 akw
 bGX
 ala
@@ -264219,22 +265026,22 @@ lta
 uwY
 lta
 oya
-aaZ
+fjk
 cTi
-vQr
+nCi
 npG
 kVz
 ygF
 gZF
 pzG
-kVz
+qsJ
 iJa
 lDn
 mGx
 fsa
 qlB
 hGQ
-qan
+iPi
 rPm
 sLD
 vuS
@@ -264476,18 +265283,18 @@ uwY
 lta
 uwY
 dVD
-aaZ
+vjA
 cTi
-vQr
-aRV
-aRV
+hxV
+plT
+wlb
 aRV
 saK
 kJu
 qca
 xOS
 lDn
-obD
+bwY
 hDc
 iaZ
 ohb
@@ -264744,7 +265551,7 @@ oKp
 iCQ
 vQr
 lDn
-obD
+mwZ
 abi
 abi
 abi
@@ -264999,8 +265806,8 @@ qjP
 pKu
 myb
 iCQ
-ldD
-aRy
+ogQ
+fIx
 bwA
 abi
 slB
@@ -265236,17 +266043,17 @@ mIr
 vwH
 kLB
 spm
-uwM
-spm
+pxC
+egl
 kAk
 oCK
 bOv
 pxC
 iXK
-vIG
-vIG
+spm
+bOv
 hjy
-vIG
+spm
 wyn
 cTi
 saB
@@ -265256,8 +266063,8 @@ lyb
 qVd
 xfa
 iCQ
-ldD
-aRy
+wGV
+cNg
 bwA
 qNq
 fhK
@@ -265508,13 +266315,13 @@ cTi
 cTi
 nuP
 vmu
-vpy
+dGP
 vmu
 nuP
 nuP
 nuP
-ldD
-aRy
+dUD
+cNg
 aTe
 dnR
 xxq
@@ -265763,15 +266570,15 @@ szn
 hNV
 nuP
 gXm
-aYX
+lib
 lyV
-wOX
+rrF
 bvN
 aYX
-mZZ
+ljH
 nuP
-ldD
-aRy
+cQG
+cNg
 bwA
 qNq
 hCC
@@ -266015,20 +266822,20 @@ lpH
 lpH
 uXb
 uXb
-ldD
+vMg
 mXj
 bwA
 vmu
 hjO
-gNz
+oRV
 hZe
-wOX
-ryh
+hjZ
+rOW
 lyV
 bAu
 vmu
 ldD
-aRy
+cNg
 bwA
 cQk
 moL
@@ -266266,26 +267073,26 @@ fUa
 aUT
 amw
 lpH
-ykr
-ykr
-ykr
+qrQ
+isy
+aUU
 lpH
 fWZ
-nLr
+nDh
 qxC
 mXj
 ngA
 vpy
 slK
-slK
-slK
+ajT
+ajT
 xFc
 oLY
 oLY
-oLY
+biK
 azI
 mXj
-aRy
+cNg
 bwA
 woW
 egP
@@ -266523,26 +267330,26 @@ nHR
 ssM
 rYa
 lpH
+iWK
 ykr
-ykr
-ykr
+nmY
 nNB
-ldD
+edy
 ngA
 oxG
 mXj
 ngA
 vpy
-wOX
-wOX
-wOX
+iDb
+jlE
+jlE
 wjK
-wOX
-wOX
-wOX
+jlE
+jlE
+tvT
 qoy
-ngA
-aRy
+lDU
+fIx
 aTe
 uyh
 elN
@@ -266780,7 +267587,7 @@ pBD
 rYa
 rVe
 lpH
-ykr
+jJg
 hLC
 biC
 pTd
@@ -266793,13 +267600,13 @@ vmu
 bAu
 lyV
 nlE
-wOX
+hjZ
 ryh
 lyV
-bAu
+voS
 vmu
 ldD
-aRy
+cNg
 bwA
 woW
 wUm
@@ -267037,17 +267844,17 @@ wHN
 ohd
 wHN
 lpH
-ykr
+vIG
 bkw
-ykr
+nmY
 nNB
 ldD
 ngA
 hil
 mXj
-bwA
+cIi
 nuP
-bAu
+xUl
 vFO
 lyV
 wOX
@@ -267055,8 +267862,8 @@ gNz
 sDv
 mZZ
 nuP
-ldD
-aRy
+drp
+cNg
 bwA
 tpX
 udA
@@ -267296,12 +268103,12 @@ rYa
 lpH
 psk
 ezN
-ykr
+nmY
 lpH
-ava
-aSp
+cpo
+gOt
 huv
-mXj
+wRV
 bwA
 nuP
 nuP
@@ -267312,8 +268119,8 @@ vmu
 nuP
 nuP
 nuP
-ldD
-aRy
+ata
+cNg
 ijA
 vJH
 vJH
@@ -267551,26 +268358,26 @@ ojn
 rYa
 rYa
 lpH
-ykr
-ykr
-ykr
+hCw
+wPm
+yeC
 lpH
 weS
 weS
-ldD
-mXj
+drp
+iXT
 pWo
-nLr
+dmJ
 hbh
-nLr
+ajL
 nLr
 ngA
 nLr
-nLr
-nLr
+tWW
+hdQ
 nLr
 qxC
-aRy
+cNg
 bwA
 pIY
 rRJ
@@ -267815,19 +268622,19 @@ lpH
 kHD
 tHv
 ldD
-mXj
-mXj
-mXj
-mXj
-mXj
-mXj
-aRy
-aRy
-aRy
-aRy
-aRy
-aRy
-aRy
+vui
+jla
+jla
+jla
+jla
+jla
+eFA
+vxj
+vxj
+vxj
+eFA
+vxj
+gjv
 bwA
 hqv
 ylM
@@ -268075,14 +268882,14 @@ ava
 aSp
 cSu
 aSp
-aSp
+csZ
 aSp
 uVZ
-aRy
+cNg
 qvo
 gSO
 aSp
-aSp
+uwM
 aSp
 tBy
 fGp
@@ -268334,12 +269141,12 @@ mSU
 xqS
 xqS
 xqS
-ldD
+vlF
 ccH
 wfu
 caz
 wWB
-tUX
+nck
 tUX
 mKJ
 wWB
@@ -268593,8 +269400,8 @@ fTq
 xqS
 qcN
 oBf
-oRV
-hdQ
+bwA
+lky
 jgG
 qtG
 cEv
@@ -269884,7 +270691,7 @@ tyN
 syS
 syS
 syS
-syS
+wym
 syS
 syS
 syS


### PR DESCRIPTION
## About The Pull Request

This PR changes the internal layout of medbay in Snowglobe Station. Between initial release and now, I've made a character that is a medbay main. At the time I think I said someone with medbay knowledge should probably redo it completely. I am god's strongest jester it turns out, and said person ended up being me. 

Logic in the alterations:

The original snowglobe medbay was straight up me stealing blueshifts homework, badly. The TC was huge and empty, Cryo was as far as it could be from the lobby, chemlab setups spilled into the halls constantly, it simply does not stack up to the other departments. Instead the rooms have been altered so the immediate "loop" focuses on triage, and you dip into the back of medbay for storage/breaks/meetings. Additionally, Medbay has gained an office for doctors to keep their personal belongings and access records. 

With the current layout the intended loop is: patient in lobby > stasis bed to diagnose > two patient rooms to convalesce OR two surgery centers for serious cases like a husking. 

## How This Contributes To The Nova Sector Roleplay Experience

Mechanically, medbay in snowglobe should be more pleasant and less thoughtless. Roleplaying wise, the addition of two patient rooms allow for 1 on 1 rp scenes with a patient and doctor, and the offices allow for non-medical medical roleplay. Additionally, the asylum allows for high risk containment roleplay. I've seen it happen once or twice, so it ought to exist. I think all these additions and alterations will combine to give snowglobes medbay it's own personality, instead of being a semi-functional imitation.

## Proof of Testing

<details>

New Trauma Center:
![traumacenter](https://github.com/user-attachments/assets/0dda8131-5384-4533-9da1-ef4364abc02f)

Patient Rooms:
![patientrooms](https://github.com/user-attachments/assets/d238332a-ad1e-433b-84bb-ed5a92927f76)

Expanded Chemlab:
![chemlab](https://github.com/user-attachments/assets/68adffbe-551d-47e7-84a8-cac557b791ac)

Asylum
![asylum](https://github.com/user-attachments/assets/ffb2c987-9c15-4c7f-9a7c-503bde1bc8e0)

Traditional Virology Airlocks:
![viro_airlocks](https://github.com/user-attachments/assets/e051ff6d-67a6-425f-a10c-10fa2656243a)

Proof that I bothered to make sure atmos/power works:
![testingproof](https://github.com/user-attachments/assets/5d011afd-15ce-4981-8c0d-3c3e09d38c5c)

The lack of decals where the laser fires here has been DRIVING ME MAD so thats also changed:
![oshacompliance](https://github.com/user-attachments/assets/d0ed9a84-73e9-4524-9be7-5865549e6547)

No new AT markers. Only existing Ice Ruins.
![testingproof2](https://github.com/user-attachments/assets/d8307d8a-0f39-4432-aec0-cff2800ae815)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Snowglobe medbay renovation
/:cl:

