### PR TITLE
Adds the hand labeler to the Security lathe

### DIFF
--- a/modular_nova/modules/security_designs/code/security_designs.dm
+++ b/modular_nova/modules/security_designs/code/security_designs.dm
@@ -1,0 +1,5 @@
+/datum/design/handlabeler
+	departmental_flags = DEPARTMENT_BITFLAG_SERVICE | DEPARTMENT_BITFLAG_SECURITY
+
+/datum/design/paperroll
+	departmental_flags = DEPARTMENT_BITFLAG_SERVICE | DEPARTMENT_BITFLAG_SECURITY

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8608,6 +8608,7 @@
 #include "modular_nova\modules\sec_haul\code\peacekeeper\peacekeeper_clothing.dm"
 #include "modular_nova\modules\sec_haul\code\peacekeeper\peacekeeper_hammer.dm"
 #include "modular_nova\modules\sec_haul\code\peacekeeper\peacekeeper_lockers.dm"
+#include "modular_nova\modules\security_designs\code\security_designs.dm"
 #include "modular_nova\modules\self_actualization_device\code\self_actualization_device.dm"
 #include "modular_nova\modules\serenitystation\code\areas.dm"
 #include "modular_nova\modules\serenitystation\code\atmosphere.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Very simple PR! All this does is make a new module for modular security design overrides, and then adds the hand labeler and its corresponding paper roll to the sec lathe within that module.

## How This Contributes To The Nova Sector Roleplay Experience
Security makes more consistent use of the labeler than any other department. It's pretty much considered common courtesy to label your weapons and your locker as a secoff, and the most annoying part of that is having to go track down a labeler at roundstart on maps that neglect to put one in the brig for you. No longer! Sec can now print the labeler and the paper it needs right from their lathe, hopefully making gear labeling more even more common.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/90c0eb34-f973-4211-92f2-bd66c5648574)

</details>

## Changelog

:cl:
qol: The hand labeler and its corresponding paper roll can now be printed from the Security protolathe.
/:cl: