### PR TITLE
[Feature] Allows to make Material Fishing Rods in the workbench

### DIFF
--- a/modular_nova/modules/reagent_forging/code/crafting_bench.dm
+++ b/modular_nova/modules/reagent_forging/code/crafting_bench.dm
@@ -41,6 +41,7 @@
 		/datum/crafting_bench_recipe/soup_pot,
 		/datum/crafting_bench_recipe/bokken,
 		/datum/crafting_bench_recipe/bow,
+		/datum/crafting_bench_recipe/fishing_rod,
 	)
 	/// Radial options for recipes in the allowed_choices list, populated by populate_radial_choice_list
 	var/list/radial_choice_list = list()

--- a/modular_nova/modules/reagent_forging/code/crafting_bench_recipes.dm
+++ b/modular_nova/modules/reagent_forging/code/crafting_bench_recipes.dm
@@ -148,3 +148,11 @@
 	)
 	resulting_item = /obj/item/forging/incomplete_bow
 	required_good_hits = 8
+
+/datum/crafting_bench_recipe/fishing_rod
+	recipe_name = "fishing rod"
+	recipe_requirements = list(
+		/obj/item/forging/complete/staff = 1,
+	)
+	resulting_item = /obj/item/fishing_rod/material
+	required_good_hits = 8


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds the recipe of Material Fishing Rods to the primitive Workbench.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

It allows the making of special material rods to be made in the workbench, at the cost of having to make an incomplete staff. This costs time, the forge insfrastructure and 1 sheet of material. Compared to the autolathe which has it cost between 0.6 and 0.4 of a sheet, and its almost instant. It allows for more variety while keeping itself balanced to the fact that the station can already do it with more ease and more efficiency.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/404071e7-8f23-44c5-b670-f3bbac4771c6)

![image](https://github.com/user-attachments/assets/223f7f33-8013-4309-98b1-5bd497d90924)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Allows Material fishing rods be made on the forge.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
