### PR TITLE
Fixes the starfruit BBQ platter failing to consume crafting ingredients.

### DIFF
--- a/modular_nova/modules/customization/modules/hydroponics/grown/starfruit.dm
+++ b/modular_nova/modules/customization/modules/hydroponics/grown/starfruit.dm
@@ -240,8 +240,8 @@
 /datum/crafting_recipe/food/meatplatter
 	name = "BBQ Meat Platter"
 	reqs = list(
-		/obj/item/food/bbqribs,
-		/obj/item/food/glazed_ribs,
+		/obj/item/food/bbqribs = 1,
+		/obj/item/food/glazed_ribs = 1,
 		/obj/item/food/roasted_bell_pepper = 2,
 	)
 	result = /obj/item/food/meatplatter


### PR DESCRIPTION
## About The Pull Request

This PR fixes the Starfruit BBQ Meat Platter not consuming its crafting ingredients aside from the two roasted red peppers when it's made.

## How This Contributes To The Nova Sector Roleplay Experience

bugs are bad. max complexity food for the price of red peppers is probably also bad. also being unable to make it the best possible ribs on the planet is EVIL and i want to be THE RIB QUEEN

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/9077d65f-775d-4369-bfaf-3bbe3a54e052)
oh wow there's no ribs or glazed ribs left on the table how awesome
</details>

## Changelog
:cl:
fix: Fixed the starfruit BBQ platter failing to consume crafting ingredients.
/:cl:

