### PR TITLE
Finish what #13138 (?) started

### DIFF
--- a/code/__DEFINES/~nova_defines/projectiles.dm
+++ b/code/__DEFINES/~nova_defines/projectiles.dm
@@ -21,3 +21,10 @@
 /// Caliber used by the kinetic gun
 #define CALIBER_KINETICBALL "Kinetic Ball"
 
+/// for the 1911, c20r, etc
+#define CALIBER_45 ".45 Ceres"
+
+/// 50cal handgun
+#define CALIBER_50AE ".454 Trucidator"
+
+#define CALIBER_50BMG ".416 Stabilis"

--- a/modular_nova/modules/aesthetics/guns/code/guns.dm
+++ b/modular_nova/modules/aesthetics/guns/code/guns.dm
@@ -414,8 +414,6 @@
 	desc = "An armor-piercing .460 bullet casing.\
 	<br><br>\
 	<i>ARMOR PIERCING: Increased armor piercing capabilities. What did you expect?</i>"
-	armour_penetration = 20
-	damage = 20
 	custom_materials = AMMO_MATS_AP
 	advanced_print_req = TRUE
 
@@ -426,6 +424,12 @@
 	<i>INCENDIARY: Leaves a trail of fire when shot, sets targets aflame.</i>"
 	custom_materials = AMMO_MATS_TEMP
 	advanced_print_req = TRUE
+
+/obj/item/ammo_casing/c45/hp
+	name = ".460 Ceres hollow point bullet casing"
+	desc = "A .460 bullet casing."
+	projectile_type = /obj/projectile/bullet/c45/hp
+
 
 /obj/item/ammo_box/c45
 	name = "ammo box (.460 Ceres)"
@@ -550,6 +554,10 @@
 
 /obj/item/ammo_box/magazine/wt550m9/wtic
 	name = "\improper WT-550 IND magazine"
+
+/obj/item/ammo_box/magazine/smgm45/hp
+	name = ".460 Ceres HP SMG magazine"
+	ammo_type = /obj/item/ammo_casing/c45/hp
 
 /obj/item/ammo_box/magazine/smgm45
 	name = ".460 Ceres SMG magazine"

--- a/modular_nova/modules/aesthetics/guns/code/guns.dm
+++ b/modular_nova/modules/aesthetics/guns/code/guns.dm
@@ -437,7 +437,7 @@
 
 /obj/item/ammo_box/magazine/m45
 	name = "handgun magazine (.460 Ceres)"
-	desc = "A magazine chambered for .460 meant to fit in submachine guns."
+	desc = "A magazine chambered in .460 meant to fit in handguns."
 
 // overrides for .50AE, used in the deagle
 /obj/item/ammo_casing/a50ae

--- a/modular_nova/modules/aesthetics/guns/code/guns.dm
+++ b/modular_nova/modules/aesthetics/guns/code/guns.dm
@@ -101,12 +101,14 @@
 	righthand_file = 'modular_nova/modules/aesthetics/guns/icons/guns_righthand.dmi'
 
 /obj/item/gun/ballistic/automatic/pistol/m1911
+	desc = "A classic handgun, modern variants of which take .460 Ceres."
 	icon = 'modular_nova/modules/aesthetics/guns/icons/guns.dmi'
 	inhand_icon_state = "colt"
 	lefthand_file = 'modular_nova/modules/aesthetics/guns/icons/guns_lefthand.dmi'
 	righthand_file = 'modular_nova/modules/aesthetics/guns/icons/guns_righthand.dmi'
 
 /obj/item/gun/ballistic/automatic/c20r
+	desc = "A bullpup three-round burst .460 Ceres SMG, designated 'C-20r'. Has a 'Scarborough Arms - Per falcis, per pravitas' buttstamp."
 	icon = 'modular_nova/modules/aesthetics/guns/icons/guns.dmi'
 
 /obj/item/gun/ballistic/automatic/m90
@@ -118,8 +120,12 @@
 /obj/item/gun/ballistic/automatic/pistol
 	icon = 'modular_nova/modules/aesthetics/guns/icons/guns.dmi'
 
+/obj/item/gun/ballistic/automatic/pistol/deagle
+	desc = "A robust .454 Trucidator handgun."
+
 /obj/item/gun/ballistic/automatic/pistol/deagle/regal
 	icon = 'icons/obj/weapons/guns/ballistic.dmi'
+	desc = "A gold plated Desert Eagle folded over a million times by superior martian gunsmiths. Uses .454 Trucidator ammo."
 
 /obj/item/gun/ballistic/automatic/pistol/clandestine/fisher
 	icon = 'icons/obj/weapons/guns/ballistic.dmi'
@@ -230,7 +236,7 @@
 
 /obj/item/gun/ballistic/automatic/sniper_rifle/syndicate
 	name = "syndicate sniper rifle"
-	desc = "An illegally modified .50 cal sniper rifle with suppression compatibility. Quickscoping still doesn't work."
+	desc = "An illegally modified .416 Stabilis sniper rifle with suppression compatibility. Quickscoping still doesn't work."
 	icon = 'modular_nova/modules/aesthetics/guns/icons/guns_gubman2.dmi'
 	icon_state = "sniper2"
 	worn_icon_state = "sniper"
@@ -408,6 +414,8 @@
 	desc = "An armor-piercing .460 bullet casing.\
 	<br><br>\
 	<i>ARMOR PIERCING: Increased armor piercing capabilities. What did you expect?</i>"
+	armour_penetration = 20
+	damage = 20
 	custom_materials = AMMO_MATS_AP
 	advanced_print_req = TRUE
 
@@ -418,6 +426,14 @@
 	<i>INCENDIARY: Leaves a trail of fire when shot, sets targets aflame.</i>"
 	custom_materials = AMMO_MATS_TEMP
 	advanced_print_req = TRUE
+
+/obj/item/ammo_box/c45
+	name = "ammo box (.460 Ceres)"
+	desc = "A box of .460 Ceres ammunition, a modern successor to the .45 round."
+
+/obj/item/ammo_box/magazine/m45
+	name = "handgun magazine (.460 Ceres)"
+	desc = "A magazine chambered for .460 meant to fit in submachine guns."
 
 // overrides for .50AE, used in the deagle
 /obj/item/ammo_casing/a50ae


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
_(I have no idea if #13138 was the one that started it. That's just the earliest blame I could find.)_

Several years ago, someone wanted to update our weapon caliber names. I do not know why, but they did.

They did not finish the job at all, and for years now we've had weapon calibers that were inconsistently labelled on the guns that used them - primarily the replacements for the .45 and .50 rounds. This ranges from minor mistakes like forgetting to change the item description of the Golden Deagle to more severe lapses like failing to update the caliber data of the rounds and _not bothering to rename .45 ammo boxes to .460._

I debated on whether to make this an update or a reversion, but '.460 Ceres' sounds cooler than '.45', so that's what I went with. If at a later date we **do** revert the ammo caliber changes, the number of things to change will at least be consistent.

If I missed a spot, please tell me! I put the finishing touches on this and made this PR when I was really tired.

## How This Contributes To The Nova Sector Roleplay Experience

We should avoid intentionally lying to our players about what ammo type weapons use, especially when the only way to get ammo boxes for them require you to recognize them by name.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/148e8a62-613c-4442-9400-a7eb686fcee1)

![image](https://github.com/user-attachments/assets/ddfc66d8-255e-427b-be24-4041ff106d21)

![image](https://github.com/user-attachments/assets/c556bea3-89f4-4dfd-9d71-99568fe0973d)

![image](https://github.com/user-attachments/assets/08d4efef-7c41-4ccd-8cd1-ea2e8ae5c1f9)

![image](https://github.com/user-attachments/assets/b87c5542-6d33-4e12-ad4a-6c57000a7e85)

![image](https://github.com/user-attachments/assets/67363c3a-01c0-4a78-a644-62e05fc32eee)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Ammo manufacturers have corrected their labelling habits, and many objects which referred to ammo types that have not existed for several years no longer do so.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->