### PR TITLE
Gateway open sesame

### DIFF
--- a/_maps/RandomZLevels/SnowCabin.dmm
+++ b/_maps/RandomZLevels/SnowCabin.dmm
@@ -3152,6 +3152,7 @@
 	name = "wooden box"
 	},
 /obj/effect/spawner/random/exotic/antag_gear,
+/obj/item/immortality_talisman,
 /turf/open/misc/ice/smooth,
 /area/awaymission/cabin/caves)
 "uz" = (

--- a/_maps/RandomZLevels/SnowCabin.dmm
+++ b/_maps/RandomZLevels/SnowCabin.dmm
@@ -1680,6 +1680,9 @@
 "iI" = (
 /obj/structure/closet/acloset,
 /obj/item/toy/foamblade,
+/obj/item/retractor/alien,
+/obj/item/scalpel/alien,
+/obj/item/surgicaldrill/alien,
 /turf/open/floor/plating/snowed,
 /area/awaymission/cabin/caves)
 "iJ" = (
@@ -3132,12 +3135,8 @@
 /turf/open/misc/asteroid/snow/snow_cabin,
 /area/awaymission/cabin/snowforest)
 "ud" = (
-/obj/structure/showcase/mecha/marauder{
-	desc = "Used by vigilantes in the past to fight ruffians causing trouble in neighborhoods and space stations.";
-	icon_state = "seraph";
-	name = "illegally acquired seraph"
-	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/vehicle/sealed/mecha/marauder,
 /turf/open/indestructible,
 /area/awaymission/cabin/caves/mountain)
 "ue" = (
@@ -3200,6 +3199,14 @@
 	},
 /turf/open/floor/plating/snowed/snow_cabin,
 /area/awaymission/cabin/snowforest/sovietsurface)
+"ux" = (
+/obj/structure/closet/crate/wooden{
+	desc = "Gotta know what waits within! Could it be a secret treasure cache or a deadly tool of sin?";
+	name = "wooden box"
+	},
+/obj/effect/spawner/random/exotic/antag_gear,
+/turf/open/misc/ice/smooth,
+/area/awaymission/cabin/caves)
 "uz" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/misc/asteroid/snow/snow_cabin,
@@ -4511,11 +4518,8 @@
 /turf/open/floor/wood/freezing,
 /area/awaymission/cabin/lumbermill)
 "LE" = (
-/obj/item/nullrod/claymore/multiverse{
-	anchored = 1;
-	force = 4
-	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/item/nullrod/claymore/multiverse,
 /turf/open/indestructible,
 /area/awaymission/cabin/caves/mountain)
 "LG" = (
@@ -12234,7 +12238,7 @@ gx
 ms
 Oe
 PV
-zB
+ux
 PV
 PV
 PV
@@ -47385,7 +47389,7 @@ gx
 gx
 gx
 Oe
-Oe
+Dl
 Oe
 Oe
 Oe

--- a/_maps/RandomZLevels/SnowCabin.dmm
+++ b/_maps/RandomZLevels/SnowCabin.dmm
@@ -1071,24 +1071,6 @@
 "fP" = (
 /turf/closed/indestructible/fakeglass,
 /area/awaymission/cabin/caves/mountain)
-"fQ" = (
-/turf/closed/indestructible/fakedoor{
-	desc = "Jail.";
-	name = "Jail Cell 7210"
-	},
-/area/awaymission/cabin/caves/mountain)
-"fR" = (
-/turf/closed/indestructible/fakedoor{
-	desc = "Jail.";
-	name = "Jail Cell 7211"
-	},
-/area/awaymission/cabin/caves/mountain)
-"fS" = (
-/turf/closed/indestructible/fakedoor{
-	desc = "Jail.";
-	name = "Jail Cell 7212"
-	},
-/area/awaymission/cabin/caves/mountain)
 "fT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -1102,30 +1084,14 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/dark,
 /area/awaymission/cabin/caves/mountain)
-"fV" = (
-/turf/closed/indestructible/fakedoor{
-	desc = "Jail.";
-	name = "Jail Cell 7214"
-	},
-/area/awaymission/cabin/caves/mountain)
 "fW" = (
-/turf/closed/indestructible/fakedoor{
-	desc = "Jail.";
-	name = "Jail Cell 7215"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/grunge,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/mineral/plastitanium/red{
+	name = "soviet floor"
 	},
-/area/awaymission/cabin/caves/mountain)
-"fX" = (
-/turf/closed/indestructible/fakedoor{
-	desc = "Jail.";
-	name = "Jail Cell 7216"
-	},
-/area/awaymission/cabin/caves/mountain)
-"fY" = (
-/turf/closed/indestructible/fakedoor{
-	desc = "Jail.";
-	name = "Jail Cell 7217"
-	},
-/area/awaymission/cabin/caves/mountain)
+/area/awaymission/cabin/caves/sovietcave)
 "fZ" = (
 /obj/structure/weightmachine,
 /obj/effect/decal/cleanable/dirt,
@@ -2313,12 +2279,6 @@
 	name = "soviet floor"
 	},
 /area/awaymission/cabin/caves/sovietcave)
-"lc" = (
-/turf/closed/indestructible/fakedoor{
-	desc = "I can't get past this.";
-	name = "Reinforced Soviet Hatch"
-	},
-/area/awaymission/cabin/caves/sovietcave)
 "ll" = (
 /obj/structure/cable,
 /obj/machinery/light/small/directional/south,
@@ -2358,12 +2318,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/mineral/plastitanium/red{
 	name = "soviet floor"
-	},
-/area/awaymission/cabin/caves/sovietcave)
-"lT" = (
-/turf/closed/indestructible/fakedoor{
-	desc = "Seriously, I can't map an entire soviet bunker and new landscape for you. You can't get past this.";
-	name = "Soviet Hatch"
 	},
 /area/awaymission/cabin/caves/sovietcave)
 "lW" = (
@@ -2411,12 +2365,6 @@
 /obj/effect/turf_decal/weather/snow,
 /turf/open/floor/iron/dark/snowdin,
 /area/awaymission/cabin/caves)
-"mK" = (
-/turf/closed/indestructible/fakedoor{
-	desc = "Seriously, You can't get past this.";
-	name = "Soviet Hatch"
-	},
-/area/awaymission/cabin/caves/sovietcave)
 "mM" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/decal/cleanable/dirt,
@@ -2507,9 +2455,8 @@
 /turf/closed/indestructible/syndicate,
 /area/awaymission/cabin/caves/sovietcave)
 "np" = (
-/turf/closed/indestructible/fakedoor{
-	desc = "Can you just stop?";
-	name = "GO BACK THE WAY YOU CAME"
+/turf/open/floor/mineral/plastitanium/red{
+	name = "soviet floor"
 	},
 /area/awaymission/cabin/caves/sovietcave)
 "nq" = (
@@ -8426,7 +8373,7 @@ fq
 fq
 fN
 fN
-fQ
+fU
 jQ
 cx
 cx
@@ -9197,7 +9144,7 @@ fq
 fq
 fN
 fN
-fR
+fU
 jQ
 cx
 cx
@@ -9968,7 +9915,7 @@ fq
 fE
 fN
 fN
-fS
+fU
 jQ
 cx
 cx
@@ -11510,7 +11457,7 @@ fs
 fq
 fN
 fN
-fV
+fU
 jQ
 cx
 cx
@@ -12281,7 +12228,7 @@ fq
 fq
 fN
 fN
-fW
+fU
 jQ
 cx
 cx
@@ -13052,7 +12999,7 @@ fr
 fq
 fN
 fN
-fX
+fU
 jQ
 cx
 cx
@@ -13823,7 +13770,7 @@ fu
 UE
 UE
 fO
-fY
+fU
 jQ
 cx
 cx
@@ -14077,8 +14024,8 @@ co
 cx
 cx
 cx
-fy
-fy
+fU
+fU
 cx
 cx
 cx
@@ -62331,8 +62278,8 @@ gx
 gx
 gx
 ii
-lc
-lc
+np
+np
 ii
 gx
 gx
@@ -63616,8 +63563,8 @@ gx
 gx
 gx
 ii
-im
-im
+fW
+fW
 ii
 gx
 gx
@@ -66700,8 +66647,8 @@ gx
 gx
 gx
 ii
-lT
-mK
+np
+np
 ii
 gx
 gx
@@ -66957,8 +66904,8 @@ gx
 gx
 gx
 ii
-im
-im
+fW
+fW
 ii
 gx
 gx
@@ -68756,8 +68703,8 @@ gx
 gx
 gx
 no
-im
-im
+fW
+fW
 no
 gx
 gx

--- a/_maps/RandomZLevels/TheBeach.dmm
+++ b/_maps/RandomZLevels/TheBeach.dmm
@@ -423,6 +423,15 @@
 	},
 /turf/open/misc/beach/sand,
 /area/awaymission/beach)
+"fp" = (
+/obj/item/toy/seashell{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/turf/open/misc/beach/coast{
+	dir = 6
+	},
+/area/awaymission/beach)
 "fu" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -589,6 +598,10 @@
 	pixel_y = 4
 	},
 /turf/open/floor/wood,
+/area/awaymission/beach)
+"hr" = (
+/obj/item/food/grown/cocoapod,
+/turf/open/misc/beach/sand,
 /area/awaymission/beach)
 "hC" = (
 /obj/structure/railing{
@@ -1058,6 +1071,11 @@
 	pixel_y = -2
 	},
 /turf/open/floor/iron/dark/diagonal,
+/area/awaymission/beach)
+"mQ" = (
+/obj/effect/spawner/random/structure/closet_empty/crate,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/misc/beach/sand,
 /area/awaymission/beach)
 "mT" = (
 /obj/machinery/vending/games,
@@ -1580,6 +1598,17 @@
 	pixel_y = 2
 	},
 /turf/open/misc/beach/sand,
+/area/awaymission/beach)
+"tQ" = (
+/obj/structure/safe/floor,
+/obj/item/gun/ballistic/shotgun/musket,
+/obj/item/language_manual/piratespeak,
+/obj/item/clothing/suit/costume/pirate/armored,
+/obj/item/clothing/head/helmet/space/pirate,
+/obj/item/clothing/shoes/pirate/armored,
+/obj/item/clothing/under/costume/pirate,
+/obj/structure/bed/maint,
+/turf/open/floor/wood/large,
 /area/awaymission/beach)
 "tU" = (
 /obj/structure/table/bronze,
@@ -2661,6 +2690,13 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/awaymission/beach)
+"FX" = (
+/obj/structure/flora/tree/palm{
+	pixel_y = 8
+	},
+/obj/structure/flora/coconuts,
+/turf/open/misc/beach/sand,
+/area/awaymission/beach)
 "FY" = (
 /obj/effect/turf_decal/sand,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -3553,6 +3589,15 @@
 /obj/effect/turf_decal/stripes/red/box,
 /turf/open/misc/beach/sand,
 /area/awaymission/beach)
+"Rq" = (
+/obj/item/toy/seashell{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/turf/open/misc/beach/coast/corner{
+	dir = 4
+	},
+/area/awaymission/beach)
 "Rr" = (
 /obj/structure/flora/tree/palm{
 	pixel_y = 10;
@@ -3854,6 +3899,15 @@
 /obj/structure/table/glass,
 /turf/open/floor/wood/large,
 /area/awaymission/beach)
+"VU" = (
+/obj/item/toy/seashell{
+	pixel_x = 12;
+	pixel_y = 5
+	},
+/turf/open/misc/beach/coast{
+	dir = 1
+	},
+/area/awaymission/beach)
 "VY" = (
 /turf/open/misc/beach/sand,
 /area/awaymission/beach)
@@ -3969,6 +4023,13 @@
 "XB" = (
 /turf/open/water/beach,
 /area/awaymission/beach)
+"XI" = (
+/obj/item/toy/seashell{
+	pixel_y = -3;
+	pixel_x = -18
+	},
+/turf/open/misc/beach/sand,
+/area/awaymission/beach)
 "XT" = (
 /obj/effect/turf_decal/siding/dark_red/corner{
 	dir = 4
@@ -4023,6 +4084,13 @@
 	pixel_x = -6
 	},
 /turf/open/floor/wood/large,
+/area/awaymission/beach)
+"Ys" = (
+/obj/structure/flora/tree/palm{
+	pixel_y = 24;
+	pixel_x = -7
+	},
+/turf/open/misc/beach/sand,
 /area/awaymission/beach)
 "YB" = (
 /obj/machinery/vending/coffee,
@@ -63232,8 +63300,8 @@ XB
 XB
 XB
 XB
-XB
-XB
+MZ
+ni
 XB
 XB
 XB
@@ -63488,10 +63556,10 @@ XB
 XB
 XB
 XB
-XB
-XB
-XB
-XB
+MZ
+Rq
+hL
+ni
 XB
 XB
 XB
@@ -63744,11 +63812,11 @@ XB
 XB
 XB
 XB
-XB
-XB
-XB
-XB
-XB
+MZ
+MF
+VY
+VY
+BK
 XB
 XB
 XB
@@ -64001,12 +64069,12 @@ XB
 XB
 XB
 XB
-XB
-XB
-XB
-XB
-XB
-XB
+VU
+VY
+GI
+VY
+hL
+ni
 XB
 XB
 XB
@@ -64257,13 +64325,13 @@ XB
 XB
 XB
 XB
-XB
-XB
-XB
-XB
-XB
-XB
-XB
+MZ
+MF
+VY
+ls
+hr
+XI
+BK
 XB
 XB
 XB
@@ -64514,13 +64582,13 @@ XB
 XB
 XB
 XB
-XB
-XB
-XB
-XB
-XB
-XB
-XB
+Vf
+VY
+VY
+Ys
+VY
+VY
+BK
 XB
 XB
 XB
@@ -64771,13 +64839,13 @@ XB
 XB
 XB
 XB
-XB
-XB
-XB
-XB
-XB
-XB
-XB
+Vf
+VY
+VY
+Zp
+VY
+VY
+BK
 XB
 XB
 XB
@@ -65028,13 +65096,13 @@ XB
 XB
 XB
 XB
-XB
-XB
-XB
-XB
-XB
-XB
-XB
+Pe
+tJ
+VY
+tQ
+VY
+Ys
+BK
 XB
 XB
 XB
@@ -65286,12 +65354,12 @@ XB
 XB
 XB
 XB
-XB
-XB
-XB
-XB
-XB
-XB
+Vf
+VY
+FX
+VY
+VY
+BK
 XB
 XB
 XB
@@ -65543,12 +65611,12 @@ XB
 XB
 XB
 XB
-XB
-XB
-XB
-XB
-XB
-XB
+Pe
+tJ
+VY
+VY
+mQ
+BK
 XB
 XB
 XB
@@ -65801,11 +65869,11 @@ XB
 XB
 XB
 XB
-XB
-XB
-XB
-XB
-XB
+Vf
+VY
+gq
+Kh
+Rj
 XB
 XB
 XB
@@ -66058,10 +66126,10 @@ XB
 XB
 XB
 XB
-XB
-XB
-XB
-XB
+Vf
+VY
+VY
+BK
 XB
 XB
 XB
@@ -66315,10 +66383,10 @@ XB
 XB
 XB
 XB
-XB
-XB
-XB
-XB
+Pe
+tJ
+Kh
+fp
 XB
 XB
 XB
@@ -66573,8 +66641,8 @@ XB
 XB
 XB
 XB
-XB
-XB
+Pe
+Rj
 XB
 XB
 XB

--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -2005,6 +2005,13 @@
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},
 /area/awaymission/caves/bmp_asteroid/level_four)
+"UZ" = (
+/obj/effect/decal/remains/human,
+/obj/structure/spawner/skeleton,
+/turf/open/floor/engine/cult{
+	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
+	},
+/area/awaymission/caves/bmp_asteroid/level_four)
 "VK" = (
 /obj/effect/mob_spawn/ghost_role/human/skeleton{
 	name = "spooky skeleton remains"
@@ -50691,7 +50698,7 @@ ad
 ad
 ad
 ao
-aw
+UZ
 ao
 ax
 ad
@@ -53519,7 +53526,7 @@ ad
 ad
 ad
 ao
-ao
+aB
 ao
 ad
 ad
@@ -58132,7 +58139,7 @@ ad
 rv
 rv
 rv
-rv
+BH
 ao
 ao
 rv
@@ -58148,7 +58155,7 @@ ao
 ap
 ao
 rv
-rv
+BH
 rv
 ax
 aP

--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -1497,9 +1497,6 @@
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},
 /area/awaymission/caves/bmp_asteroid/level_two)
-"vs" = (
-/turf/open/space/basic,
-/area/awaymission/caves/bmp_asteroid/level_four)
 "vR" = (
 /obj/structure/sign/departments/medbay/directional/west,
 /turf/open/misc/asteroid/basalt{
@@ -61006,7 +61003,7 @@ rv
 ad
 ad
 ad
-vs
+ad
 ad
 ad
 rv

--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -54,9 +54,8 @@
 /obj/item/stack/sheet/runed_metal{
 	amount = 25
 	},
-/obj/item/veilrender/honkrender,
-/obj/item/clothing/mask/gas/clown_hat,
 /obj/item/organ/heart/demon,
+/obj/item/mod/control/pre_equipped/responsory/inquisitory/commander,
 /turf/open/floor/engine/cult{
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},
@@ -226,7 +225,13 @@
 /area/awaymission/caves/bmp_asteroid/level_four)
 "ba" = (
 /obj/structure/destructible/cult/item_dispenser/altar,
-/obj/item/book/granter/martial/plasma_fist/nobomb,
+/obj/item/book/granter/martial/cqc,
+/turf/open/floor/engine/cult{
+	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
+	},
+/area/awaymission/caves/bmp_asteroid/level_four)
+"be" = (
+/obj/machinery/implantchair/brainwash,
 /turf/open/floor/engine/cult{
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},
@@ -1138,13 +1143,17 @@
 	},
 /area/awaymission/caves/bmp_asteroid)
 "gK" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/awaymission/caves/bmp_asteroid)
+/obj/effect/rune/convert,
+/turf/open/misc/asteroid/basalt/lava{
+	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
+	},
+/area/awaymission/caves/bmp_asteroid/level_four)
 "gL" = (
-/obj/item/stack/rods,
-/turf/open/floor/plating,
-/area/awaymission/caves/bmp_asteroid)
+/obj/machinery/vending/dorms,
+/turf/open/floor/engine/cult{
+	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
+	},
+/area/awaymission/caves/bmp_asteroid/level_four)
 "gM" = (
 /obj/structure/mecha_wreckage/ripley,
 /turf/open/floor/iron/recharge_floor,
@@ -1259,6 +1268,14 @@
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},
 /area/awaymission/caves/bmp_asteroid/level_two)
+"kn" = (
+/obj/structure/table/optable,
+/obj/item/knife/bloodletter,
+/obj/effect/decal/remains/human,
+/turf/open/floor/engine/cult{
+	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
+	},
+/area/awaymission/caves/bmp_asteroid/level_four)
 "kE" = (
 /mob/living/basic/spider/giant/hunter/away_caves,
 /turf/open/floor/iron,
@@ -1325,11 +1342,31 @@
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},
 /area/awaymission/caves/bmp_asteroid/level_two)
+"oW" = (
+/obj/structure/safe,
+/obj/item/melee/cultblade/dagger,
+/obj/item/tome,
+/obj/item/reagent_containers/cup/beaker/unholywater,
+/obj/item/choice_beacon/unholy,
+/obj/item/antag_granter/changeling,
+/obj/item/storage/pill_bottle/lsd,
+/turf/open/floor/engine/cult{
+	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
+	},
+/area/awaymission/caves/bmp_asteroid/level_four)
 "pc" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/wood,
 /area/awaymission/caves/northblock)
+"pn" = (
+/obj/machinery/computer/operating{
+	dir = 4
+	},
+/turf/open/floor/engine/cult{
+	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
+	},
+/area/awaymission/caves/bmp_asteroid/level_four)
 "pC" = (
 /obj/item/mjollnir,
 /mob/living/basic/spider/giant/nurse/away_caves,
@@ -1376,7 +1413,9 @@
 /area/awaymission/caves/bmp_asteroid/level_four)
 "rF" = (
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
+	},
 /area/awaymission/caves/bmp_asteroid)
 "sl" = (
 /obj/structure/spawner/mining/hivelord,
@@ -1384,12 +1423,18 @@
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},
 /area/awaymission/caves/bmp_asteroid/level_two)
+"su" = (
+/obj/structure/door_assembly/door_assembly_cult,
+/turf/open/floor/engine/cult{
+	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
+	},
+/area/awaymission/caves/bmp_asteroid/level_four)
 "sw" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/awaymission/caves/listeningpost)
 "sE" = (
-/obj/item/greentext,
+/obj/item/book/granter/crafting_recipe/dusting/laser_musket_prime,
 /turf/open/misc/asteroid/basalt{
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},
@@ -1411,6 +1456,13 @@
 /obj/item/storage/medkit/regular,
 /turf/open/floor/iron,
 /area/awaymission/caves/bmp_asteroid)
+"tM" = (
+/obj/effect/spawner/surgery_tray/full,
+/obj/item/shears,
+/turf/open/floor/engine/cult{
+	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
+	},
+/area/awaymission/caves/bmp_asteroid/level_four)
 "tU" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating{
@@ -1445,6 +1497,9 @@
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},
 /area/awaymission/caves/bmp_asteroid/level_two)
+"vs" = (
+/turf/open/space/basic,
+/area/awaymission/caves/bmp_asteroid/level_four)
 "vR" = (
 /obj/structure/sign/departments/medbay/directional/west,
 /turf/open/misc/asteroid/basalt{
@@ -1471,6 +1526,12 @@
 /area/awaymission/caves/bmp_asteroid)
 "ww" = (
 /turf/open/misc/asteroid/basalt/airless,
+/area/awaymission/caves/bmp_asteroid/level_two)
+"wS" = (
+/obj/item/storage/box/emergency_spacesuit,
+/turf/open/misc/asteroid/basalt{
+	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
+	},
 /area/awaymission/caves/bmp_asteroid/level_two)
 "wT" = (
 /obj/structure/destructible/cult/pylon,
@@ -1543,6 +1604,12 @@
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},
 /area/awaymission/caves/bmp_asteroid)
+"AM" = (
+/obj/item/tank/internals/oxygen/red,
+/turf/open/misc/asteroid/basalt{
+	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
+	},
+/area/awaymission/caves/bmp_asteroid/level_two)
 "AN" = (
 /obj/structure/trap/stun{
 	desc = "A rune inscribed in the floor, the air feeling electrified around it.";
@@ -1624,6 +1691,12 @@
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},
 /area/awaymission/caves/bmp_asteroid/level_two)
+"CI" = (
+/obj/structure/kitchenspike,
+/turf/open/floor/engine/cult{
+	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
+	},
+/area/awaymission/caves/bmp_asteroid/level_four)
 "Ds" = (
 /obj/item/pickaxe/rusted{
 	pixel_x = 5
@@ -1723,6 +1796,12 @@
 /mob/living/basic/mining_drone,
 /turf/open/floor/plating,
 /area/awaymission/caves/listeningpost)
+"II" = (
+/obj/structure/frame/machine/secured,
+/turf/open/floor/engine/cult{
+	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
+	},
+/area/awaymission/caves/bmp_asteroid/level_four)
 "IN" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating{
@@ -1777,6 +1856,12 @@
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},
 /area/awaymission/caves/bmp_asteroid/level_two)
+"LE" = (
+/obj/machinery/door/airlock/external/ruin,
+/turf/open/floor/plating{
+	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
+	},
+/area/awaymission/caves/bmp_asteroid)
 "Mk" = (
 /obj/machinery/light/small/built/directional/west,
 /turf/open/floor/wood,
@@ -1886,6 +1971,12 @@
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},
 /area/awaymission/caves/bmp_asteroid/level_two)
+"Sv" = (
+/obj/machinery/gibber,
+/turf/open/floor/engine/cult{
+	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
+	},
+/area/awaymission/caves/bmp_asteroid/level_four)
 "SV" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/misc/asteroid/basalt{
@@ -10195,13 +10286,13 @@ bL
 bL
 bL
 cx
-ej
+fy
 BK
 bM
 bM
 BK
 BK
-ej
+fy
 bM
 bM
 bM
@@ -10452,8 +10543,8 @@ bL
 bL
 bL
 cx
-cx
-ej
+fy
+fy
 BK
 bM
 BK
@@ -10710,7 +10801,7 @@ bL
 dW
 gN
 cx
-ej
+fy
 BK
 bM
 bM
@@ -10968,11 +11059,11 @@ bL
 cx
 gP
 cx
-ej
+fy
 BK
 BK
 BK
-ej
+fy
 cx
 cx
 bL
@@ -17135,7 +17226,7 @@ BK
 bM
 bM
 BK
-fN
+LE
 fH
 bM
 bM
@@ -17391,8 +17482,8 @@ bL
 BK
 BK
 fH
-ej
-ej
+fy
+fy
 fH
 bM
 bM
@@ -17645,11 +17736,11 @@ bL
 bL
 bL
 dW
-gK
+fW
 dW
 dX
-fN
-fN
+LE
+LE
 dX
 bM
 bM
@@ -17902,11 +17993,11 @@ BK
 dW
 dX
 dW
-gL
-ej
-ej
+gc
+fy
+fy
 BK
-ej
+fy
 dX
 bM
 bM
@@ -18159,8 +18250,8 @@ BK
 fy
 gF
 gH
-ej
-ej
+fy
+fy
 BK
 BK
 BK
@@ -19192,7 +19283,7 @@ fy
 bM
 BK
 BL
-ej
+fy
 BK
 BK
 bL
@@ -19448,7 +19539,7 @@ gM
 gJ
 gO
 dX
-gK
+fW
 dW
 BK
 BK
@@ -50087,11 +50178,11 @@ ad
 ad
 ad
 ad
+ax
+ax
+aS
 ad
-ad
-rv
-ad
-ad
+aS
 ad
 ad
 ad
@@ -50344,11 +50435,11 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
+aS
+kn
+pn
+Sv
+ax
 ad
 ad
 ad
@@ -50602,10 +50693,10 @@ rv
 ad
 ad
 ad
-ad
-ad
-ad
-ad
+ao
+aw
+ao
+ax
 ad
 ad
 ad
@@ -50858,11 +50949,11 @@ rv
 rv
 ad
 rv
-ad
-ad
-ad
-ad
-ad
+aS
+tM
+ao
+gL
+aS
 rv
 ad
 ad
@@ -51115,10 +51206,10 @@ rv
 rv
 ad
 rv
-ad
-ad
-ad
-ad
+ax
+oW
+ao
+II
 ad
 ad
 ad
@@ -51372,9 +51463,9 @@ rv
 rv
 rv
 rv
-ad
-ad
-ad
+ax
+CI
+ao
 ad
 ad
 ad
@@ -51629,11 +51720,11 @@ rv
 rv
 rv
 ad
-ad
-ad
-ad
-rv
-ad
+ax
+CI
+ao
+be
+aS
 ad
 ad
 ad
@@ -51886,11 +51977,11 @@ ad
 ad
 ad
 rv
-ad
-ad
-ad
-ad
-ad
+ax
+ax
+su
+aS
+ax
 ad
 ad
 ad
@@ -52145,9 +52236,9 @@ ad
 ad
 ad
 rv
-ad
-ad
-ad
+ao
+ao
+ax
 ad
 ad
 ad
@@ -52402,8 +52493,8 @@ ad
 ad
 ad
 ad
-ad
-ad
+ao
+ao
 ad
 ad
 ad
@@ -52659,8 +52750,8 @@ ad
 ad
 ad
 ad
-ad
-ad
+ao
+ao
 ad
 ad
 ad
@@ -52916,8 +53007,8 @@ ad
 ad
 ad
 ad
-ad
-ad
+ao
+ao
 ad
 ad
 ad
@@ -53173,9 +53264,9 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
+ao
+ao
+ao
 ad
 ad
 ad
@@ -53430,9 +53521,9 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
+ao
+ao
+ao
 ad
 ad
 ad
@@ -53688,8 +53779,8 @@ ad
 ad
 ad
 ad
-ad
-ad
+ao
+ao
 ad
 ad
 ad
@@ -53945,8 +54036,8 @@ ad
 ad
 ad
 ad
-ad
-ad
+ao
+ao
 ad
 ad
 ad
@@ -54129,7 +54220,7 @@ oI
 oI
 oI
 oI
-oI
+wS
 oI
 oI
 oI
@@ -54203,7 +54294,7 @@ ad
 ad
 ad
 ad
-ad
+ao
 ad
 ad
 ad
@@ -54385,7 +54476,7 @@ oI
 oI
 oI
 oI
-oI
+AM
 oI
 oI
 oI
@@ -56044,7 +56135,7 @@ ax
 ao
 ao
 rv
-rv
+gK
 rv
 ad
 ad
@@ -60915,7 +61006,7 @@ rv
 ad
 ad
 ad
-ad
+vs
 ad
 ad
 rv

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -2285,6 +2285,12 @@
 "oV" = (
 /obj/machinery/firealarm/directional/east,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/emcloset,
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/iron,
 /area/awaymission/moonoutpost19/arrivals)
 "oY" = (

--- a/_maps/RandomZLevels/museum.dmm
+++ b/_maps/RandomZLevels/museum.dmm
@@ -3714,6 +3714,11 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/awaymission/museum)
+"Ej" = (
+/obj/structure/table,
+/obj/item/reagent_containers/cup/glass/trophy/gold_cup,
+/turf/open/floor/iron/cafeteria,
+/area/awaymission/museum/cafeteria)
 "Ek" = (
 /obj/structure/table/wood,
 /obj/structure/window/spawner/directional/east,
@@ -46729,7 +46734,7 @@ Ph
 uH
 HQ
 Xi
-xp
+Ej
 nZ
 Xi
 Es

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -7434,6 +7434,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/awaymission/snowdin/cave)
+"CM" = (
+/obj/effect/spawner/random/structure/crate_abandoned,
+/obj/item/antag_granter/heretic,
+/turf/open/floor/engine/cult{
+	initial_gas_mix = "n2=82;plasma=24;TEMP=120";
+	temperature = 120
+	},
+/area/awaymission/snowdin/cave/cavern)
 "CO" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/circuit/red,
@@ -9620,7 +9628,7 @@
 /area/awaymission/snowdin/post/mining_main/mechbay)
 "Oz" = (
 /obj/structure/closet/crate/wooden,
-/obj/effect/spawner/random/exotic/antag_gear_weak,
+/obj/effect/spawner/random/exotic/antag_gear,
 /turf/open/misc/asteroid/snow{
 	floor_variance = 0;
 	icon_state = "snow_dug";
@@ -10552,6 +10560,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark/snowdin,
 /area/awaymission/snowdin/outside)
+"Tt" = (
+/obj/effect/spawner/random/structure/crate_abandoned,
+/obj/item/nullrod/vibro/talking/chainsword,
+/turf/open/floor/engine/cult{
+	initial_gas_mix = "n2=82;plasma=24;TEMP=120";
+	temperature = 120
+	},
+/area/awaymission/snowdin/cave/cavern)
 "Tv" = (
 /obj/structure/table,
 /obj/item/storage/medkit/ancient,
@@ -50186,7 +50202,7 @@ bh
 bh
 eK
 eK
-XP
+CM
 gc
 gc
 gV
@@ -50960,7 +50976,7 @@ eK
 eK
 gc
 gc
-XP
+Tt
 gV
 gc
 gc

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -7436,7 +7436,8 @@
 /area/awaymission/snowdin/cave)
 "CM" = (
 /obj/effect/spawner/random/structure/crate_abandoned,
-/obj/item/antag_granter/heretic,
+/obj/item/clothing/suit/hooded/cultrobes/eldritch,
+/obj/item/codex_cicatrix,
 /turf/open/floor/engine/cult{
 	initial_gas_mix = "n2=82;plasma=24;TEMP=120";
 	temperature = 120

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -2488,6 +2488,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"ko" = (
+/obj/structure/alien/weeds,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid/plasma,
+/area/awaymission/undergroundoutpost45/caves)
 "kp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -5064,6 +5069,16 @@
 	},
 /turf/open/floor/plating,
 /area/awaymission/undergroundoutpost45/engineering)
+"sV" = (
+/obj/structure/alien/weeds,
+/obj/structure/alien/weeds,
+/obj/structure/glowshroom/single,
+/turf/open/misc/asteroid/plasma,
+/area/awaymission/undergroundoutpost45/caves)
+"sW" = (
+/obj/effect/gibspawner/xeno,
+/turf/open/misc/asteroid/plasma,
+/area/awaymission/undergroundoutpost45/caves)
 "tb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
@@ -6344,6 +6359,12 @@
 /obj/effect/turf_decal/sand,
 /turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/mining)
+"yg" = (
+/obj/structure/alien/weeds,
+/obj/structure/alien/weeds,
+/obj/structure/bed/nest,
+/turf/open/misc/asteroid/plasma,
+/area/awaymission/undergroundoutpost45/caves)
 "yh" = (
 /obj/structure/chair{
 	dir = 8
@@ -6365,6 +6386,11 @@
 	},
 /turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/gateway)
+"yD" = (
+/obj/structure/alien/weeds,
+/obj/item/clothing/mask/facehugger/impregnated,
+/turf/open/misc/asteroid/plasma,
+/area/awaymission/undergroundoutpost45/caves)
 "yN" = (
 /obj/structure/chair/office/light{
 	dir = 1;
@@ -6373,6 +6399,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/engineering)
+"yO" = (
+/obj/structure/alien/weeds,
+/obj/structure/bed/nest,
+/obj/item/clothing/suit/armor/vest/marine/security,
+/obj/item/clothing/head/helmet/marine/security,
+/turf/open/misc/asteroid/plasma,
+/area/awaymission/undergroundoutpost45/caves)
 "yR" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/all_access,
@@ -6543,6 +6576,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/awaymission/undergroundoutpost45/central)
+"Bk" = (
+/obj/structure/alien/weeds,
+/obj/item/clothing/head/helmet/swat/nanotrasen,
+/obj/item/minigunpack,
+/obj/item/clothing/suit/armor/heavy,
+/obj/structure/bed/nest,
+/turf/open/misc/asteroid/plasma,
+/area/awaymission/undergroundoutpost45/caves)
 "Bq" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/airalarm/directional/north,
@@ -7031,6 +7072,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"JK" = (
+/obj/structure/alien/weeds,
+/obj/structure/alien/weeds,
+/obj/item/clothing/mask/facehugger/dead,
+/turf/open/misc/asteroid/plasma,
+/area/awaymission/undergroundoutpost45/caves)
 "JO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7530,6 +7577,12 @@
 	dir = 5
 	},
 /area/awaymission/undergroundoutpost45/research)
+"SU" = (
+/obj/effect/gibspawner/xeno,
+/obj/structure/alien/weeds,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid/plasma,
+/area/awaymission/undergroundoutpost45/caves)
 "SZ" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/sign/warning/secure_area/directional/west,
@@ -7709,6 +7762,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/research)
+"WP" = (
+/obj/structure/alien/weeds,
+/obj/item/clothing/mask/facehugger/dead,
+/turf/open/misc/asteroid/plasma,
+/area/awaymission/undergroundoutpost45/caves)
 "WQ" = (
 /obj/structure/bed{
 	dir = 4
@@ -7787,6 +7845,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/gateway)
+"Ya" = (
+/obj/effect/gibspawner/xeno/bodypartless,
+/obj/structure/alien/weeds,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid/plasma,
+/area/awaymission/undergroundoutpost45/caves)
 "Yb" = (
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
@@ -7814,6 +7878,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/awaymission/undergroundoutpost45/central)
+"YA" = (
+/obj/structure/alien/resin/wall,
+/turf/open/misc/asteroid/plasma,
+/area/awaymission/undergroundoutpost45/caves)
 "YD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /turf/open/floor/iron,
@@ -7854,6 +7922,12 @@
 "ZD" = (
 /obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/blood/gibs/core,
+/turf/open/misc/asteroid/plasma,
+/area/awaymission/undergroundoutpost45/caves)
+"ZG" = (
+/obj/structure/alien/weeds,
+/obj/structure/alien/weeds,
+/obj/item/clothing/mask/facehugger/impregnated,
 /turf/open/misc/asteroid/plasma,
 /area/awaymission/undergroundoutpost45/caves)
 "ZH" = (
@@ -28639,7 +28713,7 @@ zq
 Gn
 ad
 Lb
-zq
+sW
 zq
 ad
 ad
@@ -30185,7 +30259,7 @@ ad
 ad
 ad
 ad
-ad
+zq
 ad
 ad
 ad
@@ -30442,8 +30516,8 @@ ad
 ad
 ad
 ad
-ad
-ad
+zq
+zq
 ad
 ad
 ad
@@ -30699,8 +30773,8 @@ ad
 ad
 ad
 ad
-ad
-ad
+zq
+XQ
 ad
 ad
 ad
@@ -30956,7 +31030,7 @@ ad
 ad
 ad
 ad
-ad
+zq
 ad
 ad
 ad
@@ -31212,8 +31286,8 @@ ad
 ad
 ad
 ad
-ad
-ad
+YA
+zq
 ad
 ad
 ad
@@ -31469,8 +31543,8 @@ ad
 ad
 ad
 ad
-ad
-ad
+zb
+zq
 ad
 ad
 ad
@@ -31726,11 +31800,11 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
+zb
+WP
+zb
+zb
+zb
 ad
 ad
 ad
@@ -31982,13 +32056,13 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zb
+Gn
+Gn
+Gn
+Gn
+Bk
+zb
 ad
 ad
 ad
@@ -32238,14 +32312,14 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zb
+yO
+Gn
+Ya
+ko
+sV
+JK
+zb
 ad
 ad
 ad
@@ -32495,14 +32569,14 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zb
+Gn
+Gn
+ko
+ko
+ko
+ko
+zb
 ad
 ad
 ad
@@ -32752,14 +32826,14 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zb
+zK
+yD
+ko
+ko
+ZG
+yg
+zb
 ad
 ad
 ad
@@ -33009,14 +33083,14 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zb
+Gn
+HW
+ko
+ko
+SU
+yg
+zb
 ad
 ad
 ad
@@ -33266,13 +33340,13 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zb
+Gn
+Gn
+Gn
+zb
+zb
+zb
 ad
 ad
 ad
@@ -33524,9 +33598,9 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
+zb
+zb
+zb
 ad
 ad
 ad

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -2,7 +2,7 @@
 GLOBAL_LIST_INIT(potentialRandomZlevels, generateMapList(filename = "awaymissionconfig.txt"))
 GLOBAL_LIST_INIT(potentialConfigRandomZlevels, generate_map_list_from_directory(directory = "[global.config.directory]/away_missions/"))
 
-/proc/createRandomZlevel(config_gateway = FALSE)
+/proc/createRandomZlevel(config_gateway = TRUE)
 	var/map
 	if(config_gateway && GLOB.potentialConfigRandomZlevels?.len)
 		map = pick_n_take(GLOB.potentialConfigRandomZlevels)

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -2,7 +2,7 @@
 GLOBAL_LIST_INIT(potentialRandomZlevels, generateMapList(filename = "awaymissionconfig.txt"))
 GLOBAL_LIST_INIT(potentialConfigRandomZlevels, generate_map_list_from_directory(directory = "[global.config.directory]/away_missions/"))
 
-/proc/createRandomZlevel(config_gateway = TRUE)
+/proc/createRandomZlevel(config_gateway = FALSE)
 	var/map
 	if(config_gateway && GLOB.potentialConfigRandomZlevels?.len)
 		map = pick_n_take(GLOB.potentialConfigRandomZlevels)

--- a/config/awaymissionconfig.txt
+++ b/config/awaymissionconfig.txt
@@ -14,4 +14,5 @@
 #_maps/RandomZLevels/snowdin.dmm
 #_maps/RandomZLevels/research.dmm
 #_maps/RandomZLevels/SnowCabin.dmm
+#_maps/RandomZLevels/mothership_astrum
 #_maps/RandomZLevels/museum.dmm

--- a/config/awaymissionconfig.txt
+++ b/config/awaymissionconfig.txt
@@ -7,12 +7,12 @@
 #Do NOT tick the maps during compile -- the game uses this list to decide which map to load. Ticking the maps will result in them ALL being loaded at once.
 #DO tick the associated code file for the away mission you are enabling. Otherwise, the map will be trying to reference objects which do not exist, which will cause runtime errors!
 
-#_maps/RandomZLevels/TheBeach.dmm
-#_maps/RandomZLevels/moonoutpost19.dmm
-#_maps/RandomZLevels/undergroundoutpost45.dmm
-#_maps/RandomZLevels/caves.dmm
-#_maps/RandomZLevels/snowdin.dmm
-#_maps/RandomZLevels/research.dmm
-#_maps/RandomZLevels/SnowCabin.dmm
-#_maps/RandomZLevels/mothership_astrum
-#_maps/RandomZLevels/museum.dmm
+_maps/RandomZLevels/TheBeach.dmm
+_maps/RandomZLevels/moonoutpost19.dmm
+_maps/RandomZLevels/undergroundoutpost45.dmm
+_maps/RandomZLevels/caves.dmm
+_maps/RandomZLevels/snowdin.dmm
+_maps/RandomZLevels/research.dmm
+_maps/RandomZLevels/SnowCabin.dmm
+_maps/RandomZLevels/mothership_astrum
+_maps/RandomZLevels/museum.dmm

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -181,7 +181,7 @@ ALLOW_AI_MULTICAM
 ## AWAY MISSIONS ###
 
 ## Uncomment to load one of the missions from awaymissionconfig.txt or away_missions/ at roundstart.
-#ROUNDSTART_AWAY
+ROUNDSTART_AWAY
 
 ## How long the delay is before the Away Mission gate opens. Default is half an hour.
 ## 600 is one minute.


### PR DESCRIPTION

## About The Pull Request

Enables the gateways to spawn normally

## How This Contributes To The Nova Sector Roleplay Experience

this was always supposed to be a thing in the first place

## Proof of Testing

This should work, i really hope

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

Adds all the gateways back besides the mothership because that one seems goofy and ill have to come back to that one later, i also added stuff to each gateway that I had from before, nothing groundbreaking and a few things that offer roleplay oppourtunities- but also really powerful gear (there was already really powerful gear) and also adding loot to outpost 45 because there was none before hand, and a sprinkle of loot in snow cabin, a tad bit more and less loot in caves.dmm and fixing some runtimes there, along with an interrogation area for the cultist area that has a bit of loot and one semi major item.

in the future i will also later add more stuff along to museum.dmm because its currently nothing but a dissapointment at the end

:cl:
add: Added more things
/:cl:
