### PR TITLE
Making bulky pets more bulky

### DIFF
--- a/modular_nova/modules/pet_size/pet_size.dm
+++ b/modular_nova/modules/pet_size/pet_size.dm
@@ -1,0 +1,8 @@
+/mob/living/basic/pet/dog
+	held_w_class = WEIGHT_CLASS_BULKY
+
+/mob/living/basic/pet/fox
+	held_w_class = WEIGHT_CLASS_BULKY
+
+/mob/living/basic/pet/cat
+	held_w_class = WEIGHT_CLASS_BULKY

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8485,6 +8485,7 @@
 #include "modular_nova\modules\paycheck_rations\code\ticket_book.dm"
 #include "modular_nova\modules\paycheck_rations\code\tickets.dm"
 #include "modular_nova\modules\pet_owner\pet_owner.dm"
+#include "modular_nova\modules\pet_size\pet_size.dm"
 #include "modular_nova\modules\pixel_shift\code\pixel_shift_component.dm"
 #include "modular_nova\modules\pixel_shift\code\pixel_shift_keybind.dm"
 #include "modular_nova\modules\pixel_shift\code\pixel_shift_mob.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

That change will fix one thing - when people carry animals in their bags 24/7 instead of pet carriers, and it can ruin traitors' objectives.

Dogs, cats and foxes were "normal-sized", now "bulky-sized" and still fits in pet carrier.

## How This Contributes To The Nova Sector Roleplay Experience

Now pet carriers will useful!

## Proof of Testing

![изображение](https://github.com/user-attachments/assets/d25fc8a9-bbfb-4845-8dd4-c7a259f27607)

## Changelog

:cl:
balance: cats, dogs and foxes now bulky and won't fit in bag, and it's easier for traitors to find them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
