### PR TITLE
Removes the Counterfeit mail device and Tram Remote from OPFOR and Traitor Uplinks

### DIFF
--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -41,14 +41,6 @@
 	item = /obj/item/book/bible/syndicate
 	cost = 5
 
-/datum/uplink_item/device_tools/tram_remote
-	name = "Tram Remote Control"
-	desc = "When linked to a tram's on board computer systems, this device allows the user to manipulate the controls remotely. \
-		Includes direction toggle and a rapid mode to bypass door safety checks and crossing signals. \
-		Perfect for running someone over in the name of a tram malfunction!"
-	item = /obj/item/assembly/control/transport/remote
-	cost = 2
-
 /datum/uplink_item/device_tools/thermal
 	name = "Thermal Imaging Glasses"
 	desc = "These goggles can be turned to resemble common eyewear found throughout the station. \

--- a/code/modules/uplink/uplink_items/stealthy_tools.dm
+++ b/code/modules/uplink/uplink_items/stealthy_tools.dm
@@ -94,16 +94,6 @@
 	surplus = 30
 	uplink_item_flags = NONE
 
-/datum/uplink_item/stealthy_tools/mail_counterfeit
-	name = "GLA Brand Mail Counterfeit Device"
-	desc = "A device capable of counterfeiting NT's mail. Can be used to store items within as an easy means of smuggling contraband. \
-			Additionally, you may choose to \"arm\" the item inside, causing the item to be used the moment the mail is opened as if the person had just used it in hand. \
-			The most common usage of this feature is with grenades, as it forces the grenade to prime. Bonus points if the grenade is set to instantly detonate. \
-			Comes with an integrated micro-computer for configuration purposes."
-	item = /obj/item/storage/mail_counterfeit_device
-	cost = 1
-	surplus = 30
-
 /datum/uplink_item/stealthy_tools/forensics_spofer
 	name = "Forensics Spoofing Kit"
 	desc = "A box that contains the forensics spoofer (and instructions) which can scan and replicate fingerprints and fibers \

--- a/modular_nova/modules/opposing_force/code/equipment/gadgets.dm
+++ b/modular_nova/modules/opposing_force/code/equipment/gadgets.dm
@@ -117,9 +117,6 @@
 	description = "A spacecarp plushie which turns into the real deal when wet."
 	item_type = /obj/item/toy/plush/carpplushie/dehy_carp
 
-/datum/opposing_force_equipment/gadget_stealth/mailcounterfeit
-	item_type = /obj/item/storage/mail_counterfeit_device
-
 /datum/opposing_force_equipment/gadget_stealth/glue
 	item_type = /obj/item/syndie_glue
 
@@ -142,13 +139,6 @@
 
 /datum/opposing_force_equipment/gadget_stealth/borgupgrader
 	item_type = /obj/item/borg/upgrade/transform/syndicatejack
-
-/datum/opposing_force_equipment/gadget_stealth/tram_remote
-	name = "Tram Remote Control"
-	item_type = /obj/item/assembly/control/transport/remote
-	description = "When linked to a tram's on board computer systems, this device allows the user to manipulate the controls remotely. \
-		Includes direction toggle and a rapid mode to bypass door safety checks and crossing signals. \
-		Perfect for running someone over in the name of a tram malfunction!"
 
 /datum/opposing_force_equipment/gadget_stealth/cloakerbelt
 	item_type = /obj/item/shadowcloak


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does what it says in the title, removes the two items from the OPFOR and Traitor Uplinks.

## How This Contributes To The Nova Sector Roleplay Experience

Ultimately the amount of interaction that these items provides is well below our expectations as a roleplay server.  Requested by JungleRat.

## Proof of Testing
Screenshot from the live server on the left. Test Server on the right.

![image](https://github.com/user-attachments/assets/c6c9baad-8ba3-4731-9740-f1e9f1706266)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removes the counterfeit mail item along with the tram remote from uplink and OPFOR.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
