### PR TITLE
Add the Donk Manufacturer to toy guns that lacked it

### DIFF
--- a/modular_nova/modules/manufacturer_examine/code/gun_company_additions.dm
+++ b/modular_nova/modules/manufacturer_examine/code/gun_company_additions.dm
@@ -46,6 +46,15 @@
 /obj/item/gun/ballistic/shotgun/toy/give_manufacturer_examine()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_DONK)
 
+/obj/item/gun/ballistic/shotgun/toy/give_manufacturer_examine()
+	AddElement(/datum/element/manufacturer_examine, COMPANY_DONK)
+
+/obj/item/gun/ballistic/automatic/pistol/toy/give_manufacturer_examine()
+	AddElement(/datum/element/manufacturer_examine, COMPANY_DONK)
+
+/obj/item/gun/ballistic/automatic/toy/give_manufacturer_examine()
+	AddElement(/datum/element/manufacturer_examine, COMPANY_DONK)
+
 /obj/item/gun/ballistic/automatic/c20r/toy/give_manufacturer_examine()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_DONK)
 


### PR DESCRIPTION
## About The Pull Request

We have a **Donk Corporation** manufacturer specifically for the toy firearms, but the Donksoft Pistol and Donksoft SMG were both missed. The pistol was a scarborough and the SMG had no manufacturer. Remedies this and gives them the same manufacturer as the rest of the Donksoft guns.

## How This Contributes To The Nova Sector Roleplay Experience

Consistency is good. Also, Scarboroughs are critcon, and probably shouldn't be in station vendors.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/bfacf171-7031-4ce7-9180-f72403823a68)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Donk Soft 'sidearms' now use the Donk. Co label instead of missing one or being scarborough
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
