### PR TITLE
Fixes ears getting sprites they shouldn't be getting when they're set to not having visuals

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -339,6 +339,10 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		if(isnull(existing_organ) && should_have && !(new_organ.zone in excluded_zones) && organ_holder.get_bodypart(deprecise_zone(new_organ.zone)))
 			used_neworgan = TRUE
 			new_organ.set_organ_damage(new_organ.maxHealth * (1 - health_pct))
+			// NOVA EDIT ADDITION START - Added this so that organs would properly get imprinted upon insertion, so that we can ensure they're properly imprinted as they should be.
+			if(new_organ.bodypart_overlay)
+				new_organ.bodypart_overlay.imprint_on_next_insertion = TRUE
+			// NOVA EDIT END
 			new_organ.Insert(organ_holder, special = TRUE, movement_flags = DELETE_IF_REPLACED)
 
 		if(!used_neworgan)


### PR DESCRIPTION
## About The Pull Request
Apparently some synths and slime people could accidentally be getting ear sprites when they weren't supposed to. This aims to fix that, by ensuring that ears are imprinted whenever provided by the wardrobe subsystem, because we can't always be certain that the sprite is always going to be the same, unlike /tg/'s assumption.

## How This Contributes To The Nova Sector Roleplay Experience
Less characters with wrong ear overlays == more better roleplay :+1:

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  These were taken right after one-another. With ears turned on:

![image](https://github.com/user-attachments/assets/81be9e6c-11ac-45c9-8bb7-eef33aa0ae22)

With ears turned off:

![image](https://github.com/user-attachments/assets/d8b17096-f25b-42c7-9d89-4720e039a797)

</details>

## Changelog

:cl: GoldenAlpharex
fix: Synths and slimefolks should no longer be getting weird ears suddenly growing on their heads overnight, and should properly get the ears (or lack thereof) they rightfully deserve from their genetics (or whatever the equivalent of genetics is for synthetic beings... Blueprints?).
/:cl: