### PR TITLE
Additional sprites to tile sprayer

### DIFF
--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -418,12 +418,24 @@
 		list("Trimline Fill", "trimline_fill"),
 		list("Trimline Fill L", "trimline_fill__8"), // This is a hack that lives in the spritesheet builder and paint_floor
 		list("Trimline End", "trimline_end_fill"),
-		list("Trimline Box", "trimline_box_fill"),
+		list("Trimline Box Fill", "trimline_box_fill"),
+		list("Trimline", "trimline"), // NOVA ADDITION/EDIT BEGIN
+		list("Trimline Corner", "trimline_corner"),
+		list("Trimline End", "trimline_end"),
+		list("Trimline Box", "trimline_box"),
+		list("Trimline Arrow L", "trimline_arrow_cw"),
+		list("Trimline Arrow R", "trimline_arrow_ccw"),
+		list("Trimline Arrow L", "trimline_arrow_cw_fill"),
+		list("Trimline Arrow R", "trimline_arrow_ccw_fill"),
+		list("Trimline Warn", "trimline_warn"),
+		list("Trimline Warn Full", "trimline_warn_fill"),
 	)
 	nondirectional_decals = list(
 		"tile_fourcorners",
 		"trimline_box_fill",
-	)
+		"tile_full",
+		"trimline_box",
+	) // NOVA ADDITION/EDIT END
 
 	/// Regex to split alpha out.
 	var/static/regex/rgba_regex = new(@"(#[0-9a-fA-F]{6})([0-9a-fA-F]{2})")

--- a/modular_nova/master_files/code/game/objects/items/airlock_painter.dm
+++ b/modular_nova/master_files/code/game/objects/items/airlock_painter.dm
@@ -1,0 +1,44 @@
+/obj/item/airlock_painter/decal/tile/fancy
+	name = "fancy tile sprayer"
+	desc = "An airlock painter, reprogrammed to use a different style of paint in order to spray colors on floor tiles as well, in addition to repainting doors. Decals break when the floor tiles are removed."
+	desc_controls = "Alt-Click to remove the ink cartridge."
+	icon_state = "tile_sprayer"
+	stored_dir = 2
+	stored_color = "#D4D4D432"
+	stored_decal = "tile_full"
+	spritesheet_type = /datum/asset/spritesheet/decals/tiles/fancy
+
+	color_list = list(
+		list("Neutral", "#D4D4D432"),
+		list("Dark", "#0e0f0f"),
+		list("Bar Burgundy", "#79150082"),
+		list("Sec Blue", "#486091"),
+		list("Cargo Brown", "#A46106"),
+		list("Engi Yellow", "#EFB341"),
+		list("Service Green", "#9FED58"),
+		list("Med Blue", "#52B4E9"),
+		list("R&D Purple", "#D381C9"),
+	)
+	decal_list = list(
+		list("Diagonal Center", "diagonal_centre"),
+		list("Diagonal Edge", "diagonal_edge"),
+		list("Full Anti Corner Tile", "tile_anticorner"),
+		list("Full Half Tile", "tile_half"),
+		list("Full Tile", "tile_full"),
+		list("Plain Siding", "siding_plain"),
+		list("Plain Siding Corner", "siding_plain_corner"),
+		list("Plain Siding Corner Inner", "siding_plain_corner_inner"),
+		list("Plain Siding End", "siding_plain_end"),
+		list("Wood Siding", "siding_wood"),
+		list("Wood Siding Corner", "siding_wood_corner"),
+		list("Wood Siding End", "siding_wood_end"),
+	)
+	nondirectional_decals = list(
+		"tile_full",
+		"diagonal_edge",
+		"diagonal_centre",
+	)
+
+/datum/asset/spritesheet/decals/tiles/fancy
+	name = "floor_tile_decals_fancy"
+	painter_type = /obj/item/airlock_painter/decal/tile/fancy

--- a/modular_nova/master_files/code/modules/research/designs/misc_designs.dm
+++ b/modular_nova/master_files/code/modules/research/designs/misc_designs.dm
@@ -89,3 +89,15 @@
 		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_GAS_TANKS_EQUIPMENT,
 	)
 	departmental_flags = ALL
+
+/datum/design/airlock_painter/decal/tile/fancy
+	name = "Tile Sprayer"
+	id = "tile_sprayer_fancy"
+	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT*0.5, /datum/material/glass =SMALL_MATERIAL_AMOUNT*0.5)
+	build_path = /obj/item/airlock_painter/decal/tile/fancy
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING,
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6737,6 +6737,7 @@
 #include "modular_nova\master_files\code\game\objects\effects\decals\turfdecals\tilecoloring.dm"
 #include "modular_nova\master_files\code\game\objects\effects\effect_system\effect_sparks.dm"
 #include "modular_nova\master_files\code\game\objects\items\AI_modules.dm"
+#include "modular_nova\master_files\code\game\objects\items\airlock_painter.dm"
 #include "modular_nova\master_files\code\game\objects\items\cards_ids.dm"
 #include "modular_nova\master_files\code\game\objects\items\cosmetics.dm"
 #include "modular_nova\master_files\code\game\objects\items\dualsaber.dm"


### PR DESCRIPTION
## About The Pull Request

Adds additional sprites to the tile sprayer, and adds a fancy tile sprayer, allowing for more tile types to be sprayed with ease.
## How This Contributes To The Nova Sector Roleplay Experience

No real rp experience increase other than allowing people to make their builds more interesting, albeit this is niche, this also helps engineering to make an area look exactly as it was before.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
  
![image](https://github.com/user-attachments/assets/47edfbae-4df6-4856-91b2-f01a8e51927d)

![image](https://github.com/user-attachments/assets/6f7ca007-74fa-4f28-bb6b-8f0b9119eacb)

  
</details>

## Changelog
:cl:
add: Adds a new "Fancy Tile Sprayer" with much more sprays to use!
code: Gives "Tile sprayer" more sprays to play with.
/:cl:
