### PR TITLE
[MODULAR] Fixing asteroid with engines evac shuttle

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -25,7 +25,6 @@
 	transform = MAP_SWITCH(TRANSLATE_MATRIX(-4, -4), matrix())
 
 	temperature = TCMB
-	color = "#677" //NOVA EDIT ADDITION
 	var/turf/turf_type = /turf/open/misc/asteroid/airless
 	/// The path of the ore stack we spawn when we're mined.
 	var/obj/item/stack/ore/mineralType = null
@@ -311,13 +310,11 @@
 		var/path = pick(spawn_chance_list)
 		if(ispath(path, /turf))
 			var/stored_flags = 0
-			var/stored_color = color //NOVA EDIT ADDITION
 			if(turf_flags & NO_RUINS)
 				stored_flags |= NO_RUINS
 			var/turf/T = ChangeTurf(path,null,CHANGETURF_IGNORE_AIR)
 			T.flags_1 |= stored_flags
 
-			T.color = stored_color //NOVA EDIT ADDITION
 			if(ismineralturf(T))
 				var/turf/closed/mineral/M = T
 				M.turf_type = src.turf_type

--- a/modular_nova/master_files/code/game/turfs/closed/minerals.dm
+++ b/modular_nova/master_files/code/game/turfs/closed/minerals.dm
@@ -1,0 +1,4 @@
+// Seting color var is kinda depricated now
+/turf/closed/mineral/Initialize(mapload)
+	add_atom_colour("#677", FIXED_COLOUR_PRIORITY)
+	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6788,6 +6788,7 @@
 #include "modular_nova\master_files\code\game\objects\structures\plaques\static_plaques.dm"
 #include "modular_nova\master_files\code\game\objects\structures\signs\signs_maps.dm"
 #include "modular_nova\master_files\code\game\turfs\closed\_closed.dm"
+#include "modular_nova\master_files\code\game\turfs\closed\minerals.dm"
 #include "modular_nova\master_files\code\game\turfs\open\floor\iron_floor.dm"
 #include "modular_nova\master_files\code\game\turfs\open\space\space.dm"
 #include "modular_nova\master_files\code\modules\admin\admin.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Moving asteroid color to nova modules. It fixes meteor shuttle... Finally

Also put in master files, because it's just overriding TG color, without any special "module"
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Emergency shuttle will fly with walls.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/3089dec7-9ccc-47ef-ab37-7c9422d44adc)
![image](https://github.com/user-attachments/assets/76d2739c-80d9-4026-997a-afbee58b3614)
![image](https://github.com/user-attachments/assets/255ab122-e9b8-4c01-92a8-89b574e7fe2c)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Reminded asteroid with engines shuttle to pickup its walls when departing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
