### PR TITLE
Fixes the fast power drain of ethereal modsuit cores

### DIFF
--- a/code/modules/mod/mod_core.dm
+++ b/code/modules/mod/mod_core.dm
@@ -301,7 +301,7 @@
 		liquid electricity, this core makes it much more efficient, running all soft, hard, and wetware with several \
 		times less energy usage."
 	/// A modifier to all charge we use, ethereals don't need to spend as much energy as normal suits.
-	var/charge_modifier = 0.01
+	var/charge_modifier = 0.01 // NOVA EDIT CHANGE - Stop draining ethereals power at the speed of light - ORIGINAL: var/charge_modifier = 0.1
 
 /obj/item/mod/core/ethereal/charge_source()
 	var/obj/item/organ/stomach/ethereal/ethereal_stomach = mod.wearer.get_organ_slot(ORGAN_SLOT_STOMACH)


### PR DESCRIPTION
## About The Pull Request

~~Recent TG changes apparently affected the ethereal core's power consumption. It was draining far too quickly, now it should be 10x slower.~~

~~This probably was an oversight on TG as these are not nearly as accessible there and don't see much use ever. Please leave feedback if this is still not in line with the previous rates.~~

Nevermind I guess they fixed it

## Changelog

:cl:
fix: slows the power consumption of ethereal core modsuits
/:cl:
