### PR TITLE
brings the bulldog back in line with its tg iteration

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -159,7 +159,7 @@
 	accepted_magazine_type = /obj/item/ammo_box/magazine/m12g
 	can_suppress = FALSE
 	burst_size = 2
-	fire_delay = 10 //NOVA EDIT - Original: 0
+	fire_delay = 1
 	pin = /obj/item/firing_pin/implant/pindicate
 	fire_sound = 'sound/items/weapons/gun/shotgun/shot_alt.ogg'
 	actions_types = list(/datum/action/item_action/toggle_firemode)


### PR DESCRIPTION
## About The Pull Request
changes the burst firedelay from 1 whole second to 0.1 seconds (tg baseline) because frankly the fact that the burst takes this long and locks your target means if you manage to click a tile and not a target you are both wasting two shells (sucks) and also stuck waiting for two whole seconds to whiff your second shot (sucks)

## Changelog

:cl:
balance: Scarborough Arms, tired of receiving complaints from field operatives about barely-functional burst selectors on their Bulldog shotguns, has instated a voluntary refurbishing program to replace the burst fire mechanisms with ones that can actually, quote, "put holes in people without waiting a goddamn century between each half of the burst".
/:cl: