### PR TITLE
[Early Mirror] Adds a station_only subtype of Atmospherics/Station Alerts Consoles that only displays station (+mining station) alarms

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -9426,7 +9426,7 @@
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/item/circuitboard/computer/stationalert{
+/obj/item/circuitboard/computer/station_alert{
 	pixel_y = 8
 	},
 /turf/open/floor/plating,
@@ -13550,7 +13550,7 @@
 /area/station/ai_monitored/turret_protected/ai)
 "eYk" = (
 /obj/structure/cable,
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -13857,7 +13857,7 @@
 "feu" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/machinery/firealarm/directional/north,
-/obj/machinery/computer/atmos_alert,
+/obj/machinery/computer/atmos_alert/station_only,
 /turf/open/floor/iron/small,
 /area/station/engineering/atmos/office)
 "fex" = (
@@ -18665,7 +18665,7 @@
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs)
 "gHm" = (
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 1
 	},
 /turf/open/floor/iron/smooth_large,
@@ -19883,7 +19883,7 @@
 /obj/effect/turf_decal/siding/thinplating_new/terracotta{
 	dir = 1
 	},
-/obj/machinery/computer/atmos_alert{
+/obj/machinery/computer/atmos_alert/station_only{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/yellow,
@@ -19945,7 +19945,7 @@
 /obj/effect/turf_decal/siding/thinplating_new/terracotta{
 	dir = 1
 	},
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/yellow,
@@ -26709,7 +26709,7 @@
 /area/station/security/prison/workout)
 "jhj" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/south,
@@ -43713,7 +43713,7 @@
 /area/station/hallway/secondary/recreation)
 "oYS" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 8
 	},
 /obj/item/radio/intercom/command/directional/east,
@@ -59395,7 +59395,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 8
 	},
 /turf/open/floor/wood,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -3705,7 +3705,7 @@
 	anchored = 1;
 	dir = 8
 	},
-/obj/item/circuitboard/computer/stationalert,
+/obj/item/circuitboard/computer/station_alert,
 /obj/effect/turf_decal/bot/right,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
@@ -7183,7 +7183,7 @@
 /turf/open/floor/wood,
 /area/station/service/theater)
 "bKo" = (
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/south,
@@ -8831,7 +8831,7 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "cfx" = (
 /obj/structure/cable,
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
@@ -19775,7 +19775,7 @@
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
 "eSU" = (
-/obj/machinery/computer/atmos_alert,
+/obj/machinery/computer/atmos_alert/station_only,
 /obj/effect/turf_decal/bot,
 /obj/structure/sign/warning/gas_mask/directional/north,
 /obj/machinery/light/small/directional/north,
@@ -38494,7 +38494,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "jAY" = (
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 4
 	},
 /obj/effect/turf_decal/bot/left,
@@ -45376,7 +45376,7 @@
 	},
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/bot,
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -56646,7 +56646,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "oiO" = (
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
@@ -76871,7 +76871,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/machinery/computer/atmos_alert{
+/obj/machinery/computer/atmos_alert/station_only{
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -88571,7 +88571,7 @@
 /area/station/commons/dorms)
 "wgF" = (
 /obj/structure/cable,
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 1
 	},
 /obj/machinery/status_display/ai/directional/south,
@@ -88891,7 +88891,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "wkT" = (
-/obj/machinery/computer/atmos_alert,
+/obj/machinery/computer/atmos_alert/station_only,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
@@ -90657,7 +90657,7 @@
 /turf/open/floor/plating,
 /area/station/science/research/abandoned)
 "wEX" = (
-/obj/machinery/computer/atmos_alert{
+/obj/machinery/computer/atmos_alert/station_only{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -94421,7 +94421,7 @@
 	c_tag = "Engineering - Power Monitoring";
 	name = "engineering camera"
 	},
-/obj/machinery/computer/atmos_alert{
+/obj/machinery/computer/atmos_alert/station_only{
 	dir = 1
 	},
 /obj/structure/cable,

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -6886,7 +6886,7 @@
 /turf/open/floor/iron/white,
 /area/mine/living_quarters)
 "bTq" = (
-/obj/machinery/computer/atmos_alert,
+/obj/machinery/computer/atmos_alert/station_only,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
@@ -26391,7 +26391,7 @@
 	},
 /area/station/service/chapel)
 "hDh" = (
-/obj/machinery/computer/atmos_alert{
+/obj/machinery/computer/atmos_alert/station_only{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -26538,7 +26538,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/work)
 "hFJ" = (
-/obj/machinery/computer/station_alert,
+/obj/machinery/computer/station_alert/station_only,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/computer/security/telescreen/engine/directional/north,
 /turf/open/floor/iron/dark,
@@ -57642,7 +57642,7 @@
 /area/station/science/explab)
 "qFu" = (
 /obj/machinery/airalarm/directional/west,
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -58974,7 +58974,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "qXF" = (
-/obj/machinery/computer/station_alert,
+/obj/machinery/computer/station_alert/station_only,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/command/bridge)
@@ -70324,7 +70324,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/processing)
 "unG" = (
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -73511,7 +73511,7 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "vnt" = (
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 8
 	},
 /obj/machinery/button/door/directional/south{
@@ -79017,7 +79017,7 @@
 /turf/open/floor/eighties,
 /area/station/commons/lounge)
 "wUJ" = (
-/obj/machinery/computer/atmos_alert,
+/obj/machinery/computer/atmos_alert/station_only,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 8
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -10016,7 +10016,7 @@
 /turf/closed/wall,
 /area/station/hallway/primary/port)
 "dHg" = (
-/obj/machinery/computer/atmos_alert,
+/obj/machinery/computer/atmos_alert/station_only,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
@@ -13653,7 +13653,7 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "eSy" = (
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 4
 	},
 /obj/structure/cable,
@@ -18772,7 +18772,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Engineering - Power Monitoring"
 	},
-/obj/machinery/computer/station_alert,
+/obj/machinery/computer/station_alert/station_only,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
@@ -27220,7 +27220,7 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
 "jGN" = (
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
@@ -36415,7 +36415,7 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "mXj" = (
-/obj/machinery/computer/station_alert,
+/obj/machinery/computer/station_alert/station_only,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
@@ -40677,7 +40677,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "owv" = (
-/obj/machinery/computer/atmos_alert,
+/obj/machinery/computer/atmos_alert/station_only,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
@@ -44359,7 +44359,7 @@
 /turf/open/floor/iron,
 /area/station/security/warden)
 "pMH" = (
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 4
 	},
 /obj/structure/plaque/static_plaque/atmos{
@@ -46957,7 +46957,7 @@
 /area/station/security/detectives_office)
 "qJd" = (
 /obj/machinery/status_display/ai/directional/north,
-/obj/machinery/computer/station_alert,
+/obj/machinery/computer/station_alert/station_only,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
@@ -60596,7 +60596,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "vqj" = (
-/obj/machinery/computer/atmos_alert{
+/obj/machinery/computer/atmos_alert/station_only{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -7721,7 +7721,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "bHP" = (
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -17359,7 +17359,7 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "far" = (
-/obj/machinery/computer/atmos_alert{
+/obj/machinery/computer/atmos_alert/station_only{
 	dir = 4
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -31531,7 +31531,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "kis" = (
-/obj/machinery/computer/atmos_alert{
+/obj/machinery/computer/atmos_alert/station_only{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -48235,7 +48235,7 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "qcw" = (
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/south,
@@ -60239,7 +60239,7 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "ukE" = (
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 1
 	},
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -67637,7 +67637,7 @@
 /turf/open/floor/iron/checker,
 /area/station/commons/lounge)
 "wLx" = (
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -67770,7 +67770,7 @@
 /turf/open/floor/iron/white/side,
 /area/station/science/lobby)
 "wNY" = (
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 8
 	},
 /obj/machinery/requests_console/directional/east{
@@ -68556,7 +68556,7 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "xfx" = (
-/obj/machinery/computer/atmos_alert{
+/obj/machinery/computer/atmos_alert/station_only{
 	dir = 8
 	},
 /obj/machinery/button/door/directional/east{

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -2205,7 +2205,7 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat/uppersouth)
 "aKj" = (
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -10576,7 +10576,7 @@
 /turf/closed/wall/r_wall,
 /area/station/cargo/storage)
 "dLW" = (
-/obj/machinery/computer/atmos_alert{
+/obj/machinery/computer/atmos_alert/station_only{
 	dir = 4
 	},
 /obj/machinery/camera/autoname/directional/south,
@@ -34417,7 +34417,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "mio" = (
-/obj/machinery/computer/station_alert,
+/obj/machinery/computer/station_alert/station_only,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "mit" = (
@@ -39852,7 +39852,7 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/uppersouth)
 "ogH" = (
-/obj/machinery/computer/atmos_alert,
+/obj/machinery/computer/atmos_alert/station_only,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 8
 	},
@@ -45000,7 +45000,7 @@
 /turf/open/misc/asteroid,
 /area/station/hallway/primary/starboard)
 "pVC" = (
-/obj/machinery/computer/station_alert,
+/obj/machinery/computer/station_alert/station_only,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,

--- a/_maps/templates/lazy_templates/nukie_base.dmm
+++ b/_maps/templates/lazy_templates/nukie_base.dmm
@@ -515,7 +515,7 @@
 	pixel_x = 4;
 	pixel_y = -2
 	},
-/obj/item/circuitboard/computer/stationalert{
+/obj/item/circuitboard/computer/station_alert{
 	pixel_y = 1;
 	pixel_x = 3
 	},

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -3,15 +3,23 @@
 	desc = "Used to access the station's automated alert system."
 	icon_screen = "alert:0"
 	icon_keyboard = "atmos_key"
-	circuit = /obj/item/circuitboard/computer/stationalert
+	circuit = /obj/item/circuitboard/computer/station_alert
 	light_color = LIGHT_COLOR_CYAN
 	/// Station alert datum for showing alerts UI
 	var/datum/station_alert/alert_control
 
+/obj/machinery/computer/station_alert/examine(mob/user)
+	. = ..()
+	var/obj/item/circuitboard/computer/station_alert/my_circuit = circuit
+	. += span_info("The console is set to [my_circuit.station_only ? "track all station and mining alarms" : "track alarms on the same z-level"].")
+
 /obj/machinery/computer/station_alert/Initialize(mapload)
-	alert_control = new(src, list(ALARM_ATMOS, ALARM_FIRE, ALARM_POWER), list(z), title = name)
-	RegisterSignals(alert_control.listener, list(COMSIG_ALARM_LISTENER_TRIGGERED, COMSIG_ALARM_LISTENER_CLEARED), PROC_REF(update_alarm_display))
+	link_alerts()
 	return ..()
+
+/obj/machinery/computer/station_alert/on_construction(mob/user)
+	. = ..()
+	link_alerts()
 
 /obj/machinery/computer/station_alert/Destroy()
 	QDEL_NULL(alert_control)
@@ -35,6 +43,26 @@
 		. += "alert:2"
 
 /**
+ * Clears out any active alert_control listeners, then sets up a new one based on the circuit settings
+ */
+/obj/machinery/computer/station_alert/proc/link_alerts()
+	//Start from scratch, clear out the existing alert listeners
+	QDEL_NULL(alert_control)
+
+	//Then we check the circuit to determine if it should show alarms from Station & Mining areas,
+	//or Local (z-level) areas
+	var/obj/item/circuitboard/computer/station_alert/my_circuit = circuit
+	if(my_circuit.station_only)
+		name = "station alert console"
+		var/list/alert_areas
+		alert_areas = (GLOB.the_station_areas + typesof(/area/mine))
+		alert_control = new(src, list(ALARM_ATMOS, ALARM_FIRE, ALARM_POWER), listener_areas = alert_areas, title = name)
+	else
+		name = "local alert console"
+		alert_control = new(src, list(ALARM_ATMOS, ALARM_FIRE, ALARM_POWER), list(z), title = name)
+	RegisterSignals(alert_control.listener, list(COMSIG_ALARM_LISTENER_TRIGGERED, COMSIG_ALARM_LISTENER_CLEARED), PROC_REF(update_alarm_display))
+
+/**
  * Signal handler for calling an icon update in case an alarm is added or cleared
  *
  * Arguments:
@@ -43,3 +71,7 @@
 /obj/machinery/computer/station_alert/proc/update_alarm_display(datum/source)
 	SIGNAL_HANDLER
 	update_icon()
+
+// Subtype which only checks station areas and the mining station
+/obj/machinery/computer/station_alert/station_only
+	circuit = /obj/item/circuitboard/computer/station_alert/station_only

--- a/code/game/objects/effects/spawners/random/techstorage.dm
+++ b/code/game/objects/effects/spawners/random/techstorage.dm
@@ -74,7 +74,7 @@
 	name = "engineering circuit board spawner"
 	loot = list(
 		/obj/item/circuitboard/computer/atmos_alert,
-		/obj/item/circuitboard/computer/stationalert,
+		/obj/item/circuitboard/computer/station_alert,
 		/obj/item/circuitboard/computer/powermonitor,
 	)
 

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -44,6 +44,20 @@
 	name = "Atmospheric Alert"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/computer/atmos_alert
+	var/station_only = FALSE
+
+/obj/item/circuitboard/computer/atmos_alert/station_only
+	station_only = TRUE
+
+/obj/item/circuitboard/computer/atmos_alert/examine(mob/user)
+	. = ..()
+	. += span_info("The board is configured to [station_only ? "track all station and mining alarms" : "track alarms on the same z-level"].")
+	. += span_notice("The board mode can be changed with a [EXAMINE_HINT("multitool")].")
+
+/obj/item/circuitboard/computer/atmos_alert/multitool_act(mob/living/user)
+	station_only = !station_only
+	balloon_alert(user, "tracking set to [station_only ? "station" : "z-level"]")
+	return TRUE
 
 /obj/item/circuitboard/computer/atmos_control
 	name = "Atmospheric Control"
@@ -223,10 +237,24 @@
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/power/solar_control
 
-/obj/item/circuitboard/computer/stationalert
+/obj/item/circuitboard/computer/station_alert
 	name = "Station Alerts"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/computer/station_alert
+	var/station_only = FALSE
+
+/obj/item/circuitboard/computer/station_alert/station_only
+	station_only = TRUE
+
+/obj/item/circuitboard/computer/station_alert/examine(mob/user)
+	. = ..()
+	. += span_info("The board is configured to [station_only ? "track all station and mining alarms" : "track alarms on the same z-level"].")
+	. += span_notice("The board mode can be changed with a [EXAMINE_HINT("multitool")].")
+
+/obj/item/circuitboard/computer/station_alert/multitool_act(mob/living/user)
+	station_only = !station_only
+	balloon_alert(user, "tracking set to [station_only ? "station" : "z-level"]")
+	return TRUE
 
 /obj/item/circuitboard/computer/turbine_computer
 	name = "Turbine Computer"


### PR DESCRIPTION
## Identical to the TG PR, but including modular station maps (god knows Blueshift needs it)

## About The Pull Request
A more proper way to be solving the alarm appearing in #88335 (That PR still actually makes the alarm read the inside of the booth so its still important)

As it turns out, Canary already does this - when creating a new `/datum/station_alert/` to track the alarms, it passes the optional areas filter included in the datum with a preset of all station areas plus the mining station areas.

This PR (after a slight rework) adds a Subtype of the monitoring consoles called `station_only`, which have checks that only display alarms from the station and miningstation. These replace all pre-mapped consoles in stations only.
This will mostly be notable on Icebox and other Multi-Z stations, where ruins will stop polluting the alarm boards and alarms on all levels will be displayed - and, on other stations, the fact that alarm boards will now also display the mining station.
<details><summary>z-level vs station_only</summary>


![image](https://github.com/user-attachments/assets/625eeb1a-0dcf-4842-b02d-4d4dcf9fed51)


![image](https://github.com/user-attachments/assets/1627b062-11bd-4f1e-ac3d-f8824018460f)


</details>

Examining the console will display if it's in z-level or station-area mode, and this can be changed by multitooling the circuitboard (for crew rebuilding both damaged station consoles, or space ruins)

<details><summary>examines</summary>


![image](https://github.com/user-attachments/assets/3e9d863e-a7f8-4fdf-8545-cf5c2c4b3bf5)

![image](https://github.com/user-attachments/assets/7e06cdc0-8dce-4006-9d75-29f2fb291cab)


</details>

- [x] TO-DO: Fix Station Alerts Consoles not get set up correctly when rebuilt ~~(the tracking is set up before the circuit can pass on `station_only`)~~ (Done much cleaner now, thank you Lemon/Potato)
- [x] TO-DO: Test how this behaves with renamed or newly created areas... (Renamed functions fine, Newly Created is probably better fixed in the creation code so that it applies to other station area checks.)

## Why It's Good For The Game
Engineering shouldn't need to worry about ruins or otherwise non-station alarms. Appearing in the station consoles is confusing and annoying to those who like to see the board green all across.
Plus, they SHOULD be at least slightly worried about the mining station, or at least able to tell somebody else about alerts there. Also of course they should just be able to see all of icebox/tram/other multi-z stations from alert consoles instead of needing to have one per-zlevel
## Changelog
:cl:
qol: Atmospherics/Station Alerts Consoles can now be set to only display station (+mining station) areas. Station-mapped ones are set to this by default. Use a multitool on the circuitboard to toggle between z-level or station-area tracking!
fix: In turn, Atmospherics Alert Consoles now actually show the whole of multi-z stations instead of ignoring other z-levels /:cl: