### PR TITLE
Allows Felinids to shower

### DIFF
--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -638,6 +638,7 @@
 		stam_recovery *= 1.5
 	else if(water_hater)
 		recovery *= 0
+		stam_recovery = 0 // NOVA EDIT ADDITIION - null the stamina damage.
 	recovery *= seconds_between_ticks
 
 	var/healed = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Sets the malus of Water Hater quirk havers when taking a shower / being on a hotspring to 0

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

I can't think of something as inmersion breaking as a race thats at least 95% human like  to faint when submerged in water, they enter a stamina crit cycle when in a shower or when in a hotspring. This will let people have their scenes in peace without getting the benefit of the shower/hotspring, and still getting the bad modlet.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
No stamina damage
![image](https://github.com/user-attachments/assets/fdd85ebe-3fb6-4f69-b4b9-b52aeeeec2cc)

  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Allows those with the Water Hater Quirk (Felinids, Tajarans, etc) to bathe or shower without getting stamina damage. They still get a negative Moodlet and dont heal as others do.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
