### PR TITLE
Improve Blueshield Armor

### DIFF
--- a/modular_nova/modules/blueshield/code/clothing.dm
+++ b/modular_nova/modules/blueshield/code/clothing.dm
@@ -42,9 +42,40 @@
 	fire = 95
 	acid = 95
 
+/datum/armor/armor_blueshield
+	melee = 35
+	bullet = 45
+	laser = 35
+	energy = 45
+	bomb = 50
+	fire = 50
+	acid = 50
+	wound = 15
+
+/datum/armor/armor_blueshield_light // for the armor that provides arm coverage
+	melee = 30
+	bullet = 40
+	laser = 30
+	energy = 40
+	bomb = 40
+	fire = 45
+	acid = 45
+	wound = 10
+
+/datum/armor/beret_blueshield // cosmetic_sec stats in comment
+	melee = 40 // 30
+	bullet = 35 // 25
+	laser = 35 // 25
+	energy = 45 // 35
+	bomb = 40 // 25
+	fire = 30 // 20
+	acid = 55 // 50
+	wound = 10 // 4
+
 /obj/item/clothing/head/beret/blueshield
 	name = "blueshield's beret"
 	desc = "A blue beret made of durathread with a genuine golden badge, denoting its owner as a Blueshield Lieuteneant. It seems to be padded with nano-kevlar, making it tougher than standard reinforced berets."
+	armor_type = /datum/armor/beret_blueshield
 	greyscale_config = /datum/greyscale_config/beret_badge
 	greyscale_config_worn = /datum/greyscale_config/beret_badge/worn
 	greyscale_colors = "#3A4E7D#DEB63D"
@@ -54,6 +85,7 @@
 /obj/item/clothing/head/beret/blueshield/navy
 	name = "navy blueshield's beret"
 	desc = "A navy-blue beret made of durathread with a silver badge, denoting its owner as a Blueshield Lieuteneant. It seems to be padded with nano-kevlar, making it tougher than standard reinforced berets."
+	armor_type = /datum/armor/beret_blueshield
 	greyscale_colors = "#3C485A#BBBBBB"
 
 /obj/item/storage/backpack/blueshield
@@ -93,6 +125,7 @@
 	name = "blueshield's armor"
 	desc = "A tight-fitting kevlar-lined vest with a blue badge on the chest of it."
 	icon_state = "blueshieldarmor"
+	armor_type = /datum/armor/armor_blueshield
 	body_parts_covered = CHEST
 	uses_advanced_reskins = TRUE
 	unique_reskin = list(
@@ -120,6 +153,7 @@
 	name = "blueshield's jacket"
 	desc = "An expensive kevlar-lined jacket with a golden badge on the chest and \"NT\" emblazoned on the back. It weighs surprisingly little, despite how heavy it looks."
 	icon_state = "blueshield"
+	armor_type = /datum/armor/armor_blueshield_light
 	body_parts_covered = CHEST|ARMS
 	unique_reskin = null
 
@@ -133,7 +167,7 @@
 	desc = "A comfy kevlar-lined coat with blue highlights, fit to keep the blueshield armored and warm."
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/nova/blueshield
 	allowed = list(/obj/item/melee/baton/security/loaded)
-	armor_type = /datum/armor/suit_armor
+	armor_type = /datum/armor/armor_blueshield_light
 
 /obj/item/clothing/suit/hooded/wintercoat/nova/blueshield/Initialize(mapload)
 	. = ..()
@@ -142,4 +176,4 @@
 /obj/item/clothing/head/hooded/winterhood/nova/blueshield
 	icon_state = "hood_blueshield"
 	desc = "A comfy kevlar-lined hood to go with the comfy kevlar-lined coat."
-	armor_type = /datum/armor/suit_armor
+	armor_type = /datum/armor/armor_blueshield_light


### PR DESCRIPTION
## About The Pull Request

Gives the blueshield beret armor, consistent with the berets of every other combatant role in existence, and improves the statistics of the blueshield's armor to be better than average instead of bog standard. It's about a score lower than the captain's equipment. The arm-covering jackets provide less armor than the armless vest.

## How This Contributes To The Nova Sector Roleplay Experience

The blueshield is supposed to be an elite bodyguard, authorized by Central Command to protect their most important assets (and the assets of their partnered corporations) - despite this, they are scarcely better equipped for their job than the average security officer.

Other people are currently working on weapons for the blueshield, but at base, making their body armor more than just reskinned security gear will hopefully help make them less of a non-factor.

Also, their Beret is described as 'padded with nano-kevlar' and 'tougher than standard reinforced berets', but both provide no armor. That just needed fixing anyway.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![bluevest](https://github.com/user-attachments/assets/308da02e-abab-41e8-98cb-9c8e12323c4e)

![bluejacket](https://github.com/user-attachments/assets/db403231-931d-472a-bb91-5857f4e1427a)

![hm](https://github.com/user-attachments/assets/5b19e32d-9d27-43ca-823a-580288d46b06)

</details>

## Changelog

:cl:
balance: Nanotrasen has finally elected to stop sourcing the Blueshield's equipment from space goodwill. Blueshield armor is now significantly more protective.
balance: The Blueshield's armor vest is now more resilient than the jacket, to make up for its lack of arm coverage.
fix: The Blueshield's beret(s) now provide protection as their descriptions imply.
/:cl:
