### PR TITLE
fixes ablative trenchcoat and digitigrade

### DIFF
--- a/modular_nova/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
+++ b/modular_nova/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
@@ -196,3 +196,7 @@
 	icon = 'modular_nova/master_files/icons/obj/clothing/shoes.dmi'
 	worn_icon = 'modular_nova/master_files/icons/mob/clothing/feet.dmi'
 	icon_state = "peacekeeper"
+
+/obj/item/clothing/suit/hooded/ablative
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+


### PR DESCRIPTION


## About The Pull Request
closes: https://github.com/NovaSector/NovaSector/issues/4839
## How This Contributes To The Nova Sector Roleplay Experience
Makes the suit no longer remind you that you forgot CS-source


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: the ablative trench-coat no longer turns into purple and black squares when you have bendy-legs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
