### PR TITLE
snips the 'breast overlay' from the Enterprise Managment feline suit.

### DIFF
--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_clothing/latex_catsuit.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_clothing/latex_catsuit.dm
@@ -14,10 +14,9 @@
 	equip_sound = 'modular_nova/modules/modular_items/lewd_items/sounds/latex.ogg'
 	can_adjust = FALSE
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	strip_delay = 80
+	strip_delay = 10
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
-	var/mutable_appearance/breasts_overlay
-	var/mutable_appearance/breasts_icon_overlay
+
 
 //this fragment of code makes unequipping not instant
 /obj/item/clothing/under/misc/latex_catsuit/attack_hand(mob/user)
@@ -32,7 +31,6 @@
 /obj/item/clothing/under/misc/latex_catsuit/equipped(mob/living/affected_mob, slot)
 	. = ..()
 	var/mob/living/carbon/human/affected_human = affected_mob
-	var/obj/item/organ/genital/breasts/affected_breasts = affected_human.get_organ_slot(ORGAN_SLOT_BREASTS)
 	if(src == affected_human.w_uniform)
 		if(affected_mob.gender == FEMALE)
 			icon_state = "latex_catsuit_female"
@@ -41,45 +39,13 @@
 
 		affected_mob.update_worn_undersuit()
 
-	breasts_overlay = mutable_appearance('modular_nova/modules/modular_items/lewd_items/icons/mob/lewd_clothing/lewd_uniform/lewd_uniform.dmi', "none")
-	update_overlays()
-
-	//Breasts overlay for catsuit
-	if(affected_breasts?.genital_size >= 6 || affected_breasts?.genital_type == "pair")
-		breasts_overlay.icon_state = "breasts_double"
-		breasts_icon_overlay.icon_state = "iconbreasts_double"
-		accessory_overlay = breasts_overlay
-		add_overlay(breasts_icon_overlay)
-		update_overlays()
-	if(affected_breasts?.genital_type == "quad")
-		breasts_overlay.icon_state = "breasts_quad"
-		breasts_icon_overlay.icon_state = "iconbreasts_quad"
-		accessory_overlay = breasts_overlay
-		add_overlay(breasts_icon_overlay)
-		update_overlays()
-	if(affected_breasts?.genital_type == "sextuple")
-		breasts_overlay.icon_state = "breasts_sextuple"
-		breasts_icon_overlay.icon_state = "iconbreasts_sextuple"
-		accessory_overlay = breasts_overlay
-		add_overlay(breasts_icon_overlay)
-		update_overlays()
-
-	affected_human.regenerate_icons()
 
 /obj/item/clothing/under/misc/latex_catsuit/dropped(mob/living/affected_mob)
 	. = ..()
 	accessory_overlay = null
-	breasts_overlay.icon_state = "none"
-	cut_overlay(breasts_icon_overlay)
-	breasts_icon_overlay.icon_state = "none"
+
 
 //Plug to bypass the bug with instant suit equip/drop
 /obj/item/clothing/under/misc/latex_catsuit/mouse_drop_dragged(atom/over, mob/user, src_location, over_location, params)
 	return
 
-/obj/item/clothing/under/misc/latex_catsuit/Initialize(mapload)
-	. = ..()
-	breasts_overlay = mutable_appearance('modular_nova/modules/modular_items/lewd_items/icons/mob/lewd_clothing/lewd_uniform/lewd_uniform.dmi', "none", ABOVE_MOB_LAYER)
-	breasts_overlay.icon_state = ORGAN_SLOT_BREASTS
-	breasts_icon_overlay = mutable_appearance('modular_nova/modules/modular_items/lewd_items/icons/obj/lewd_clothing/lewd_uniform.dmi', "none")
-	breasts_icon_overlay.icon_state = ORGAN_SLOT_BREASTS


### PR DESCRIPTION


## About The Pull Request

Tin, it added un-needed complexity to the item, and when I started respriting all-these-things I saw it and got IRL stunlocked by both how terrible it would look with absolutely anything in your suit slot, and the age of question of 'it's also one size of breast, so why is this even here (ecup, I think)

## How This Contributes To The Nova Sector Roleplay Experience

This shit be both strange, and unusual

## Proof of Testing (soon-tm)

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Removes the one-size-fits-all chestical sprite from the suit made of rubber, also drastically lowers it's strip-time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
