### PR TITLE
a very indepth and complicated PR that helps you understand the intricasies of the universe, time, space, reality, and your inner-self. The secret to world peace is a shrimp, on a plate, who has not ever once, fried that rice. 

### DIFF
--- a/modular_nova/modules/contractor/code/items/modsuit/modules.dm
+++ b/modular_nova/modules/contractor/code/items/modsuit/modules.dm
@@ -13,7 +13,6 @@
 	incompatible_modules = list(/obj/item/mod/module/baton_holster)
 	cooldown_time = 0.5 SECONDS
 	allow_flags = MODULE_ALLOW_INACTIVE
-	required_slots = list(ITEM_SLOT_GLOVES)
 	/// Have they sacrificed a baton to actually be able to use this?
 	var/eaten_baton = FALSE
 


### PR DESCRIPTION

## About The Pull Request

Lets contractors flick out their baton, without needing the gloves out

## How This Contributes To The Nova Sector Roleplay Experience
it removes it being kinda lowkey if they need to have the suit ready to go, and to flick the baton out

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  l8r
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: contractors can use their baton again, without needing the modsuit gloves
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
