### PR TITLE
Turns the Food Replicator order into a flatpack; properly applies its inherent efficiency debuffs 

### DIFF
--- a/modular_nova/modules/company_imports/code/armament_datums/nri_military_surplus.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/nri_military_surplus.dm
@@ -98,7 +98,7 @@
 	description = "A widespread technology previously used by far colonies on the NRI's borders, over time being shifted from the foundation of colonies \
 	to a simple disaster relief solution. It can turn spoiled or inedible plant matter into food, medical supplies, and other general items. \
 	These particular units were displaced during a stock count in an NRI warehouse."
-	item_type = /obj/item/circuitboard/machine/biogenerator/food_replicator
+	item_type = /obj/item/flatpack/food_replicator
 	cost = CARGO_CRATE_VALUE * 9
 
 /datum/armament_entry/company_import/nri_surplus/misc/nri_flag

--- a/modular_nova/modules/food_replicator/code/replicator.dm
+++ b/modular_nova/modules/food_replicator/code/replicator.dm
@@ -10,8 +10,6 @@
 	from clothes to food to first-aid medical supplies."
 	icon = 'modular_nova/modules/food_replicator/icons/biogenerator.dmi'
 	circuit = /obj/item/circuitboard/machine/biogenerator/food_replicator
-	efficiency = 0.75
-	productivity = 0.75
 	show_categories = list(
 		RND_CATEGORY_NRI_FOOD,
 		RND_CATEGORY_NRI_MEDICAL,

--- a/modular_nova/modules/food_replicator/code/replicator.dm
+++ b/modular_nova/modules/food_replicator/code/replicator.dm
@@ -18,6 +18,15 @@
 		RND_CATEGORY_NRI_CLOTHING,
 	)
 
+/obj/machinery/biogenerator/food_replicator/RefreshParts()
+	. = ..()
+	efficiency *= 0.75
+	productivity *= 0.75
+
 /obj/item/circuitboard/machine/biogenerator/food_replicator
 	name = "Colonial Supply Core"
 	build_path = /obj/machinery/biogenerator/food_replicator
+
+/obj/item/flatpack/food_replicator
+	name = "colonial supply core"
+	board = /obj/item/circuitboard/machine/biogenerator/food_replicator


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Colonial Supply Core order is now a /tg/ flatpack.
Its inherent 25% debuffs to productivity and efficiency are now applied correctly and affect its... productivity, and efficiency, duh.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Having to completely build the thing from scratch is very tedious.
Fixes the bug that was never really addressed but was still a bug, as fun as it is to have a perfect machine that can produce infinite sutures.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Stalkeros
qol: The Colonial Supply Core now arrives as a /tg/ flatpack, no longer needing a shitload of resources to be deployed but only a multitool.
balance: The Colonial Supply Core's intended efficiency maluses are now properly applied.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
