### PR TITLE
Brand intelligence unanchors rebellious vending machines

### DIFF
--- a/modular_nova/modules/modular_vending/code/vending.dm
+++ b/modular_nova/modules/modular_vending/code/vending.dm
@@ -58,6 +58,11 @@
 	QDEL_NULL(contraband_nova)
 	return ..()
 
+/obj/machinery/vending/spawn_frame(disassembled)
+	if(ai_controller) // Vendor uprising, vending machines that are jumping around shouldn't be anchored
+		set_anchored(FALSE)
+	. = ..()
+
 /// This proc checks for forbidden traits cause it'd be pretty bad to have 5 insuls available to assistants roundstart at the vendor!
 /obj/machinery/vending/proc/allow_increase(obj/item/clothing/clothing_path)
 	var/obj/item/clothing/clothing = new clothing_path()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Vending machines that are hopping around and crushing people clearly aren't secured to the ground anymore, this reflects that. Happens on deconstruction.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
People cleaning up after events don't have to spend quite so long waiting for progress bars to fill up
## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
pending
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: vending machines deconstructed during a vendor uprising are no bolted to the ground
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
