### PR TITLE
sets the CIN jumpsuit, and belts to be recolorable in the loadout

### DIFF
--- a/modular_nova/modules/novaya_ert/code/surplus_armor.dm
+++ b/modular_nova/modules/novaya_ert/code/surplus_armor.dm
@@ -121,6 +121,7 @@
 	greyscale_config_worn = /datum/greyscale_config/cin_surplus_undersuit
 	greyscale_config_worn_digi = /datum/greyscale_config/cin_surplus_undersuit/digi
 	greyscale_colors = "#bbbbc9#bbbbc9#34343a"
+	flags_1 = IS_PLAYER_COLORABLE_1
 
 /obj/item/clothing/under/syndicate/rus_army/cin_surplus/desert
 	greyscale_colors = "#aa6d4c#aa6d4c#34343a"
@@ -198,6 +199,7 @@
 	greyscale_config = /datum/greyscale_config/cin_surplus_chestrig/object
 	greyscale_config_worn = /datum/greyscale_config/cin_surplus_chestrig
 	greyscale_colors = CIN_WINTER_COLORS_COMPLIMENT
+	flags_1 = IS_PLAYER_COLORABLE_1
 
 /obj/item/storage/belt/military/cin_surplus/desert
 	greyscale_colors = CIN_MOUNTAIN_DESERT_COLORS_COMPLIMENT


### PR DESCRIPTION
## About The Pull Request
It's drip or drown on this bitch an earth.

## How This Contributes To The Nova Sector Roleplay Experience

I don't think there's much to be said outside the usual 'more player customization is good, especially when the alternative is soft-white (for the jumpsuit) and 1 of 4 colors for the belts

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/f47e1ade-a76e-41db-9333-1bb5ff0424c7)
![image](https://github.com/user-attachments/assets/fa8bf240-a54c-4e95-b945-fe083df63407)
![image](https://github.com/user-attachments/assets/ba24c75c-a172-44e9-807e-7738bccb8814)

</details>

## Changelog
:cl:
qol: The CIN outfit parts in the loadout can now be colored in said loadout.
/:cl:
