### PR TITLE
Rogues! The On-Station Abductors!

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -411,6 +411,7 @@ ROUNDSTART_RACES ghoul
 ROUNDSTART_RACES teshari
 ROUNDSTART_RACES hemophage
 ROUNDSTART_RACES vox_primalis
+ROUNDSTART_RACES abductorweak
 
 ##-------------------------------------------------------------------------------------------
 

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/human.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/human.dm
@@ -72,6 +72,9 @@
 /mob/living/carbon/human/species/skrell
 	race = /datum/species/skrell
 
+/mob/living/carbon/human/species/abductorweak
+	race = /datum/species/abductor/abductorweak
+
 /mob/living/carbon/human/verb/toggle_undies()
 	set category = "IC"
 	set name = "Toggle underwear visibility"

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/abductorweak.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/abductorweak.dm
@@ -1,0 +1,87 @@
+/datum/species/abductor/abductorweak
+	name = "Rogue"
+	id = SPECIES_ABDUCTORWEAK
+	sexes = TRUE
+	inherent_traits = list(
+		TRAIT_CHUNKYFINGERS_IGNORE_BATON,
+		TRAIT_NOBREATH,
+		TRAIT_NOHUNGER,
+	)
+	mutanttongue = /obj/item/organ/tongue/abductor
+	mutantstomach = null
+	mutantlungs = null
+	mutantbrain = /obj/item/organ/brain/abductor
+	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
+
+	bodypart_overrides = list(
+		BODY_ZONE_HEAD = /obj/item/bodypart/head/abductor,
+		BODY_ZONE_CHEST = /obj/item/bodypart/chest/abductor,
+		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/abductor,
+		BODY_ZONE_R_ARM = /obj/item/bodypart/arm/right/abductor,
+		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/abductor,
+		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/abductor,
+	)
+
+/datum/species/abductor/abductorweak/get_physical_attributes()
+	return "Rogues do not need to breathe, eat, have a stomach, or lungs but their naturally chunky tridactyl hands make it hard to operate generic equipment."
+
+/datum/species/abductor/abductorweak/on_species_gain(mob/living/carbon/C, datum/species/old_species)
+	. = ..()
+	var/datum/atom_hud/abductor_hud = GLOB.huds[DATA_HUD_ABDUCTOR]
+	abductor_hud.show_to(C)
+
+/datum/species/abductor/abductorweak/on_species_loss(mob/living/carbon/C)
+	. = ..()
+	var/datum/atom_hud/abductor_hud = GLOB.huds[DATA_HUD_ABDUCTOR]
+	abductor_hud.hide_from(C)
+
+/datum/species/abductor/abductorweak/get_species_description()
+	return "Abductors are naturally three fingered, pale skinned inquisitive aliens who can't communicate well to the average crew-member \
+		without either a Text-To-Speech device or a replacement voicebox.",
+
+/datum/species/abductor/abductorweak/get_species_lore()
+	return list(
+		"The Rogues are a, as the name implies, rogue offshoot of the Abductors. \
+		While they themselves do not abduct or experiment on other species, generally, the stigma \
+			associated with their progenitors is something all Rogues have to deal with if they do not undergo \
+			any form of cosmetic changes. And many do opt in for cosmetic changes, being almost unrecognizable as Rogues \
+			but still holding that innate need for discovery or change.",
+	)
+
+/datum/species/abductor/abductorweak/create_pref_traits_perks()
+	var/list/perks = list()
+	perks += list(list(
+		SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
+		SPECIES_PERK_ICON = FA_ICON_WIND,
+		SPECIES_PERK_NAME = "Lungs Optional",
+		SPECIES_PERK_DESC = "Rogues don't need to breathe, though exposure to a vacuum is still a hazard. \
+			Some Rogues elect to have new lungs placed inside them, usually for some degree of expression, more rarely for experimentation.",
+	))
+	return perks
+
+/datum/species/abductor/abductorweak/create_pref_unique_perks()
+	var/list/perks = list()
+	perks += list(list(
+		SPECIES_PERK_TYPE = SPECIES_NEUTRAL_PERK, // It may be a stretch to call nohunger a neutral perk but the Abductor's tongue describes it as much, so.
+		SPECIES_PERK_ICON = FA_ICON_UTENSILS,
+		SPECIES_PERK_NAME = "Hungry for Knowledge",
+		SPECIES_PERK_DESC = "Rogues have a greater hunger for knowledge and expression than food, and as such don't need to eat. \
+			Which is fortunate, as their natural speech matrix prevents them from consuming food.",
+	))
+	perks += list(list(
+		SPECIES_PERK_TYPE = SPECIES_NEUTRAL_PERK,
+		SPECIES_PERK_ICON = FA_ICON_VOLUME_XMARK,
+		SPECIES_PERK_NAME = "Superlingual Matrix",
+		SPECIES_PERK_DESC = "Rogues cannot physically speak with their natural tongue. \
+			They instead naturally communicate telepathically to other Rogues, a process which all other species cannot hear. \
+			Great for secret conversations, not so great for ordering something from the bar. \
+			Many Rogues who plan to leave the Collectives usually replace their matrix with a cybernetic or replacement voice box.",
+	))
+	perks += list(list(
+		SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,
+		SPECIES_PERK_ICON = FA_ICON_HANDSHAKE_SLASH,
+		SPECIES_PERK_NAME = "Tridactyl Hands",
+		SPECIES_PERK_DESC = "Rogue hands are not designed for human equipment. Utilizing the station's equipment is difficult for them.\
+		Some Rogues often replace their natural hands with cybernetic hands, or genetically augment themselves and change their hands to something else.",
+	))
+	return perks

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5329,6 +5329,7 @@
 #include "code\modules\mob\living\carbon\alien\special\alien_embryo.dm"
 #include "code\modules\mob\living\carbon\alien\special\facehugger.dm"
 #include "code\modules\mob\living\carbon\human\_species.dm"
+#include "code\modules\mob\living\carbon\human\abductorweak.dm"
 #include "code\modules\mob\living\carbon\human\death.dm"
 #include "code\modules\mob\living\carbon\human\dummy.dm"
 #include "code\modules\mob\living\carbon\human\emote.dm"


### PR DESCRIPTION
Initial Commit for playable Abductors, because I have no shame and want to just play Gamma Iota Kappa as a Gray, but I did also write lore for it

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a much weaker version of the Abductors to general station population, some lore has also been posted as a suggestion in the Lore Discord, kinda waiting on more feedback on that

## How This Contributes To The Nova Sector Roleplay Experience

It adds a sense of disunity in a mysterious group, it also adds a Roleplay angle that people who do events or for Antags to use, the idea being that the Rogues (What the On-Station abductors are called) are a very vague connection TO the Abductors, no memories of their time as Abductors but they're biologically the same and are clearly FROM the Abductors. I think I describe it better in my lore document

## Proof of Testing

Actually still working on this, Jungle said push it to the Github and it'll show me some problems why it isn't working in my testing, will get testing screenies once I get it working 

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Rogues; Descendants of the Mysterious Abductors are now employed by Nanotrasen, sure they have three fingers and most are missing vocal cords, but they can still work!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
