### PR TITLE
Port of "Fix niche bitrunner avatar name bug and make net avatar ID take on avatar name" (but without TGS DMAPI)

### DIFF
--- a/code/modules/bitrunning/components/avatar_connection.dm
+++ b/code/modules/bitrunning/components/avatar_connection.dm
@@ -64,7 +64,9 @@
 	var/alias = our_client?.prefs?.read_preference(/datum/preference/name/hacker_alias) || pick(GLOB.hacker_aliases)
 
 	if(alias && avatar.real_name != alias)
-		avatar.fully_replace_character_name(avatar.real_name, alias)
+		avatar.fully_replace_character_name(newname = alias)
+
+	update_avatar_id()
 
 	for(var/skill_type in old_mind.known_skills)
 		avatar.mind.set_experience(skill_type, old_mind.get_skill_exp(skill_type), silent = TRUE)
@@ -109,6 +111,20 @@
 		COMSIG_LIVING_PILL_CONSUMED,
 		COMSIG_MOB_APPLY_DAMAGE,
 	))
+
+
+/// Updates our avatar's ID to match our avatar's name.
+/datum/component/avatar_connection/proc/update_avatar_id()
+	var/mob/living/avatar = parent
+	var/obj/item/card/id/our_id = locate() in avatar.get_all_contents()
+	if(isnull(our_id))
+		return
+
+	our_id.registered_name = avatar.real_name
+	our_id.update_label()
+	our_id.update_icon()
+	if(our_id.registered_account)
+		our_id.registered_account.account_holder = avatar.real_name
 
 
 /// Disconnects the avatar and returns the mind to the old_body.


### PR DESCRIPTION
## About The Pull Request
See https://github.com/tgstation/tgstation/pull/87879 for more information.
Tin; bitrunner names no longer override the crew manifest.
## How This Contributes To The Nova Sector Roleplay Experience
Fixes jank.
It's nicer to have the IDs use the actual names rather than being generic.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/e47bd70b-814c-4dc2-908b-0e9c795875d4)
![image](https://github.com/user-attachments/assets/2c7160d6-dd59-4036-9f84-4f88d12fed04)
![image](https://github.com/user-attachments/assets/639a161b-a5e8-4732-9c4d-c6dae3ccfcc1)

</details>

## Changelog
:cl: Stalkeos, 00-Steven
fix: A bitrunner avatar spawning with the exact same name as a name currently on the records no longer updates that record to match when the hacker alias gets applied.
qol: Net avatar ID cards use the net avatar's name instead of being generic.
/:cl:
