### PR TITLE
Adds "Psychiatric Hold Prisoner" to the list of alternate Prisoner job titles

### DIFF
--- a/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -320,6 +320,7 @@
 		"Maximum Security Prisoner",
 		"SuperMax Security Prisoner",
 		"Protective Custody Prisoner",
+		"Psychiatric Hold Prisoner",
 	)
 
 /datum/job/psychologist


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tin. This is a one-line change to modular_nova/modules/alt_job_titles.dm, and it does exactly what the title says it does.

## How This Contributes To The Nova Sector Roleplay Experience
This was a suggestion made in #development-suggest on the Discord, and it was received pretty positively, so people seem to be interested in it. It's neat when prisoners have more ways to express themselves in RP.
## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/7a633e68-3faf-466d-87dd-8a90b2a93183)
![image](https://github.com/user-attachments/assets/3476f892-2c17-4b47-a67e-29b15b61b089)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added "Psychiatric Hold Prisoner" as an alternate job title for Prisoner.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
