### PR TITLE
[Balance] Blocks NPC's and Explosions from removing fishing uniques. Adds regen to items that dont have it, adds skeleton keys to lavaland fish spots.

### DIFF
--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -360,8 +360,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 	if(HAS_TRAIT(rod, TRAIT_ROD_REMOVE_FISHING_DUD))
 		final_table -= FISHING_DUD
 
-
-	if(HAS_TRAIT(fisherman, TRAIT_PROFOUND_FISHER) && !fisherman.client)
+	if(!fisherman.client) // NOVA EDIT CHANGE - Original: if(HAS_TRAIT(fisherman, TRAIT_PROFOUND_FISHER) && !fisherman.client)
 		final_table -= profound_fisher_blacklist
 	for(var/result in final_table)
 		final_table[result] *= rod.hook.get_hook_bonus_multiplicative(result)

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -334,6 +334,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 	//and it would suck if the pool of bottle messages were constantly being emptied by explosive fishing.
 	if(from_explosion)
 		table -= /obj/effect/spawner/message_in_a_bottle
+		table -= fish_counts // NOVA EDIT ADDITION - avoids explosions to get rare stuff. Fish for it!
 	for(var/result in table)
 		if(!isnull(fish_counts[result]) && fish_counts[result] <= 0)
 			table -= result
@@ -362,6 +363,8 @@ GLOBAL_LIST_INIT(specific_fish_icons, generate_specific_fish_icons())
 
 	if(!fisherman.client) // NOVA EDIT CHANGE - Original: if(HAS_TRAIT(fisherman, TRAIT_PROFOUND_FISHER) && !fisherman.client)
 		final_table -= profound_fisher_blacklist
+		final_table -= fish_counts // NOVA EDIT ADDITION - avoids npc's to get rare stuff. Fish for it!
+		final_table -= /obj/effect/spawner/message_in_a_bottle // NOVA EDIT ADDITION - avoids npc's to get messages in a bottle. Fish for them!
 	for(var/result in final_table)
 		final_table[result] *= rod.hook.get_hook_bonus_multiplicative(result)
 		final_table[result] += rod.hook.get_hook_bonus_additive(result)//Decide on order here so it can be multiplicative

--- a/modular_nova/modules/fishing/code/_fish_source.dm
+++ b/modular_nova/modules/fishing/code/_fish_source.dm
@@ -1,0 +1,9 @@
+/datum/fish_source/New()
+	..()
+
+	if (!fish_count_regen)
+		fish_count_regen = list()
+
+	for(var/path in fish_counts)
+		if (!(path in fish_count_regen))
+			fish_count_regen[path] = 35 MINUTES

--- a/modular_nova/modules/fishing/code/_fish_source.dm
+++ b/modular_nova/modules/fishing/code/_fish_source.dm
@@ -6,4 +6,4 @@
 
 	for(var/path in fish_counts)
 		if (!(path in fish_count_regen))
-			fish_count_regen[path] = 35 MINUTES
+			fish_count_regen[path] = 30 MINUTES

--- a/modular_nova/modules/fishing/code/source_types.dm
+++ b/modular_nova/modules/fishing/code/source_types.dm
@@ -1,0 +1,25 @@
+/datum/fish_source/lavaland/New()
+	..()
+
+	fish_table[/obj/item/skeleton_key] = 1
+	fish_counts[/obj/item/skeleton_key] = 1
+	fish_count_regen[/obj/item/skeleton_key] = 13 MINUTES
+	fish_table[/obj/item/stack/sheet/mineral/abductor] = 1
+	fish_counts[/obj/item/stack/sheet/mineral/abductor] = 1
+	fish_count_regen[/obj/item/stack/sheet/mineral/abductor] = 20 MINUTES
+	fish_table[/obj/item/stack/sheet/mineral/runite] = 1
+	fish_counts[/obj/item/stack/sheet/mineral/runite] = 2
+	fish_count_regen[/obj/item/stack/sheet/mineral/runite] = 15 MINUTES
+
+/datum/fish_source/lavaland/icemoon/New()
+	..()
+
+	fish_table[/obj/structure/closet/crate/necropolis/tendril] = 1
+	fish_counts[/obj/structure/closet/crate/necropolis/tendril] = 1
+	fish_count_regen[/obj/structure/closet/crate/necropolis/tendril] = 30 MINUTES
+	fish_table[/obj/item/skeleton_key] = 1
+	fish_counts[/obj/item/skeleton_key] = 1
+	fish_count_regen[/obj/item/skeleton_key] = 15 MINUTES
+	fish_table[/obj/item/stack/sheet/mineral/abductor] = 1
+	fish_counts[/obj/item/stack/sheet/mineral/abductor] = 1
+	fish_count_regen[/obj/item/stack/sheet/mineral/abductor] = 20 MINUTES

--- a/modular_nova/modules/fishing/code/source_types.dm
+++ b/modular_nova/modules/fishing/code/source_types.dm
@@ -4,9 +4,6 @@
 	fish_table[/obj/item/skeleton_key] = 1
 	fish_counts[/obj/item/skeleton_key] = 1
 	fish_count_regen[/obj/item/skeleton_key] = 13 MINUTES
-	fish_table[/obj/item/stack/sheet/mineral/abductor] = 1
-	fish_counts[/obj/item/stack/sheet/mineral/abductor] = 1
-	fish_count_regen[/obj/item/stack/sheet/mineral/abductor] = 20 MINUTES
 	fish_table[/obj/item/stack/sheet/mineral/runite] = 1
 	fish_counts[/obj/item/stack/sheet/mineral/runite] = 2
 	fish_count_regen[/obj/item/stack/sheet/mineral/runite] = 15 MINUTES
@@ -20,6 +17,3 @@
 	fish_table[/obj/item/skeleton_key] = 1
 	fish_counts[/obj/item/skeleton_key] = 1
 	fish_count_regen[/obj/item/skeleton_key] = 15 MINUTES
-	fish_table[/obj/item/stack/sheet/mineral/abductor] = 1
-	fish_counts[/obj/item/stack/sheet/mineral/abductor] = 1
-	fish_count_regen[/obj/item/stack/sheet/mineral/abductor] = 20 MINUTES

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7877,6 +7877,8 @@
 #include "modular_nova\modules\faction\code\mapping\mapping_helpers.dm"
 #include "modular_nova\modules\faction\code\mapping\ruins.dm"
 #include "modular_nova\modules\fauna_reagent\fauna_reagent.dm"
+#include "modular_nova\modules\fishing\code\_fish_source.dm"
+#include "modular_nova\modules\fishing\code\source_types.dm"
 #include "modular_nova\modules\food_replicator\code\clothing.dm"
 #include "modular_nova\modules\food_replicator\code\medical.dm"
 #include "modular_nova\modules\food_replicator\code\rationpacks.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This fixes a TG bug where the NPC's dependending on having a trait to be screened for a blacklist, but the system never detects the trait. Instead we just check if its an npc and apply the blacklist.

This also furthers both the npc and explosion fishing methods, so they dont remove message bottles or unique items, the idea is for people to fish for those, plus, explosive or npc automation fishing is already a big enough reward, given you can sell stuff for a lot using quantity.

All this ensuring allows me to add something specific for our codebase and playtimes, as we can ensure the special stuff is gotten only by players fishing, which is a check to see if an item has a regen time, if it doesnt, add one with 30 minutes on it, , as a way to ensure not only round starters get the fishing stuff.

Finally, I equalized the tribal roles fishing a bit, I made it so Plasma lakes get tendril chests, and Lava lakes get Runite. I additionally made it so Skeleton keys can be obtained via fishing in these two, as otherwise only miners or ashwalkers (via ritual) could get one. 

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

The first two is a matter of making sure an active reward is gotten by an active player, using ways like explosion and npc fishing is good for the basic reward on a massive scale, which I believe its a reward enough to figure these two ways of passive fishing.

The regen count on 30 minutes for anything not contemplated by tg is simply to future proof stuff and ensure not only people at roundstart or the fastest reaps fishing benefits,  which was a little sad, and our rounds are 3 hours long, not 40 minutes, so, a needed change.

Finally, the runite for lavaland is mostly to be fair and give ashwalkers something, while they can get runite if a particular ruin appear, I though it was better for the entire ecosystem to have a way to get it consistently in both flavours of mining. The introduction of chests in the Ice maps ecosystem is significant, as it gives them a rewneable source of artifacts, if practically speaking it means that at most they will get 5 chests with a dedicated fisher per round, but thats still significant. I also added skeleton keys to fishing for this purpose, as otherwise you end up with an inusable chest that only drops wood on destruction. 


## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

before:

![image](https://github.com/user-attachments/assets/33ba112f-b7a0-4c8f-a8d5-c96284f8c19c)

after:

![image](https://github.com/user-attachments/assets/eb9edbd8-10f7-4ced-98d6-2aa509bf0639)
 
![image](https://github.com/user-attachments/assets/1c779cec-3f1f-4624-bdbf-2c531dea6921)

![image](https://github.com/user-attachments/assets/bda39abb-471d-4dfa-b11c-0ff5297c5ed0)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: To future proof and due to our long rounds, all limited fishing items regenerate after 30 minutes if they dont have a regeneration time.
add: Skeleton keys, Tendril chests, Runite can be found in Lava and Plasma lakes now, although they are rare! Tribals Rejoice!
balance: Explosions and NPC's no longer nets you uniques from fishing... Fish if you want them!
fix: NPC's now actually follow their blacklist (no more lobstrocities spawning more lobstrocities)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
