### PR TITLE
reduced the items used, and the time to make for most improvised tools

### DIFF
--- a/modular_nova/modules/modular_items/code/recipes_misc.dm
+++ b/modular_nova/modules/modular_items/code/recipes_misc.dm
@@ -2,19 +2,17 @@
 	name = "Makeshift Crowbar"
 	result = /obj/item/crowbar/makeshift
 	reqs = list(/obj/item/stack/sheet/iron = 4,
-				/obj/item/stack/sheet/cloth = 1,
-				/obj/item/stack/cable_coil = 1)
-	time = 120
+				/obj/item/stack/sheet/cloth = 1)
+	time = 60
 	category = CAT_MISC
 
 /datum/crafting_recipe/makeshift/screwdriver
 	name = "Makeshift Screwdriver"
 	tool_paths = list(/obj/item/crowbar/makeshift)
 	result = /obj/item/screwdriver/makeshift
-	reqs = list(/obj/item/stack/cable_coil = 1,
-				/obj/item/stack/sheet/cloth = 2,
+	reqs = list(/obj/item/stack/sheet/cloth = 2,
 				/obj/item/stack/rods = 2)
-	time = 80
+	time = 60
 	category = CAT_MISC
 
 /datum/crafting_recipe/makeshift/welder
@@ -24,9 +22,8 @@
 	result = /obj/item/weldingtool/makeshift
 	reqs = list(/obj/item/tank/internals/emergency_oxygen = 1,
 				/obj/item/stack/sheet/iron = 6,
-				/obj/item/stack/sheet/glass = 2,
-				/obj/item/stack/cable_coil = 2)
-	time = 160
+				/obj/item/lighter)
+	time = 60
 	category = CAT_MISC
 
 /datum/crafting_recipe/makeshift/wirecutters
@@ -34,9 +31,8 @@
 	tool_paths = list(/obj/item/crowbar/makeshift)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
 	result = /obj/item/wirecutters/makeshift
-	reqs = list(/obj/item/stack/cable_coil = 2,
-				/obj/item/stack/rods = 4)
-	time = 80
+	reqs = list(/obj/item/stack/rods = 4)
+	time = 60
 	category = CAT_MISC
 
 /datum/crafting_recipe/makeshift/wrench
@@ -44,9 +40,8 @@
 	tool_paths = list(/obj/item/crowbar/makeshift)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
 	result = /obj/item/wrench/makeshift
-	reqs = list(/obj/item/stack/cable_coil = 1,
-				/obj/item/stack/sheet/iron = 3,
+	reqs = list(/obj/item/stack/sheet/iron = 3,
 				/obj/item/stack/rods = 1,
 				/obj/item/stack/sheet/cloth = 2)
-	time = 80
+	time = 60
 	category = CAT_MISC


### PR DESCRIPTION

## About The Pull Request
Improvised tools are, as I imagine, meant to be made when you can't make anything else, but requires like (cable) mean you essentially had to go to a tool-storage anyway, leaving them in a state of "why would I ever"

They were also kinda abandoned in this state for like, actual years.

## How This Contributes To The Nova Sector Roleplay Experience
Sometimes, people might need them bootleg tools.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  Soon TM
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Improv tools are notably easier to make.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
