### PR TITLE
Fix missing company imports tab

### DIFF
--- a/tgui/packages/tgui/interfaces/Cargo/index.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/index.tsx
@@ -14,6 +14,7 @@ enum TAB {
   Requests = 'requests',
   Cart = 'cart',
   Help = 'help',
+  CompanyImports = 'company_import_window', // NOVA EDIT ADDITION
 }
 
 export function Cargo(props) {
@@ -63,7 +64,7 @@ export function CargoContent(props) {
           {/* NOVA EDIT ADDITION START */}
           <Tabs.Tab
             icon="clipboard-list"
-            selected={tab === 'company_import_window'}
+            selected={tab === TAB.CompanyImports}
             onClick={() => act('company_import_window')}
           >
             Company Imports
@@ -95,6 +96,9 @@ export function CargoContent(props) {
         {tab === TAB.Requests && <CargoRequests />}
         {tab === TAB.Cart && <CargoCart />}
         {tab === TAB.Help && <CargoHelp />}
+        {/* NOVA EDIT ADDITION START*/}
+        {tab === TAB.CompanyImports && tab === 'catalog'}
+        {/* NOVA EDIT ADDITION END */}
       </Stack.Item>
     </Stack>
   );


### PR DESCRIPTION
## About The Pull Request

Got lost in a recent update that touched like 800 tgui files due to not being properly marked as Nova edits. Should be working again. Please report any further issues!

## How This Contributes To The Nova Sector Roleplay Experience

Bugfix

## Proof of Testing

<details>
<summary>It's back</summary>

![vrtRaCveLO](https://github.com/user-attachments/assets/1783c2ec-cdb8-4e9e-afe5-788295a13ed4)

</details>

## Changelog

:cl:
fix: company imports button has returned to the cargo console
/:cl: