### PR TITLE
Fix OPFOR bluescreen

### DIFF
--- a/modular_nova/modules/opposing_force/code/opposing_force_datum.dm
+++ b/modular_nova/modules/opposing_force/code/opposing_force_datum.dm
@@ -378,8 +378,8 @@
 	user.client?.admin_follow(mind_reference.current)
 
 /datum/opposing_force/proc/set_equipment_count(mob/user, datum/opposing_force_selected_equipment/equipment, new_count)
-	var/sanitized_newcount = sanitize_integer(new_count, 1, equipment.opposing_force_equipment.max_amount)
-	equipment.count = new_count
+	var/sanitized_newcount = sanitize_integer(new_count, 1, equipment.opposing_force_equipment.max_amount, default = 1)
+	equipment.count = sanitized_newcount
 	add_log(user.ckey, "Set equipment '[equipment.opposing_force_equipment.name] count to [sanitized_newcount]")
 
 /datum/opposing_force/proc/handle(mob/user)

--- a/tgui/packages/tgui/interfaces/OpposingForcePanel.jsx
+++ b/tgui/packages/tgui/interfaces/OpposingForcePanel.jsx
@@ -541,11 +541,11 @@ export const EquipmentTab = (props) => {
                     buttons={
                       <>
                         <NumberInput
-                          animated
                           value={equipment.count}
+                          step={1}
                           minValue={1}
                           maxValue={5}
-                          onChange={(e, value) =>
+                          onChange={(value) =>
                             act('set_equipment_count', {
                               selected_equipment_ref: equipment.ref,
                               new_equipment_count: value,


### PR DESCRIPTION
i'm really running out of energy to write descriptive commit message
## About The Pull Request
Fixes a tgui bluescreen from getting a NaN sent to the backend (due to lack of a `step` argument) which failed to get sanitized because the original argument was used instead of the sanitized one (and it also wasn't sanitized properly even if it was)
Fixes #4541
Fixes #4271
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage 
maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
bugn't!
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

  https://github.com/user-attachments/assets/10aa5024-b3a1-49a8-b7ae-e6e9a1ec612c

i hate how unresponsive (or incredibly oversensitive) these damn sliders are for small values but that's not my problem
</details>

## Changelog
:cl:
fix: OPFOR equipment quantity can now actually be adjusted
/:cl:
