### PR TITLE
[perhaps a testmerge] sample-run of what if the colonial modsuit (essentially unused) went on the belt, and was spaceproof (but also had like, no mod complexity)

### DIFF
--- a/modular_nova/modules/kahraman_equipment/code/clothing/mod.dm
+++ b/modular_nova/modules/kahraman_equipment/code/clothing/mod.dm
@@ -8,7 +8,7 @@
 		designs, there are flaws and no single one is perfect, but they achieve a singular goal and that is the \
 		important part. Suits such as these are made specifically for the rare emergency that creates a hazard \
 		environment that other equipment just can't quite handle. Often, these suits are able to protect their users \
-		from not only electricity, but also radiation, biological hazards, other people, so on. This suit will not, \
+		from not only electricity, but also temperature differences, and especially pressure ones, it will not \
 		however, protect you from yourself."
 
 	default_skin = "colonist"
@@ -16,12 +16,13 @@
 	resistance_flags = FIRE_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
-	complexity_max = DEFAULT_MAX_COMPLEXITY - 7
-	charge_drain = DEFAULT_CHARGE_DRAIN * 2
-	slowdown_inactive = 1.5
-	slowdown_active = 1
+	complexity_max = DEFAULT_MAX_COMPLEXITY - 8 // Just enough to fit the kinesis module, for the deadspace larp.
+	charge_drain = DEFAULT_CHARGE_DRAIN * 1.3
+	slowdown_inactive = 0
+	slowdown_active = 0
+	slot_flags = ITEM_SLOT_BELT
 	inbuilt_modules = list(
-		/obj/item/mod/module/plate_compression/permanent,
+		/obj/item/mod/module/storage/civilian,
 		/obj/item/mod/module/joint_torsion/permanent
 	)
 	allowed_suit_storage = list(
@@ -84,14 +85,11 @@
 	applied_cell = /obj/item/stock_parts/power_store/cell/high
 	applied_modules = list(
 		/obj/item/mod/module/welding,
-		/obj/item/mod/module/magboot,
 		/obj/item/mod/module/flashlight,
 		/obj/item/mod/module/status_readout,
 		/obj/item/mod/module/thermal_regulator,
-		/obj/item/mod/module/rad_protection,
 	)
 	default_pins = list(
-		/obj/item/mod/module/magboot,
 		/obj/item/mod/module/flashlight,
 		/obj/item/mod/module/thermal_regulator,
 	)
@@ -105,6 +103,7 @@
 /obj/item/mod/module/plate_compression/permanent
 	removable = FALSE
 	complexity = 0
+	incompatible_modules = list(/obj/item/mod/module/holster)
 
 // Joint torsion module that can't be removed and has no complexity
 


### PR DESCRIPTION


## About The Pull Request
A sample run of a belt slot, electric and spaceproof modsuit, essentially toolbelt ++ (i can up the price if the memetainers wish so)
## How This Contributes To The Nova Sector Roleplay Experience
Drip your honor, drip and the dead of space.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The 'hazard' modsuit is now spaceproof, retaining it's shockproofness, but losing the ability to fit it in your backpack, as it goes on the beltslot now!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
