### PR TITLE
Revert #4772, increase the Regal Condor's recipe price

### DIFF
--- a/code/modules/cargo/packs/imports.dm
+++ b/code/modules/cargo/packs/imports.dm
@@ -96,14 +96,14 @@
 	)
 	crate_name = "putrid dumpster"
 	crate_type = /obj/structure/closet/crate/trashcart
-/* NOVA EDIT REMOVAL BEGIN - any person shouldn't have an oneshot hitscan gun just because they have emag
+
 /datum/supply_pack/imports/error
 	name = "NULL_ENTRY"
 	desc = "(*!&@#OKAY, OPERATIVE, WE SEE HOW MUCH MONEY YOU'RE FLAUNTING. FINE. HAVE THIS, AND GOOD LUCK PUTTING IT TOGETHER!#@*$"
 	cost = CARGO_CRATE_VALUE * 100
 	hidden = TRUE
 	contains = list(/obj/item/book/granter/crafting_recipe/regal_condor)
-NOVA EDIT REMOVAL END */
+
 /datum/supply_pack/imports/mafia
 	name = "Cosa Nostra Starter Pack"
 	desc = "This crate contains everything you need to set up your own ethnicity-based racketeering operation."

--- a/modular_nova/modules/cargo/code/packs.dm
+++ b/modular_nova/modules/cargo/code/packs.dm
@@ -718,3 +718,6 @@
 		/obj/item/seeds/starfruit = 2,
 		/obj/item/book/manual/starfruit = 1,
 	)
+
+/datum/supply_pack/imports/error
+	cost = CARGO_CRATE_VALUE * 250 // 20k is a lot on TG, it's not as much here.


### PR DESCRIPTION

## About The Pull Request
#4772 removed the regal condor. For reasons stated below, I do not think there is any good reason to remove the regal condor, though I do agree with something brought up surrounding it that it should have its recipe price increased.

## How This Contributes To The Nova Sector Roleplay Experience

#4772 refers to this weapon as a 'one-shot gun' and claims people get it 'just for having an emag'. What is neglected to mention is the actual efficacy of the weapon and the fact that it is _comically difficult to obtain._

Firstly: The efficacy of the condor is overstated. While it is extremely powerful, it takes two volleys to down even an unarmored target, averaging a TTD of just under a second. It has a poor ammo capacity and consumes two rounds every time it fires, meaning a full magazine with a bullet in the chamber can only fire four times before having to reload with difficult to obtain ammo. The Qarad kills faster than this weapon and can be ordered outright for less than even the Condor's recipe.

Secondly: The condor is not "given to anyone with an emag". The extreme power of the weapon is balanced by it being hilariously difficult to obtain, so much so that I've literally never seen anyone obtain it, and I thought for a while it was actually impossible.

To obtain the regal condor, you must:

1. As a pre-requisite, be both a traitor, have black market connections, and have not spent more than 4 TC.
2. EMAG the cargo console. The regal condor is only obtainable by antags, so if cargo hasn't binyat it, you'll have to do it.
3. Burn 20k (now rebalanced to 50k for economy reasons) of the cargo budget (or personal money) on the NULL_ENTRY order, giving you the recipe book. Hope the QM doesn't notice.
4. Obtain the following raw materials: 10x Iron, 25x Silver, 25x Gold, a Donk Pocket, and a Screwdriver.
5. Order all of the following from your uplink: 
- Tactical Toolbox (1 TC)
- Makarov Pistol (7 TC)
- Cryptographic Sequencer (4 TC)
- Withdraw 4 TC from your uplink into item form.
(This totals about 16 TC out of your starting 20 TC budget. The price is comparable to sleeping carp.)
6. Order all of the following from the black market, _and hope to god they don't spawn in the brig_, and go through the steps to break in to wherever they spawn: 
- Tactical Turtleneck
- Syndicate Mask
7. Now that you've done all that, you have to break into the captain's office and steal the crown from their garment bag. Good luck!
8. Lay all of it out on the floor somewhere secure and spend about a minute putting the regal condor together.

and don't get too excited! That'll give you a regal condor with a full magazine and one in the chamber, but that's only enough for four and a half shots. If you want to use the thing, which if you made it, you do, you need to obtain:

- 10 Iron
- 10 Silver
- 10 Gold
- 10 Plasma
- Another Donk Pocket

and then put them all together with your regal condor, a screwdriver, a welder, a syndicate mask, and a tactical turtleneck all within arm's reach. Repeat for each magazine you want. Magazines can be refilled, but not with reaper ammo, which is the stronger ammo the Condor starts with.

_**And for the love of god, don't lose it.**_ Only one can be made because it requires and **consumes** the captain's crown.

There is absolutely no question the gun is extremely strong. It _should_ be - it's a gimmick weapon that's so difficult to obtain almost nobody even tries. If you do get it, it's arguably _less_ effective than bombs, chemical warfare, sleeping carp stunlocks, thermal eye shenanigans, or just getting an elite modsuit and going loud with a cargo gun, implant setup and stimulants.

Scarp makes bullets ineffective and is a free kill on basically any single target - it can even KO with a single action. Thermal eyes can make you practically invisible while everyone else is blind. The Condor has no such mechanism - you're vulnerable the entire time you're using it, because all it is a firearm that devours your entire TC budget.

If people finally start making it consistently (somehow) and it becomes an issue, we can consider a nerf, but as it stands there is no evidence this gun is causing problems to justify its removal.

As mentioned, I agree with the idea that its price should be increased, so I did - from 20k to 50k. 20k is a shitload for TG Cargo, but for Nova Sector, that's not nearly as much. Hopefully having it at 50k means if you buy this, Cargo will take notice of the massive hole in their budget all of a sudden. That's a lot to lose.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/56497722-a2f8-48d3-994e-aebe8cbbe7fb)

</details>

## Changelog
:cl:
add: Re-added the regal condor.
balance: The Regal Condor's cargo recipe price has been increased. Watch for holes in your budget, Quartermaster.
/:cl:
