### PR TITLE
Add Some Extra Stuff to Bitrunning Disks

### DIFF
--- a/modular_nova/modules/bitrunning/code/disks.dm
+++ b/modular_nova/modules/bitrunning/code/disks.dm
@@ -19,6 +19,7 @@
 		/obj/item/dice/d20,
 		/obj/item/storage/pouch/medical/firstaid/stabilizer,
 		/obj/item/storage/pouch/cin_medkit,
+		/obj/item/storage/medkit/robotic_repair/preemo/stocked,
 	)
 
 /obj/item/bitrunning_disk/prefs
@@ -121,6 +122,7 @@
 	selectable_items += list(
 		/obj/item/storage/belt/military,
 		/obj/item/book_of_babel,
+		/obj/item/storage/toolbox/syndicate,
 	)
 
 /obj/item/bitrunning_disk/item/tier2/Initialize(mapload)
@@ -133,8 +135,9 @@
 		/obj/item/autosurgeon/syndicate/hackerman/bitrunning,
 		/obj/item/clothing/head/helmet,
 		/obj/item/melee/energy/sword/saber/blue,
-		/obj/item/shield/energy,
+		/obj/item/shield/riot/pointman/nri, // previously /obj/item/shield/energy,
 		/obj/item/storage/medkit/expeditionary/surplus,
+		/obj/item/syndicate_contacts,
 	)
 
 /obj/item/autosurgeon/syndicate/hackerman/bitrunning


### PR DESCRIPTION
## About The Pull Request

Glark had some things he wanted to put in bitrunning disks, but he's out in Moscow, and asked someone to help him out and add them while he's gone.

## How This Contributes To The Nova Sector Roleplay Experience

Toolsets for alternative approaches, synth kits so synths can actually heal in domains, and other misc options hopefully both increase variety and approachability of bitrunning

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![prof1](https://github.com/user-attachments/assets/f0f83026-790b-4ef7-a0b3-9e08397e6ea8)

![evidence](https://github.com/user-attachments/assets/5df8ed8f-0645-4345-a485-f9d2d37b2629)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Tactical Toolboxes and Flash-Proof lenses have been added to bitrunning disks.
add: Synthetic healing supplies are now available to bitrunners through a T0 disk.
balance: The E-Shield from tier 2 bitrunning disks has been replaced by the NRI corpsman shield.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
