### PR TITLE
[Temporal (?) Patch] Makes crusher loots drop regardless of the damage used.

### DIFF
--- a/code/datums/elements/crusher_loot.dm
+++ b/code/datums/elements/crusher_loot.dm
@@ -34,10 +34,13 @@
 /datum/element/crusher_loot/proc/on_death(mob/living/target, gibbed)
 	SIGNAL_HANDLER
 
+	/* // NOVA EDIT CHANGE START - Bandaid for crusher loot until TG makes the crusher fix.
 	var/datum/status_effect/crusher_damage/damage = target.has_status_effect(/datum/status_effect/crusher_damage)
 	var/datum/status_effect/ashwalker_damage/ashie_damage = target.has_status_effect(/datum/status_effect/ashwalker_damage) // NOVA EDIT ADDITION - Ashwalker trophies
 	var/final_damage_total = damage?.total_damage + ashie_damage?.total_damage // NOVA EDIT ADDITION - Ashwalker trophies
 	if(final_damage_total && prob((final_damage_total/target.maxHealth) * drop_mod)) // NOVA EDIT CHANGE - Ashwalker trophies - ORIGINAL: if(damage && prob((damage.total_damage/target.maxHealth) * drop_mod)) //on average, you'll need to kill 4 creatures before getting the item. by default.
+	*/
+	if (prob(drop_mod)) // NOVA EDIT CHANGE END- Bandaid for crusher loot until TG makes the crusher fix.
 		if(islist(trophy_type))
 			for(var/trophypath in trophy_type)
 				make_path(target, trophypath)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -100,6 +100,7 @@
 	if(!crusher_kill && ashie_damage && crusher_loot && ashie_damage.total_damage >= maxHealth * 0.6)
 		spawn_crusher_loot()
 	// NOVA EDIT ADDITION END
+	spawn_crusher_loot() // NOVA EDIT ADDITION - Spawns the crusher loot regardless.
 	if(true_spawn && !(flags_1 & ADMIN_SPAWNED_1))
 		var/tab = "megafauna_kills"
 		if(crusher_kill)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Forces Megafauna to always drop their crusher loot.

Makes it so regular fauna drop it with the drop_mod value chance, instead of based on how much damage with the crusher was done. (Generally 25%)

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

First, the tracking of the damage is borked, regular hits accrue negative, backstabs do positive, and then it further breaks as this is changed depending on if its a basic or simple mob, which in short breaks everything and we had been waiting on TG to fix it and looks like it will take much more, 

![image](https://github.com/user-attachments/assets/96884b6d-b941-4d1b-be3c-e872e50cfed9)

https://github.com/tgstation/tgstation/pull/89243 is the potential fix.

Second, as it was discussed by some long time miners, there is a lot of OOC conflict on the way people fight megas, crusher players get mad if a blood drunk is defeated by a non crusher, since they lose the blood drunk eye forever, and thus unable to do their content otherwise.

Third, it fosters cooperation regardless of the fighting style, letting crusher and non crusher players fight the same thing without blocking the drop for the other.

Fourth, lets be real, if you arent using a crusher, there are very little use cases for crusher trophies to even be used by a non crusher player.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/34429f14-f88b-4772-8862-a8e94115bf25)

![image](https://github.com/user-attachments/assets/0ef69241-777d-4dd5-aa75-592d75901b63)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Crusher Trophies drop regardless of wherever you use a crusher or not. Crusher loot should be 25% drop from regular fauna as it used to be.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
