### PR TITLE
Adds Regaleira to Koru's Donator Items

### DIFF
--- a/modular_nova/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
+++ b/modular_nova/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
@@ -139,12 +139,12 @@
 /datum/loadout_item/mask/divemask_koru
 	name = "S.O.K.O. Gaiter"
 	item_path = /obj/item/clothing/mask/gas/signalis_gaiter
-	ckeywhitelist = list("koruu", "foxyandiknowit", "candlejax", "shyelf", "opportunerover22")
+	ckeywhitelist = list("koruu", "foxyandiknowit", "candlejax", "shyelf", "opportunerover22", "Regaleira")
 
 /datum/loadout_item/under/jumpsuit/divesuit_koru
 	name = "S.O.K.O. Bodysuit"
 	item_path = /obj/item/clothing/under/bodysuit_koruu
-	ckeywhitelist = list("koruu", "foxyandiknowit", "candlejax", "shyelf", "opportunerover22")
+	ckeywhitelist = list("koruu", "foxyandiknowit", "candlejax", "shyelf", "opportunerover22", "Regaleira")
 
 /datum/loadout_item/under/jumpsuit/anasuit
 	name = "Azulean's Enviro-Suit"


### PR DESCRIPTION

## About The Pull Request

Adds Ckey Regaleria to Koru's Donator Items by request of Koru.

## How This Contributes To The Nova Sector Roleplay Experience

It doesn't.

## Proof of Testing

This isn't really possible for me to test outside of it being able to compile. Also included the DM of Koru asking me to do this.


![image](https://github.com/user-attachments/assets/ea959eb0-da36-471a-bb07-8f8492e2db29)
![image](https://github.com/user-attachments/assets/21f5b093-7930-4750-9e28-6dd9d14a7f28)


## Changelog
:cl:
add: Adds Regaleira to Koru's donator items.
/:cl:
