### PR TITLE
[Hella not Modular] Adds a few things to maint loot, and raises the chance of getting the rarer stuff

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -86,6 +86,9 @@ GLOBAL_LIST_INIT(common_loot, list( //common: basic items
 		/obj/item/weldingtool = 1,
 		/obj/item/wirecutters = 1,
 		/obj/item/wrench = 1,
+		/obj/item/multitool/fock = 1, // NOVA EDIT ADDITION
+		/obj/item/weldingtool/electric/arc_welder = 1, // NOVA EDIT ADDITION
+		/obj/item/crowbar/large/doorforcer = 1, // NOVA EDIT ADDITION
 		) = 1,
 
 	list(//equipment
@@ -103,6 +106,11 @@ GLOBAL_LIST_INIT(common_loot, list( //common: basic items
 		/obj/item/storage/backpack = 1,
 		/obj/item/storage/belt/fannypack = 1,
 		/obj/item/storage/wallet/random = 1,
+		/obj/item/clothing/mask/gas/atmos/frontier_colonist = 1, // NOVA EDIT ADDITION
+		/obj/item/radio/headset/headset_frontier_colonist = 1, // NOVA EDIT ADDITION 
+		/obj/item/clothing/suit/frontier_colonist_flak = 1, // NOVA EDIT ADDITION 
+		/obj/item/clothing/head/frontier_colonist_helmet = 1, // NOVA EDIT ADDITION
+		/obj/item/storage/pouch/cin_general = 1, // NOVA EDIT ADDITION
 		) = 1,
 
 	list(//construction and crafting
@@ -135,7 +143,14 @@ GLOBAL_LIST_INIT(common_loot, list( //common: basic items
 		/obj/item/reagent_containers/syringe = 1,
 		/obj/item/stock_parts/power_store/cell/lead = 1,
 		/obj/item/storage/box/matches = 1,
-		/obj/item/storage/fancy/cigarettes/dromedaryco = 1,
+		/obj/item/storage/fancy/cigarettes/dromedaryco = 1, 
+		/obj/item/storage/medkit/civil_defense/stocked = 1, // NOVA EDIT ADDITION
+		/obj/item/storage/medkit/frontier/stocked = 1, // NOVA EDIT ADDITION
+		/obj/item/storage/medkit/combat_surgeon/stocked = 1, // NOVA EDIT ADDITION
+		/obj/item/stack/medical/suture = 1, // NOVA EDIT ADDITION
+		/obj/item/stack/medical/ointment/red_sun = 1, // NOVA EDIT ADDITION
+		/obj/item/reagent_containers/hypospray/medipen/deforest/morpital = 1, // NOVA EDIT ADDITION
+		/obj/item/reagent_containers/hypospray/medipen/deforest/aranepaine =1, // NOVA EDIT ADDITION
 		) = 1,
 
 	list(//food
@@ -177,6 +192,10 @@ GLOBAL_LIST_INIT(uncommon_loot, list(//uncommon: useful items
 		/obj/item/weldingtool/largetank = 1,
 		/obj/item/market_uplink/blackmarket = 1,
 		/obj/item/circuitboard/machine/ltsrbt = 1, //NOVA EDIT ADDITION - More widespread Black Market
+		/obj/item/melee/baton/security/stun_gun/stun_knife = 1, // NOVA EDIT ADDITION
+		/obj/item/melee/baton/security/stun_gun = 1, //NOVA EDIT ADDITION
+		/obj/item/gun/energy/taser/crank = 1, //NOVA EDIT ADDITION
+		/obj/item/gun/ballistic/automatic/pistol/doorhickey = 1, //NOVA EDIT ADDITION, yes it's lower in the code too, but it should be alot more common now
 		) = 8,
 
 	list(//equipment
@@ -387,8 +406,8 @@ GLOBAL_LIST_INIT(oddity_loot, list(//oddity: strange or crazy items
 	))
 
 //Maintenance loot spawner pools
-#define maint_trash_weight 4500
-#define maint_common_weight 4500
+#define maint_trash_weight 1200 // NOVA EDIT: Made these two alot less common so you get more varied items, does make oddities alot more common aswell Original: maint_trash_weight 4500
+#define maint_common_weight 1200 // NOVA EDIT: Made these two alot less common so you get more varied items does make oddities alot more common aswell Original: maint_common_weight 4500
 #define maint_uncommon_weight 900
 #define maint_rarity_weight 99
 #define maint_oddity_weight 1 //1 out of 10,000 would give metastation (180 spawns) a 2 in 111 chance of spawning an oddity per round, similar to xeno egg


### PR DESCRIPTION

## About The Pull Request
Tin, shuffles around maint-loot a bit so you can find sketchier stuff in there more often

## How This Contributes To The Nova Sector Roleplay Experience

maint-gremlins need some kickbacks

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  did not do yet
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Maint loot piles should be dropping not only more varied loot, but 'rarer' loot more often! (making it atleast slightly worth-while)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
