### PR TITLE
reverts the ID default age to the tg-standard (30)

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -92,7 +92,7 @@
 	var/holopay_name = "holographic pay stand"
 
 	/// Registered owner's age.
-	var/registered_age = 18 //NOVA EDIT - ORIGINAL (13)
+	var/registered_age = 30
 
 	/// The job name registered on the card (for example: Assistant).
 	var/assignment


### PR DESCRIPTION

## About The Pull Request

tin

not player facing, it was changed a few years ago on TG and doesn't need to be how it was anymore, the reason really shows itself in what the default used to be