### PR TITLE
Makes the gorillas no longer GBJ you

### DIFF
--- a/modular_nova/modules/basic_mobs/code/gorilla.dm
+++ b/modular_nova/modules/basic_mobs/code/gorilla.dm
@@ -1,6 +1,6 @@
 // This is just to remove the TG paralyze on the gorilla, if this is still here after that's gone, uh-oh.
 /mob/living/basic/gorilla
-  var/paralyze_chance = 20
+	var/paralyze_chance = 20
 
   
 /mob/living/basic/gorilla/melee_attack(mob/living/target, list/modifiers, ignore_cooldown)

--- a/modular_nova/modules/basic_mobs/code/gorilla.dm
+++ b/modular_nova/modules/basic_mobs/code/gorilla.dm
@@ -1,0 +1,15 @@
+// This is just to remove the TG paralyze on the gorilla, if this is still here after that's gone, uh-oh.
+/mob/living/basic/gorilla
+  var/paralyze_chance = 20
+
+  
+/mob/living/basic/gorilla/melee_attack(mob/living/target, list/modifiers, ignore_cooldown)
+	. = ..()
+	if (!. || !isliving(target))
+		return
+	ooga_ooga()
+	if (prob(paralyze_chance))
+		target.Knockdown(1 SECONDS)
+		visible_message(span_danger("[src] knocks [target] down!"))
+	else
+		target.throw_at(get_edge_target_turf(target, dir), range = rand(1, 2), speed = 7, thrower = src)

--- a/modular_nova/modules/basic_mobs/code/gorilla.dm
+++ b/modular_nova/modules/basic_mobs/code/gorilla.dm
@@ -1,6 +1,6 @@
 // This is just to remove the TG paralyze on the gorilla, if this is still here after that's gone, uh-oh.
 /mob/living/basic/gorilla
-	var/paralyze_chance = 20
+	var/paralyze_chance = 10
 
   
 /mob/living/basic/gorilla/melee_attack(mob/living/target, list/modifiers, ignore_cooldown)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7242,6 +7242,7 @@
 #include "modular_nova\modules\barsigns\code\barsigns.dm"
 #include "modular_nova\modules\basic_mobs\code\bananaspider.dm"
 #include "modular_nova\modules\basic_mobs\code\chinchilla.dm"
+#include "modular_nova\modules\basic_mobs\code\gorilla.dm"
 #include "modular_nova\modules\basic_mobs\code\kiwi.dm"
 #include "modular_nova\modules\better_vox\code\vox_bodycolor.dm"
 #include "modular_nova\modules\better_vox\code\vox_bodyparts.dm"


### PR DESCRIPTION

## About The Pull Request
Gorillas for some ungodly reason do a bunch of brute, and also entirely stunlock you, and also throw you back, which sounds OK in theory until you realize they're not only pretty easy to get, but there's an entire icebox ruin with like 10 of the goobers.

## How This Contributes To The Nova Sector Roleplay Experience
imagine i posted a picture of like 20 dead bodies inside the first room of the ruin here

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  soon :tm: per usual
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The nanotrasen-news-network is happy to report gorillas are going through an intergalactic phase of muscle atrophy, and no longer stunlock crew, or elsewise against walls!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
