### PR TITLE
Places the right amount of HFR corner boxes on snowglobe

### DIFF
--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -5750,17 +5750,25 @@
 /area/station/science/xenobiology)
 "byI" = (
 /obj/structure/table/reinforced,
-/obj/item/hfr_box/body/interface{
-	pixel_x = 11;
-	pixel_y = 11
-	},
 /obj/item/wrench{
 	pixel_x = -5;
 	pixel_y = 7
 	},
 /obj/item/hfr_box/corner{
 	pixel_x = 8;
+	pixel_y = 10
+	},
+/obj/item/hfr_box/corner{
+	pixel_x = 8;
 	pixel_y = 2
+	},
+/obj/item/hfr_box/corner{
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/obj/item/hfr_box/corner{
+	pixel_x = -6;
+	pixel_y = 10
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
@@ -52284,6 +52292,10 @@
 	pixel_y = 9
 	},
 /obj/item/hfr_box/body/fuel_input,
+/obj/item/hfr_box/body/interface{
+	pixel_x = 8;
+	pixel_y = 5
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "nXc" = (


### PR DESCRIPTION

## About The Pull Request
To build the HFR with the boxes, you need 4 corners, the map only has 1 mapped in
## How This Contributes To The Nova Sector Roleplay Experience
Not having to build the HFR from scratch on snowglobe
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
map: Snowglobe station has the right amount of HFR corner boxes in the HFR room now
/:cl:
