### PR TITLE
Fixes disarming airbags as a ghost

### DIFF
--- a/modular_nova/modules/window_airbags/code/window_airbag.dm
+++ b/modular_nova/modules/window_airbags/code/window_airbag.dm
@@ -42,7 +42,7 @@
 /datum/element/airbag/proc/on_altclick(atom/movable/clicked_atom, mob/living/clicker)
 	SIGNAL_HANDLER
 
-	if(!clicker.can_interact_with(clicked_atom))
+	if(!clicker.can_interact_with(clicked_atom) || !clicker.can_perform_action(clicked_atom, ALLOW_RESTING))
 		return
 	INVOKE_ASYNC(src, PROC_REF(disarm_airbag), clicked_atom, clicker)
 


### PR DESCRIPTION

## About The Pull Request
fixes https://github.com/NovaSector/NovaSector/issues/4595
## How This Contributes To The Nova Sector Roleplay Experience
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: Ghosts can no longer disarm window airbags.
/:cl:
