### PR TITLE
fixes the mining drill (implant) addition removing all the other options in the adv_mining techtree addon

### DIFF
--- a/modular_nova/modules/implants/code/medical_nodes.dm
+++ b/modular_nova/modules/implants/code/medical_nodes.dm
@@ -42,7 +42,7 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS)
 
 /datum/techweb_node/mining_adv/New() //Here for the integrated drill augments.
-	design_ids = list(
-		"ci-drill-diamond"
+	design_ids += list(
+		"ci-drill-diamond",
 	)
 	return ..()


### PR DESCRIPTION

## About The Pull Request
tl;dr the + means it'll add to the list, instead of overwrite it

## Changelog
:cl:
fix: fixed the mining drill overwriting, instead of adding to the advanced mining node
/:cl:
