### PR TITLE
adds .38 and .357 haywire, for finishing up your MvM Tour of Duty

### DIFF
--- a/modular_nova/master_files/code/modules/research/designs/weapon_designs.dm
+++ b/modular_nova/master_files/code/modules/research/designs/weapon_designs.dm
@@ -1,0 +1,30 @@
+/datum/design/c38_haywire
+	name = "Speed Loader (.38 Haywire) (Lethal)"
+	desc = "Designed to quickly reload revolvers. Haywire bullets create small electromagnetic pulses on impact; devastating against electronics."
+	id = "c38_haywire"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(
+		/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT * 10,
+		/datum/material/uranium = HALF_SHEET_MATERIAL_AMOUNT * 3,
+	)
+	build_path = /obj/item/ammo_box/c38/haywire
+	category = list(
+		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+
+/datum/design/c38_haywire_mag
+	name = "Magazine (.38 Haywire) (Lethal)"
+	desc = "Designed to tactically reload a NT BR-38 Battle Rifle. Haywire bullets create small electromagnetic pulses on impact; devastating against electronics."
+	id = "c38_haywire_mag"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(
+		/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT * 30,
+		/datum/material/uranium = HALF_SHEET_MATERIAL_AMOUNT * 9,
+		/datum/material/plastic = HALF_SHEET_MATERIAL_AMOUNT * 3,
+	)
+	build_path = /obj/item/ammo_box/magazine/m38/haywire
+	category = list(
+		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY

--- a/modular_nova/master_files/code/modules/research/techweb/all_nodes.dm
+++ b/modular_nova/master_files/code/modules/research/techweb/all_nodes.dm
@@ -245,6 +245,13 @@
 	)
 	return ..()
 
+/datum/techweb_node/exotic_ammo/New()
+	design_ids += list(
+		"c38_haywire",
+		"c38_haywire_mag",
+	)
+	return ..()
+
 ////////////////////////Alien technology////////////////////////
 
 /datum/techweb_node/alien_surgery/New()

--- a/modular_nova/modules/modular_weapons/code/modular_projectiles.dm
+++ b/modular_nova/modules/modular_weapons/code/modular_projectiles.dm
@@ -9,6 +9,75 @@
 // whatever goblin decided to spread out bullets over like 3 files and god knows however many overrides i wish you a very stubbed toe
 
 /*
+*	.38 Special
+*/
+#define COLOR_AMMO_EMP "#5f959c" // not undefining because it might be applicable for other EMP bullets in the future. no modular color defines file exists
+
+/obj/item/ammo_casing/c38/haywire
+	name = ".38 Haywire bullet casing"
+	desc = "A .38 Haywire bullet casing, with an electromagnetic generator in the tip.\
+	<br><br>\
+	<i>HAYWIRE: Electromagnetic pulse ammo. Deals little damage, but causes a small electromagnetic pulse.</i>"
+	projectile_type = /obj/projectile/bullet/c38/haywire
+	custom_materials = AMMO_MATS_EMP
+	advanced_print_req = TRUE
+
+/obj/item/ammo_box/c38/haywire
+	name = "speed loader (.38 Haywire)"
+	desc = "Designed to quickly reload revolvers. These rounds create small electromagnetic pulses upon impact."
+	ammo_type = /obj/item/ammo_casing/c38/haywire
+	ammo_band_color = COLOR_AMMO_EMP
+
+/obj/item/ammo_box/magazine/m38/haywire
+	name = "battle rifle magazine (.38 Haywire)"
+	desc = parent_type::desc + " These bullets create small electromagnetic pulses on impact; devastating against electronics."
+	ammo_type = /obj/item/ammo_casing/c38/haywire
+	ammo_band_color = COLOR_AMMO_EMP
+
+/obj/projectile/bullet/c38/haywire
+	name = ".38 haywire bullet"
+	damage = 10
+	ricochets_max = 0
+	embed_type = null
+	/// EMP radius when this bullet hits a target.
+	var/emp_radius = 0
+
+/obj/projectile/bullet/c38/haywire/on_hit(atom/target, blocked, pierce_hit)
+	. = ..()
+	empulse(target, 0, emp_radius)
+
+/*
+*	.357 Magnum
+*/
+
+/obj/item/ammo_casing/c357/haywire
+	name = ".357 Haywire+ bullet casing"
+	desc = "A .357 Haywire+ bullet casing, with a high-efficiency electromagnetic generator in the tip.\
+	<br><br>\
+	<i>HAYWIRE+: Electromagnetic pulse ammo. Deals moderate damage, and cause a small, but powerful, electromagnetic pulse.</i>"
+	projectile_type = /obj/projectile/bullet/c357/haywire
+	custom_materials = AMMO_MATS_EMP
+	advanced_print_req = TRUE
+
+/obj/item/ammo_box/a357/haywire
+	name = "speed loader (.357 Haywire+)"
+	desc = "Designed to quickly reload revolvers. These rounds create small, but powerful electromagnetic pulses upon impact."
+	ammo_type = /obj/item/ammo_casing/c357/haywire
+	ammo_band_color = COLOR_AMMO_EMP
+
+/obj/projectile/bullet/c357/haywire
+	name = ".357 haywire+ bullet"
+	damage = 40
+	ricochets_max = 0
+	embed_type = null
+	/// EMP radius when this bullet hits a target.
+	var/emp_radius = 1
+
+/obj/projectile/bullet/c357/haywire/on_hit(atom/target, blocked, pierce_hit)
+	. = ..()
+	empulse(target, emp_radius, emp_radius)
+
+/*
 *	.460 Ceres (renamed tgcode .45)
 */
 
@@ -74,7 +143,7 @@
 */
 
 /obj/item/ammo_casing/a223/rubber
-	name = ".277 rubber bullet casing"
+	name = ".277 Aestus rubber bullet casing"
 	desc = "A .277 rubber bullet casing.\
 	<br><br>\
 	<i>RUBBER: Less than lethal ammo. Deals both stamina damage and regular damage.</i>"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7087,6 +7087,7 @@
 #include "modular_nova\master_files\code\modules\research\designs\mining_designs.dm"
 #include "modular_nova\master_files\code\modules\research\designs\misc_designs.dm"
 #include "modular_nova\master_files\code\modules\research\designs\tool_designs.dm"
+#include "modular_nova\master_files\code\modules\research\designs\weapon_designs.dm"
 #include "modular_nova\master_files\code\modules\research\machinery\_production.dm"
 #include "modular_nova\master_files\code\modules\research\techweb\all_nodes.dm"
 #include "modular_nova\master_files\code\modules\shuttle\shuttle.dm"


### PR DESCRIPTION
## About The Pull Request
![image](https://github.com/user-attachments/assets/79b4f2dd-06f0-42ec-b1ef-2708b28f44e2)
Adds .38 and .357 haywire ammo. .38 haywire can be acquired via research or ammo bench, .357 haywire+ can only be acquired by ammo bench since I was too lazy to duct tape it into the uplink.

## How This Contributes To The Nova Sector Roleplay Experience

botkiller ammo funny

## Changelog

:cl:
add: .38 Haywire and .357 Haywire+ designs are now in circulation on advanced ammo workbench disks, and in security lathes/fabs with Exotic Ammunition research. These create small (or not so small) electromagnetic pulses on impact, in return for dealing much less direct damage.
/:cl:
