### PR TITLE
Gives cin_surplus suit sensors

### DIFF
--- a/modular_nova/modules/novaya_ert/code/surplus_armor.dm
+++ b/modular_nova/modules/novaya_ert/code/surplus_armor.dm
@@ -121,6 +121,7 @@
 	greyscale_config_worn = /datum/greyscale_config/cin_surplus_undersuit
 	greyscale_config_worn_digi = /datum/greyscale_config/cin_surplus_undersuit/digi
 	greyscale_colors = "#bbbbc9#bbbbc9#34343a"
+	has_sensor = HAS_SENSORS
 	flags_1 = IS_PLAYER_COLORABLE_1
 
 /obj/item/clothing/under/syndicate/rus_army/cin_surplus/desert


### PR DESCRIPTION
## About The Pull Request

Worlds smallest PR. When I was playing dress up I noticed the cin_surplus undersuit has no sensors which is weird for something that is explicitly designed for combat. This pr simply adds suit sensors to it. That's it.

## How This Contributes To The Nova Sector Roleplay Experience

the cin_surplus suit in the loadout menu has no sensors by default. This tiny change allows people to engage in military cosplay without losing the game-critical ability to be found by a paramed. Anyone who wishes to be clandestine while wearing it can turn off the sensors like any other suit in the game.

## Proof of Testing

<details>
behold:

![test1](https://github.com/user-attachments/assets/72dd54ae-98dd-475e-814f-e8ac26558f6a)

![test2](https://github.com/user-attachments/assets/e8302a50-8be9-4311-8683-0ed81ba31a7c)
 
</details>

## Changelog

:cl:
qol: cin surplus undersuit now comes with sensors.
/:cl:

