### PR TITLE
Fixes a bug with hash grinding

### DIFF
--- a/code/modules/hydroponics/grown/cannabis.dm
+++ b/code/modules/hydroponics/grown/cannabis.dm
@@ -20,7 +20,7 @@
 		/obj/item/seeds/cannabis/white,
 		/obj/item/seeds/cannabis/ultimate,
 	)
-	reagents_add = list(/datum/reagent/drug/thc = 0.15) //NOVA EDIT - MORENARCOTICS - axed lipolicide, replaced space drugs with thc
+	reagents_add = list(/datum/reagent/drug/thc = 0.15) // NOVA EDIT - CHANGE - MORENARCOTICS - ORIGINAL: reagents_add = list(/datum/reagent/drug/cannabis = 0.15)
 
 
 /obj/item/seeds/cannabis/rainbow
@@ -44,7 +44,7 @@
 	plantname = "Deathweed"
 	product = /obj/item/food/grown/cannabis/death
 	mutatelist = null
-	reagents_add = list(/datum/reagent/toxin/cyanide = 0.35, /datum/reagent/drug/thc = 0.15) //NOVA EDIT - MORENARCOTICS
+	reagents_add = list(/datum/reagent/toxin/cyanide = 0.35, /datum/reagent/drug/thc = 0.15) // NOVA EDIT CHANGE - MORENARCOTICS - ORIGINAL: agents_add = list(/datum/reagent/toxin/cyanide = 0.35, /datum/reagent/drug/cannabis = 0.15)
 	rarity = 40
 
 /obj/item/seeds/cannabis/white
@@ -57,7 +57,7 @@
 	instability = 30
 	product = /obj/item/food/grown/cannabis/white
 	mutatelist = null
-	reagents_add = list(/datum/reagent/medicine/omnizine = 0.35, /datum/reagent/drug/thc = 0.15) //NOVA EDIT - MORENARCOTICS
+	reagents_add = list(/datum/reagent/medicine/omnizine = 0.35, /datum/reagent/drug/thc = 0.15) // NOVA EDIT CHANGE - MORENARCOTICS - ORIGINAL: reagents_add = list(/datum/reagent/medicine/omnizine = 0.35, /datum/reagent/drug/cannabis = 0.15)
 	rarity = 40
 
 
@@ -72,7 +72,7 @@
 	product = /obj/item/food/grown/cannabis/ultimate
 	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/glow/green, /datum/plant_gene/trait/modified_volume/omega_weed)
 	mutatelist = null
-	reagents_add = list(/datum/reagent/drug/thc = 0.3, //NOVA EDIT CHANGE - MORE NARCOTICS - ORIGINAL: reagents_add = list(/datum/reagent/drug/cannabis = 0.3,
+	reagents_add = list(/datum/reagent/drug/thc = 0.3, // NOVA EDIT CHANGE - MORE NARCOTICS - ORIGINAL: reagents_add = list(/datum/reagent/drug/cannabis = 0.3,
 		/datum/reagent/toxin/mindbreaker = 0.3,
 		/datum/reagent/mercury = 0.15,
 		/datum/reagent/lithium = 0.15,

--- a/modular_nova/modules/morenarcotics/code/thc.dm
+++ b/modular_nova/modules/morenarcotics/code/thc.dm
@@ -1,8 +1,9 @@
 /obj/item/food/grown/cannabis/on_grind()
-	. = ..()
 	if(HAS_TRAIT(src, TRAIT_DRIED))
-		grind_results = list(/datum/reagent/drug/thc/hash = 0.15*src.seed.potency)
-		reagents.clear_reagents() //prevents anything else from coming out
+		if(!reagents)
+			return ..()
+		reagents.convert_reagent(/datum/reagent/drug/thc, /datum/reagent/drug/thc/hash, 1, include_source_subtypes = FALSE)
+	return ..()
 
 /datum/chemical_reaction/hash
 	required_reagents = list(/datum/reagent/drug/thc/hash = 10)


### PR DESCRIPTION
## About The Pull Request

So it came to my attention that hash creation does not work currently. You are supposed to be able to grind **dried** cannabis leaves using a mortar and pestle or reagent grinder but it fails to do so due to a bug.

The original code was trying to do some hackish stuff that no longer works with all the subsequent changes to grinding post-foodening. This PR just restores the ability to make this.

Some notes: You can still make hash from grinding dried mutated strains but it gets to be a bit silly with all the extra reagents that you get in your beaker or mortar. That cannot really be helped short of changing the way hash gets created but I do not really see it as an issue so much as just how produce grinding works. Another note: rainbow cannabis contains no thc so thus does not yield any hash when ground.

## How This Contributes To The Nova Sector Roleplay Experience

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

Foxboi druglab...

![image](https://github.com/user-attachments/assets/47abdfbd-00c3-4756-b7f3-15c7feccfc5f)

![dreamseeker_NzuR0b8E6Q](https://github.com/user-attachments/assets/dfa41a46-2ac4-4ef2-980e-3027f8d6b620)

![dreamseeker_vHVzMhhipJ](https://github.com/user-attachments/assets/8abcb9fd-9c4b-44ed-a7e8-f324f9a9544b)

</details>

## Changelog

:cl:
fix: hash can now be created again by grinding dried cannabis leaves in a grinder or with a mortar and pestle
/:cl:

