### PR TITLE
[No GBP] Fixes of the Special Bitrunning Vending Machine

### DIFF
--- a/modular_nova/modules/bitrunning/code/disks.dm
+++ b/modular_nova/modules/bitrunning/code/disks.dm
@@ -91,6 +91,10 @@
 
 	allowed_areas = list(
 		/area/virtual_domain,
+		/area/space/virtual_domain,
+		/area/ruin/space/virtual_domain,
+		/area/icemoon/underground/explored/virtual_domain,
+		/area/lavaland/surface/outdoors/virtual_domain,
 	)
 
 	selectable_atoms = list(
@@ -100,8 +104,10 @@
 	area_string = "virtual domains"
 	supply_pod_stay = FALSE
 
-/obj/machinery/vending/dorms/bitrunning
+/obj/machinery/vending/dorms/bitrunning/Initialize(mapload)
+	. = ..()
 	all_products_free = TRUE
+	onstation = FALSE
 
 /datum/orderable_item/bitrunning_tech/item_tierlewd
 	cost_per_order = 250

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_items/size_items.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_items/size_items.dm
@@ -15,6 +15,11 @@
 		/area/centcom/interlink/dorm_rooms,
 		/area/centcom/holding/cafedorms,
 		/area/misc/hilbertshotel,
+		/area/virtual_domain,
+		/area/space/virtual_domain,
+		/area/ruin/space/virtual_domain,
+		/area/icemoon/underground/explored/virtual_domain,
+		/area/lavaland/surface/outdoors/virtual_domain,
 	)
 
 /obj/item/clothing/neck/size_collar/attack_self(mob/user, modifiers)


### PR DESCRIPTION
## About The Pull Request
You can now actually buy things from it.
It is entirely free so instead of buying you actually get things for free.
As a bonus, it can be placed in any bitrunning zone.
## How This Contributes To The Nova Sector Roleplay Experience
:) ~~vending machine code is hard~~
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/37ce9584-5ece-4a12-9576-3890aa55b363)
![image](https://github.com/user-attachments/assets/a500e2f5-0873-4ced-9fdd-7b61c39a15b0)
![image](https://github.com/user-attachments/assets/1855cc8b-21d0-453a-a12e-b95209856c5a)

</details>

## Changelog
:cl: Stalkeros
fix: Very Interesting Vending Machine that bitrunners have can now actually be used, no longer requiring money nor access.
/:cl:
