### PR TITLE
[QoL] Turn off by default talking and Soulcatcher on the Hoshi and the Hyeseong.

### DIFF
--- a/modular_nova/modules/modular_implants/code/soulcatcher/soulcatcher_devices.dm
+++ b/modular_nova/modules/modular_implants/code/soulcatcher/soulcatcher_devices.dm
@@ -1,0 +1,4 @@
+/datum/component/soulcatcher/modular_laser  //Used in the Hoshi and Hyeseong.
+	max_souls = 1
+	communicate_as_parent = TRUE
+	ghost_joinable = FALSE

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/saibasan/laser_guns.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/saibasan/laser_guns.dm
@@ -64,8 +64,8 @@
 	var/speech_json_file = LONG_MOD_LASER_SPEECH
 	/// Keeps track of the last processed charge, prevents message spam
 	var/last_charge = 0
-	/// If the gun's personality speech thing is on, defaults to on because just listen to her
-	var/personality_mode = TRUE
+	/// If the gun's personality speech thing is on, defaults to on because just listen to her // Defaults its to Off, so its easier to advertice that someone wants a talking gun and companion.
+	var/personality_mode = FALSE
 	/// Keeps track of our soulcatcher component
 	var/datum/component/soulcatcher/tracked_soulcatcher
 	/// What is this gun's extended examine, we only have to do this because the carbine is a subtype
@@ -248,10 +248,6 @@
 	name = "Toggle Weapon Personality"
 	desc = "Toggles the weapon's personality core. Studies find that turning them off makes them quite sad, however."
 	background_icon_state = "bg_mod"
-
-/datum/component/soulcatcher/modular_laser
-	max_souls = 1
-	communicate_as_parent = TRUE
 
 //Short version of the above modular rifle, has less charge and different modes
 /obj/item/gun/energy/modular_laser_rifle/carbine

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8180,6 +8180,7 @@
 #include "modular_nova\modules\modular_implants\code\soulcatcher\handheld_soulcatcher.dm"
 #include "modular_nova\modules\modular_implants\code\soulcatcher\soulcatcher_body_component.dm"
 #include "modular_nova\modules\modular_implants\code\soulcatcher\soulcatcher_component.dm"
+#include "modular_nova\modules\modular_implants\code\soulcatcher\soulcatcher_devices.dm"
 #include "modular_nova\modules\modular_implants\code\soulcatcher\soulcatcher_mob.dm"
 #include "modular_nova\modules\modular_implants\code\soulcatcher\soulcatcher_tgui.dm"
 #include "modular_nova\modules\modular_implants\code\soulcatcher\soulcatcher_verbs.dm"


### PR DESCRIPTION

## About The Pull Request
Sets to Off the talking component of the Modular lasers by default, and to not joinable the Soulcatcher component. Also moves the Soulcatcher component with the rest of the soulcatcher components, as the coding fathers intended.

## How This Contributes To The Nova Sector Roleplay Experience
First, ghosts dont get 20 open soulcatchers to unatended weapons no one is gonna pick up, which was annoying. Second, it improves my experience by not having to manually turn off the talking of the gun, letting others to choose to do so.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

Proof is that all features can be turned back on and continue to work as usual.  

![image](https://github.com/user-attachments/assets/9aed473b-b8a5-4ea1-af6a-2dca3aad6056)

![image](https://github.com/user-attachments/assets/1fbfe770-5769-4869-bf7a-f83d4bb74ff8)

![image](https://github.com/user-attachments/assets/b4229029-c50c-42e6-9754-69e5b676528e)


</details>

## Changelog
:cl:
qol: Turns off by default the Soulcatcher and talking of the Hoshi and the Hyeseong. They are still usable, just not out of the box, the user has to manually turn them on.
/:cl:
