### PR TITLE
Bitrunning server ghost communication and domain anchor balancing

### DIFF
--- a/modular_nova/modules/bitrunning/code/anchor.dm
+++ b/modular_nova/modules/bitrunning/code/anchor.dm
@@ -11,9 +11,13 @@
 
 /obj/item/domain_anchor/attack_self(mob/user, modifiers)
 	for(var/obj/machinery/quantum_server/server in SSmachines.get_machines_by_type(/obj/machinery/quantum_server))
+		if(server.current_anchors >= server.max_anchors)
+			user.balloon_alert(user, "bandwidth limit reached!")
+			return FALSE
 		server.exit_turfs += get_turf(src)
 		server.retries_spent -= 1
 		server.threat += 1
+		server.current_anchors += 1
 		server.radio.talk_into(src, "Potential secure datastream detected. Locking on the new spawn point.", RADIO_CHANNEL_SUPPLY)
 	new /obj/effect/landmark/bitrunning/domain_anchor(drop_location())
 	user.balloon_alert(user, "connection stabilized!")

--- a/modular_nova/modules/bitrunning/code/server.dm
+++ b/modular_nova/modules/bitrunning/code/server.dm
@@ -3,7 +3,7 @@
 	var/list/spam_queue = list()
 	///Toggles whether the server accepts new messages or not.
 	var/message_protected = FALSE
-	///Maximum amount of connections that can be added via domain anchors. 0 for T1, 1 for T2, so on.
+	///Maximum amount of connections that can be added via domain anchors. 1 for T1, 2 for T2, etc.
 	var/max_anchors = -1
 	///Current amount of used domain anchors.
 	var/current_anchors = 0
@@ -11,7 +11,7 @@
 /obj/machinery/quantum_server/examine(mob/user)
 	. = ..()
 	if(max_anchors >= 1)
-		. += span_infoplain("- Its domain vulnerability scanners permit for [max_anchors] anchors to be used.")
+		. += span_infoplain("- Its domain vulnerability scanners permit for up to [max_anchors] domain anchors to be used.")
 
 /obj/machinery/quantum_server/RefreshParts()
 	. = ..()

--- a/modular_nova/modules/bitrunning/code/server.dm
+++ b/modular_nova/modules/bitrunning/code/server.dm
@@ -1,0 +1,45 @@
+/obj/machinery/quantum_server
+	///List of ckeys containing players who have recently activated the device, players on this list are prohibited from activating the device untill their residue decays.
+	var/list/spam_queue = list()
+
+/obj/machinery/quantum_server/attack_ghost(mob/user)
+	. = ..()
+	if(!is_operational)
+		return
+
+	for(var/player_key in spam_queue)
+		if(player_key == user.ckey)
+			return
+	ghost_mark(user)
+
+/obj/machinery/quantum_server/proc/ghost_mark(mob/activator)
+	if(!use_energy(active_power_usage, force = FALSE))
+		return
+	var/message = tgui_input_text(activator, "Send a play request", "Holonet Gaming Network", max_length = MAX_PLAQUE_LEN)
+	if(!message)
+		return
+	var/messenger = tgui_input_text(activator, "Set your username", "Holonet Gaming Network", max_length = MAX_NAME_LEN)
+	if(!messenger)
+		messenger = pick(GLOB.hacker_aliases)
+	playsound(loc, 'sound/machines/ectoscope_beep.ogg', 75)
+	radio.talk_into(src, "You have a new message from [messenger]: [message]", RADIO_CHANNEL_SUPPLY)
+	if(activator?.ckey)
+		spam_queue += activator.ckey
+		addtimer(CALLBACK(src, PROC_REF(clear_spam), activator.ckey), 15 SECONDS)
+
+/obj/machinery/quantum_server/Destroy()
+	spam_queue = null
+	. = ..()
+
+/obj/machinery/quantum_server/examine(mob/user)
+	. = ..()
+	. += span_notice("Any intercepted Resonance patterns, 'ghastly apparitions', or connected bitrunners can leave a custom-written play request on the quantum server, \
+	causing a small, audible blip and sending message, indicating their activity to on-station bitrunners.")
+
+///Removes the ghost from the ectoplasmic_residues list and lets them know they are free to activate the sniffer again.
+/obj/machinery/quantum_server/proc/clear_spam(ghost_ckey)
+	spam_queue -= ghost_ckey
+	var/mob/ghost = get_mob_by_ckey(ghost_ckey)
+	if(!ghost || isliving(ghost))
+		return
+	to_chat(ghost, "[FOLLOW_LINK(ghost, src)] <span class='nicegreen'>The spam protection of [src] has deactivated.</span>")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7194,6 +7194,7 @@
 #include "modular_nova\modules\bitrunning\code\loot.dm"
 #include "modular_nova\modules\bitrunning\code\mobs.dm"
 #include "modular_nova\modules\bitrunning\code\outfit.dm"
+#include "modular_nova\modules\bitrunning\code\server.dm"
 #include "modular_nova\modules\bitrunning\code\spells.dm"
 #include "modular_nova\modules\bitrunning\code\virtual_domains\ancient_milsim\area.dm"
 #include "modular_nova\modules\bitrunning\code\virtual_domains\ancient_milsim\choice_beacon.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ghosts are now able to send messages to bitrunners with a custom set message (duh) and the username. Message is sent over Supply radio channel.
![image](https://github.com/user-attachments/assets/505e179d-cd86-49cc-a9e1-96cf7c8e1939)
To prevent malicious use by some less unsavory folks, you can also interact with the quantum server to toggle its messaging protection on/off. It's off by default.
![image](https://github.com/user-attachments/assets/94d986e1-caaf-4e0a-8724-554f27c76661)
![image](https://github.com/user-attachments/assets/d5f3127a-a2e6-4f26-98b3-91185e9befb7)
Anchors are now limited in amount and are dependent on the scanner tier, which was previously only used to see domain info. One additional anchor per tier, starting with one.
![image](https://github.com/user-attachments/assets/ca99cd20-80b3-4204-aab9-3d75980f8829)
![image](https://github.com/user-attachments/assets/3438acd1-d9e7-422c-995f-a0ac1de8f7ab)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Lack of communication between the ghosts and bitrunners is rather bad, as you can't really tell whether you'll be getting people willing to fight more or to talk more. Now, it's actually possible; with an additional check ensuring that you won't get shittalked into the floor by some CoD:MW2 riot shield hater.
*Uh yeah infinitely respawning into domains was rather terrible.* I planned to add this earlier but I was in Moscow so alas.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  Images above.
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Stalkeros
qol: Ghosts are now capable of communicating with bitrunners by clicking the bitrunning server, and assuming that it wasn't locked from messaging by the runners.
balance: Bitrunning domain anchors are now locked behind the scanner tier, allowing for one initially, up to four at maximum parts tier.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
