### PR TITLE
Removes the fire trail from .460 Ceres incendiary rounds

### DIFF
--- a/modular_nova/modules/aesthetics/guns/code/guns.dm
+++ b/modular_nova/modules/aesthetics/guns/code/guns.dm
@@ -522,6 +522,7 @@
 
 /obj/projectile/bullet/incendiary/c45
 	name = ".460 incendiary bullet"
+	leaves_fire_trail = FALSE
 
 /obj/projectile/bullet/c46x30mm
 	name = "8mm Usurpator bullet"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
While we're slowly modernizing .460 and returning it to active play with the NT20, I figured the next step would be to take away the comically large trail of fire that the incendiary rounds leave in their path. It's an oldcode way to do it, and most of our incendiary weapons do `leaves_fire_trail: FALSE` nowadays, with the exception of Dragon's Breath which uses this behaviour as its unique selling point. Turns out, this is as easy as changing a single variable, so I did. 

## How This Contributes To The Nova Sector Roleplay Experience

That's not how incendiary rounds work, and also this is parity with how most of our incendiary weapons already do it, _and also_ the fire trail tends to be a little griefy, especially in an automatic weapon.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
https://github.com/user-attachments/assets/ffef33e2-7e35-46a1-a711-8fa5ef169bb7

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: After receiving letters of complaint regarding "arson" and "collateral damage," the manufacturers of .460 Ceres incendiary rounds have opted to remove the massive fire trail the round leaves in flight.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
