### PR TITLE
Removes gun safety from deathmatch and bitrunning

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -79,7 +79,7 @@
 	add_seclight_point()
 	// NOVA EDIT ADDITION BEGIN - GUN SAFETIES AND MANUFACTURER EXAMINE
 	// Adds gun safety as long as it isn't in deathmatch or VR
-	if(!is_reserved_level(src.z) && !istype(get_area(loc), /area/shuttle))
+	if(!is_reserved_level(src.z) || istype(get_area(loc), /area/shuttle))
 		give_gun_safeties()
 	give_manufacturer_examine()
 	// NOVA EDIT ADDITION END

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -77,8 +77,12 @@
 		pin = new pin(src)
 
 	add_seclight_point()
-	give_gun_safeties() // NOVA EDIT ADDITION - GUN SAFETIES
-	give_manufacturer_examine() // NOVA EDIT ADDITON - MANUFACTURER EXAMINE
+	// NOVA EDIT ADDITION BEGIN - GUN SAFETIES AND MANUFACTURER EXAMINE
+	// Adds gun safety as long as it isn't in deathmatch or VR
+	if(!is_reserved_level(src.z) && !istype(get_area(loc), /area/shuttle))
+		give_gun_safeties()
+	give_manufacturer_examine()
+	// NOVA EDIT ADDITION END
 	add_bayonet_point()
 
 /obj/item/gun/Destroy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds a check that doesn't give the gun safety features if it was spawned in a reserved z level (deathmatch/vr, also transit but it's been coded to be excluded)

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
Gun safety is fine for anywhere else but annoying in deathmatch and bitdomains since you're meant to go out, guns blazing in both of them, where depending on the map or domain it becomes a race to turn the safety off before you can shoot each other.

I don't expect this to affect bitrunner and SNPC RP much since if either want to say something first they usually do so by speaking or spam pointing with their weapon holstered


## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
Tested and works as intended. Guns spawned in station, interlink and shuttle still gets safety as well.
<details>
<summary>Screenshots/Videos</summary>
 
Bitrunning

![dreamseeker_lIlQWcy59S](https://github.com/user-attachments/assets/6142fdab-3eb9-47b4-9914-634bfc67b161)


Deathmatch

![dreamseeker_X0z7Ru8w67](https://github.com/user-attachments/assets/0f7458fa-ec98-4d12-abd9-be69a4ae29a3)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Hardly
qol: Guns in deathmatch and bitdomains no longer have gun safety.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
