### PR TITLE
[Fix] Adds the Unlimited Fishing flag to the Ghost Cafe so any fishing done there doesnt remove loot from the fishing loot tables.

### DIFF
--- a/modular_nova/modules/mapping/code/areas/centcom.dm
+++ b/modular_nova/modules/mapping/code/areas/centcom.dm
@@ -6,6 +6,7 @@
 
 /area/centcom/holding
 	name = "Holding Facility"
+	area_flags = parent_type::area_flags | UNLIMITED_FISHING 
 	mood_bonus = 25
 	mood_message = "I am taking a well deserved rest!"
 


### PR DESCRIPTION

## About The Pull Request
At the suggestion of Ghommie, adds the UNLIMITED_FISHING flag to the area_type of the ghost cafe. This avoids people in that area fishing and removing special loot when in that area. Like fishing a treasure chest and ruining it for the players of the station. 

## How This Contributes To The Nova Sector Roleplay Experience
It allows people in the ghost cafe to enjoy fishing without affecting people playing the actual game.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/5bb3fbf5-1767-4163-8721-72018f668417)

</details>

## Changelog
:cl:
fix: Fishing can now be done on the Ghost Cafe without removing loot from the station's loot tables. This will allow mappers to add fishing to the cafe without affecting the ongoing round.
/:cl:
