### PR TITLE
Fix: Invisible Ears Overlays

### DIFF
--- a/modular_nova/modules/customization/modules/surgery/organs/ears.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/ears.dm
@@ -1,3 +1,6 @@
+/obj/item/organ/ears
+	bodypart_overlay = /datum/bodypart_overlay/mutant/ears
+
 /obj/item/organ/ears/mutant
 	name = "fluffy ears"
 	desc = "Wait, there's two pairs of these?"


### PR DESCRIPTION
## About The Pull Request

Fixes #4815 by adding `/datum/bodypart_overlay/mutant/ears` to the base ears organ `/obj/item/organ/ears`.

Currently, when players pick a non-default ears organ via the Augments+ screen, or swap ears via surgery, their ears have `/datum/bodypart_overlay/mutant` which doesn't render mutant ears, so their ears become invisible.

The change in the PR appears to function without any unexpected visual glitches. Characters who do not have mutant ears selected will not have them rendered on their character. The reason I picked this solution instead of the others I posited in https://github.com/NovaSector/NovaSector/issues/4815#issuecomment-2628631479 is because this solution preserves the most functionality while proving to be less buggy.

## How This Contributes To The Nova Sector Roleplay Experience

Characters will be able to use non-default ears and have their mutant ears sprites appear as expected.

Applies to ears selected via the Augments+ screen, via quirks, and via surgery.

## Proof of Testing

Tested a synth humanoid and a human to ensure things looked correct.

<details>
<summary>Screenshots/Videos</summary>

![Screenshot 2025-02-02 045131](https://github.com/user-attachments/assets/26155319-3d70-49de-babd-a730c95e0037) ![Screenshot 2025-02-02 052718](https://github.com/user-attachments/assets/a0d6bd2b-a7ab-479e-89a9-b782691c5286)
  
</details>

## Changelog

:cl:
fix: Fixes ears sprites becoming invisible for non-default ears options.
/:cl: