### PR TITLE
The Spidering Pt 1

### DIFF
--- a/modular_nova/modules/spider/giant_spider/giant_spiders.dm
+++ b/modular_nova/modules/spider/giant_spider/giant_spiders.dm
@@ -1,0 +1,164 @@
+/**
+ * ### Webslinger Spider
+ * A subtype of the giant spider which is slower, can throw webs to ensnare those pesky bipeds.
+ */
+/mob/living/basic/spider/giant/webslinger
+	name = "webslinger spider"
+	desc = "Furry and white, it makes you shudder to look at it. Sharp green eyes are all that can be seen.."
+	icon = 'modular_nova/modules/spider/icon/spider.dmi'
+	icon_state = "webslinger"
+	icon_living = "webslinger"
+	icon_dead = "webslinger_dead"
+	gender = FEMALE
+	maxHealth = 175
+	health = 175
+	obj_damage = 45
+	melee_damage_lower = 25
+	melee_damage_upper = 30
+	speed = 5
+	player_speed_modifier = -3.1
+	gold_core_spawnable = NO_SPAWN
+	menu_description = "somewhat slow, throw webs to ensnare."
+	innate_actions = list(
+		/datum/action/cooldown/mob_cooldown/command_spiders/communication_spiders,
+		/datum/action/cooldown/mob_cooldown/sneak/webslinger,
+		/datum/action/cooldown/mob_cooldown/wrap,
+		/datum/action/cooldown/mob_cooldown/lay_web/web_passage,
+		/datum/action/cooldown/spell/pointed/projectile/web_restraints = BB_ARACHNID_RESTRAIN,
+		)
+
+/mob/living/basic/spider/giant/ambush/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_STRONG_GRABBER, INNATE_TRAIT)
+	AddElement(/datum/element/web_walker, /datum/movespeed_modifier/slow_web)
+
+/**
+ * ### Voltaic Spider
+ * A subtype of the giant spider which similar to the viper, but instead of toxin it injects teslium.
+ * Far more squishier than all other types, it is an ambush predator meant to bite and run while the Teslium works its way into them.
+ */
+/mob/living/basic/spider/giant/voltaic
+	name = "voltaic spider"
+	desc = "Chitenous and yellow with electrical arcs running across its carapace, it makes you shudder to look at it. This one has effervescent yellow eyes."
+	icon = 'modular_nova/modules/spider/icon/spider.dmi'
+	icon_state = "voltaic"
+	icon_living = "voltaic"
+	icon_dead = "voltaic_dead"
+	gender = FEMALE
+	maxHealth = 115
+	health = 115
+
+	melee_damage_lower = 8
+	melee_damage_upper = 8
+	poison_per_bite = 2
+	poison_type = /datum/reagent/teslium
+	speed = 2.8
+	player_speed_modifier = -3.1
+	gold_core_spawnable = NO_SPAWN
+	menu_description = "fast but not sturdy, your bites inject teslium"
+	innate_actions = list(
+		/datum/action/cooldown/mob_cooldown/command_spiders/communication_spiders,
+		/datum/action/cooldown/mob_cooldown/wrap,
+		)
+
+/mob/living/basic/spider/giant/ambush/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_STRONG_GRABBER, INNATE_TRAIT)
+	AddElement(/datum/element/web_walker, /datum/movespeed_modifier/slow_web)
+
+/**
+ * ### Pit Spider
+ * A behemoth of a spider, doing both high damage but mid-level health. Front line commander.
+ */
+/mob/living/basic/spider/giant/pit
+	name = "pit spider"
+	desc = "Furry and Brown with an Orange top, massive jaws strike fear in you and into walls. This one has bright orange eyes."
+	icon = 'modular_nova/modules/spider/icon/spider.dmi'
+	icon_state = "pit"
+	icon_living = "pit"
+	icon_dead = "pit_dead"
+	maxHealth = 250
+	health = 250
+	armour_penetration = 25
+	melee_damage_lower = 5
+	melee_damage_upper = 15
+	unsuitable_atmos_damage = 0
+	minimum_survivable_temperature = 25
+	maximum_survivable_temperature = 1100
+	unsuitable_cold_damage = 0
+	wound_bonus = 25
+	bare_wound_bonus = 50
+	sharpness = SHARP_EDGED
+	obj_damage = 60
+	web_speed = 0.25
+	limb_destroyer = 50
+	speed = 5
+	player_speed_modifier = -4
+	sight = SEE_TURFS
+	menu_description = "Has the ability to destroy walls and limbs, and to send warnings to the nest."
+	innate_actions = list(
+		/datum/action/cooldown/mob_cooldown/wrap,
+		/datum/action/cooldown/mob_cooldown/command_spiders,
+		/datum/action/cooldown/mob_cooldown/charge/basic_charge,
+		)
+/mob/living/basic/spider/giant/pit/Initialize(mapload)
+	. = ..()
+	var/datum/action/cooldown/mob_cooldown/lay_web/solid_web/web_solid = new(src)
+	web_solid.Grant(src)
+
+	AddElement(/datum/element/wall_tearer)
+	AddElement(/datum/element/web_walker, /datum/movespeed_modifier/below_average_web)
+
+/**
+ * ### Ogre Spider
+ * A fat armored cute spider, completely utility focused and to soak damage for the weaker variants.
+ */
+/mob/living/basic/spider/giant/ogre
+	name = "ogre spider"
+	desc = "Furry and Brown with an fat, while kind of cute its size horrifies you. This one has dark purple eyes and seems heavily armored."
+	icon = 'modular_nova/modules/spider/icon/spider.dmi'
+	icon_state = "ogre"
+	icon_living = "ogre"
+	icon_dead = "ogre_dead"
+	maxHealth = 600 // hah fat
+	health = 600
+	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, STAMINA = 1, OXY = 1)
+	poison_per_bite = 1
+	poison_type = /datum/reagent/toxin/hunterspider
+	melee_damage_lower = 5
+	melee_damage_upper = 5
+	obj_damage = 15
+	speed = 5
+	player_speed_modifier = -4
+	menu_description = "Extremly tanky with very poor offence. Able to self heal and lay reflective silk screens, passages and traps."
+	innate_actions = list(
+		/datum/action/cooldown/mob_cooldown/wrap,
+		/datum/action/cooldown/mob_cooldown/command_spiders/communication_spiders,
+		/datum/action/cooldown/mob_cooldown/lay_web/solid_web,
+		/datum/action/cooldown/mob_cooldown/lay_web/sticky_web,
+		/datum/action/cooldown/mob_cooldown/lay_web/web_passage,
+		/datum/action/cooldown/mob_cooldown/lay_web/web_spikes,
+	)
+/mob/living/basic/spider/giant/ogre/Initialize(mapload)
+	. = ..()
+
+	AddElement(/datum/element/web_walker, /datum/movespeed_modifier/below_average_web)
+
+	AddComponent(/datum/component/healing_touch,\
+		heal_brute = 50,\
+		heal_burn = 50,\
+		heal_time = 5 SECONDS,\
+		self_targeting = HEALING_TOUCH_SELF_ONLY,\
+		interaction_key = DOAFTER_SOURCE_SPIDER,\
+		valid_targets_typecache = typecacheof(list(/mob/living/basic/spider/giant/ogre)),\
+		extra_checks = CALLBACK(src, PROC_REF(can_mend)),\
+		action_text = "%SOURCE% begins mending themselves...",\
+		complete_text = "%SOURCE%'s wounds mend together.",\
+	)
+
+/// Prevent you from healing other spiders spiders, or healing when on fire
+/mob/living/basic/spider/giant/ogre/proc/can_mend(mob/living/source, mob/living/target)
+	if (on_fire)
+		balloon_alert(src, "on fire!")
+		return FALSE
+	return TRUE

--- a/modular_nova/modules/spider/spider_abilities/spider_abilities.dm
+++ b/modular_nova/modules/spider/spider_abilities/spider_abilities.dm
@@ -1,0 +1,58 @@
+/**
+ * ### Webslinger
+ * These are the abilities tailored to specifically the webslinger spider
+ */
+/// Webslinger snare
+/datum/action/cooldown/spell/pointed/projectile/web_restraints
+	name = "sticky restraints"
+	desc = "Launch at your prey to immobilize them."
+	button_icon = 'modular_nova/modules/spider/icon/spider.dmi'
+	button_icon_state = "spideregg"
+	background_icon_state = "bg_alien"
+	overlay_icon_state = "bg_alien_border"
+
+	cooldown_time = 15 SECONDS
+	spell_requirements = NONE
+
+	active_msg = "You prepare to throw a restraint at your target!"
+	cast_range = 8
+	projectile_type = /obj/projectile/webslinger_snare
+
+/obj/projectile/webslinger_snare
+	name = "web snare"
+	icon = 'modular_nova/modules/spider/icon/spider.dmi'
+	icon_state = "spideregg"
+	damage = 0
+
+/obj/projectile/webslinger_snare/on_hit(atom/target, blocked = 0, pierce_hit)
+	. = ..()
+	if(!iscarbon(target) || blocked >= 100)
+		return
+	var/obj/item/restraints/legcuffs/beartrap/webslinger_snare/restraint = new(get_turf(target))
+	restraint.spring_trap(target)
+
+/obj/item/restraints/legcuffs/beartrap/webslinger_snare
+	name = "stickyy restraints"
+	desc = "Used by mega arachnids to immobilize their prey."
+	flags_1 = NONE
+	item_flags = DROPDEL
+	icon_state = "web_snare"
+	armed = TRUE
+
+/obj/item/restraints/legcuffs/beartrap/webslinger_snare/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/swabable, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
+
+/// Webslinger sneak
+/datum/action/cooldown/mob_cooldown/sneak/webslinger
+	name = "Webslinger Spider Sneak"
+	desc = "Blend into the webs to stalk your prey."
+	button_icon = 'modular_nova/modules/spider/icon/spider.dmi'
+	button_icon_state = "webslinger"
+	background_icon_state = "bg_alien"
+	overlay_icon_state = "bg_alien_border"
+
+/**
+ * ### Carrier
+ * These are the abilities tailored to specifically the Carrier spider
+ */

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8644,6 +8644,8 @@
 #include "modular_nova\modules\specialist_armor\code\peacekeeper.dm"
 #include "modular_nova\modules\specialist_armor\code\sacrificial.dm"
 #include "modular_nova\modules\species_synthesizer\sing_tones.dm"
+#include "modular_nova\modules\spider\giant_spider\giant_spiders.dm"
+#include "modular_nova\modules\spider\spider_abilities\spider_abilities.dm"
 #include "modular_nova\modules\stasisrework\code\all_nodes.dm"
 #include "modular_nova\modules\stasisrework\code\bodybag.dm"
 #include "modular_nova\modules\stasisrework\code\bodybag_structure.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The custom spiders i've been running in-game are now going to be actually coded in, finally no more mass-VV changes and dealing with the innate issues that comes with as well. There's four-five more spiders i've gotten mapped out but ran into code challenges in creating what i want so that will come in pt2 along with further changes.

Sprite credits to Eris

# Introducing the **Webslinger Spider**:

![image](https://github.com/user-attachments/assets/732c1df7-b303-477d-b8e5-6d6ccbfc1b38)

Somewhat slow, can throw a ball of silk to ensare others at 15 second intervals
Low damage and low ish health, mostly support without venom
has a cloak ability that makes them harder to see mostly inside webbing

![image](https://github.com/user-attachments/assets/b7c00cf8-7e07-47d3-8c24-9c9b8a88b472)



# Introducing the **Pit Spider**:

![image](https://github.com/user-attachments/assets/2d945325-004f-4616-8663-75b17c3e9278)

She **big**
She **fat**(ish)
She **eat walls**
She **eat you**
Has bonus wound chances to those unarmed
Has armor pen

Commander of the bunch in a sense, can send hive orders that come off as bold to the hive.

This is the spider you should focus above all others to kill first

# Introducing the Volatic Spider:

![image](https://github.com/user-attachments/assets/78ed5e8a-8ca4-410f-b65a-2b7a423600ff)


Injects a small amount of Teslium before skittering away to safety, very low health compared to other spiders but its speed makes up for it. 

Very tailored towards ambush and run, will lose to a welder if trying to bite their way to victory. (though the Teslium will get them later)


# Introducing the cute and cuddly Ogre Spider:

![image](https://github.com/user-attachments/assets/82a4929a-002f-4a65-95c8-57da91be42e3)

Hah Fat

Large health pool but microscopic offense, designed to soak damage and protect the other lil spiders. Can sneak off to heal some damage to itself (not to others)
Can lay down Sticky web, Solid wall webs, reflective screens, passages and web spikes

## How This Contributes To The Nova Sector Roleplay Experience

More variety, the spider events i've been running manually take a lot of time to prep, these wont really be anything new to those who have seen them. Eventually i'll turn these into a runnable event versus a manually created instance.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  mostly shown above



</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new deadlier spiders to encounter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
