### PR TITLE
Fix oversized stomachs and implants being dropped 

### DIFF
--- a/modular_nova/modules/customization/modules/client/augment/implants.dm
+++ b/modular_nova/modules/customization/modules/client/augment/implants.dm
@@ -1,11 +1,11 @@
 /datum/augment_item/implant
 	category = AUGMENT_CATEGORY_IMPLANTS
 
-/datum/augment_item/implant/apply(mob/living/carbon/human/H, character_setup = FALSE, datum/preferences/prefs)
+/datum/augment_item/implant/apply(mob/living/carbon/human/organ_receiver, character_setup = FALSE, datum/preferences/prefs)
 	if(character_setup)
 		return
-	var/obj/item/organ/new_organ = new path()
-	new_organ.Insert(H,FALSE,FALSE)
+	var/obj/item/organ/new_organ = new path
+	new_organ.Insert(organ_receiver, special = FALSE, movement_flags = DELETE_IF_REPLACED)
 
 //BRAIN IMPLANTS
 /datum/augment_item/implant/brain

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species.dm
@@ -48,11 +48,11 @@ GLOBAL_LIST_EMPTY(customizable_races)
 	var/obj/item/organ/internal/stomach/oversized/new_stomach = new //YOU LOOK HUGE, THAT MUST MEAN YOU HAVE HUGE GUTS! RIP AND TEAR YOUR HUGE GUTS!
 	oversized_quirk.old_organs += list(old_stomach)
 
-	if(new_stomach.Insert(human_holder, special = TRUE))
-		to_chat(human_holder, span_warning("You feel your massive stomach rumble!"))
-		if(old_stomach)
-			old_stomach.moveToNullspace()
-			STOP_PROCESSING(SSobj, old_stomach)
+	new_stomach.Insert(human_holder, special = TRUE)
+	to_chat(human_holder, span_warning("You feel your massive stomach rumble!"))
+	if(old_stomach)
+		old_stomach.moveToNullspace()
+		STOP_PROCESSING(SSobj, old_stomach)
 
 /datum/species/dullahan
 	mutant_bodyparts = list()

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species.dm
@@ -41,6 +41,8 @@ GLOBAL_LIST_EMPTY(customizable_races)
 
 /// Replacing organs with oversized versions, for the oversized quirk. Add implementation for species-specific oversized organs as needed
 /datum/species/proc/gain_oversized_organs(mob/living/carbon/human/human_holder, datum/quirk/oversized/oversized_quirk)
+	if(isnull(human_holder.loc))
+		return // preview characters don't need funny organs, prevents a runtime
 	var/obj/item/organ/internal/stomach/old_stomach = human_holder.get_organ_slot(ORGAN_SLOT_STOMACH)
 	if(old_stomach?.is_oversized) // don't override augments that are already oversized. Need to do this because augments get applied first, so quirks will overwrite them. TODO: Maybe the augments middleware should be renamed so it gets applied last.
 		return

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -76,20 +76,20 @@
 	// To prevent ghosting. We have to do this manually here because TG has replace_into() hardcoded to qdel the old brain no matter what and there is no way around it.
 	old_brain.Remove(human_holder, special = TRUE, movement_flags = NO_ID_TRANSFER)
 
-	if(new_slime_brain.Insert(human_holder, special = TRUE, movement_flags = NO_ID_TRANSFER))
-		to_chat(human_holder, span_warning("Your massive core pulses with bioelectricity!"))
-		if(old_brain)
-			old_brain.moveToNullspace()
-			STOP_PROCESSING(SSobj, old_brain)
+	new_slime_brain.Insert(human_holder, special = TRUE, movement_flags = NO_ID_TRANSFER)
+	to_chat(human_holder, span_warning("Your massive core pulses with bioelectricity!"))
+	if(old_brain)
+		old_brain.moveToNullspace()
+		STOP_PROCESSING(SSobj, old_brain)
 	if(old_stomach.is_oversized) // don't override augments that are already oversized
 		oversized_quirk.old_organs -= old_stomach
 		qdel(new_slime_stomach)
 		return
-	if(new_slime_stomach.Insert(human_holder, special = TRUE))
-		to_chat(human_holder, span_warning("You feel your massive golgi apparatus squish!"))
-		if(old_stomach)
-			old_stomach.moveToNullspace()
-			STOP_PROCESSING(SSobj, old_stomach)
+	new_slime_stomach.Insert(human_holder, special = TRUE)
+	to_chat(human_holder, span_warning("You feel your massive golgi apparatus squish!"))
+	if(old_stomach)
+		old_stomach.moveToNullspace()
+		STOP_PROCESSING(SSobj, old_stomach)
 
 /obj/item/organ/internal/eyes/jelly
 	name = "photosensitive eyespots"

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -63,6 +63,9 @@
 	)
 
 /datum/species/jelly/gain_oversized_organs(mob/living/carbon/human/human_holder, datum/quirk/oversized/oversized_quirk)
+	if(isnull(human_holder.loc))
+		return // preview characters don't need funny organs, prevents a runtime
+
 	var/obj/item/organ/internal/brain/slime/oversized/new_slime_brain = new
 	var/obj/item/organ/internal/stomach/slime/oversized/new_slime_stomach = new //YOU LOOK HUGE! THAT MUST MEAN YOU HAVE HUGE golgi apparatus! RIP AND TEAR YOUR HUGE golgi apparatus!
 

--- a/modular_nova/modules/synths/code/species/synthetic.dm
+++ b/modular_nova/modules/synths/code/species/synthetic.dm
@@ -161,6 +161,9 @@
 		UnregisterSignal(human, COMSIG_LIVING_DEATH)
 
 /datum/species/synthetic/gain_oversized_organs(mob/living/carbon/human/human_holder, datum/quirk/oversized/oversized_quirk)
+	if(isnull(human_holder.loc))
+		return // preview characters don't need funny organs, prevents a runtime
+
 	var/obj/item/organ/internal/stomach/old_stomach = human_holder.get_organ_slot(ORGAN_SLOT_STOMACH)
 	if(old_stomach.is_oversized) // don't override augments that are already oversized
 		return

--- a/modular_nova/modules/synths/code/species/synthetic.dm
+++ b/modular_nova/modules/synths/code/species/synthetic.dm
@@ -169,11 +169,11 @@
 
 	oversized_quirk.old_organs += list(old_stomach)
 
-	if(new_synth_stomach.Insert(human_holder, special = TRUE))
-		to_chat(human_holder, span_warning("You feel your massive engine rumble!"))
-		if(old_stomach)
-			old_stomach.moveToNullspace()
-			STOP_PROCESSING(SSobj, old_stomach)
+	new_synth_stomach.Insert(human_holder, special = TRUE)
+	to_chat(human_holder, span_warning("You feel your massive engine rumble!"))
+	if(old_stomach)
+		old_stomach.moveToNullspace()
+		STOP_PROCESSING(SSobj, old_stomach)
 
 /datum/species/synthetic/proc/on_emag_act(mob/living/carbon/human/source, mob/user)
 	SIGNAL_HANDLER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Oversized stomachs used the return value of `Insert` to check if something was actually inserted, which isn't valid anymore (and never used to return anything but true)

And loadout implants just don't care what they're replacing, so things like charging implants get dropped on the ground if overwritten
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
bugn't
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/75a87d69-7798-4470-8dec-50e065c6e4b1)
_Pictured: A large robot dog observing a lack of organs on their arrival seat. Convenient!_
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: stomachs no longer drop out of oversized characters on spawn
fix: charging implants no longer drop out of synth characters on spawn
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
