### PR TITLE
Fixes Icemoon Interdyne Food Vendors

### DIFF
--- a/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1.dmm
+++ b/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1.dmm
@@ -4387,7 +4387,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/poster/contraband/cybersun_six_hundred/directional/west,
 /obj/machinery/vending/imported/mothic{
-	onstation = 0
+	onstation = 0;
+	all_products_free = 1
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/main/dorms)
@@ -4712,7 +4713,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/vending/imported/tiziran{
-	onstation = 0
+	onstation = 0;
+	all_products_free = 1
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/main/dorms)
@@ -7417,7 +7419,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/poster/contraband/interdyne_gene_clinics/directional/west,
 /obj/machinery/vending/imported/yangyu{
-	onstation = 0
+	onstation = 0;
+	all_products_free = 1
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/main/dorms)


### PR DESCRIPTION

## About The Pull Request
`all_products_free = 1`

## How This Contributes To The Nova Sector Roleplay Experience
Dyne doesn't get a paycheck. Needs to monch. Missed them in a previous pass.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: icemoon's interdyne food vendors are free again
/:cl:
