### PR TITLE
Add Mannitol and Other Items to Imports

### DIFF
--- a/modular_nova/modules/company_imports/code/armament_datums/deforest_medical.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/deforest_medical.dm
@@ -108,6 +108,10 @@
 	item_type = /obj/item/stack/medical/wound_recovery/robofoam_super
 	cost = PAYCHECK_COMMAND * 4
 
+/datum/armament_entry/company_import/deforest/first_aid/mannitol // Bitrunners and Degenerative players should not be out of a job if med is slow, gone or bad
+	item_type = /obj/item/storage/pill_bottle/mannitol
+	cost = PAYCHECK_COMMAND * 4 // pricey to not obsolete med if they ARE here
+
 // Autoinjectors for healing
 
 /datum/armament_entry/company_import/deforest/medpens

--- a/modular_nova/modules/company_imports/code/armament_datums/sol_defense.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/sol_defense.dm
@@ -39,6 +39,11 @@
 	name = "type I vest"
 	item_type = /obj/item/clothing/suit/armor/vest
 
+/datum/armament_entry/company_import/sol_defense/armor/combat_boots // boots
+	name = "Combat Boots"
+	cost = PAYCHECK_CREW * 4
+	item_type = /obj/item/clothing/shoes/combat
+
 /datum/armament_entry/company_import/sol_defense/armor_hardened
 	subcategory = "Hardened Armor"
 	cost = PAYCHECK_CREW * 3

--- a/modular_nova/modules/company_imports/code/armament_datums/vitezstvi_ammo.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/vitezstvi_ammo.dm
@@ -28,6 +28,10 @@
 	item_type = /obj/item/suppressor/standard
 	cost = PAYCHECK_COMMAND
 
+/datum/armament_entry/company_import/vitezstvi/accessory/seclight
+	item_type = /obj/item/flashlight/seclite
+	cost = PAYCHECK_COMMAND * 1.5 // now get yo shotgun with the flashlight modification
+
 /datum/armament_entry/company_import/vitezstvi/accessory/small_case
 	item_type = /obj/item/storage/toolbox/guncase/nova/pistol/empty
 	cost = PAYCHECK_COMMAND
@@ -35,6 +39,16 @@
 /datum/armament_entry/company_import/vitezstvi/accessory/large_case
 	item_type = /obj/item/storage/toolbox/guncase/nova/empty
 	cost = PAYCHECK_COMMAND * 2
+
+/datum/armament_entry/company_import/vitezstvi/accessory/bandolier
+	item_type = /obj/item/storage/belt/bandolier
+	cost = PAYCHECK_COMMAND * 2
+	contraband = TRUE
+
+/datum/armament_entry/company_import/vitezstvi/accessory/pouch
+	item_type = /obj/item/storage/pouch/ammo
+	cost = PAYCHECK_COMMAND * 3
+	contraband = TRUE // the 'combat accessories' require broadbanding
 
 // Boxes of non-shotgun ammo
 


### PR DESCRIPTION
## About The Pull Request

Adds otherwise mundane items that were either possible to easily completely run out of or could become difficult to obtain to cargo imports. Specifically adds:

Mannitol to Deforest (the most important addition here),
Combat Boots to Sol Defense,
Ammo Pouches, Seclights, and Bandoliers to Vitezstvi Ammo & Weapon Accessories

Ammo Pouches and Bandoliers require broadbanding

with justifications described below

## How This Contributes To The Nova Sector Roleplay Experience

All of the items added are items that either require unreasonable expenditure to obtain or can not always be reliably obtained at all due to the staffing of the station.

Mannitol is a _requirement_ for both bitrunners and anyone with brain degeneration. If there is no chemist, or they are not especially good at their job, Bitrunners basically can't run, and Brain Degeneration players are stuck in a loop of death or surgery. Making it available (at medical premium) makes sure that while it is not the _preferable_ option, those who need it can still obtain it without breaking into medbay.

Seclights, Ammo Pouches, Combat Boots and Bandoliers are all either oddly finite (in the case of seclights), not available to most crew without extreme expenditure or uncommon events (Combat Boots and Bandoliers), or rely on a department that isn't always present (Ammo Pouches). Placing them under company imports makes these mundane items more available to the crew in general, and allow departments which start with them to restock on them reliably as well.

Combat boots are like, the main appeal of military surplus for a lot of people, anyway, right?

## Proof of Testing

![image](https://github.com/user-attachments/assets/a0abf61f-8048-4a0a-8d50-01f15e9d849a)
![image](https://github.com/user-attachments/assets/90691c41-d76f-4d02-923b-0016ffcfcf88)


<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Some hard or inconsistent to obtain mundane items, namely Seclites, Ammo Pouches, Bandoliers and Combat Boots can now be cargo ordered.
add: Due to human rights concerns regarding those suffering from Brain Tumors, Deforest has obtained a license to sell Mannitol through imports.
/:cl:
