### PR TITLE
"The incoming Glark PR" (Removes Poly's headset modularly)

### DIFF
--- a/modular_nova/master_files/code/modules/mob/basic/alien/pets/parrot/poly.dm
+++ b/modular_nova/master_files/code/modules/mob/basic/alien/pets/parrot/poly.dm
@@ -1,0 +1,2 @@
+/mob/living/basic/parrot/poly/setup_headset()
+	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6981,6 +6981,7 @@
 #include "modular_nova\master_files\code\modules\mob\basic\alien\drone.dm"
 #include "modular_nova\master_files\code\modules\mob\basic\alien\queen.dm"
 #include "modular_nova\master_files\code\modules\mob\basic\alien\sentinel.dm"
+#include "modular_nova\master_files\code\modules\mob\basic\alien\pets\parrot\poly.dm"
 #include "modular_nova\master_files\code\modules\mob\dead\new_player\latejoin_menu.dm"
 #include "modular_nova\master_files\code\modules\mob\dead\new_player\new_player.dm"
 #include "modular_nova\master_files\code\modules\mob\dead\new_player\preferences_setup.dm"


### PR DESCRIPTION

## About The Pull Request
Title. Poly no longer has their headset.
## How This Contributes To The Nova Sector Roleplay Experience
Let's be entirely honest with ourselves and each other and admit that Poly's presence on the radio is a blight. It was a funny joke for maybe the first year of SS13's existence, but I think by now it's run its course, particularly on an HRP environment like Nova. Poly exists to get the headset wrenched from them at roundstart by anyone who has the access to do it, or to be placed on the Common channel by people who want to create spam that we don't administratively punish, for some reason. Practically the entire server loudly dislikes Poly being in their ear all the time, and it's hard to blame them, considering it's pretty much mechanically-implemented radio spam.
This doesn't remove Poly's gimmick or make them the same as a normal parrot. It just means they don't spam department radio channels by default. And we will all be better off for it.
One-to-one copy of the previous non-modular PR, as I was about to write a paraphrased version of this, re-read the original, and thought that I might as well.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/b5cf5eca-ba9d-4606-85cd-c012692a58fe)
![image](https://github.com/user-attachments/assets/46e19413-593e-4475-ac76-899c2f0c9c30)

</details>

## Changelog
:cl: Stalkeros
del: Poly's roundstart headset.
/:cl:
