### PR TITLE
sets this back to 0.5

### DIFF
--- a/modular_nova/modules/oversized/code/oversized_quirk.dm
+++ b/modular_nova/modules/oversized/code/oversized_quirk.dm
@@ -1,4 +1,4 @@
-#define OVERSIZED_SPEED_SLOWDOWN 0.9
+#define OVERSIZED_SPEED_SLOWDOWN 0.5
 #define OVERSIZED_HUNGER_MOD 1.5
 
 // Before making any changes to oversized, please see the module's readme.md file


### PR DESCRIPTION


## About The Pull Request
I presumed this was like every slowdown for 0.5 was making then 2x faster then a normal crewman, as it turns out, i have no clue what this is or was doing, so it's just getting reset to what it was


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: oversized is reset to it's original speed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
