### PR TITLE
Allows the construction of tiny fans (Now plasma powered ™)

### DIFF
--- a/modular_nova/modules/modular_items/code/fan.dm
+++ b/modular_nova/modules/modular_items/code/fan.dm
@@ -1,0 +1,59 @@
+/obj/machinery/nova/fan //Due to constrains, atmos effects arent stopped on depower, so only the self powered version is player buildable.
+	name = "tiny fan"
+	desc = "A tiny fan, releasing a thin gust of air."
+	layer = HIGH_PIPE_LAYER
+	power_channel = AREA_USAGE_ENVIRON
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION
+	use_power = IDLE_POWER_USE
+	max_integrity = 150
+	density = FALSE
+	icon = 'icons/obj/mining_zones/survival_pod.dmi'
+	icon_state = "fan_tiny"
+	can_atmos_pass = ATMOS_PASS_NO
+	rad_insulation = RAD_LIGHT_INSULATION
+	resistance_flags = FIRE_PROOF | FREEZE_PROOF
+
+/obj/machinery/nova/fan/Initialize(mapload)
+	. = ..()
+	air_update_turf(TRUE, TRUE)
+	var/static/list/turf_traits = list(TRAIT_FIREDOOR_STOP)
+	AddElement(/datum/element/give_turf_traits, turf_traits)
+
+/obj/machinery/nova/fan/Destroy()
+	air_update_turf(TRUE, FALSE)
+	. = ..()
+
+/obj/machinery/nova/fan/block_superconductivity() //Needed to avoid some heat issues. If you allow to use the powered version, figure a way to turn this off when its depowered.
+	return TRUE
+
+/obj/machinery/nova/fan/wrench_act(mob/living/user, obj/item/tool)
+	balloon_alert_to_viewers("deconstructing...")
+	if(!do_after(user, 2 SECONDS, src))
+		balloon_alert_to_viewers("stopped deconstructing")
+		return TRUE
+
+	tool.play_tool_sound(src)
+	deconstruct(TRUE)
+	// Machinery is not friendly with dissasembly and getting items back.
+	var/turf/location = get_turf(user)
+	new /obj/item/stack/sheet/iron/five(location)
+	new /obj/item/stack/cable_coil/five(location)
+	return TRUE
+
+/obj/machinery/nova/fan/self_powered
+	name = "self powered tiny fan"
+	desc = parent_type::desc + " This one seems to have a heated plasma shard that propels the blades!"
+	use_power = NO_POWER_USE
+
+/datum/crafting_recipe/nova/fan/self
+	name = "Self Powered Tiny Fan"
+	tool_behaviors = list(TOOL_WRENCH, TOOL_WELDER)
+	result = /obj/machinery/nova/fan
+	reqs = list(
+		/obj/item/pipe = 1,
+		/obj/item/stack/sheet/iron = 4,
+		/obj/item/stack/cable_coil = 5,
+		/obj/item/stack/sheet/mineral/plasma=1,
+	)
+	time = 2 SECONDS
+	category = CAT_ATMOSPHERIC

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8125,6 +8125,7 @@
 #include "modular_nova\modules\modular_items\code\ciggies.dm"
 #include "modular_nova\modules\modular_items\code\cross.dm"
 #include "modular_nova\modules\modular_items\code\designs.dm"
+#include "modular_nova\modules\modular_items\code\fan.dm"
 #include "modular_nova\modules\modular_items\code\fock.dm"
 #include "modular_nova\modules\modular_items\code\makeshift.dm"
 #include "modular_nova\modules\modular_items\code\modular_glasses.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Creates two variants of TG's tiny fan, based on atmos machinery rather than structure, as the colonist fathers intended. These variants also block superconductivity unlike the current tiny fans, so they could be theorically used on the SM. 

Currently, only the Self Powered version is buildable by players, as the base, powered version still have some kinks and sprites to be worked on related to it being depowered and being completly devoid of functions when so.

The Self powered version can be built with 1 pipe, 4 iron sheets, 5 cable pieces, 1 plasma sheet, and while having a welder and wrench, from the crafting menu.  When deconstructed, it will return 5 iron sheets and 5 cable pieces, as the plasma sheet should be the price for the magic power.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

~~For starters, it's Moon's birthday.~~

We use tiny fans everywhere, but we cant build them, and given the nature of the game, I always though it was a great breach of inmersion, as in only mappers and admins could create beautiful doors to places, or we had to use weird tricks like getting mining survival pods and deconstructing them all so that the door wouldn't suck with the big ass holo fan.

Balance wise, it requires 1 plasma instead of 0.3 silver and gold, takes 10 seconds total to set it (when accounted for the pipe construction) compared to instantly, and deconstructing one will mean you lose the sheet of plasma, as the in universe explanation of this is that its a slap crafted fan with a little turbine that uses a heated shard to produce its power.

Overmap is coming, and if ships are damaged things like this will be nessesary, as they are nessesary nowadays.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/ab385473-28b0-4a25-9938-8128a0d5893c)

![image](https://github.com/user-attachments/assets/5fcd9324-df95-4609-977a-0feef099f8cf)

![image](https://github.com/user-attachments/assets/a097619c-78e8-45d2-ad7b-3398f50c4d7e)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Our engineering cats found a way to replicate the Tiny Fans technology, slapcrafting a tube with a couple of blades and super heating a shard of plasma in a consumer grade battery recharger, these atmos blocking, aesthetically pleasing, and now superconductivity insulators can be made by the average crewmember if they follow the easy  to follow 32 steps!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
