### PR TITLE
one-line changed to the syndicate spacetrooper (shotgon), definately not modular

### DIFF
--- a/code/modules/mob/living/basic/trooper/syndicate.dm
+++ b/code/modules/mob/living/basic/trooper/syndicate.dm
@@ -189,7 +189,7 @@
 	casingtype = /obj/item/ammo_casing/shotgun/buckshot //buckshot (up to 72.5 brute) fired in a two-round burst
 	ai_controller = /datum/ai_controller/basic_controller/trooper/ranged/shotgunner
 	ranged_cooldown = 3 SECONDS
-	burst_shots = 2
+	burst_shots = 1 // NOVA EDIT (prevents instant one-tap) - Original: burst_shots = 2
 	r_hand = /obj/item/gun/ballistic/shotgun/bulldog
 
 /mob/living/basic/trooper/syndicate/ranged/shotgun/space


### PR DESCRIPTION

## About The Pull Request

Makes them less-likely to instantly nuke you, as they're high-health, fast moving, and able to move freely in space

## How This Contributes To The Nova Sector Roleplay Experience
Less space-tiders getting McNuked by some random dude the second he sonar detects them

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Syndicate space troopers (with the shotty) not only fire one-shot, meaning they're alot less likely to instantly nuke you on first-contact (but still hurt, really bad)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
