### PR TITLE
makes strongarm not restricted to medical

### DIFF
--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -191,6 +191,8 @@
 	contains = list(/obj/item/organ/cyberimp/arm/strongarm = 2)
 	crate_name = "Strong-Arm implant crate"
 	discountable = SUPPLY_PACK_RARE_DISCOUNTABLE
+	access = FALSE // NOVA EDIT - ADDITION
+	access_view = FALSE // NOVA EDIT - ADDITION
 
 /datum/supply_pack/medical/paperwork_implants
 	name = "Paperwork Implant Set"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

removes the access restriction from strongarm implant, it being purely medical-only is stupid and nonsensical, robotics is the ones who do implants, not medical. i would like to swap this to science/robo access (including department order console), but dont know how

## How This Contributes To The Nova Sector Roleplay Experience

we have a whole thing with who does what and why, medical being able to order what constitutes as combat implants, aswell as nobody else being able to get them as it is access locked to medical, makes no sense for here.

## Proof of Testing

it worked (trust me i tested it and forgot to record)

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl:
balance: made strong-arm implants not restricted to medical access
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
