### PR TITLE
Fixes jobs page expanding infinitely

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/JobsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/JobsPage.tsx
@@ -331,7 +331,7 @@ function Department(props: DepartmentProps) {
 
   return (
     <Box>
-      {/* // NOVA EDIT REMOVAL - For the alt titles dropdowns to not be screwed up - <Stack vertical fill>*/}
+      {/* <Stack vertical fill> // NOVA EDIT REMOVAL - For the alt titles dropdowns to not be screwed up */}
       {jobsForDepartment.map(([name, job]) => {
         return (
           <JobRow
@@ -342,7 +342,7 @@ function Department(props: DepartmentProps) {
           />
         );
       })}
-      {/* </Stack>*/}
+      {/* </Stack> // NOVA EDIT REMOVAL */}
 
       {children}
     </Box>


### PR DESCRIPTION
## About The Pull Request

Partial fix of https://github.com/NovaSector/NovaSector/issues/4804

## How This Contributes To The Nova Sector Roleplay Experience

Buggy ui bad

## Changelog

:cl:
fix: fixes a bug that would cause the occupations page to grow larger each time you clicked an alt title dropdown
/:cl: