### PR TITLE
Makes colossus and the icemoon megafauna not dust

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -200,23 +200,25 @@
 /obj/projectile/colossus/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()
 	if(isliving(target))
-	/* // NOVA EDIT REMOVAL START - Replaced with calling devour, below this commented code
+		/* // NOVA EDIT REMOVAL START - Replaced with calling devour, below this commented code
 		var/mob/living/dust_mob = target
 		if(dust_mob.stat == DEAD)
 			dust_mob.investigate_log("has been dusted by a death bolt (colossus).", INVESTIGATE_DEATHS)
 			dust_mob.dust()
 		return
-	*/ // NOVA EDIT REMOVAL END
-	// NOVA EDIT ADDITION START - Colossus and icemoon megafauna devour instead of dusting
+		*/ // NOVA EDIT REMOVAL END
+		// NOVA EDIT ADDITION START - Colossus and icemoon megafauna devour instead of dusting
 		var/mob/living/dead_mob = target
-		if(dead_mob.stat == DEAD)
-			if(dead_mob.has_status_effect(/datum/status_effect/gutted))
-				return BULLET_ACT_FORCE_PIERCE
-			if(ismegafauna(firer))
-				var/mob/living/simple_animal/hostile/megafauna/megafauna = firer
-				megafauna.devour(target)
-				return
-	// NOVA EDIT ADDITION END
+		if(dead_mob.stat != DEAD)
+			return
+		if(dead_mob.has_status_effect(/datum/status_effect/gutted))
+			return BULLET_ACT_FORCE_PIERCE
+		if(ismegafauna(firer))
+			var/mob/living/simple_animal/hostile/megafauna/megafauna = firer
+			megafauna.devour(target)
+			return
+		return
+		// NOVA EDIT ADDITION END
 	if(!explode_hit_objects || istype(target, /obj/vehicle/sealed))
 		return
 	if(isturf(target) || isobj(target))


### PR DESCRIPTION

## About The Pull Request
Title

The bolts will proc devour from the megafauna if it was fired from one, they will also pass through devoured people
## How This Contributes To The Nova Sector Roleplay Experience
Less round removals
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  

https://github.com/user-attachments/assets/f3e7ccbd-bb88-4eb0-86b0-207601aa5638


https://github.com/user-attachments/assets/fdbd691e-4ed7-4ec2-9581-02d1329361e0


</details>

## Changelog
:cl:
balance: Colossus, Wendigo, and demonic-frost miner no longer dust people
/:cl:
