### PR TITLE
Dragonfly Snout Variant

### DIFF
--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/snout.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/snout.dm
@@ -112,6 +112,13 @@
 	name = "Corvid Beak"
 	icon_state = "corvidbeak"
 
+/datum/sprite_accessory/snouts/mammal/dragonfly
+	name = "Dragonfly"
+	icon_state = "fdragonfly"
+	flags_for_organ = NONE
+	color_src = USE_MATRIXED_COLORS
+	organ_type = /obj/item/organ/snout/top_adj
+
 /datum/sprite_accessory/snouts/mammal/bug
 	name = "Bug"
 	icon_state = "bug"

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/snout.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/snout.dm
@@ -114,7 +114,7 @@
 
 /datum/sprite_accessory/snouts/mammal/dragonfly
 	name = "Dragonfly"
-	icon_state = "fdragonfly"
+	icon_state = "dragonfly"
 	flags_for_organ = NONE
 	color_src = USE_MATRIXED_COLORS
 	organ_type = /obj/item/organ/snout/top_adj


### PR DESCRIPTION
## About The Pull Request

When I made my original bug dlc I COMPLETELY forgot to add the second dragonfly snout that wasn't on the top layer. And someone whose using the dragonfly snout wants to wear hats but they get covered up. This will FIX that issue.

It does kind of ruin the shading of the eyes and spacing, but, if someone wants to wear hats I say let them!

## How This Contributes To The Nova Sector Roleplay Experience

Hats for the creatures.

## Proof of Testing


  From this... 
![image](https://github.com/user-attachments/assets/1ca87e89-91e4-4b56-bbe5-635068035d4c)
to THIS.
![image](https://github.com/user-attachments/assets/016c9476-9895-4128-8717-46f1d9166213)