### PR TITLE
Swaps Syndicate Assault's and Ancient MilSim's difficulties around

### DIFF
--- a/modular_nova/modules/bitrunning/code/virtual_domains/ancient_milsim/virtual_domain.dm
+++ b/modular_nova/modules/bitrunning/code/virtual_domains/ancient_milsim/virtual_domain.dm
@@ -2,17 +2,17 @@
 /datum/lazy_template/virtual_domain/ancient_milsim
 	name = "Ancient Military Simulator"
 	announce_to_ghosts = TRUE
-	cost = BITRUNNER_COST_HIGH
+	cost = BITRUNNER_COST_MEDIUM
 	desc = "Recreate the events of the Border War's 'hot' part-long-gone as a Solarian strike team sweeping CIN compounds; sponsored by the SolFed recreation enthusiasts. \
 	Multiplayer playthrough and proper preparation highly recommended."
 	completion_loot = list(/obj/item/stack/spacecash/c200 = 3) //Sponsored
-	difficulty = BITRUNNER_DIFFICULTY_HIGH
+	difficulty = BITRUNNER_DIFFICULTY_MEDIUM
 	help_text = "The last part of this domain has a chance to be very PvP-centric. It's best if you don't come alone, and smuggle some ability and gear disks."
 	forced_outfit = /datum/outfit/solfed_bitrun
 	key = "ancient_milsim"
 	map_name = "ancientmilsim_nova"
 	mob_modules = list(/datum/modular_mob_segment/cin_mobs)
-	reward_points = BITRUNNER_REWARD_HIGH
+	reward_points = BITRUNNER_REWARD_MEDIUM
 	secondary_loot = list(
 		/obj/item/stack/spacecash/c100 = 12,
 		/obj/item/bitrunning_disk/item/ancient_milsim = 3,

--- a/modular_nova/modules/bitrunning/code/virtual_domains/syndicate_assault/virtual_domain.dm
+++ b/modular_nova/modules/bitrunning/code/virtual_domains/syndicate_assault/virtual_domain.dm
@@ -1,0 +1,4 @@
+/datum/lazy_template/virtual_domain/syndicate_assault
+	cost = BITRUNNER_COST_HIGH
+	difficulty = BITRUNNER_DIFFICULTY_HIGH
+	reward_points = BITRUNNER_REWARD_HIGH

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7217,6 +7217,7 @@
 #include "modular_nova\modules\bitrunning\code\virtual_domains\syndicate_assault\ghost_spawner.dm"
 #include "modular_nova\modules\bitrunning\code\virtual_domains\syndicate_assault\mod.dm"
 #include "modular_nova\modules\bitrunning\code\virtual_domains\syndicate_assault\outfit.dm"
+#include "modular_nova\modules\bitrunning\code\virtual_domains\syndicate_assault\virtual_domain.dm"
 #include "modular_nova\modules\blastwave_outfits\code\cargo_packs.dm"
 #include "modular_nova\modules\blastwave_outfits\code\clothing\blastwave_head.dm"
 #include "modular_nova\modules\blastwave_outfits\code\clothing\blastwave_mask.dm"


### PR DESCRIPTION

## About The Pull Request
Title. Makes Syndicate Assault a hard domain, whereas Ancient Military Simulator is now a medium domain.
## How This Contributes To The Nova Sector Roleplay Experience
Even before the rework, Syndicate was way more difficult [by the lack of any designing whatsoever] compared to MilSim, from medicine not being as prevalent, to the entire domain structure- I mean really it's just a copypaste of the Cybersun ghost role/space ruin, there's not much to say about it. And this lack of designing makes it genuinely really difficult.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/83344056-383e-4489-840a-a49955a9faf5)
![image](https://github.com/user-attachments/assets/074d5648-ea08-4392-9101-faca08f020d7)

</details>

## Changelog
:cl: Stalkeros
balance: Syndicate Assault has been recategorized as a hard difficulty bitrunning domain.
balance: Ancient Military Simulator has been recategorised as a medium difficulty bitrunning domain
/:cl:
