### PR TITLE
Minor QoL for Ghost Cafe

### DIFF
--- a/_maps/map_files/generic/CentCom_nova_z2.dmm
+++ b/_maps/map_files/generic/CentCom_nova_z2.dmm
@@ -200,14 +200,14 @@
 /area/centcom/holding/cafepark)
 "afD" = (
 /obj/structure/closet/crate,
-/obj/machinery/plumbing/synthesizer/colony_hydroponics,
-/obj/machinery/plumbing/synthesizer/colony_hydroponics,
-/obj/machinery/plumbing/synthesizer/colony_hydroponics,
-/obj/machinery/plumbing/synthesizer/colony_hydroponics,
 /obj/item/construction/plumbing/service,
 /obj/item/construction/plumbing/service,
 /obj/item/construction/plumbing/service,
 /obj/item/construction/plumbing/service,
+/obj/item/flatpacked_machine/hydro_synth,
+/obj/item/flatpacked_machine/hydro_synth,
+/obj/item/flatpacked_machine/hydro_synth,
+/obj/item/flatpacked_machine/hydro_synth,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "afF" = (
@@ -1196,7 +1196,9 @@
 /turf/open/misc/grass/planet,
 /area/centcom/holding/cafepark)
 "asp" = (
-/obj/machinery/hydroponics/constructable,
+/obj/machinery/hydroponics/constructable/fullupgrade{
+	dir = 1
+	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
@@ -1422,8 +1424,10 @@
 /turf/open/misc/beach/sand,
 /area/centcom/holding/cafepark)
 "auU" = (
-/obj/machinery/hydroponics/constructable,
 /obj/machinery/light/directional/south,
+/obj/machinery/hydroponics/constructable/fullupgrade{
+	dir = 1
+	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
@@ -2172,8 +2176,8 @@
 /turf/open/indestructible/carpet,
 /area/centcom/holding/cafe)
 "aBW" = (
-/obj/machinery/hydroponics/constructable,
 /obj/machinery/light/directional/north,
+/obj/machinery/hydroponics/constructable/fullupgrade,
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
@@ -3648,6 +3652,12 @@
 /obj/effect/turf_decal/sand,
 /turf/open/indestructible/plating,
 /area/centcom/holding/cafepark)
+"aSu" = (
+/obj/machinery/hydroponics/constructable/fullupgrade,
+/turf/open/indestructible/hoteltile{
+	icon_state = "darkfull"
+	},
+/area/centcom/holding/cafe)
 "aSy" = (
 /obj/structure/bookcase/random,
 /turf/open/indestructible/hotelwood,
@@ -62689,7 +62699,7 @@ ajj
 aqP
 aPf
 aqf
-asp
+aSu
 api
 ayx
 ayx
@@ -63203,7 +63213,7 @@ ajj
 aqP
 aPf
 aqf
-asp
+aSu
 aJA
 aIt
 aEp
@@ -63460,7 +63470,7 @@ ajj
 aqP
 aPf
 aqf
-asp
+aSu
 aJA
 asQ
 auo
@@ -63717,7 +63727,7 @@ ajj
 aqP
 aPf
 aqf
-asp
+aSu
 aiV
 ahK
 ahK
@@ -63974,7 +63984,7 @@ ajj
 aqP
 aPf
 aqf
-asp
+aSu
 aJA
 awn
 aOi
@@ -64488,7 +64498,7 @@ ajj
 aqP
 aPf
 aqf
-asp
+aSu
 alD
 aUZ
 aUZ
@@ -71169,7 +71179,7 @@ aaa
 ajj
 aPf
 aPf
-ayI
+tgP
 ayI
 ayI
 jBZ

--- a/_maps/map_files/generic/CentCom_nova_z2.dmm
+++ b/_maps/map_files/generic/CentCom_nova_z2.dmm
@@ -200,8 +200,14 @@
 /area/centcom/holding/cafepark)
 "afD" = (
 /obj/structure/closet/crate,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/reagent_containers/cup/glass/shaker,
+/obj/machinery/plumbing/synthesizer/colony_hydroponics,
+/obj/machinery/plumbing/synthesizer/colony_hydroponics,
+/obj/machinery/plumbing/synthesizer/colony_hydroponics,
+/obj/machinery/plumbing/synthesizer/colony_hydroponics,
+/obj/item/construction/plumbing/service,
+/obj/item/construction/plumbing/service,
+/obj/item/construction/plumbing/service,
+/obj/item/construction/plumbing/service,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "afF" = (
@@ -6957,6 +6963,9 @@
 	dir = 4
 	},
 /obj/item/storage/bag/trash,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
@@ -10009,6 +10018,18 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding/cafedorms)
+"lcD" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "floor"
+	},
+/area/centcom/holding/cafe)
 "lcR" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/interlink/dorm_rooms)
@@ -15252,6 +15273,10 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "white"
 	},
+/area/centcom/holding/cafepark)
+"tgP" = (
+/obj/structure/wall_torch/spawns_lit,
+/turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "tgU" = (
 /obj/structure/chair/wood{
@@ -64226,7 +64251,7 @@ aOR
 aOp
 axL
 azT
-azT
+lcD
 agG
 asC
 jZb
@@ -68830,7 +68855,7 @@ aaa
 aaa
 ajj
 aPf
-ayI
+tgP
 ayI
 ayI
 ajj
@@ -71662,7 +71687,7 @@ aPf
 aPf
 ayI
 ayI
-ayI
+tgP
 ayI
 ayI
 ayI
@@ -71920,11 +71945,11 @@ aPf
 aPf
 dai
 aPf
-aNU
-aPf
-aPf
-aPf
 kHZ
+aPf
+aPf
+aPf
+aNU
 ayI
 aPf
 pCd


### PR DESCRIPTION
## About The Pull Request
This PR adds the following to the ghost cafe:

- Replaces redundant crate near botany with service plumbing and hydroponics kits
- Replaces trays with T4s and optimizing them for plumbing
- Space cleaners on custodial room
- Torches to the entry and vendor part of the cave
- Fixes the nanotrasen logo looking a bit off, keeping it consistent with the decals you'd see across centcom and other maps

## How This Contributes To The Nova Sector Roleplay Experience
The service plumbing and the kit will be very useful for those who would like to make use of the cafe's botany without having to manually shove in the same nutriments over and over.

Cleaner is, obviously to keep the cafe clean as the janidrobe lacks any.

Torches, well, visibility's sake. Unless you know your way around the map it's a pain to get across places or the vendor. I personally want to see if I can unify all of vendors into one place at one point since it's a bit awkward that everything is all over the place but that's a plan for the future.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

![dreamseeker_qduCKu5ou0](https://github.com/user-attachments/assets/f29ca007-0c21-4603-ba22-9c9d112bcb1e)

Example of a plumbing setup

![dreamseeker_0xx2AodqnE](https://github.com/user-attachments/assets/3b04d479-f544-4539-ab4b-7a3153ece5eb)

![dreamseeker_bQFroAwguj](https://github.com/user-attachments/assets/5b935bb3-a508-44a9-aca2-d2e24aa36c23)

![dreamseeker_Lug8Q9yzu5](https://github.com/user-attachments/assets/8b903d6f-442a-4a30-90cd-a885fe08e10c)

Before NT logo fix:

![Screenshot_20250201_200809](https://github.com/user-attachments/assets/78e40371-39b4-456d-85b1-4388dbf19b91)

After NT logo fix:

![Screenshot_20250201_200818](https://github.com/user-attachments/assets/df56b96c-5caf-47d3-a7a9-ee3ced4b476f)

</details>

## Changelog
:cl: Hardly
fix: Ghost Cafe: Fixed the Nanotrasen logo on the lobby
qol: Ghost Cafe: Added hydroponics kits and service plumbing on a crate
qol: Ghost Cafe: All hydroponics trays are now fully upgraded
qol: Ghost Cafe: Space Cleaners added to custodial room
qol: Ghost Cafe: Torches added around the caves, no more need for flashlights!
/:cl:
