### PR TITLE
adds crusher retool kits to loadout

### DIFF
--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_pocket.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_pocket.dm
@@ -343,6 +343,24 @@
 	name = "Amber Perfume"
 	item_path = /obj/item/perfume/amber
 
+/*
+JOB SPECIFIC MISCELLANY
+*/
+
+/datum/loadout_item/pocket_items/crusher_sword_kit
+	name = "Crusher Sword Retool Kit"
+	item_path = /obj/item/crusher_trophy/retool_kit
+	restricted_roles = list(JOB_SHAFT_MINER) //needs to be in a list or causes tgui errors, tgui continues to amaze
+
+/datum/loadout_item/pocket_items/crusher_harpoon_kit
+	name = "Crusher Harpoon Retool Kit"
+	item_path = /obj/item/crusher_trophy/retool_kit/harpoon
+	restricted_roles = list(JOB_SHAFT_MINER)
+
+/datum/loadout_item/pocket_items/crusher_dagger_kit
+	name = "Crusher Dagger Retool Kit"
+	item_path = /obj/item/crusher_trophy/retool_kit/dagger
+	restricted_roles = list(JOB_SHAFT_MINER)
 
 /*
 *	DONATOR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the crusher retool kits to loadout, restricted by job.

The PKA adjustable bolt modkits will *not* be added, as they have a practical use with the style meter attachment - Unless a maintainer overrides this decision

## How This Contributes To The Nova Sector Roleplay Experience

Allows miners to have their favourite fluff crushers from roundstart, always a fun talking point if somehow the miner can't get points immediately to pay for the 97 point retool.

## Proof of Testing
Not really much to put here, but, go hog wild staring at the loadout screen I suppose.
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/a935d7f9-4737-4505-b3fd-b38d4d1828f0)

And a lil' proof you can't get it as a non-shaft miner.

![image](https://github.com/user-attachments/assets/b441ad69-050b-48d4-b5af-c10e2d2981e0)

  
</details>

## Changelog


:cl:
add: Adds crusher retool kits to loadout
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
