### PR TITLE
adjusts Bitrunning rewards based on feedback and testing

### DIFF
--- a/code/modules/bitrunning/server/loot.dm
+++ b/code/modules/bitrunning/server/loot.dm
@@ -30,9 +30,9 @@
 
 	spark_at_location(cache) // abracadabra!
 	qdel(cache) // and it's gone!
-	SEND_SIGNAL(src, COMSIG_BITRUNNER_DOMAIN_COMPLETE, cache, generated_domain.reward_points * 2) // NOVA EDIT CHANGE - Original : SEND_SIGNAL(src, COMSIG_BITRUNNER_DOMAIN_COMPLETE, cache, generated_domain.reward_points)
+	SEND_SIGNAL(src, COMSIG_BITRUNNER_DOMAIN_COMPLETE, cache, generated_domain.reward_points * 1.5) // NOVA EDIT CHANGE - Original : SEND_SIGNAL(src, COMSIG_BITRUNNER_DOMAIN_COMPLETE, cache, generated_domain.reward_points)
 
-	points += (generated_domain.reward_points * 2) // NOVA EDIT CHANGE - Original : points += generated_domain.reward_points
+	points += generated_domain.reward_points
 	playsound(src, 'sound/machines/terminal/terminal_success.ogg', 30, vary = TRUE)
 
 	var/bonus = calculate_rewards()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Makes it so bit runner points are set to 1.5 instead of 2x

Reverts Domain Points (Stars) to be back at 1x, from 2x

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

The amount of Domain points broke the progression of domains, and the amount of bitrunner points was a tad excesive with the changes, so we toned it down a bit in the hope to strike a good balance between a buff to bitrunners to reduce grinding and making it too easy.


## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/26f4d641-a7d9-4679-adf5-7b26bc3e2155)

![image](https://github.com/user-attachments/assets/a9c071e2-4afc-4f01-82b4-2108b4df8e2c)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Bitrunning - Reverted Domain points to 1x from 2x, and reduced BitRunner points to 1.5x from 2x
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
