### PR TITLE
nerfs liquid spill slips, and the paralyze it had for some reason

### DIFF
--- a/modular_nova/modules/liquids/code/liquid_systems/liquid_effect.dm
+++ b/modular_nova/modules/liquids/code/liquid_systems/liquid_effect.dm
@@ -415,7 +415,7 @@
 								step(C, dir)
 								if(prob(60) && C.body_position != LYING_DOWN)
 									to_chat(C, span_userdanger("The current knocks you down!"))
-									C.Paralyze(60)
+									C.Knockdown(10)
 						else
 							step(AM, dir)
 
@@ -442,7 +442,7 @@
 	else if (isliving(AM))
 		var/mob/living/L = AM
 		if(prob(7) && !(L.movement_type & FLYING))
-			L.slip(60, T, NO_SLIP_WHEN_WALKING, 20, TRUE)
+			L.slip(10, T, NO_SLIP_WHEN_WALKING, 20, TRUE)
 	if(fire_state)
 		AM.fire_act((T20C+50) + (50*fire_state), 125)
 


### PR DESCRIPTION


## About The Pull Request

what it says on the tin, for something that's really easy to do, covers a wide area, and lasts awhile, these were a _bit_ to good


## Proof of Testing

this one is actually just a numbers change

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Liquids spills slip alot less slippery-like, and also don't hardstun for six seconds when you get 'washed away.'
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
