### PR TITLE
Fixes a typo in horrorform bone fragment embed datum

### DIFF
--- a/modular_nova/modules/horrorform/code/true_changeling.dm
+++ b/modular_nova/modules/horrorform/code/true_changeling.dm
@@ -148,9 +148,9 @@
 	ricochet_incidence_leeway = 0
 	embed_falloff_tile = -2
 	shrapnel_type = /obj/item/shrapnel/bone_fragment
-	embed_type = /datum/embed_data/tomahawk
+	embed_type = /datum/embed_data/bone_fragment
 
-/datum/embed_data/tomahawk
+/datum/embed_data/bone_fragment
 	embed_chance = 55
 	fall_chance = 2
 	jostle_chance = 7


### PR DESCRIPTION

## About The Pull Request
title
presumed copypaste mistake in https://github.com/NovaSector/NovaSector/pull/3609/commits/47b431cb945cc98abdd317e82488b772485f57c9, which causes tomahawks to share the embed data of bone fragments.
## How This Contributes To The Nova Sector Roleplay Experience
fix
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: The bone fragments shot out by dying horrorform changelings have the correct embed chance. Same with the expedition tomahawk.
/:cl:
