### PR TITLE
[sample run an ur discrection] ups the delam-suppression system timer to 60 minutes, instead of 30 (2x)

### DIFF
--- a/modular_nova/modules/delam_emergency_stop/code/scram.dm
+++ b/modular_nova/modules/delam_emergency_stop/code/scram.dm
@@ -138,9 +138,9 @@
 		audible_message(span_danger("[src] makes a series of sad beeps. Someone has corrupted its software!"))
 		return FALSE
 
-	if(world.time - SSticker.round_start_time > 30 MINUTES && trigger_reason != DIVINE_INTERVENTION)
+	if(world.time - SSticker.round_start_time > 60 MINUTES && trigger_reason != DIVINE_INTERVENTION)
 		playsound(src, 'sound/machines/compiler/compiler-failure.ogg', 100, FALSE, MACHINE_SOUND_RANGE, ignore_walls = TRUE, use_reverb = TRUE, falloff_distance = MACHINE_SOUND_FALLOFF_DISTANCE)
-		audible_message(span_danger("[src] makes a series of sad beeps. The internal charge only lasts about 30 minutes... what a feat of engineering!"))
+		audible_message(span_danger("[src] makes a series of sad beeps. The internal charge only lasts about 60 minutes... what a feat of engineering!"))
 		investigate_log("Delam SCRAM signal was received but failed precondition check. (Round time or trigger reason)", INVESTIGATE_ATMOS)
 		return FALSE
 
@@ -328,9 +328,9 @@
 	COOLDOWN_START(src, scram_button, 15 SECONDS)
 
 	// For roundstart only, after that it's on you!
-	if(world.time - SSticker.round_start_time > 30 MINUTES)
+	if(world.time - SSticker.round_start_time > 60 MINUTES)
 		playsound(src.loc, 'sound/machines/compiler/compiler-failure.ogg', 50, FALSE, BUTTON_SOUND_RANGE, falloff_distance = BUTTON_SOUND_FALLOFF_DISTANCE)
-		audible_message(span_danger("[src] makes a series of sad beeps. The internal charge only lasts about 30 minutes... what a feat of engineering! Looks like it's all on you to save the day."))
+		audible_message(span_danger("[src] makes a series of sad beeps. The internal charge only lasts about 60 minutes... what a feat of engineering! Looks like it's all on you to save the day."))
 		burn_out()
 		return
 


### PR DESCRIPTION


## About The Pull Request
sample run of how much it being around an hour helps compared to only the very-start of the round




# donut merge unles maintainer says is OK
(i'll make the changelog more serious when a good time is figured out, it's like a safety net against this being merged)
:cl:
qol: made the sm less of the dangerous, by the scram machine do the much less explode in more time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
