### PR TITLE
Fixes xeno maid not having a sprite

### DIFF
--- a/modular_nova/master_files/code/modules/mob/basic/alien/_alien.dm
+++ b/modular_nova/master_files/code/modules/mob/basic/alien/_alien.dm
@@ -6,3 +6,8 @@
 	icon_dead = "aliendrone_dead"
 	pixel_x = -16
 	base_pixel_x = -16
+
+/mob/living/basic/alien/maid // Back to their normal sprite because we don't have a custom one
+	icon = 'icons/mob/nonhuman-player/alien.dmi'
+	pixel_x = 0
+	base_pixel_x = 0


### PR DESCRIPTION
## About The Pull Request
We override the base alien icon, but don't have an icon state for the xeno maid, so lets just don't
## How This Contributes To The Nova Sector Roleplay Experience
The people need their lusty ~~argonian~~ xenomorph maid
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> 
  
![image](https://github.com/user-attachments/assets/40449e7e-3eb6-4a26-8651-a467bb6d6531)

</details>

## Changelog
:cl:
fix: Xenomorph maid has a sprite
/:cl:
