### PR TITLE
Patch AI Uplink Brain to work with self-actualizator + add it to Advanced AI Upgrades

### DIFF
--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -1135,12 +1135,39 @@
 
 /obj/item/organ/brain/cybernetic/ai
 	name = "AI-uplink brain"
-	desc = "Can be inserted into a body with NO ORGANIC INTERNAL ORGANS (robotic organs only) to allow AIs to control it. Comes with its own health sensors beacon. MUST be a humanoid or bad things happen to the consciousness."
+	desc = "Can be inserted into a body with NO ORGANIC INTERNAL ORGANS (robotic organs only) to allow AIs to control it. Comes with its own health sensors beacon. MUST be a humanoid or bad things happen to the consciousness. \
+		P.S. Extenral organs such as tails, snouts, etc still work fine."
 	can_smoothen_out = FALSE
 	/// if connected, our AI
 	var/mob/living/silicon/ai/mainframe
 	/// action for undeployment
 	var/datum/action/innate/brain_undeployment/undeployment_action = new
+	/// Nova addition. Slots to ignore in check for organic organs. Used to bypass things that do not have ORGAN_EXTERNAL flag, since
+	/// not all of actual external organs have it. Better to double check in case someone messes up with flags or something.
+	var/list/ignored_organ_slots = list(
+		ORGAN_SLOT_EXTERNAL_CAP,
+		ORGAN_SLOT_EXTERNAL_FLUFF,
+		ORGAN_SLOT_EXTERNAL_FRILLS,
+		ORGAN_SLOT_EXTERNAL_HEAD_ACCESSORY,
+		ORGAN_SLOT_EXTERNAL_HORNS,
+		ORGAN_SLOT_EXTERNAL_MOTH_MARKINGS,
+		ORGAN_SLOT_EXTERNAL_NECK_ACCESSORY,
+		ORGAN_SLOT_EXTERNAL_POD_HAIR,
+		ORGAN_SLOT_EXTERNAL_SKRELL_HAIR,
+		ORGAN_SLOT_EXTERNAL_SYNTH_ANTENNA,
+		ORGAN_SLOT_EXTERNAL_SYNTH_SCREEN,
+		ORGAN_SLOT_EXTERNAL_TAUR,
+		ORGAN_SLOT_EXTERNAL_XENODORSAL,
+		ORGAN_SLOT_EXTERNAL_XENOHEAD,
+		ORGAN_SLOT_EXTERNAL_TAIL,
+		ORGAN_SLOT_EXTERNAL_SPINES,
+		ORGAN_SLOT_EXTERNAL_SNOUT,
+		ORGAN_SLOT_EXTERNAL_FRILLS,
+		ORGAN_SLOT_EXTERNAL_HORNS,
+		ORGAN_SLOT_EXTERNAL_WINGS,
+		ORGAN_SLOT_EXTERNAL_ANTENNAE,
+		ORGAN_SLOT_EXTERNAL_POD_HAIR,
+	)
 
 /obj/item/organ/brain/cybernetic/ai/Initialize(mapload)
 	. = ..()
@@ -1271,6 +1298,12 @@
 	for(var/obj/item/organ/organ as anything in carb_owner.organs)
 		if(organ.organ_flags & ORGAN_EXTERNAL)
 			continue
+		/// NOVA ADDITION START
+		// Probably best way to deal with furry bodyparts, since a lot of them аren't robotic, but still present in synths
+		// Yeah, there's a check three lines upper, but it doesnt work all the time, since not all of external organs actually have ORGAN_EXTERNAL
+		if(organ.slot in ignored_organ_slots)
+			continue
+		/// NOVA ADDITION END
 		if(!IS_ROBOTIC_ORGAN(organ) && !istype(organ, /obj/item/organ/tongue)) //tongues are not in the exosuit fab and nobody is going to bother to find them so
 			return FALSE
 

--- a/code/modules/research/techweb/nodes/robo_nodes.dm
+++ b/code/modules/research/techweb/nodes/robo_nodes.dm
@@ -95,7 +95,8 @@
 		"freeformcore_module",
 		"onehuman_module",
 		"purge_module",
-		"ai_power_upgrade"
+		"ai_power_upgrade",
+		"ai_uplink_brain" // Nova addition
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_3_POINTS)
 	announce_channels = list(RADIO_CHANNEL_SCIENCE, RADIO_CHANNEL_COMMAND)

--- a/modular_nova/modules/ai_uplink_upload/design.dm
+++ b/modular_nova/modules/ai_uplink_upload/design.dm
@@ -1,0 +1,11 @@
+/datum/design/ai_uplink_upload
+	name = "AI Uplink Brain"
+	desc = "A synthetic brain with capability to let AI control bodies directly."
+	id = "ai_uplink_brain"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron =SHEET_MATERIAL_AMOUNT * 2.5, /datum/material/glass =SHEET_MATERIAL_AMOUNT * 2.5)
+	build_path = /obj/item/organ/brain/cybernetic/ai
+	category = list(
+		RND_CATEGORY_AI + RND_SUBCATEGORY_AI_UPGRADES
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE

--- a/modular_nova/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_nova/modules/self_actualization_device/code/self_actualization_device.dm
@@ -213,8 +213,22 @@
 	var/mob/living/carbon/human/patient = occupant
 	var/original_name = patient.dna.real_name
 
-	patient.client?.prefs?.safe_transfer_prefs_to_with_damage(patient)
+	// Check for AI-brain upload. If it was the brain before, then we should replace "new me"s brain with cybernetic one.
+	var/obj/item/organ/brain/cybernetic/ai/old_ai_brain = patient.get_organ_by_type(/obj/item/organ/brain/cybernetic/ai)
+	var/mob/living/silicon/ai/real_ai_player
+	if(old_ai_brain)
+		real_ai_player = old_ai_brain.mainframe
+		old_ai_brain.undeploy()
+		real_ai_player.client?.prefs?.safe_transfer_prefs_to_with_damage(patient)
+	else
+		patient.client?.prefs?.safe_transfer_prefs_to_with_damage(patient)
+
 	patient.dna.update_dna_identity()
+
+	if(old_ai_brain)
+		var/obj/item/organ/brain/cybernetic/ai/new_ai_brain = new
+		new_ai_brain.Insert(patient, movement_flags = DELETE_IF_REPLACED)
+
 	log_game("[key_name(patient)] used a Self-Actualization Device at [loc_name(src)].")
 
 	if(patient.dna.real_name != original_name)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7174,6 +7174,7 @@
 #include "modular_nova\modules\aesthetics\walls\code\walls.dm"
 #include "modular_nova\modules\aesthetics\washing_machine\code\washing_machine.dm"
 #include "modular_nova\modules\aesthetics\windows\code\windows.dm"
+#include "modular_nova\modules\ai_uplink_upload\design.dm"
 #include "modular_nova\modules\airlock_override\code\airlock_override.dm"
 #include "modular_nova\modules\akula\code\wetsuit.dm"
 #include "modular_nova\modules\alcohol_processing\code\alcohol_processing.dm"


### PR DESCRIPTION
## About The Pull Request

So, recently I've discovered, that we have brain type, that allows AI to take control of synthetic humanoids (with no organic organs), but it has some problems:
1. It doesn't work properly with "furry" organs, considering them organic, since not all organs have ORGAN_EXTERNAL for some reason(and synths can choose them in character creation menu);
2. It doesn't work with a self-actualization machine, since it resets organs, deleting AI-Uplink;
3. It is IceboxStation ruin reward, which locks AI-Uplink behind mining, map and random generation.

This PR fixed first two points and adds AI-Uplink Brain to Advanced AI Upgrades tech node to make it more available.
However, this leaves Icebox ruin with pretty much no unique reward. Currently I don't really know what to do with it and left it as it is.

Now, AI can enter bodies with tails,snouts,fluffs,caps,etc without much trouble and use self-actualization machine to transform blank body to their character.

!!! **IMPORTANT NOTE: to work properly AI has to select synth with no organic organs in character preferences(augments+), otherwise it will not let you back into the body.** !!!

Implantation note: body must have no positronic brain. AI-Uplink installs only in the head.

## How This Contributes To The Nova Sector Roleplay Experience

AI-Uplink is a cool feature and making it more available, while allowing AI to actually use their character prefs gives both mechanical (AI with hands!!!) and RP options.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/d2648817-47d8-455a-b652-40726c3da07d)
![image](https://github.com/user-attachments/assets/1d8d50f5-a274-4510-bdb7-e692568f1d40)
![image](https://github.com/user-attachments/assets/efa1089f-f98f-4eb0-8583-348bc42a17c5)
![image](https://github.com/user-attachments/assets/7c265a90-98ae-4309-ad0e-4a1f7b1ab0a8)
![image](https://github.com/user-attachments/assets/9f34cc21-26fd-4f65-9f84-6b5a198198d6)
![image](https://github.com/user-attachments/assets/ae8b94b0-7b70-41fe-bc0e-0d606b3cc2bb)

</details>

## Changelog


:cl: SuperDrish
add: AI Uplink Brain is now available at your local RnD
fix: AI Uplink Brain now works properly with self-actualizator
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
