### PR TITLE
Ash ritual fixes

### DIFF
--- a/modular_nova/modules/ashwalkers/code/effects/ash_rituals.dm
+++ b/modular_nova/modules/ashwalkers/code/effects/ash_rituals.dm
@@ -56,7 +56,11 @@
 		if(!atom_check)
 			ritual_fail(checked_rune)
 			return FALSE
-
+		if(isliving(atom_check))
+			var/mob/living/human_sacrifice = atom_check
+			if(human_sacrifice.stat < DEAD)
+				ritual_fail(checked_rune)
+				return FALSE
 		if(is_type_in_list(atom_check, consumed_components))
 			qdel(atom_check)
 			checked_rune.balloon_alert_to_viewers("[checked_component] component has been consumed...")

--- a/modular_nova/modules/ashwalkers/code/effects/ash_rune.dm
+++ b/modular_nova/modules/ashwalkers/code/effects/ash_rune.dm
@@ -23,9 +23,10 @@ GLOBAL_LIST_EMPTY(ash_rituals)
 	. += span_notice("<br>The current ritual is: [current_ritual.name]")
 	. += span_notice(current_ritual.desc)
 	. += span_warning("<br>The required components are as follows:")
-	for(var/the_components in current_ritual.required_components)
-		var/atom/component_name = current_ritual.required_components[the_components]
-		. += span_warning("[the_components] component is [initial(component_name.name)]")
+	for(var/direction in current_ritual.required_components)
+		var/atom/component_type = current_ritual.required_components[direction]
+		var/component_name = ispath(component_type, /mob/living/carbon/human) ? "a humanoid corpse" : component_type::name
+		. += span_warning("[direction] component is [component_name]")
 
 /obj/effect/ash_rune/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ash rituals which require a human-like creature as a component are more clear in their requirements, and requires the human to to be alive to avoid accidentally deleting people
Closes #4679

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
More intuitive functionality with less self-deletion
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/b552fae2-edaf-429a-bcd2-9d9078c6568d)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Ashwalker rituals are a bit more clear about mob-based components
fix: Ashwalker rituals cannot consume living mobs as components
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
