### PR TITLE
Port of "Bitrunning: falling into chasms returns back to body" (but without TGS DMAPI)

### DIFF
--- a/code/modules/bitrunning/components/avatar_connection.dm
+++ b/code/modules/bitrunning/components/avatar_connection.dm
@@ -95,7 +95,7 @@
 	 */
 	RegisterSignals(parent, list(COMSIG_BITRUNNER_ALERT_SEVER, COMSIG_BITRUNNER_CACHE_SEVER, COMSIG_BITRUNNER_LADDER_SEVER), PROC_REF(on_safe_disconnect))
 	RegisterSignal(parent, COMSIG_LIVING_PILL_CONSUMED, PROC_REF(disconnect_if_red_pill))
-	RegisterSignal(parent, COMSIG_LIVING_DEATH, PROC_REF(on_sever_connection))
+	RegisterSignals(parent, list(COMSIG_LIVING_DEATH, COMSIG_QDELETING), PROC_REF(on_sever_connection))
 	RegisterSignal(parent, COMSIG_MOB_APPLY_DAMAGE, PROC_REF(on_linked_damage))
 
 


### PR DESCRIPTION
## About The Pull Request
See https://github.com/tgstation/tgstation/pull/87512 for more information.
When the avatar is qdel'd, the player returns to original body
## How This Contributes To The Nova Sector Roleplay Experience
Less bugs good.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/e9a9c7ba-5c16-4d88-a989-f5ae7cc3def4)
![image](https://github.com/user-attachments/assets/7eb4b69f-1602-4dbe-b7bd-1a0efce4a3f7)
![image](https://github.com/user-attachments/assets/2d0bbad5-d799-43b7-8aaa-aa426fe4894a)

</details>

## Changelog
:cl: Stalkeros, larentoun
fix: falling into chasms and other ways of destroying your virtual body instead of killing it, WILL now return you to your body
/:cl:
