### PR TITLE
[MODULAR] Minor MagFed Turret Tweaks 

### DIFF
--- a/modular_nova/modules/magfed_turret/code/turret_framework.dm
+++ b/modular_nova/modules/magfed_turret/code/turret_framework.dm
@@ -356,7 +356,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	////// Can this turret load more than one ammunition type. Mostly for sound handling. Might be more important if used in a rework.
 	var/adjustable_magwell = TRUE
 	////// Does this turret auto-eject its magazines? Will be used later.
-	var/auto_mag_drop = FALSE
+	var/mag_drop_collect = FALSE
 	//////This is for manual target acquisition stuff. If present, should immediately over-ride as a target.
 	var/datum/weakref/target_override
 	//////Target Assessment System. Whether or not it's targeting according to flags or even ignoring everyone.
@@ -556,7 +556,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	if(magazine_ref)
 		var/obj/item/ammo_box/magazine/mag = magazine_ref?.resolve()
 		if(istype(mag))
-			if(auto_mag_drop)
+			if(mag_drop_collect)
 				var/obj/item/storage/toolbox/emergency/turret/mag_fed/auto_loader = mag_box?.resolve()
 				auto_loader.atom_storage?.attempt_insert(mag, override = TRUE)
 				UnregisterSignal(magazine_ref, COMSIG_MOVABLE_MOVED)
@@ -574,7 +574,6 @@ DEFINE_BITFIELD(turret_flags, list(
 	if(!auto_loader.get_mag())
 		balloon_alert_to_viewers("magazine well empty!") // hey, this is actually important info to convey.
 		toggle_on(FALSE) // I know i added the shupt-up toggle after adding this, This is just to prevent rapid proccing
-		timer_id = addtimer(CALLBACK(src, PROC_REF(toggle_on), TRUE), 5 SECONDS, TIMER_STOPPABLE)
 		return
 	magazine_ref = WEAKREF(auto_loader.get_mag(FALSE))
 	var/obj/item/ammo_box/magazine/get_that_mag = magazine_ref?.resolve()
@@ -609,6 +608,7 @@ DEFINE_BITFIELD(turret_flags, list(
 		return
 	balloon_alert(guy_with_mag, "magazine inserted!")
 	auto_loader?.atom_storage.attempt_insert(magaroni, guy_with_mag, TRUE)
+	toggle_on(TRUE)
 	return
 
 ////// I rewrite/add to the entire proccess. //////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Mag-fed turrets no-longer infinitely yell at you how their magazine well is empty.

Renames 1 variable to be more accurate to what it does

## How This Contributes To The Nova Sector Roleplay Experience

Pls Sir I'd Like The Turrets To Stop Yelling At Me

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  

https://github.com/user-attachments/assets/f743a786-d079-4ced-bf0b-85b63c049ef3




</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: turrets will turn off instead of yelling endlessly when empty (stoping it from infilooping)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
