### PR TITLE
Syndicate Assault domain (relatively minor) rework

### DIFF
--- a/_maps/virtual_domains/syndicate_assault_nova.dmm
+++ b/_maps/virtual_domains/syndicate_assault_nova.dmm
@@ -89,6 +89,7 @@
 	},
 /obj/item/storage/box/syndie_kit/recharger,
 /obj/effect/spawner/random/contraband/armory,
+/obj/item/ammo_box/c9mm,
 /turf/open/floor/mineral/plastitanium/red,
 /area/virtual_domain)
 "cw" = (
@@ -502,6 +503,7 @@
 	secure = 1
 	},
 /obj/effect/spawner/random/contraband/armory,
+/obj/item/ammo_box/c9mm,
 /turf/open/floor/mineral/plastitanium/red,
 /area/virtual_domain)
 "rP" = (
@@ -534,6 +536,7 @@
 	secure = 1
 	},
 /obj/item/storage/box/syndie_kit/recharger,
+/obj/item/ammo_box/c9mm,
 /turf/open/floor/mineral/plastitanium/red,
 /area/virtual_domain)
 "sK" = (
@@ -729,7 +732,8 @@
 	secure = 1
 	},
 /obj/item/crowbar/red,
-/obj/item/gun/energy/laser/carbine/cybersun,
+/obj/item/storage/toolbox/guncase,
+/obj/item/ammo_box/c9mm,
 /turf/open/floor/carpet/royalblack,
 /area/virtual_domain)
 "Cn" = (
@@ -846,6 +850,14 @@
 "Hq" = (
 /turf/closed/indestructible/binary,
 /area/virtual_domain/fullbright)
+"HF" = (
+/obj/structure/table/reinforced,
+/obj/item/toy/figure/bitrunner{
+	name = "\improper Counter-Bitrunner action figure";
+	toysay = "Oooh, Force Wall! I am a pussy and I use Force Wall!"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
 "HU" = (
 /obj/item/storage/toolbox/syndicate,
 /turf/open/floor/mineral/plastitanium,
@@ -1148,8 +1160,9 @@
 	secure = 1
 	},
 /obj/item/crowbar/red,
-/obj/item/gun/energy/laser/carbine/cybersun,
+/obj/item/storage/toolbox/guncase,
 /obj/machinery/light/small/directional/south,
+/obj/item/ammo_box/c9mm,
 /turf/open/floor/mineral/plastitanium,
 /area/virtual_domain)
 "Sq" = (
@@ -2258,7 +2271,7 @@ qx
 qx
 ru
 ru
-vp
+HF
 ru
 bm
 Ci

--- a/_maps/virtual_domains/syndicate_assault_nova.dmm
+++ b/_maps/virtual_domains/syndicate_assault_nova.dmm
@@ -87,7 +87,7 @@
 	req_access = list("syndicate");
 	secure = 1
 	},
-/obj/item/ammo_box/c9mm,
+/obj/item/storage/box/syndie_kit/recharger,
 /obj/effect/spawner/random/contraband/armory,
 /turf/open/floor/mineral/plastitanium/red,
 /area/virtual_domain)
@@ -140,6 +140,15 @@
 "dd" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/r_wall/syndicate,
+/area/virtual_domain)
+"de" = (
+/obj/structure/closet/secure_closet/freezer/fridge/all_access,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/turf/open/floor/mineral/plastitanium,
 /area/virtual_domain)
 "di" = (
 /obj/machinery/power/terminal{
@@ -301,6 +310,11 @@
 	},
 /turf/open/space/basic,
 /area/space/virtual_domain)
+"kk" = (
+/obj/structure/table/reinforced,
+/obj/machinery/coffeemaker,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
 "kI" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 8
@@ -519,8 +533,7 @@
 	req_access = list("syndicate");
 	secure = 1
 	},
-/obj/item/ammo_box/c9mm,
-/obj/item/ammo_box/c9mm,
+/obj/item/storage/box/syndie_kit/recharger,
 /turf/open/floor/mineral/plastitanium/red,
 /area/virtual_domain)
 "sK" = (
@@ -623,16 +636,9 @@
 /turf/open/floor/mineral/plastitanium,
 /area/virtual_domain/protected_space)
 "xJ" = (
-/obj/structure/closet/syndicate{
-	anchored = 1;
-	desc = "A basic closet for all your villainous needs.";
-	locked = 1;
-	name = "Closet";
-	req_access = list("syndicate");
-	secure = 1
-	},
-/obj/item/ammo_box/c9mm,
-/turf/open/floor/mineral/plastitanium/red,
+/obj/machinery/microwave,
+/obj/structure/table/reinforced,
+/turf/open/floor/mineral/plastitanium,
 /area/virtual_domain)
 "xS" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
@@ -723,9 +729,7 @@
 	secure = 1
 	},
 /obj/item/crowbar/red,
-/obj/item/ammo_box/magazine/m9mm_aps,
-/obj/item/ammo_box/magazine/m9mm_aps,
-/obj/item/gun/ballistic/automatic/pistol/aps,
+/obj/item/gun/energy/laser/carbine/cybersun,
 /turf/open/floor/carpet/royalblack,
 /area/virtual_domain)
 "Cn" = (
@@ -1144,9 +1148,7 @@
 	secure = 1
 	},
 /obj/item/crowbar/red,
-/obj/item/ammo_box/magazine/m9mm,
-/obj/item/ammo_box/magazine/m9mm,
-/obj/item/gun/ballistic/automatic/pistol,
+/obj/item/gun/energy/laser/carbine/cybersun,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/mineral/plastitanium,
 /area/virtual_domain)
@@ -3251,9 +3253,9 @@ uP
 FN
 uP
 Cn
-uP
-uP
-uP
+kk
+xJ
+de
 ru
 hD
 ru
@@ -3361,7 +3363,7 @@ qx
 qx
 UQ
 rM
-xJ
+sH
 Kz
 Kz
 tI

--- a/_maps/virtual_domains/syndicate_assault_nova.dmm
+++ b/_maps/virtual_domains/syndicate_assault_nova.dmm
@@ -1,0 +1,4328 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aq" = (
+/obj/item/storage/backpack/duffelbag/syndie/surgery,
+/obj/structure/table/reinforced,
+/turf/open/floor/plastic,
+/area/virtual_domain)
+"aw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/landmark/bitrunning/mob_segment,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"aN" = (
+/obj/structure/closet/crate/secure/gear{
+	req_access = list("syndicate")
+	},
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/plasteel/twenty,
+/obj/item/stack/sheet/mineral/plastitanium{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/rods/fifty,
+/turf/open/floor/pod/dark,
+/area/virtual_domain/protected_space)
+"aO" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"bh" = (
+/turf/open/floor/carpet/royalblack,
+/area/virtual_domain)
+"bm" = (
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/item/bedsheet/syndie{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblack,
+/area/virtual_domain)
+"bD" = (
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"bG" = (
+/turf/open/floor/pod/dark,
+/area/virtual_domain/protected_space)
+"bK" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Syndicate Ship Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/plastic,
+/area/virtual_domain)
+"cc" = (
+/obj/structure/closet/crate/secure/gear{
+	req_access = list("syndicate")
+	},
+/obj/effect/spawner/random/clothing/costume,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"cj" = (
+/obj/structure/transit_tube/crossing{
+	resistance_flags = 115
+	},
+/turf/closed/wall/r_wall/syndicate,
+/area/virtual_domain/protected_space)
+"co" = (
+/obj/item/storage/medkit/robotic_repair/preemo/stocked,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"ct" = (
+/obj/structure/closet/syndicate{
+	anchored = 1;
+	desc = "A basic closet for all your villainous needs.";
+	locked = 1;
+	name = "Closet";
+	req_access = list("syndicate");
+	secure = 1
+	},
+/obj/item/ammo_box/c9mm,
+/obj/effect/spawner/random/contraband/armory,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"cw" = (
+/obj/structure/closet/syndicate{
+	anchored = 1;
+	desc = "A basic closet for all your villainous needs.";
+	locked = 1;
+	name = "Closet";
+	req_access = list("syndicate");
+	secure = 1
+	},
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/clothing/under/syndicate/skirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"cy" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/virtual_domain)
+"cB" = (
+/obj/machinery/camera/xray{
+	c_tag = "Medbay";
+	dir = 6;
+	network = list("fsci");
+	screen_loc = ""
+	},
+/turf/open/floor/plastic,
+/area/virtual_domain)
+"cR" = (
+/obj/machinery/door/airlock/multi_tile/metal{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"cZ" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/automatic/l6_saw/unrestricted,
+/obj/item/ammo_box/magazine/m7mm,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain/protected_space)
+"da" = (
+/obj/machinery/stasis,
+/turf/open/floor/plastic,
+/area/virtual_domain)
+"dd" = (
+/obj/structure/sign/warning/vacuum/external,
+/turf/closed/wall/r_wall/syndicate,
+/area/virtual_domain)
+"di" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/item/paper/fluff/ruins/forgottenship/powerissues,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"dp" = (
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain/protected_space)
+"dw" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"dz" = (
+/obj/effect/landmark/bitrunning/cache_spawn,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"dU" = (
+/obj/structure/sink/directional/south,
+/obj/structure/mirror/directional/north,
+/turf/open/floor/iron/dark,
+/area/virtual_domain)
+"eB" = (
+/obj/machinery/camera/xray{
+	c_tag = "Cargo pod";
+	dir = 9;
+	network = list("fsci");
+	screen_loc = ""
+	},
+/obj/structure/closet,
+/obj/item/clothing/under/syndicate/tacticool,
+/obj/item/clothing/under/syndicate/tacticool,
+/obj/item/clothing/under/syndicate/tacticool,
+/obj/item/card/id/advanced/black/syndicate_command/crew_id,
+/obj/item/card/id/advanced/black/syndicate_command/crew_id,
+/obj/item/card/id/advanced/black/syndicate_command/crew_id,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain/protected_space)
+"fd" = (
+/obj/structure/transit_tube/crossing{
+	resistance_flags = 115
+	},
+/turf/open/space/basic,
+/area/virtual_domain/protected_space)
+"fG" = (
+/obj/structure/marker_beacon/burgundy,
+/turf/closed/wall/r_wall/syndicate,
+/area/space/virtual_domain)
+"fJ" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"fV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"gD" = (
+/obj/effect/mob_spawn/ghost_role/human/virtual_domain/syndie,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"hg" = (
+/obj/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/door/poddoor{
+	id = "fslockdown";
+	name = "Ship Blast Door";
+	state_open = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"hy" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"hA" = (
+/obj/effect/baseturf_helper/virtual_domain,
+/turf/closed/wall/r_wall/syndicate,
+/area/virtual_domain)
+"hD" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"ip" = (
+/obj/effect/landmark/bitrunning/mob_segment,
+/turf/open/floor/plastic,
+/area/virtual_domain)
+"iB" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"iL" = (
+/obj/structure/sign/departments/cargo,
+/turf/closed/wall/r_wall/syndicate,
+/area/virtual_domain/protected_space)
+"iU" = (
+/obj/structure/closet/crate/secure/gear{
+	req_access = list("syndicate")
+	},
+/obj/item/melee/energy/sword/saber/red,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/pod/dark,
+/area/virtual_domain/protected_space)
+"iW" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "fslockdown";
+	name = "Window shutters";
+	req_access = list("syndicate")
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"iX" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"ja" = (
+/obj/machinery/door/window/left/directional/north{
+	name = "Spare Equipment";
+	req_access = list("syndicate")
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"jl" = (
+/turf/closed/wall/mineral/titanium,
+/area/space/virtual_domain)
+"jA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"jJ" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Syndicate Ship Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/virtual_domain)
+"kh" = (
+/obj/structure/lattice,
+/obj/machinery/door/poddoor/ancient_milsim,
+/turf/open/space/basic,
+/area/space/virtual_domain)
+"kI" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"kJ" = (
+/obj/modular_map_root/safehouse{
+	key = "shuttle_space"
+	},
+/obj/machinery/porta_turret/syndicate/nri_raider/ancient_milsim,
+/turf/template_noop,
+/area/virtual_domain/safehouse)
+"kV" = (
+/obj/item/bedsheet/syndie,
+/obj/structure/bed,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"kX" = (
+/obj/machinery/door/airlock/multi_tile/metal,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"li" = (
+/obj/structure/transit_tube/station/dispenser/reverse{
+	dir = 4;
+	resistance_flags = 115
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain/protected_space)
+"ln" = (
+/obj/machinery/turretid{
+	control_area = "/area/ruin/space/has_grav/syndicate_forgotten_ship";
+	enabled = 0;
+	icon_state = "control_kill";
+	lethal = 1;
+	name = "Ship turret control panel";
+	pixel_y = 32;
+	req_access = list("syndicate")
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"lo" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/door/poddoor/ancient_milsim,
+/turf/open/space/basic,
+/area/space/virtual_domain)
+"lN" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"lQ" = (
+/obj/structure/cable,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"mo" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"mA" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain/protected_space)
+"mD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"mL" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain/protected_space)
+"nk" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"nn" = (
+/turf/closed/mineral/random,
+/area/virtual_domain/protected_space)
+"nB" = (
+/turf/closed/mineral/random,
+/area/ruin/space/virtual_domain)
+"nG" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"nU" = (
+/obj/structure/sign/poster/contraband/syndicate_pistol,
+/turf/closed/wall/r_wall/syndicate,
+/area/virtual_domain)
+"og" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/cup/glass/trophy/silver_cup,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"oM" = (
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"pl" = (
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"pz" = (
+/obj/machinery/computer/security{
+	desc = "Used to access interrogation room camera.";
+	dir = 8;
+	name = "Ship cameras console";
+	network = list("fsc","fsci");
+	screen_loc = ""
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"pH" = (
+/obj/structure/table/reinforced,
+/obj/item/toy/plush/nukeplushie,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"pM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"pS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"pU" = (
+/obj/machinery/shower/directional/north,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/virtual_domain)
+"qf" = (
+/obj/structure/table/optable,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plastic,
+/area/virtual_domain)
+"qx" = (
+/turf/open/space/basic,
+/area/space/virtual_domain)
+"qU" = (
+/obj/structure/sign/poster/contraband/c20r,
+/turf/closed/wall/r_wall/syndicate,
+/area/virtual_domain/protected_space)
+"qY" = (
+/obj/machinery/light/small/directional/south,
+/obj/effect/landmark/bitrunning/cache_spawn,
+/turf/open/floor/iron/dark,
+/area/virtual_domain)
+"rm" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/multi_tile/metal,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"ru" = (
+/turf/closed/wall/r_wall/syndicate,
+/area/virtual_domain)
+"rH" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"rM" = (
+/obj/structure/closet/syndicate{
+	anchored = 1;
+	desc = "A basic closet for all your villainous needs.";
+	locked = 1;
+	name = "Closet";
+	req_access = list("syndicate");
+	secure = 1
+	},
+/obj/effect/spawner/random/contraband/armory,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"rP" = (
+/turf/open/floor/plating,
+/area/virtual_domain)
+"sg" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain/protected_space)
+"sq" = (
+/obj/machinery/door/window/left/directional/south{
+	name = "Control Room";
+	req_access = list("syndicate")
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"sz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"sH" = (
+/obj/structure/closet/syndicate{
+	anchored = 1;
+	desc = "A basic closet for all your villainous needs.";
+	locked = 1;
+	name = "Closet";
+	req_access = list("syndicate");
+	secure = 1
+	},
+/obj/item/ammo_box/c9mm,
+/obj/item/ammo_box/c9mm,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"sK" = (
+/obj/structure/closet/crate/secure/gear{
+	req_access = list("syndicate")
+	},
+/obj/item/stack/sheet/mineral/titanium{
+	amount = 40
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 15
+	},
+/turf/open/floor/pod/dark,
+/area/virtual_domain/protected_space)
+"sL" = (
+/obj/item/stack/cable_coil/thirty,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"sM" = (
+/turf/template_noop,
+/area/virtual_domain/safehouse)
+"sT" = (
+/obj/effect/landmark/bitrunning/cache_spawn,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"tv" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "fscaproom";
+	name = "Room shutters control";
+	req_access = list("syndicate")
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"tB" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"tI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"uP" = (
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"vp" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"vD" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"vK" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Syndicate Ship Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"vU" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"wb" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
+/obj/machinery/portable_atmospherics/scrubber{
+	anchored = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"we" = (
+/turf/closed/mineral/random/high_chance,
+/area/ruin/space/virtual_domain)
+"wn" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/multi_tile/metal,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"wK" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Syndicate Ship Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/iron/dark,
+/area/virtual_domain)
+"wL" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/regular,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain/protected_space)
+"xJ" = (
+/obj/structure/closet/syndicate{
+	anchored = 1;
+	desc = "A basic closet for all your villainous needs.";
+	locked = 1;
+	name = "Closet";
+	req_access = list("syndicate");
+	secure = 1
+	},
+/obj/item/ammo_box/c9mm,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"xS" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/virtual_domain)
+"yl" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Captain's Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/door/poddoor{
+	id = "fscaproom";
+	name = "Captain's Blast Door";
+	state_open = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"yJ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"yR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"yT" = (
+/obj/item/ai_module/core/full/cybersun,
+/obj/structure/table/reinforced,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"yV" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"yZ" = (
+/turf/closed/mineral,
+/area/ruin/space/virtual_domain)
+"zi" = (
+/obj/machinery/vending/cigarette/syndicate,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"zt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"zN" = (
+/turf/closed/wall/r_wall/syndicate,
+/area/virtual_domain/protected_space)
+"Aa" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"Bm" = (
+/obj/effect/baseturf_helper/virtual_domain,
+/turf/closed/indestructible/syndicate,
+/area/virtual_domain/protected_space)
+"BK" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/space/virtual_domain)
+"BN" = (
+/obj/structure/transit_tube/crossing{
+	resistance_flags = 115
+	},
+/turf/template_noop,
+/area/virtual_domain/safehouse)
+"Cf" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"Ci" = (
+/obj/structure/closet/syndicate{
+	anchored = 1;
+	desc = "A basic closet for all your villainous needs.";
+	locked = 1;
+	name = "Closet";
+	req_access = list("syndicate");
+	secure = 1
+	},
+/obj/item/crowbar/red,
+/obj/item/ammo_box/magazine/m9mm_aps,
+/obj/item/ammo_box/magazine/m9mm_aps,
+/obj/item/gun/ballistic/automatic/pistol/aps,
+/turf/open/floor/carpet/royalblack,
+/area/virtual_domain)
+"Cn" = (
+/obj/machinery/camera/xray/directional/east{
+	c_tag = "Conference room";
+	network = list("fsc");
+	screen_loc = ""
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"CK" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/mob/living/basic/trooper/syndicate/ranged/smg/pilot,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"CR" = (
+/obj/item/summon_beacon/lustwish,
+/obj/structure/closet/syndicate{
+	anchored = 1;
+	desc = "A basic closet for all your villainous needs.";
+	locked = 1;
+	name = "Closet";
+	req_access = list("syndicate");
+	secure = 1
+	},
+/obj/item/dnainjector/thermal,
+/obj/item/coin/antagtoken,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"De" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Syndicate Ship Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"Dj" = (
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/magazine/smgm45,
+/obj/item/ammo_box/magazine/smgm45,
+/obj/item/ammo_box/magazine/smgm45,
+/obj/item/gun/ballistic/automatic/c20r/unrestricted,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain/protected_space)
+"DA" = (
+/obj/structure/closet/crate/secure/gear{
+	req_access = list("syndicate")
+	},
+/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"EB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"Fp" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"FN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"Gh" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/barricade/security,
+/turf/open/space/basic,
+/area/space/virtual_domain)
+"Gn" = (
+/obj/item/bedsheet/syndie{
+	dir = 1
+	},
+/obj/structure/bed{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"Gs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"GB" = (
+/obj/structure/cable,
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/door/airlock/multi_tile/metal,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"GH" = (
+/obj/machinery/light/small/directional/south,
+/obj/structure/dresser,
+/turf/open/floor/carpet/royalblack,
+/area/virtual_domain)
+"GZ" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/virtual_domain)
+"Hq" = (
+/turf/closed/indestructible/binary,
+/area/virtual_domain/fullbright)
+"HU" = (
+/obj/item/storage/toolbox/syndicate,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"Ia" = (
+/obj/effect/mob_spawn/ghost_role/human/virtual_domain/syndie,
+/turf/open/floor/carpet/royalblack,
+/area/virtual_domain)
+"Id" = (
+/obj/machinery/power/shuttle_engine/huge{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/virtual_domain)
+"If" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/obj/effect/landmark/bitrunning/mob_segment,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"Ig" = (
+/obj/machinery/porta_turret/syndicate/energy{
+	dir = 4;
+	name = "Syndicate Ship Turret";
+	on = 0;
+	shot_delay = 10
+	},
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/virtual_domain)
+"Im" = (
+/obj/machinery/door/poddoor/ancient_milsim,
+/turf/open/space/basic,
+/area/space/virtual_domain)
+"Io" = (
+/obj/effect/landmark/bitrunning/cache_spawn,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"IC" = (
+/obj/structure/table/reinforced,
+/obj/item/paper,
+/obj/item/pen,
+/obj/machinery/computer/security/telescreen/forgotten_ship/sci/directional/south,
+/turf/open/floor/carpet/royalblack,
+/area/virtual_domain)
+"IH" = (
+/obj/machinery/door/airlock/external/ruin{
+	name = "Syndicate Ship Airlock";
+	resistance_flags = 115
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/structure/cable,
+/obj/structure/fans/tiny{
+	resistance_flags = 115
+	},
+/turf/open/floor/plating,
+/area/virtual_domain/protected_space)
+"IV" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Syndicate Ship Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/plating,
+/area/virtual_domain)
+"Jg" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"Jq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"Jz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"JA" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"JN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"JP" = (
+/obj/machinery/door/airlock/multi_tile/metal{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"Kz" = (
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"Lk" = (
+/obj/structure/transit_tube/crossing{
+	resistance_flags = 115
+	},
+/turf/closed/mineral/random,
+/area/virtual_domain/protected_space)
+"Lo" = (
+/obj/structure/filingcabinet,
+/obj/machinery/door/window/left/directional/west{
+	name = "Syndicate Interior Door";
+	req_access = list("syndicate")
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"LB" = (
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain/protected_space)
+"Mc" = (
+/obj/structure/dresser,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"Mm" = (
+/obj/structure/closet/syndicate{
+	anchored = 1;
+	desc = "A basic closet for all your villainous needs.";
+	locked = 1;
+	name = "Closet";
+	req_access = list("syndicate");
+	secure = 1
+	},
+/obj/item/clothing/head/hats/hos/beret/syndicate,
+/obj/item/clothing/suit/armor/vest/capcarapace/syndicate,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/clothing/under/syndicate,
+/obj/item/clothing/under/syndicate/skirt,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/shoes/combat,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"Mp" = (
+/obj/structure/marker_beacon/burgundy,
+/obj/machinery/door/poddoor/ancient_milsim,
+/turf/closed/wall/r_wall/syndicate,
+/area/space/virtual_domain)
+"MD" = (
+/obj/item/clothing/head/utility/welding,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain/protected_space)
+"MR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"Nh" = (
+/obj/machinery/power/shuttle_engine/large{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/virtual_domain)
+"Nm" = (
+/obj/structure/closet/crate/secure/gear{
+	req_access = list("syndicate")
+	},
+/turf/open/floor/pod/dark,
+/area/virtual_domain/protected_space)
+"Nr" = (
+/obj/structure/closet/crate/secure/gear{
+	req_access = list("syndicate")
+	},
+/obj/item/stack/sheet/mineral/gold{
+	amount = 30
+	},
+/obj/item/stack/sheet/mineral/silver{
+	amount = 30
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/pod/dark,
+/area/virtual_domain/protected_space)
+"Of" = (
+/obj/structure/closet/crate/secure/gear{
+	req_access = list("syndicate")
+	},
+/obj/item/disk/surgery/forgottenship,
+/turf/open/floor/pod/dark,
+/area/virtual_domain/protected_space)
+"Ox" = (
+/obj/machinery/atmospherics/components/unary/vent_pump,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"OH" = (
+/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/syndicate,
+/obj/item/storage/toolbox/syndicate,
+/obj/machinery/button/door/indestructible/ancient_milsim{
+	pixel_y = 24;
+	name = "Firewall Control"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain/protected_space)
+"OI" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"PR" = (
+/obj/machinery/door/password/voice/sfc{
+	password = null
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/grunge{
+	desc = "Vault airlock preventing air from going out.";
+	name = "Syndicate Vault Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/pod/dark,
+/area/virtual_domain/protected_space)
+"Qg" = (
+/obj/structure/urinal/directional/west,
+/turf/open/floor/iron,
+/area/virtual_domain)
+"Qi" = (
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 15
+	},
+/obj/structure/cable,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"QF" = (
+/obj/structure/table/reinforced,
+/obj/item/dualsaber/green,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain/protected_space)
+"QG" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/closed/mineral/random,
+/area/ruin/space/virtual_domain)
+"QX" = (
+/obj/effect/landmark/bitrunning/mob_segment,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"Ra" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"RF" = (
+/obj/machinery/power/shuttle_engine/propulsion{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/virtual_domain)
+"RQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"RU" = (
+/obj/machinery/suit_storage_unit/syndicate,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain/protected_space)
+"Sc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"Sd" = (
+/obj/structure/closet/syndicate{
+	anchored = 1;
+	desc = "A basic closet for all your villainous needs.";
+	locked = 1;
+	name = "Closet";
+	req_access = list("syndicate");
+	secure = 1
+	},
+/obj/item/crowbar/red,
+/obj/item/ammo_box/magazine/m9mm,
+/obj/item/ammo_box/magazine/m9mm,
+/obj/item/gun/ballistic/automatic/pistol,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"Sq" = (
+/obj/machinery/power/smes,
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"Sv" = (
+/obj/structure/closet/crate/secure/gear{
+	req_access = list("syndicate")
+	},
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"Sz" = (
+/turf/open/floor/iron/dark,
+/area/virtual_domain)
+"SA" = (
+/obj/machinery/porta_turret/syndicate/nri_raider/ancient_milsim,
+/turf/template_noop,
+/area/virtual_domain/safehouse)
+"SN" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/ancient_milsim,
+/turf/open/space/basic,
+/area/space/virtual_domain)
+"SX" = (
+/obj/machinery/vending/medical/syndicate/cybersun,
+/turf/open/floor/plastic,
+/area/virtual_domain)
+"TB" = (
+/turf/closed/indestructible/syndicate,
+/area/virtual_domain/protected_space)
+"UM" = (
+/obj/item/storage/medkit/robotic_repair/preemo/stocked,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain/protected_space)
+"UQ" = (
+/obj/structure/sign/poster/contraband/syndicate_recruitment,
+/turf/closed/wall/r_wall/syndicate,
+/area/virtual_domain)
+"UU" = (
+/obj/structure/marker_beacon/burgundy,
+/turf/closed/wall/mineral/titanium,
+/area/space/virtual_domain)
+"Vg" = (
+/turf/open/space/basic,
+/area/virtual_domain/protected_space)
+"Vk" = (
+/obj/machinery/porta_turret/syndicate/energy{
+	dir = 4;
+	name = "Syndicate Ship Turret";
+	on = 0;
+	shot_delay = 10
+	},
+/turf/closed/wall/r_wall/syndicate,
+/area/virtual_domain)
+"Vo" = (
+/obj/item/stack/cable_coil/thirty,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain/protected_space)
+"Vq" = (
+/obj/structure/transit_tube/station/dispenser/reverse{
+	dir = 8;
+	resistance_flags = 115
+	},
+/turf/template_noop,
+/area/virtual_domain/safehouse)
+"Wd" = (
+/obj/item/clothing/head/utility/welding,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"Wy" = (
+/obj/structure/closet/crate/secure/gear{
+	req_access = list("syndicate")
+	},
+/obj/item/stack/ore/plasma{
+	amount = 19
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"WQ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/barricade/security,
+/turf/open/space/basic,
+/area/space/virtual_domain)
+"WR" = (
+/obj/machinery/power/port_gen/pacman/super{
+	anchored = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium/red,
+/area/virtual_domain)
+"Xp" = (
+/turf/open/space/basic,
+/area/virtual_domain)
+"XS" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"Yb" = (
+/obj/structure/closet/crate/secure/gear{
+	req_access = list("syndicate")
+	},
+/obj/item/clothing/head/helmet/space/syndicate/black/engie,
+/obj/item/clothing/suit/space/syndicate/black/engie,
+/turf/open/floor/pod/dark,
+/area/virtual_domain/protected_space)
+"Yi" = (
+/obj/effect/landmark/bitrunning/cache_spawn,
+/turf/open/floor/plastic,
+/area/virtual_domain)
+"Yj" = (
+/obj/structure/closet/crate/secure/gear{
+	req_access = list("syndicate")
+	},
+/obj/item/stack/ore/diamond{
+	amount = 3
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"Yk" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Captain's Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/door/poddoor{
+	id = "fscaproom";
+	name = "Captain's Blast Door";
+	state_open = 1
+	},
+/turf/open/floor/carpet/royalblack,
+/area/virtual_domain)
+"Yr" = (
+/obj/effect/baseturf_helper/virtual_domain,
+/obj/machinery/porta_turret/syndicate/nri_raider/ancient_milsim,
+/turf/template_noop,
+/area/virtual_domain/safehouse)
+"Yu" = (
+/obj/structure/chair/comfy/black,
+/turf/open/floor/carpet/royalblack,
+/area/virtual_domain)
+"YI" = (
+/obj/effect/landmark/bitrunning/cache_spawn,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/virtual_domain)
+"YV" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/virtual_domain)
+"Za" = (
+/obj/machinery/computer/operating,
+/turf/open/floor/plastic,
+/area/virtual_domain)
+"Zb" = (
+/turf/open/floor/plastic,
+/area/virtual_domain)
+"ZA" = (
+/obj/machinery/power/shuttle_engine/propulsion{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/virtual_domain)
+
+(1,1,1) = {"
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+"}
+(2,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(3,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(4,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+fG
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(5,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+fG
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(6,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+fG
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Im
+kh
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+fG
+GZ
+qx
+qx
+qx
+qx
+Hq
+"}
+(7,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+kh
+Mp
+GZ
+qx
+qx
+qx
+qx
+we
+we
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(8,1,1) = {"
+Hq
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Im
+kh
+qx
+qx
+qx
+qx
+qx
+we
+we
+we
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(9,1,1) = {"
+Hq
+GZ
+fG
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+qx
+we
+we
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(10,1,1) = {"
+Hq
+qx
+GZ
+qx
+qx
+qx
+qx
+Xp
+Xp
+Id
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Xp
+Xp
+Id
+qx
+qx
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(11,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+qx
+qx
+Xp
+Xp
+Xp
+qx
+qx
+Xp
+Nh
+Xp
+Nh
+qx
+qx
+Xp
+Xp
+Xp
+qx
+qx
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+Hq
+"}
+(12,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+qx
+ZA
+Xp
+Xp
+Xp
+ZA
+ZA
+Xp
+Xp
+Xp
+Xp
+ZA
+ZA
+Xp
+Xp
+Xp
+RF
+qx
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+fG
+GZ
+qx
+qx
+we
+we
+we
+qx
+qx
+qx
+qx
+GZ
+fG
+GZ
+qx
+qx
+Hq
+"}
+(13,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+qx
+ru
+ru
+ru
+ru
+ru
+ru
+ru
+ru
+ru
+ru
+ru
+ru
+ru
+ru
+ru
+ru
+qx
+qx
+qx
+qx
+Im
+Im
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+we
+we
+we
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+Hq
+"}
+(14,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+Vk
+ru
+Sv
+vD
+uP
+Io
+Yj
+vD
+yV
+sL
+Wy
+DA
+Io
+uP
+vD
+cc
+ru
+Vk
+qx
+qx
+qx
+Im
+kh
+fG
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(15,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+ru
+YI
+uP
+uP
+QX
+lN
+co
+HU
+uP
+Wd
+uP
+uP
+lN
+uP
+QX
+uP
+sT
+hA
+qx
+qx
+qx
+Im
+Im
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(16,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+ru
+ru
+ru
+ru
+ru
+ru
+ru
+ru
+rP
+cR
+ru
+ru
+ru
+IV
+ru
+ru
+ru
+ru
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(17,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+ru
+ru
+vp
+ru
+bm
+Ci
+ru
+Sq
+di
+Kz
+WR
+ru
+aO
+uP
+vK
+gD
+Gn
+ru
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+nB
+we
+nB
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(18,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+ru
+og
+Jg
+ru
+Ia
+GH
+ru
+Qi
+sz
+Kz
+hy
+ru
+fJ
+uP
+ru
+Mc
+Sd
+ru
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+nB
+nB
+nB
+nB
+nB
+nB
+qx
+qx
+qx
+qx
+GZ
+fG
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(19,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+ru
+Kz
+Kz
+yl
+bh
+bh
+Yk
+pS
+RQ
+Kz
+Jz
+vK
+uP
+Io
+ru
+ru
+ru
+ru
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+nB
+nB
+TB
+TB
+TB
+TB
+nB
+nB
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(20,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+ru
+CR
+Kz
+ru
+bh
+bh
+Yk
+pM
+zt
+Kz
+pM
+vK
+uP
+uP
+ru
+Mc
+Sd
+ru
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+nB
+nB
+TB
+TB
+Yb
+Yb
+TB
+Bm
+nB
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+UU
+jl
+jl
+jl
+jl
+UU
+qx
+Hq
+"}
+(21,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+ru
+yT
+Kz
+ru
+Yu
+IC
+ru
+mD
+JN
+JN
+MR
+ru
+fJ
+uP
+vK
+gD
+kV
+ru
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+nB
+QG
+nB
+TB
+aN
+bG
+bG
+sK
+TB
+nB
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+GZ
+qx
+Hq
+"}
+(22,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+Ig
+ru
+Lo
+ru
+tv
+hD
+nU
+wb
+EB
+Kz
+pl
+ru
+ru
+De
+ru
+ru
+ru
+Ig
+qx
+qx
+qx
+kh
+Im
+qx
+qx
+nB
+we
+nB
+TB
+iU
+bG
+bG
+Nr
+TB
+nB
+we
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+GZ
+qx
+Hq
+"}
+(23,1,1) = {"
+Hq
+qx
+GZ
+qx
+qx
+qx
+ru
+ru
+ru
+ru
+ru
+ru
+ru
+yR
+cR
+ru
+ru
+Sz
+Sz
+ru
+Qg
+ru
+qx
+qx
+qx
+GZ
+Mp
+kh
+qx
+qx
+qx
+nB
+nB
+TB
+Nm
+bG
+bG
+Of
+TB
+nB
+nB
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+SA
+sM
+sM
+sM
+sM
+kJ
+qx
+Hq
+"}
+(24,1,1) = {"
+Hq
+GZ
+fG
+GZ
+qx
+qx
+ru
+Za
+Yi
+Zb
+SX
+ru
+uP
+yR
+uP
+uP
+ru
+dU
+Sz
+jJ
+YV
+ru
+qx
+qx
+qx
+qx
+kh
+Im
+qx
+qx
+nB
+nB
+nB
+TB
+TB
+PR
+TB
+TB
+TB
+nB
+nB
+nB
+qx
+qx
+qx
+qx
+qx
+qx
+sM
+sM
+sM
+sM
+sM
+sM
+qx
+Hq
+"}
+(25,1,1) = {"
+Hq
+qx
+GZ
+qx
+qx
+qx
+ru
+qf
+Zb
+ip
+da
+ru
+Ra
+Sc
+uP
+dw
+ru
+dU
+qY
+ru
+ru
+ru
+qx
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+nB
+nB
+we
+zN
+zN
+Vo
+sg
+zN
+zN
+nn
+nn
+nn
+nn
+Vg
+Vg
+Vg
+Vg
+Vg
+sM
+sM
+sM
+sM
+sM
+sM
+qx
+Hq
+"}
+(26,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+qx
+ru
+aq
+cB
+Zb
+Zb
+bK
+Ox
+Gs
+uP
+uP
+wK
+Sz
+Sz
+jJ
+pU
+ru
+qx
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+nB
+nB
+qU
+mL
+MD
+dp
+li
+cj
+Lk
+Lk
+fd
+fd
+fd
+fd
+fd
+fd
+fd
+BN
+Vq
+sM
+sM
+sM
+sM
+qx
+Hq
+"}
+(27,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+Vk
+ru
+ru
+ru
+bK
+ru
+ru
+ru
+yR
+cR
+ru
+ru
+ru
+wK
+ru
+ru
+ru
+Vk
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+nB
+nB
+zN
+eB
+UM
+dp
+dp
+zN
+nn
+Vg
+Vg
+Vg
+Vg
+Vg
+Vg
+Vg
+Vg
+sM
+sM
+sM
+sM
+sM
+sM
+qx
+Hq
+"}
+(28,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+ru
+Fp
+uP
+ru
+nk
+oM
+lQ
+oM
+yR
+uP
+oM
+lQ
+oM
+uP
+ru
+uP
+Fp
+ru
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+nB
+zN
+wL
+LB
+dp
+mA
+zN
+yZ
+nB
+nB
+nB
+qx
+qx
+qx
+qx
+qx
+sM
+sM
+sM
+sM
+sM
+sM
+qx
+Hq
+"}
+(29,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+ru
+uP
+dw
+ru
+rH
+uP
+JA
+JA
+iX
+JA
+JA
+JA
+oM
+uP
+ru
+fJ
+uP
+ru
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+zN
+OH
+LB
+dp
+RU
+zN
+we
+nB
+nB
+qx
+qx
+qx
+qx
+qx
+qx
+SA
+sM
+sM
+sM
+sM
+Yr
+qx
+Hq
+"}
+(30,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+wn
+uP
+uP
+kX
+uP
+Aa
+hD
+yJ
+bD
+hD
+hD
+hD
+OI
+oM
+rm
+oM
+oM
+GB
+BK
+BK
+BK
+SN
+SN
+WQ
+BK
+BK
+BK
+BK
+IH
+LB
+LB
+dp
+RU
+zN
+nB
+nB
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+GZ
+qx
+Hq
+"}
+(31,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+uP
+uP
+uP
+uP
+uP
+uP
+uP
+uP
+jA
+uP
+uP
+uP
+uP
+uP
+uP
+uP
+uP
+uP
+cy
+cy
+cy
+lo
+lo
+Gh
+cy
+cy
+cy
+cy
+iL
+cZ
+dp
+dp
+RU
+zN
+nB
+nB
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+GZ
+qx
+Hq
+"}
+(32,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+ru
+uP
+uP
+dd
+uP
+uP
+uP
+Ox
+aw
+uP
+uP
+uP
+uP
+uP
+dd
+uP
+uP
+ru
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+nB
+zN
+zN
+Dj
+QF
+zN
+zN
+nB
+nB
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+UU
+jl
+jl
+jl
+jl
+UU
+qx
+Hq
+"}
+(33,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+ru
+aO
+dw
+ru
+XS
+uP
+uP
+uP
+FN
+uP
+uP
+uP
+uP
+Cf
+ru
+fJ
+aO
+ru
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+nB
+nB
+nB
+zN
+zN
+zN
+zN
+nB
+nB
+we
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(34,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+xS
+ru
+hD
+ru
+zi
+uP
+uP
+uP
+FN
+uP
+Cn
+uP
+uP
+uP
+ru
+hD
+ru
+xS
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+nB
+nB
+nB
+nB
+we
+nB
+nB
+nB
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(35,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+qx
+ru
+ru
+ru
+ru
+ru
+ru
+ru
+Jq
+JP
+ru
+ru
+ru
+ru
+ru
+ru
+ru
+qx
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+we
+nB
+nB
+nB
+nB
+nB
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(36,1,1) = {"
+Hq
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+UQ
+rM
+xJ
+Kz
+Kz
+tI
+Kz
+Kz
+Kz
+ct
+sH
+ru
+qx
+qx
+qx
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(37,1,1) = {"
+Hq
+GZ
+fG
+GZ
+qx
+Vk
+ru
+ru
+ru
+Kz
+Kz
+Kz
+Kz
+tI
+Kz
+Kz
+Kz
+Kz
+Kz
+ru
+ru
+ru
+Vk
+qx
+qx
+qx
+Im
+kh
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+fG
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(38,1,1) = {"
+Hq
+qx
+GZ
+qx
+qx
+ru
+ln
+Kz
+ru
+iB
+Kz
+Kz
+fV
+If
+Kz
+Kz
+Kz
+Kz
+nG
+ru
+cw
+cw
+ru
+qx
+qx
+qx
+kh
+Mp
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(39,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+ru
+tB
+dz
+sq
+Kz
+CK
+Kz
+vU
+mo
+Kz
+vU
+Kz
+CK
+Kz
+ja
+Kz
+Jg
+ru
+qx
+qx
+qx
+Im
+kh
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(40,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+xS
+ru
+Kz
+ru
+Kz
+Kz
+Kz
+pz
+Kz
+Kz
+kI
+Kz
+Kz
+Kz
+ru
+Mm
+ru
+xS
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+fG
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(41,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+qx
+ru
+ru
+ru
+Kz
+Kz
+Kz
+Kz
+Kz
+Kz
+Kz
+Kz
+Kz
+dz
+ru
+ru
+ru
+qx
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+we
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+Hq
+"}
+(42,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+qx
+qx
+ru
+ru
+vp
+vp
+pH
+vp
+iW
+vp
+vp
+vp
+vp
+vp
+ru
+ru
+qx
+qx
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+we
+we
+we
+we
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+fG
+GZ
+qx
+qx
+Hq
+"}
+(43,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Ig
+hg
+hg
+hg
+hg
+hg
+hg
+hg
+hg
+hg
+hg
+Ig
+qx
+qx
+qx
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+we
+we
+we
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+Hq
+"}
+(44,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Im
+Im
+qx
+we
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(45,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Im
+Im
+we
+we
+we
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(46,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+Im
+Im
+we
+we
+we
+we
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(47,1,1) = {"
+Hq
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+fG
+GZ
+qx
+qx
+Im
+Im
+qx
+we
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(48,1,1) = {"
+Hq
+qx
+qx
+GZ
+fG
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+fG
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(49,1,1) = {"
+Hq
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+fG
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(50,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+GZ
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(51,1,1) = {"
+Hq
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Im
+Im
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+Hq
+"}
+(52,1,1) = {"
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
+"}

--- a/_maps/virtual_domains/syndicate_assault_nova.dmm
+++ b/_maps/virtual_domains/syndicate_assault_nova.dmm
@@ -296,7 +296,9 @@
 /area/virtual_domain)
 "kh" = (
 /obj/structure/lattice,
-/obj/machinery/door/poddoor/ancient_milsim,
+/obj/machinery/door/poddoor/ancient_milsim{
+	id = "engagement_control"
+	},
 /turf/open/space/basic,
 /area/space/virtual_domain)
 "kI" = (
@@ -343,7 +345,9 @@
 /area/virtual_domain)
 "lo" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/door/poddoor/ancient_milsim,
+/obj/machinery/door/poddoor/ancient_milsim{
+	id = "engagement_control"
+	},
 /turf/open/space/basic,
 /area/space/virtual_domain)
 "lN" = (
@@ -872,7 +876,9 @@
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/virtual_domain)
 "Im" = (
-/obj/machinery/door/poddoor/ancient_milsim,
+/obj/machinery/door/poddoor/ancient_milsim{
+	id = "engagement_control"
+	},
 /turf/open/space/basic,
 /area/space/virtual_domain)
 "Io" = (
@@ -990,7 +996,9 @@
 /area/virtual_domain)
 "Mp" = (
 /obj/structure/marker_beacon/burgundy,
-/obj/machinery/door/poddoor/ancient_milsim,
+/obj/machinery/door/poddoor/ancient_milsim{
+	id = "engagement_control"
+	},
 /turf/closed/wall/r_wall/syndicate,
 /area/space/virtual_domain)
 "MD" = (
@@ -1164,7 +1172,9 @@
 "SN" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/obj/machinery/door/poddoor/ancient_milsim,
+/obj/machinery/door/poddoor/ancient_milsim{
+	id = "engagement_control"
+	},
 /turf/open/space/basic,
 /area/space/virtual_domain)
 "SX" = (

--- a/modular_nova/modules/bitrunning/code/virtual_domains/syndicate_assault/virtual_domain.dm
+++ b/modular_nova/modules/bitrunning/code/virtual_domains/syndicate_assault/virtual_domain.dm
@@ -1,0 +1,7 @@
+/datum/lazy_template/virtual_domain/syndicate_assault
+	name = "Syndicate Assault"
+	desc = "Board the enemy ship and recover the stolen cargo."
+	help_text = "A group of Syndicate operatives have stolen valuable cargo from the station. \
+	They have boarded their ship and are attempting to escape. Infiltrate their ship and recover \
+	the crate. 	Be careful, they are extremely armed."
+	map_name = "syndicate_assault_nova"

--- a/modular_nova/modules/bitrunning/code/virtual_domains/syndicate_assault/virtual_domain.dm
+++ b/modular_nova/modules/bitrunning/code/virtual_domains/syndicate_assault/virtual_domain.dm
@@ -1,7 +1,7 @@
 /datum/lazy_template/virtual_domain/syndicate_assault
-	name = "Syndicate Assault"
-	desc = "Board the enemy ship and recover the stolen cargo."
-	help_text = "A group of Syndicate operatives have stolen valuable cargo from the station. \
-	They have boarded their ship and are attempting to escape. Infiltrate their ship and recover \
-	the crate. 	Be careful, they are extremely armed."
+	name = "'Cybersun' Resource Acquisition"
+	desc = "Hijack the enemy domain and recover the stolen cargo."
+	help_text = "A group of (allegedly) Cybersun bitrunners have stolen valuable data from us. \
+	They have offloaded it to their Counter-Bitrunner Division for payment validation processing. Infiltrate the intermediary domain and recover \
+	the crate. Be careful, they are extremely armed."
 	map_name = "syndicate_assault_nova"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7217,6 +7217,7 @@
 #include "modular_nova\modules\bitrunning\code\virtual_domains\syndicate_assault\ghost_spawner.dm"
 #include "modular_nova\modules\bitrunning\code\virtual_domains\syndicate_assault\mod.dm"
 #include "modular_nova\modules\bitrunning\code\virtual_domains\syndicate_assault\outfit.dm"
+#include "modular_nova\modules\bitrunning\code\virtual_domains\syndicate_assault\virtual_domain.dm"
 #include "modular_nova\modules\blastwave_outfits\code\cargo_packs.dm"
 #include "modular_nova\modules\blastwave_outfits\code\clothing\blastwave_head.dm"
 #include "modular_nova\modules\blastwave_outfits\code\clothing\blastwave_mask.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
We're now using a modular variation of the Syndicate Assault domain, with the following changes:
Domain has been reflavored into *whatever the hell this'd be in-lore idk*. Sounds real cool though.
![image](https://github.com/user-attachments/assets/4cac1d69-d655-4c9e-ae96-90ae2b415994)
![image](https://github.com/user-attachments/assets/8fd8c06e-403b-4610-8ffd-fcc51a1788ad)

Numerous 'movement buoys', as I've decided to call them, have been spread around the map to make it easier to maneuver.
![image](https://github.com/user-attachments/assets/d763a8ac-0228-444e-9e94-620ae912ad64)

Most importantly, the zone between the Bitrunners and Counter-Bitrunners has been separated with a fog of war. Works like MilSim's - by deleting itself whenever a button's pushed.
![image](https://github.com/user-attachments/assets/525b25eb-7f5c-4c82-8d21-817188c71b5e)

On the Bitrunners' side, their shuttle's tubes has become indestructible, and additional protection side walls have been added to prevent spawn camping and malicious soft locking.
![image](https://github.com/user-attachments/assets/4ed774f7-a8a3-48ba-9557-5c1c15c87c5d)

To prevent getting sniped right off the bat, a barricade has been provided near the Bitrunners' entrance.
![image](https://github.com/user-attachments/assets/3a86f4a8-2f67-430e-81a9-2a07467c9cba)

On the Counter-Bitrunners' side, their ship has become bigger in general, to facilitate easier maneuvering; they, also, have been provided with a room each, because I felt that'd be cute honestly. Also some tools and premapped synthetic medical supplies have been added to either side.
![image](https://github.com/user-attachments/assets/62afd41a-32de-4003-87ff-d5df674fedeb)

Counter-Bitrunners can brew coffee and heat up Donk Pockets now. (big change)
![image](https://github.com/user-attachments/assets/6f147f16-f9b5-41c3-9743-3b81427ab5cc)

Among several minuscule other changes, like 9mm pistols now coming in gun cases; and additional recharger construction kits being provided to Counter-Bitrunners, a flavor thingy of singular quantity has been added:
![image](https://github.com/user-attachments/assets/dff9bce8-be3c-4686-bf5a-d592d9e06bf9)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Previous Syndicate Assault iteration, frankly, kinda sucked. I mean- It's like, literally just a carbon copy of the now-gone Cybersun ghost role. That's all there's to it. It wasn't adapted to bitrunning, resulting in a steamroll for either side, even on the /tg/'s unmodified version, thanks to really terrible chokepointing and lack of spawn protection; among some other, non-/tg/ issues that have cropped up from us (me frankly) allowing both runners and ghost roles to spawn in as their characters, specifically synths. All of those changes should in theory make it at least more bearable for completion, and hopefully more fun for either side; or at least the one I have been mainly doing this for.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  Genuinely, screenshots above are all there is to it. That's literally me loading it in and testing the thing.
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Stalkeros
qol: Syndicate Assault bitrunning domain has been reflavored into a 'Cybersun' Resource Acquisition domain.
map: Syndicate Assault map has received a rather major touch-up, fixing up some of the more glaring game design issues. Like the lack of caffeine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
