### PR TITLE
Makes Jaunters react anywhere in your inmediate inventory (same as bitrunning disks)

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -122,8 +122,9 @@
 				return CHASM_REGISTER_SIGNALS
 		if(ishuman(dropped_thing))
 			var/mob/living/carbon/human/victim = dropped_thing
-			if(istype(victim.belt, /obj/item/wormhole_jaunter))
-				var/obj/item/wormhole_jaunter/jaunter = victim.belt
+			var/obj/item/wormhole_jaunter/jaunter = locate() in victim.get_contents() // NOVA EDIT ADDITION 
+			if (jaunter) // NOVA EDIT - ORIGINAL: if(istype(victim.belt, /obj/item/wormhole_jaunter))
+				// NOVA EDIT REMOVAL - ORIGINAL: var/obj/item/wormhole_jaunter/jaunter = victim.belt
 				var/turf/chasm = get_turf(victim)
 				var/fall_into_chasm = jaunter.chasm_react(victim)
 				if(!fall_into_chasm)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Uses the same logic used to locate bitrunning disks in an user (so no jaunter inside a box inside a backpack), but otherwise works in places that are not the belt too!

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

The jaunter is a good safeway against lag, or the invariable deathbolt of the collosus hitting a tendril. With mining being a job that is so intensive equipmentwise, the sacrifice of the belt slot was significant, plus it made it worse by being a case where you discovered that fact after someone in dead chat told you why the jaunter didnt activate. It was not intuitive at all.

This should reduce the amount of RR's due to chasm without compromising future updates or the lavaland experience from upstream.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/32a9e379-d409-4c1d-bb0a-6f9dd85a9cbe)

![image](https://github.com/user-attachments/assets/97d74f89-b5df-4671-b972-9d7a5bab1c7e)
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Our scientists upgraded the wormhole jaunters activation! Now with a newly added gyroscope the system inmediatly tells you are falling through a chasm and activates, regardless of where you have it in your person, be it your pockets, your belt, or your backpack. Just dont put it in a box inside your backpack as the gyro wont activate otherwise!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
