### PR TITLE
Icemoon Interdyne photocopier is now free to use

### DIFF
--- a/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1.dmm
+++ b/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1.dmm
@@ -3681,7 +3681,7 @@
 /turf/open/floor/carpet/royalblue,
 /area/ruin/interdyne_planetary_base/main/dorms/lib)
 "jL" = (
-/obj/machinery/photocopier,
+/obj/machinery/photocopier/gratis,
 /obj/structure/sign/flag/interdyne/directional/north{
 	pixel_x = -13
 	},


### PR DESCRIPTION

## About The Pull Request
fixes https://github.com/NovaSector/NovaSector/issues/4562
## How This Contributes To The Nova Sector Roleplay Experience
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: The photocopier in Interdyne on icemoon is now free.
/:cl:
