### PR TITLE
[Removal]  Vendors dont Crit anymore, they just deal damage instead of insta trauma

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -855,11 +855,11 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 				if (prob(chance_to_crit))
 					crit_case = pick_weight(get_crit_crush_chances())
 			var/crit_rebate_mult = 1 // lessen the normal damage we deal for some of the crits
-
+			/* // NOVA EDIT REMOVAL
 			if (!isnull(crit_case))
 				crit_rebate_mult = fall_and_crush_crit_rebate_table(crit_case)
 				apply_crit_crush(crit_case, atom_target)
-
+			*/
 			var/adjusted_damage = damage * crit_rebate_mult
 			var/crushed
 			if (isliving(atom_target))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Removes the roll for auto trauma from vending machines, they still deal a good amount of damage which can and do cause regular traumas.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Causing auto traumas seems a bit forced when we already got a regular damage system integrated, not really need for things that bypass races, armor, and such to go and cripple someone permanently.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/7bd674ae-95bf-4d53-a5ed-40377398206b)

![image](https://github.com/user-attachments/assets/c70946e8-a22f-4b5e-85fd-11275d2d15e1)

![image](https://github.com/user-attachments/assets/15c8a4aa-5326-4aaf-b589-3842093b7e2a)

![image](https://github.com/user-attachments/assets/64370239-fd1c-4583-8241-a36c07752c83)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed Vending Machines Crit table, they just do the old deal a lot of damage on you when they crush you
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
