### PR TITLE
[QoL] Toggles (Most) Eating and Drinking sounds

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -472,7 +472,7 @@ Behavior that's still missing from this component that original food items had t
 		return FALSE
 	if(eater.satiety > -200)
 		eater.satiety -= junkiness
-	playsound(eater.loc,'sound/items/eatfood.ogg', rand(10,50), TRUE)
+	playsound_if_pref(eater.loc,'sound/items/eatfood.ogg', rand(10,50), TRUE, pref_to_check = /datum/preference/toggle/sound_eating) // NOVA EDIT Original: playsound(eater.loc,'sound/items/eatfood.ogg', rand(10,50), TRUE)
 	if(!owner.reagents.total_volume)
 		return
 	var/sig_return = SEND_SIGNAL(parent, COMSIG_FOOD_EATEN, eater, feeder, bitecount, bite_consumption)

--- a/code/datums/elements/basic_eating.dm
+++ b/code/datums/elements/basic_eating.dm
@@ -94,9 +94,9 @@
 /datum/element/basic_eating/proc/finish_eating(mob/living/eater, atom/target, mob/living/feeder)
 	set waitfor = FALSE
 	if(drinking)
-		playsound(eater.loc,'sound/items/drink.ogg', rand(10,50), TRUE)
+		playsound_if_pref(eater.loc,'sound/items/drink.ogg', rand(10,50), TRUE, pref_to_check = /datum/preference/toggle/sound_eating) // NOVA EDIT Original: playsound(eater.loc,'sound/items/drink.ogg', rand(10,50), TRUE)
 	else
-		playsound(eater.loc,'sound/items/eatfood.ogg', rand(10,50), TRUE)
+		playsound_if_pref(eater.loc,'sound/items/eatfood.ogg', rand(10,50), TRUE, pref_to_check = /datum/preference/toggle/sound_eating) // NOVA EDIT Original: playsound(eater.loc,'sound/items/eatfood.ogg', rand(10,50), TRUE)
 	var/atom/final_target = target
 	if(SEND_SIGNAL(eater, COMSIG_MOB_ATE, final_target, feeder) & COMSIG_MOB_TERMINATE_EAT)
 		return

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -93,7 +93,7 @@
 	var/fraction = min(gulp_size/reagents.total_volume, 1)
 	reagents.trans_to(target_mob, gulp_size, transferred_by = user, methods = reagent_consumption_method)
 	checkLiked(fraction, target_mob)
-	playsound(target_mob.loc, consumption_sound, rand(10,50), TRUE)
+	playsound_if_pref(target_mob.loc, consumption_sound, rand(10,50), TRUE, pref_to_check = /datum/preference/toggle/sound_eating) // NOVA EDIT Original: playsound(target_mob.loc, consumption_sound, rand(10,50), TRUE)
 	if(!iscarbon(target_mob))
 		return
 	var/mob/living/carbon/carbon_drinker = target_mob

--- a/modular_nova/master_files/code/modules/client/preferences/sounds.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/sounds.dm
@@ -1,0 +1,4 @@
+/datum/preference/toggle/sound_eating
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "sound_eating"
+	savefile_identifier = PREFERENCE_PLAYER

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6857,6 +6857,7 @@
 #include "modular_nova\master_files\code\modules\client\preferences\out_of_combat_fov_darkness.dm"
 #include "modular_nova\master_files\code\modules\client\preferences\scream.dm"
 #include "modular_nova\master_files\code\modules\client\preferences\sensitive_snout.dm"
+#include "modular_nova\master_files\code\modules\client\preferences\sounds.dm"
 #include "modular_nova\master_files\code\modules\client\preferences\tgui_prefs_migration.dm"
 #include "modular_nova\master_files\code\modules\client\preferences\underwear_color.dm"
 #include "modular_nova\master_files\code\modules\client\preferences\voice.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/nova/sounds.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/nova/sounds.tsx
@@ -1,0 +1,8 @@
+import { CheckboxInput, FeatureToggle } from '../../base';
+
+export const sound_eating: FeatureToggle = {
+  name: 'Enable eating and drinking sounds',
+  category: 'SOUND',
+  description: 'When enabled, hear eating and drinking sounds when appropriate.',
+  component: CheckboxInput,
+};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This attacks the 97% of the eating and drinking sounds, it doesnt fixes stuff like xenobio reproductives, unalive verbs and other small variations that use the same sound, is just for when you as a basic mob or human try to eat or drink something,  so you dont get the slurp from yourself or others. It's a toggle thats saves per player, as other sound toggles

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Well, sometimes the over the top sounds of drinking and eating can be completly disruptive to the experience, and sound so bad that they even seem caricaturesque. This allow each individual player to opt in or out of these sounds. 

Additionally, it allows people with Misophonia to suffer not the eating of others and to even play things other than robots and podpeople.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/f3af71d5-d8c7-4af0-8858-6933067bf111)

![image](https://github.com/user-attachments/assets/00e0f679-59dd-4ad5-8e01-f102fd32ab80)

I dont have the video thingie.

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Made a new config in the Game Preferences Sound Menu to toggle eating and drinking sounds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
