### PR TITLE
xenomorph larva can evolve again

### DIFF
--- a/code/modules/mob/living/carbon/alien/larva/powers.dm
+++ b/code/modules/mob/living/carbon/alien/larva/powers.dm
@@ -48,8 +48,6 @@
 
 	return TRUE
 
-//NOVA EDIT REMOVAL BEGIN - NOVA_XENO_REDO - Moved to: modular_nova\modules\xenos_nova_redo\code\xeno_types\larva.dm
-/*
 /datum/action/cooldown/alien/larva_evolve/Activate(atom/target)
 	var/mob/living/carbon/alien/larva/larva = owner
 	var/static/list/caste_options
@@ -103,5 +101,3 @@
 
 	larva.alien_evolve(new_xeno)
 	return TRUE
-*/
-//NOVA EDIT REMOVAL END

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -200,8 +200,6 @@
 			apply_damage(damage, BRUTE, affecting, run_armor_check(affecting, MELEE))
 		return TRUE
 
-//NOVA EDIT REMOVAL BEGIN - NOVA_XENO_REDO - Moved to: modular_nova\modules\xenos_nova_redo\code\human_defense.dm
-/*
 /mob/living/carbon/human/attack_alien(mob/living/carbon/alien/adult/user, list/modifiers)
 	. = ..()
 	if(!.)
@@ -253,8 +251,6 @@
 		if(!dismembering_strike(user, user.zone_selected)) //Dismemberment successful
 			return TRUE
 		apply_damage(damage, BRUTE, affecting, armor_block)
-*/
-//NOVA EDIT REMOVAL END
 
 
 /mob/living/carbon/human/attack_larva(mob/living/carbon/alien/larva/L, list/modifiers)


### PR DESCRIPTION

## About The Pull Request

In [this](https://github.com/NovaSector/NovaSector/pull/4307) it was forgotten to remove comments that remove some things related to xenomorphs. I just removed these comments
## How This Contributes To The Nova Sector Roleplay Experience

Xenomorphs are functional again
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/2dd8f885-cb4c-48d0-9c17-9121c873324c)
![image](https://github.com/user-attachments/assets/1f6ff278-cabc-456b-aa55-cefd12d32aa1)
![image](https://github.com/user-attachments/assets/b9514cea-e7f0-4c3e-af19-2228d4e4c6da)

  
</details>

## Changelog
:cl:
fix: xenomorph larva can evolve again
/:cl:
