### PR TITLE
2 line change, nerfs the wound-chance of .40 long-sol

### DIFF
--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/ammo/rifle.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/ammo/rifle.dm
@@ -22,8 +22,8 @@
 	name = ".40 Sol Long bullet"
 	damage = 35
 
-	wound_bonus = 10
-	bare_wound_bonus = 20
+	wound_bonus = 5
+	bare_wound_bonus = 10
 
 
 /obj/item/ammo_box/c40sol


### PR DESCRIPTION


## About The Pull Request

Despite the total vibe of it hitting like a truck, these have been rolling a catastrophic amount of wounds on pretty much anyone they hit, all the time, which's not great for guns that fire so fast

## How This Contributes To The Nova Sector Roleplay Experience

Less super-killer-rifles

## Proof of Testing

this one is fr just a wound-chance change

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: .40 Sol Long projectiles no longer spin viciously in the air, leading to over-all less wounding chance potential, and less accidental casualties at the firing-range!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
