### PR TITLE
Fixes Crusher variants Mark speed

### DIFF
--- a/modular_nova/modules/mining_crushers/code/miningweapons.dm
+++ b/modular_nova/modules/mining_crushers/code/miningweapons.dm
@@ -21,10 +21,26 @@
 	throwforce = 5
 	throw_speed = 4
 	armour_penetration = 10
-	custom_materials = list(/datum/material/iron=HALF_SHEET_MATERIAL_AMOUNT*1.15, /datum/material/glass=HALF_SHEET_MATERIAL_AMOUNT*2)
+	custom_materials = list(
+		/datum/material/iron=HALF_SHEET_MATERIAL_AMOUNT*1.15,
+		/datum/material/glass=HALF_SHEET_MATERIAL_AMOUNT*2,
+		)
 	hitsound = 'sound/items/weapons/bladeslice.ogg'
-	attack_verb_continuous = list("slashes", "cuts", "cleaves", "chops", "swipes")
-	attack_verb_simple = list("cleave", "chop", "cut", "swipe", "slash")
+	attack_verb_continuous = list(
+		"slashes",
+		"cuts",
+		"cleaves",
+		"chops",
+		"swipes",
+		)
+	attack_verb_simple = list(
+		"cleave",
+		"chop",
+		"cut",
+		"swipe",
+		"slash",
+	)
+
 	sharpness = SHARP_EDGED
 	actions_types = list(/datum/action/item_action/toggle_light)
 	obj_flags = NONE
@@ -32,7 +48,7 @@
 	light_range = 5
 	light_on = FALSE
 	charged = TRUE
-	charge_time = 10
+	charge_time =  1 SECONDS
 	detonation_damage = 35
 	backstab_bonus = 20
 	acts_as_if_wielded = TRUE
@@ -66,10 +82,25 @@
 	throwforce = 5
 	throw_speed = 4
 	armour_penetration = 15
-	custom_materials = list(/datum/material/iron=HALF_SHEET_MATERIAL_AMOUNT*1.15, /datum/material/glass=HALF_SHEET_MATERIAL_AMOUNT*2)
+	custom_materials = list(
+		/datum/material/iron=HALF_SHEET_MATERIAL_AMOUNT*1.15,
+		/datum/material/glass=HALF_SHEET_MATERIAL_AMOUNT*2,
+		)
 	hitsound = 'sound/items/weapons/bladeslice.ogg'
-	attack_verb_continuous = list("pierces", "stabs", "impales", "pokes", "jabs")
-	attack_verb_simple = list("imaple", "stab", "pierce", "jab", "poke")
+	attack_verb_continuous = list(
+		"pierces",
+		"stabs",
+		"impales",
+		"pokes",
+		"jabs",
+		)
+	attack_verb_simple = list(
+		"imaple",
+		"stab",
+		"pierce",
+		"jab",
+		"poke",
+		)
 	sharpness = SHARP_EDGED
 	actions_types = list(/datum/action/item_action/toggle_light)
 	obj_flags = UNIQUE_RENAME
@@ -77,9 +108,9 @@
 	light_range = 8
 	light_on = FALSE
 	charged = TRUE
-	charge_time = 15
+	charge_time =  1.5 SECONDS
 	detonation_damage = 35
-	backstab_bonus = 20
+	backstab_bonus = 25
 	reach = 2
 
 /obj/item/kinetic_crusher/spear/Initialize(mapload)
@@ -112,10 +143,25 @@
 	throwforce = 5
 	throw_speed = 4
 	armour_penetration = 0
-	custom_materials = list(/datum/material/iron=HALF_SHEET_MATERIAL_AMOUNT*1.15, /datum/material/glass=HALF_SHEET_MATERIAL_AMOUNT*2)
+	custom_materials = list(
+		/datum/material/iron=HALF_SHEET_MATERIAL_AMOUNT*1.15,
+		/datum/material/glass=HALF_SHEET_MATERIAL_AMOUNT*2,
+		)
 	hitsound = 'sound/items/weapons/sonic_jackhammer.ogg'
-	attack_verb_continuous = list("slams", "crushes", "smashes", "flattens", "pounds")
-	attack_verb_simple = list("slam", "crush", "smash", "flatten", "pound")
+	attack_verb_continuous = list(
+		"slams",
+		"crushes",
+		"smashes",
+		"flattens",
+		"pounds",
+		)
+	attack_verb_simple = list(
+		"slam",
+		"crush",
+		"smash",
+		"flatten",
+		"pound",
+		)
 	sharpness = NONE
 	actions_types = list(/datum/action/item_action/toggle_light)
 	obj_flags = UNIQUE_RENAME
@@ -123,7 +169,7 @@
 	light_range = 5
 	light_on = FALSE
 	charged = TRUE
-	charge_time = 20
+	charge_time = 2 SECONDS
 	detonation_damage = 70
 	backstab_bonus = 0
 	acts_as_if_wielded = FALSE
@@ -163,10 +209,23 @@
 	throwforce = 5
 	throw_speed = 4
 	armour_penetration = 0
-	custom_materials = list(/datum/material/iron=HALF_SHEET_MATERIAL_AMOUNT*1.15, /datum/material/glass=HALF_SHEET_MATERIAL_AMOUNT*2)
+	custom_materials = list(
+		/datum/material/iron=HALF_SHEET_MATERIAL_AMOUNT*1.15,
+		/datum/material/glass=HALF_SHEET_MATERIAL_AMOUNT*2,
+		)
 	hitsound = 'sound/items/weapons/pierce.ogg'
-	attack_verb_continuous = list("swipes", "slashes", "cuts", "slaps")
-	attack_verb_simple = list("swipe", "slash", "cut", "slap")
+	attack_verb_continuous = list(
+		"swipes",
+		"slashes",
+		"cuts",
+		"slaps",
+		)
+	attack_verb_simple = list(
+		"swipe",
+		"slash",
+		"cut",
+		"slap",
+		)
 	sharpness = SHARP_POINTY
 	actions_types = list(/datum/action/item_action/toggle_light)
 	obj_flags = UNIQUE_RENAME
@@ -174,9 +233,9 @@
 	light_range = 4
 	light_on = FALSE
 	charged = TRUE
-	charge_time = 2
+	charge_time = 1 SECONDS
 	detonation_damage = 40
-	backstab_bonus = 120
+	backstab_bonus = 25
 	acts_as_if_wielded = TRUE
 
 /obj/item/kinetic_crusher/claw/Initialize(mapload)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes: https://github.com/NovaSector/NovaSector/issues/4803

A bit back crushers got updated to a time define, while the others really didn't change much - the claw specifically had a 2 attack speed for the mark. Which means you could basically machine gun it.

This just fixes that and gives it a 1 second recharge.

Looking at them as well, there's zero reason why the claw should be as OP as it is. Currently it does 180 damage on a backstab and you can hold a shield to get block chance as well.

Current: 

![image](https://github.com/user-attachments/assets/2b12917b-435d-4206-8b81-cb60433f1aa2)

Brought the claw backstab bonus down to 25, and while that is a DRASTIC drop - it still has a 1 second mark recharge meaning it will still outdps the other variants in most cases even without backstabbing. 

## How This Contributes To The Nova Sector Roleplay Experience

Corrects a missed define from a baseline update for the crushers, and brings the claw down to reality to be more in-line with all the others who are relatively balanced around each other.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
  
![image](https://github.com/user-attachments/assets/f2c2bcff-e1b1-4dcf-b3c4-2ff909df92f0)

  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Claw crusher bonus damage reduced to be just slightly better than other crushers
fix: fixes crusher marking spam
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
