### PR TITLE
[Balance] Minor Adjustment to Xenoarch rewards

### DIFF
--- a/modular_nova/modules/xenoarch/code/modules/research/xenoarch/xenoarch_item.dm
+++ b/modular_nova/modules/xenoarch/code/modules/research/xenoarch/xenoarch_item.dm
@@ -253,3 +253,9 @@
 			<br> \
 			<i>- KB</i><br> \
 			Director of Xenoarchaeological Studies"}
+
+/obj/item/organ/monster_core/regenerative_core/legion/preserved
+
+/obj/item/organ/monster_core/regenerative_core/legion/preserved/Initialize(mapload)
+	. = ..()
+	src.preserve()

--- a/modular_nova/modules/xenoarch/code/modules/research/xenoarch/xenoarch_reward.dm
+++ b/modular_nova/modules/xenoarch/code/modules/research/xenoarch/xenoarch_reward.dm
@@ -1,9 +1,9 @@
 GLOBAL_LIST_INIT(tier1_reward, list(
-	/obj/item/xenoarch/useless_relic = 5,
+	/obj/item/xenoarch/useless_relic = 10,
 	/obj/item/stack/sheet/sinew = 1,
 	/obj/item/stack/sheet/animalhide/goliath_hide = 1,
 	/obj/item/stack/sheet/bone = 1,
-	/obj/item/organ/monster_core/regenerative_core/legion = 1,
+	/obj/item/organ/monster_core/regenerative_core/legion/preserved = 2,
 ))
 
 GLOBAL_LIST_INIT(tier2_reward, list(
@@ -11,14 +11,13 @@ GLOBAL_LIST_INIT(tier2_reward, list(
 	/obj/item/xenoarch/broken_item/plant = 1,
 	/obj/item/xenoarch/broken_item/clothing = 1,
 	/obj/item/xenoarch/broken_item/animal = 1,
-	/obj/item/xenoarch/useless_relic = 5,
 ))
 
 GLOBAL_LIST_INIT(tier3_reward, list(
 	/obj/item/xenoarch/broken_item/weapon = 3,
 	/obj/item/xenoarch/broken_item/illegal = 1,
-	/obj/item/xenoarch/broken_item/alien = 1,
-	/obj/item/stack/spacecash/c10000 = 1,
+	/obj/item/xenoarch/broken_item/alien = 2,
+	/obj/item/stack/spacecash/c5000 = 2,
 ))
 
 
@@ -40,14 +39,13 @@ GLOBAL_LIST_INIT(tech_reward, list(
 ))
 
 GLOBAL_LIST_INIT(weapon_reward, list(
-	/obj/item/spear/bonespear = 6,
+	/obj/item/spear/bonespear = 2,
 	/obj/item/gun/ballistic/bow/tribalbow/ashen = 2,
 	/obj/item/ammo_casing/arrow/ash = 1,
 	/obj/item/claymore/cutlass = 1,
-	/obj/item/gun/ballistic/automatic/pistol = 1,
+	/obj/item/pen/edagger = 1,
 	/obj/item/shield/riot = 1,
 	/obj/item/shield/roman = 1,
-	/obj/item/pneumatic_cannon = 1,
 	/obj/item/gun/syringe/rapidsyringe = 1,
 ))
 
@@ -71,10 +69,11 @@ GLOBAL_LIST_INIT(clothing_reward, list(
 	/obj/item/clothing/neck/necklace/translator/hearthkin = 1,
 	/obj/item/clothing/head/helmet/gladiator = 1,
 	/obj/item/clothing/under/costume/gladiator/ash_walker = 1,
+	/obj/item/storage/box/syndie_kit/chameleon = 5,
 ))
 
 GLOBAL_LIST_INIT(illegal_reward, list(
-	/obj/item/stack/telecrystal = 1,
+	/obj/item/card/emag/doorjack = 1,
 	/obj/item/storage/box/rndboards = 1,
 ))
 
@@ -96,7 +95,7 @@ GLOBAL_LIST_INIT(animal_reward, list(
 	/obj/item/stack/sheet/sinew = 1,
 	/obj/item/stack/sheet/animalhide/goliath_hide = 1,
 	/obj/item/stack/sheet/bone = 1,
-	/obj/item/organ/monster_core/regenerative_core/legion = 1,
+	/obj/item/organ/monster_core/regenerative_core/legion/preserved = 2,
 ))
 
 GLOBAL_LIST_INIT(alien_reward, list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This is an early sample of the xenoarch reward list rework. Changes the Items that were used to make the regal condor for others that serve the same purpose, and might even get more use / be more interesting for Xenoarcheologists, as well as alter slightly some of the weights, again, the idea is to later come back and properly redo this list. 

It also implements something that used to be quite annoying, which was the organs that were produced by xenoarch werent preserved, despite the strange rocks preserving them for all the time, so, they come pre- preserved, and likely on a future update more monster organs will be added, but this was mostly a reaction on the Regal Condor issue and how Xenoarch allowed for such, you still have the same (and I would dare say, more) chance to get illegal tech and alien tech, thanks to the adjustments.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Well, as regal condor is treated like an item that only antags should get, it came to reason xenoarch shouldn't aid to skip that requisite, and the xenoarch reward list is overdue to get its list revamped, but as a small sneak peak I think this will do until the final one is properly done and revised.

The makarov was changed for a energy dagger, the TC was changed for an airlocks only emag, the money was nerfed to 5k instead of 10k, as it will appear a bit more to make both the doorjack and the liberator legacy rarer, useless relics were made more common at lower levels and removed from higher tiers to make those more interesting, and the preserved organs were made slightly more common. 

This is of course, far from what it should be, but it is a good start. 


## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/9bcd2e91-748b-440d-bea2-1dddb102d93b)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Xenoarch rewards were slightly adjusted, legion cores that appear in it are now pre stabilized so they have an actual impact on the game.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
