### PR TITLE
adds two mr-2543 kits into the armory, that's about it.

### DIFF
--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/gunsets.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/gunsets.dm
@@ -40,6 +40,22 @@
 /obj/item/storage/toolbox/guncase/nova/carwo_large_case/sindano/evil
 	weapon_to_spawn = /obj/item/gun/ballistic/automatic/sol_smg/evil/no_mag
 
+// For the armory, generic-john-halo rifle.
+
+/obj/item/storage/toolbox/guncase/nova/carwo_large_case/sol_rifle
+	name = "\improper MR-2543 Rifle Kit"
+
+	weapon_to_spawn = /obj/item/gun/ballistic/automatic/sol_rifle/no_mag
+	extra_to_spawn = /obj/item/ammo_box/magazine/c40sol_rifle/starts_empty
+
+/obj/item/storage/toolbox/guncase/nova/carwo_large_case/sol_rifle/PopulateContents()
+	new weapon_to_spawn (src)
+
+	generate_items_inside(list(
+		/obj/item/ammo_box/c40sol = 3,
+		/obj/item/ammo_box/magazine/c40sol_rifle/starts_empty = 2,
+	), src)
+
 // Boxed grenade launcher, grenades sold seperately on this one
 
 /obj/item/storage/toolbox/guncase/nova/carwo_large_case/kiboko_magless

--- a/modular_nova/modules/sec_haul/code/guns/armory_spawns.dm
+++ b/modular_nova/modules/sec_haul/code/guns/armory_spawns.dm
@@ -89,9 +89,10 @@
 	)
 
 /obj/effect/spawner/armory_spawn/smg
-	vertical_guns = FALSE
+	vertical_guns = FALSE // Name slightly misleading, but i'd probably do more damage renaming it from SMG then letting it be.
 	guns = list(
 		/obj/item/storage/toolbox/guncase/nova/carwo_large_case/sindano,
 		/obj/item/storage/toolbox/guncase/nova/carwo_large_case/sindano,
-		/obj/item/storage/toolbox/guncase/nova/carwo_large_case/sindano,
+		/obj/item/storage/toolbox/guncase/nova/carwo_large_case/sol_rifle,
+		/obj/item/storage/toolbox/guncase/nova/carwo_large_case/sol_rifle,
 	)


### PR DESCRIPTION


## About The Pull Request

With the rifles getting redone, it leaves the armory a little lacking compared to what could possibly be around within the first 30 minutes, so sec gets the tiny-treat of two rifle kits added to their sindano pile, (and lose one sindano kit)

## How This Contributes To The Nova Sector Roleplay Experience
Sec should have atleast a few of these around to handle 'general threats' (janitors) that might have the same thing or better, without needing to always spend the budget or bounty grind.

## Proof of Testing (not done yet, i'll remove the pin on this grenade when I test it)

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Sec now starts off with two MR-2543 kits in their armory, with their third sindano being lost in a stock cycling method that's yet to be disclosed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
