### PR TITLE
tg 88082 early port - armor helps against getting your eye exploded

### DIFF
--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -133,12 +133,17 @@
 	is_emissive = FALSE // NOVA EDIT ADDITION
 	UnregisterSignal(organ_owner, COMSIG_ATOM_BULLET_ACT)
 
-/obj/item/organ/internal/eyes/proc/on_bullet_act(datum/source, obj/projectile/proj, def_zone)
+/obj/item/organ/internal/eyes/proc/on_bullet_act(mob/living/carbon/source, obj/projectile/proj, def_zone)
 	SIGNAL_HANDLER
 
 	// Once-a-dozen-rounds level of rare
 	if (def_zone != BODY_ZONE_HEAD || !prob(proj.damage * 0.1) || !(proj.damage_type == BRUTE || proj.damage_type == BURN))
 		return
+
+	var/blocked = source.check_projectile_armor(def_zone, proj, is_silent = TRUE)
+	if (blocked && source.is_eyes_covered())
+		if (!proj.armour_penetration || prob(blocked - proj.armour_penetration))
+			return
 
 	var/valid_sides = list()
 	if (!(scarring & RIGHT_EYE_SCAR))


### PR DESCRIPTION
## About The Pull Request

[uuuh see title.](https://github.com/tgstation/tgstation/pull/88082)

## How This Contributes To The Nova Sector Roleplay Experience

eye explode through helmet probably suboptimal. deserved if you didn't have a helmet though

## Changelog

:cl: SmArtKar
balance: Armor now decreases the chances of getting your eye blown out by a rogue bullet
/:cl:
