### PR TITLE
[Early Mirror]Adds a .NET 9 SDK setup action to linters (#88988)

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -75,6 +75,10 @@ jobs:
         with:
           path: tools/icon_cutter/cache
           key: ${{ runner.os }}-cutter-${{ hashFiles('dependencies.sh') }}
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4.2.0
+        with:
+          dotnet-version: 9.x
       - name: Install OpenDream
         uses: robinraju/release-downloader@v1.11
         with:


### PR DESCRIPTION
## About The Pull Request

Early Mirror of https://github.com/tgstation/tgstation/pull/88988

OpenDream was recently bumped to .NET 9, which is not on our runner image. I added an action which installs the required .NET version for DMCompiler to function.

## Why It's Good

Adding this action is not only good as a quick hack fix, but also for posterity.
I also considered the impact this has on our runner execution time, but my hope is that it should not matter if we have .NET installed already.
## About The Pull Request
## How This Contributes To The Nova Sector Roleplay Experience
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
code: Hopefully fixes opendream issues
/:cl:
