### PR TITLE
sloppy port of subtler sound, and it's prefs

### DIFF
--- a/modular_nova/modules/verbs/code/subtle.dm
+++ b/modular_nova/modules/verbs/code/subtle.dm
@@ -141,12 +141,14 @@
 		var/obj/effect/overlay/holo_pad_hologram/hologram = GLOB.hologram_impersonators[user]
 		if((get_dist(user.loc, target_mob.loc) <= subtler_range) || (hologram && get_dist(hologram.loc, target_mob.loc) <= subtler_range))
 			target_mob.show_message(subtler_message, alt_msg = subtler_message)
+			target_mob.playsound_local(get_turf(target_mob), 'sound/effects/glockenspiel_ping.ogg', 50)
 		else
 			to_chat(user, span_warning("Your emote was unable to be sent to your target: Too far away."))
 	else if(istype(target, /obj/effect/overlay/holo_pad_hologram))
 		var/obj/effect/overlay/holo_pad_hologram/hologram = target
 		if(hologram.Impersonation?.client)
 			hologram.Impersonation.show_message(subtler_message, alt_msg = subtler_message)
+			hologram.Impersonation.playsound_local(get_turf(hologram.Impersonation), 'sound/effects/glockenspiel_ping.ogg', 50)
 	else
 		var/ghostless = get_hearers_in_view(target, user) - GLOB.dead_mob_list
 
@@ -160,6 +162,7 @@
 
 		for(var/mob/receiver in ghostless)
 			receiver.show_message(subtler_message, alt_msg = subtler_message)
+			reciever.playsound_local(get_turf(reciever), 'sound/effects/glockenspiel_ping.ogg', 50)
 
 	return TRUE
 

--- a/modular_nova/modules/verbs/code/subtle.dm
+++ b/modular_nova/modules/verbs/code/subtle.dm
@@ -141,14 +141,18 @@
 		var/obj/effect/overlay/holo_pad_hologram/hologram = GLOB.hologram_impersonators[user]
 		if((get_dist(user.loc, target_mob.loc) <= subtler_range) || (hologram && get_dist(hologram.loc, target_mob.loc) <= subtler_range))
 			target_mob.show_message(subtler_message, alt_msg = subtler_message)
-			target_mob.playsound_local(get_turf(target_mob), 'sound/effects/glockenspiel_ping.ogg', 50)
+			var/datum/preferences/prefs = target_mob.client?.prefs
+			if(prefs && prefs.read_preference(/datum/preference/toggle/subtler_sound))
+				target_mob.playsound_local(get_turf(target_mob), 'sound/effects/glockenspiel_ping.ogg', 50)
 		else
 			to_chat(user, span_warning("Your emote was unable to be sent to your target: Too far away."))
 	else if(istype(target, /obj/effect/overlay/holo_pad_hologram))
 		var/obj/effect/overlay/holo_pad_hologram/hologram = target
 		if(hologram.Impersonation?.client)
 			hologram.Impersonation.show_message(subtler_message, alt_msg = subtler_message)
-			hologram.Impersonation.playsound_local(get_turf(hologram.Impersonation), 'sound/effects/glockenspiel_ping.ogg', 50)
+			var/datum/preferences/prefs = hologram.Impersonation.client?.prefs
+			if(prefs && prefs.read_preference(/datum/preference/toggle/subtler_sound))
+				hologram.Impersonation.playsound_local(get_turf(hologram.Impersonation), 'sound/effects/glockenspiel_ping.ogg', 50)
 	else
 		var/ghostless = get_hearers_in_view(target, user) - GLOB.dead_mob_list
 
@@ -162,7 +166,9 @@
 
 		for(var/mob/receiver in ghostless)
 			receiver.show_message(subtler_message, alt_msg = subtler_message)
-			reciever.playsound_local(get_turf(reciever), 'sound/effects/glockenspiel_ping.ogg', 50)
+			var/datum/preferences/prefs = reciever.client?.prefs
+			if(prefs && prefs.read_preference(/datum/preference/toggle/subtler_sound))
+				reciever.playsound_local(get_turf(reciever), 'sound/effects/glockenspiel_ping.ogg', 50)
 
 	return TRUE
 

--- a/modular_nova/modules/verbs/code/subtle.dm
+++ b/modular_nova/modules/verbs/code/subtle.dm
@@ -11,6 +11,15 @@
 	message = null
 	mob_type_blacklist_typecache = list(/mob/living/brain)
 
+/datum/config_entry/flag/play_subtler_sound
+	default = TRUE
+
+/datum/preference/toggle/subtler_sound
+	savefile_key = "subtler_sound"
+	savefile_identifier = PREFERENCE_PLAYER
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	default_value = TRUE
+
 /datum/emote/living/subtle/run_emote(mob/user, params, type_override = null)
 	if(!can_run_emote(user))
 		to_chat(user, span_warning("You can't emote at this time."))

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/nova/erp_preferences.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/nova/erp_preferences.tsx
@@ -23,6 +23,13 @@ export const erp_sounds_pref: FeatureToggle = {
   component: CheckboxInput,
 };
 
+export const subtler_sound: FeatureToggle = {
+  name: 'Toggle Subtler Sound',
+  category: 'SOUND',
+  description: 'Toggles whether you hear subtler emote sound effects',
+  component: CheckboxInput,
+};
+
 export const bimbofication_pref: FeatureToggle = {
   name: 'Bimbofication',
   category: 'ERP',


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
see these two for ex: 
https://github.com/Bubberstation/Bubberstation/pull/752
https://github.com/Bubberstation/Bubberstation/pull/881

## How This Contributes To The Nova Sector Roleplay Experience
idk it probably doesn't

## Proof of Testing   will-do (it touches prefs this is very important)

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: subtler makes a sound, that you can also turn off
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
