### PR TITLE
[QoL] Chipped and Chip Connector no longer cause brain damage / remove your brain.

### DIFF
--- a/code/datums/quirks/positive_quirks/chipped.dm
+++ b/code/datums/quirks/positive_quirks/chipped.dm
@@ -46,9 +46,11 @@
 
 /datum/quirk/chipped/proc/apply_effect(datum/source, obj/item/brain_applied)
 	SIGNAL_HANDLER
+	/* NOVA EDIT REMOVAL - we disable the itchy status effect so people dont get brain damage from a positive quirk.
 	var/mob/living/carbon/quirk_holder_carbon = quirk_holder
 	if(brain_applied == quirk_holder_carbon.get_organ_slot(ORGAN_SLOT_BRAIN))
 		itchy_effect = quirk_holder.apply_status_effect(/datum/status_effect/itchy_skillchip_quirk)
+	*/
 
 /datum/quirk/chipped/proc/remove_effect(datum/source, obj/item/brain_removed)
 	SIGNAL_HANDLER

--- a/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
@@ -254,6 +254,7 @@
 	addtimer(CALLBACK(src, PROC_REF(reboot)), 90 / severity)
 
 /obj/item/organ/cyberimp/brain/connector/proc/remove_brain(obj/item/organ/brain/chippy_brain, severity = 1)
+	/* NOVA EDIT REMOVAL - blocks the brain damage and brain removal from the positive quirk.
 	playsound(owner, 'sound/effects/meatslap.ogg', 25, TRUE)
 	if(!chippy_brain)
 		return
@@ -265,6 +266,7 @@
 		return chippy_brain
 
 	new /obj/effect/decal/cleanable/blood/gibs/up(get_turf(owner))
+	*/
 	return FALSE
 
 /obj/item/organ/cyberimp/brain/connector/proc/reboot()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Nullified the Remove_Brain() proc from  Chip Connector, Nullified the application of the Itchy brain status effect for chipped, noticed that the chips dont fall on EMP, when activating chip connector, but thats an upstream issue. 

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

In TG for 40 minutes roundsd it doesnt matter much if you get a bit of brain damage, maybe you get one manitol pil and thats it, here that brain damage thats constantly being applied its a death sentence, pilling on brain traumas upon traumas, plus it doesnt really make sense on why anyone would get a quirk that lets you get debrained on EMP or give you constant brain damage if you already have the machine in any library for it. A positive quirk should be convenient, or at least give you an important advantage in return (like settler with reduced 80% slowdown in exchange for a flat 0.2 slowdown).

It really doesnt make sense for our server culture, its funny on tg, but I dont see it of use here.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/62790bef-30e0-4810-acda-10f85c62a687)

![image](https://github.com/user-attachments/assets/82fd46fe-0455-43a8-aa41-137998345b95)

added/removed quirk via admin, no issues:

![image](https://github.com/user-attachments/assets/13d0d421-6544-4600-8fcc-6bab8dd4d666)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Chipped no longer gives you random Brain Damage. Chip Connector no longer REMOVES YOUR BRAIN upon EMP. How these things passed down the R&D phase is beyond us.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
