### PR TITLE
gives contractor modsuits cuff assist + baton resist modules, comparable to traitor modsuits

### DIFF
--- a/modular_nova/modules/contractor/code/items/modsuit/modsuit.dm
+++ b/modular_nova/modules/contractor/code/items/modsuit/modsuit.dm
@@ -9,6 +9,8 @@
 	applied_modules = list(
 		/obj/item/mod/module/dna_lock,
 		/obj/item/mod/module/emp_shield,
+		/obj/item/mod/module/shock_absorber,
+		/obj/item/mod/module/quick_cuff,
 		/obj/item/mod/module/flashlight,
 		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/storage/syndicate,
@@ -25,6 +27,8 @@
 		/obj/item/mod/module/baton_holster/preloaded,
 		/obj/item/mod/module/dna_lock,
 		/obj/item/mod/module/emp_shield,
+		/obj/item/mod/module/shock_absorber,
+		/obj/item/mod/module/quick_cuff,
 		/obj/item/mod/module/jetpack,
 		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/storage/syndicate,
@@ -39,6 +43,8 @@
 	applied_modules = list(
 		/obj/item/mod/module/baton_holster/preloaded,
 		/obj/item/mod/module/emp_shield,
+		/obj/item/mod/module/shock_absorber,
+		/obj/item/mod/module/quick_cuff,
 		/obj/item/mod/module/jetpack,
 		/obj/item/mod/module/scorpion_hook,
 		/obj/item/mod/module/springlock/contractor/no_complexity,


### PR DESCRIPTION
## About The Pull Request
adds restraint assist and baton resistance modules to the contractor suit variants to bring them in-line with the other syndicate suits available to traitors

## How This Contributes To The Nova Sector Roleplay Experience

parity with other suits in a similar category of "you should just kill this guy if he has it"

## Proof of Testing

![image](https://github.com/user-attachments/assets/51f9dc9b-7b11-45b0-8cb5-f964773cc219)

## Changelog

:cl:
fix: For consistency's sake, Cybersun Industries has finally remembered to update their backlog of Contractor MODsuits with baton knockdown resistance and restraint assistance modules. Prospective operators are reminded that this will not stop them from being shot with disablers, or being shot in general.
/:cl:

