### PR TITLE
[Event PR] Drone Chanting - Drones speak Binary and talk on the robot talk.

### DIFF
--- a/code/datums/saymode.dm
+++ b/code/datums/saymode.dm
@@ -76,14 +76,12 @@
 	mode = MODE_BINARY
 
 /datum/saymode/binary/handle_message(mob/living/user, message, datum/language/language)
-  //NOVA EDIT REMOVAL BEGIN - Drones speaking Robot instead of drone talk
-  /*
+	/* //NOVA EDIT REMOVAL BEGIN - Drones speaking Robot instead of drone talk
 	if(isdrone(user))
 		var/mob/living/basic/drone/drone_user = user
 		drone_user.drone_chat(message)
 		return FALSE
-  */
-  //NOVA EDIT REMOVAL END
+	*/ //NOVA EDIT REMOVAL END
 	if(user.binarycheck())
 		user.robot_talk(message)
 		return FALSE

--- a/code/datums/saymode.dm
+++ b/code/datums/saymode.dm
@@ -76,10 +76,14 @@
 	mode = MODE_BINARY
 
 /datum/saymode/binary/handle_message(mob/living/user, message, datum/language/language)
+  //NOVA EDIT REMOVAL BEGIN - Drones speaking Robot instead of drone talk
+  /*
 	if(isdrone(user))
 		var/mob/living/basic/drone/drone_user = user
 		drone_user.drone_chat(message)
 		return FALSE
+  */
+  //NOVA EDIT REMOVAL END
 	if(user.binarycheck())
 		user.robot_talk(message)
 		return FALSE

--- a/modular_nova/master_files/code/modules/language/language_holder.dm
+++ b/modular_nova/master_files/code/modules/language/language_holder.dm
@@ -125,5 +125,5 @@ GLOBAL_DATUM_INIT(language_holder_adjustor, /datum/language_holder_adjustor, new
 	)
 
 /datum/language_holder/drone_nova
-	understood_languages = list(/datum/language/drone = list(LANGUAGE_ATOM), /datum/language/common = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/drone = list(LANGUAGE_ATOM))
+	understood_languages = list(/datum/language/machine = list(LANGUAGE_ATOM), /datum/language/common = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/machine = list(LANGUAGE_ATOM))

--- a/modular_nova/modules/drones/_drone.dm
+++ b/modular_nova/modules/drones/_drone.dm
@@ -13,3 +13,9 @@
 	"<span class='warning'>Please keep these rules in mind, failing to do so can lead to a ban.</span>\n"+\
 	"<span class='warning'><u>If you do not have the regular drone laws, follow your laws to the best of your ability.</u></span>\n"+\
 	"<span class='notice'>Prefix your message with :b to speak in Drone Chat.</span>\n"
+
+/mob/living/basic/drone/binarycheck()
+	var/area/our_area = get_area(src)
+	if(our_area.area_flags & BINARY_JAMMING)
+		return FALSE
+	return TRUE


### PR DESCRIPTION

## About The Pull Request
Makes it so drones use the Robot talk instead of the Drone talk, with the same rules for jamming and all.
Drones lose the drone chant language and get Binary instead, they still understand, but not speak, common.

## How This Contributes To The Nova Sector Roleplay Experience
Well, it is fundamental for the Mother Drone event, so I guess thats an easy TM there for the event at least. 

But I personally think this should be a change to keep, cute lil drones should be able to work or at least chat with their fellows, even if they follow different laws, its always been weird that they were made apart, but understandable in a sense where you have Malf AI's every third or fourth shift.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/df76b760-49be-49f2-bad4-b16242c01cc8)

![image](https://github.com/user-attachments/assets/6390d48b-d786-4a30-bd6a-474d2bb02e25)

</details>

## Changelog
:cl:
qol: Drones Speak Binary and speak on the robotic channel, they no longer speak drone chant nor they have their own chat. All Silicons Unite!
/:cl:
