### PR TITLE
Snowglobe detective shutters

### DIFF
--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -16005,7 +16005,7 @@
 "epB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
+	dir = 8;
 	id = "detectiveshutters"
 	},
 /turf/open/floor/plating,
@@ -54060,7 +54060,8 @@
 	dir = 8
 	},
 /obj/machinery/button/door/directional/south{
-	id = "detectiveshutters"
+	id = "detectiveshutters";
+	name = "Shutters"
 	},
 /turf/open/floor/wood/large,
 /area/station/security/detectives_office)
@@ -66708,14 +66709,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/ordnance_maint_lesser)
-"scg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "detectiveshutters"
-	},
-/turf/open/floor/plating,
-/area/station/security/detectives_office)
 "sch" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/east,
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
@@ -69887,6 +69880,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/commons/vacant_room/commissary)
+"sSI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id = "detectiveshutters"
+	},
+/turf/open/floor/plating,
+/area/station/security/detectives_office)
 "sSJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -251386,8 +251387,8 @@ ezi
 bRb
 ugL
 ugL
-scg
-scg
+epB
+epB
 ugL
 iJf
 ugL
@@ -251641,7 +251642,7 @@ gBJ
 sNr
 vvm
 bRb
-epB
+sSI
 rDV
 ydt
 mxW
@@ -251898,7 +251899,7 @@ aSG
 vAm
 ahk
 sxO
-epB
+sSI
 ret
 nxB
 rll

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -16004,6 +16004,10 @@
 /area/station/hallway/primary/aft)
 "epB" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id = "detectiveshutters"
+	},
 /turf/open/floor/plating,
 /area/station/security/detectives_office)
 "epE" = (
@@ -54055,6 +54059,9 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/machinery/button/door/directional/south{
+	id = "detectiveshutters"
+	},
 /turf/open/floor/wood/large,
 /area/station/security/detectives_office)
 "ozS" = (
@@ -66701,6 +66708,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/ordnance_maint_lesser)
+"scg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "detectiveshutters"
+	},
+/turf/open/floor/plating,
+/area/station/security/detectives_office)
 "sch" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/east,
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
@@ -251371,8 +251386,8 @@ ezi
 bRb
 ugL
 ugL
-epB
-epB
+scg
+scg
 ugL
 iJf
 ugL


### PR DESCRIPTION
## About The Pull Request

Adds privacy shutters and a button to the detective office in snowglobe. I earnestly thought it had them already. It did not. Now it does.

## How This Contributes To The Nova Sector Roleplay Experience

Gives more control over detective roleplay on snowglobe. This makes it much easier to be a corrupt bend-the-rules noir protagonist now.

## Proof of Testing

<details>

![1](https://github.com/user-attachments/assets/34eae9d7-72d3-4096-ad5f-9548a8f6edf2)

![2](https://github.com/user-attachments/assets/cdbe26bc-c99b-41fc-81a4-484f1095d801)
 
</details>

## Changelog

:cl:
add: Privacy shutters added to snowglobe's detective office.
/:cl:
