### PR TITLE
Removes whitelisting from some of the previously Akula-restricted Loadout gear

### DIFF
--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_heads.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_heads.dm
@@ -628,14 +628,10 @@
 /datum/loadout_item/head/azulea_oldblood
 	name = "Oldblood's Royal cap"
 	item_path = /obj/item/clothing/head/hats/caphat/azulean/old_blood
-	restricted_roles = list(JOB_CAPTAIN, JOB_NT_REP)
-	restricted_species = list(SPECIES_AKULA)
 
 /datum/loadout_item/head/azulea_upstart
 	name = "Upstart's Noble cap"
 	item_path = /obj/item/clothing/head/hats/caphat/azulean/upstart
-	restricted_roles = list(JOB_CAPTAIN, JOB_NT_REP)
-	restricted_species = list(SPECIES_AKULA)
 
 /*
 *	JOB BERETS


### PR DESCRIPTION
## About The Pull Request

While we're cleaning up some of the Akula's unusual exclusives left over from an age long past, I figured we should take a look at the Akula-only Loadout items, namely the Upstart's Noble Getup/Cap, and the Oldblood's Royal Regalia/Cap.
All four items were previously whitelisted to just Akula, and just Captain/Rep. Neither of those restrictions strike me as necessary; they're just ornate formalwear, they don't break non-Akula sprites, and they don't confer any sort of mechanical advantage over other suit gear. 

## How This Contributes To The Nova Sector Roleplay Experience

They're good looking clothes, that some people would like to wear! Having them so absurdly restricted to Captain _and_ Akula made them practically unused, and having variety in your choice of clothing is neat.

## Proof of Testing
![image](https://github.com/user-attachments/assets/f11ebb0d-d050-4fab-8355-a9ae456451ce)
![image](https://github.com/user-attachments/assets/103eea0e-0945-4ebc-89fd-25f01e6f639a)
![image](https://github.com/user-attachments/assets/7d266eaa-5ce0-4705-b743-1786d033f230)
## Changelog

:cl: Trillium
qol: Removed species- and job-whitelisting from the Akula-only suit items in Loadout
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
