### PR TITLE
unapologetic sks buff

### DIFF
--- a/modular_nova/master_files/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/modular_nova/master_files/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -1,0 +1,3 @@
+// todo: repath this to ballistic/rifle/sks when a 3/7+ upstream merge comes through
+/obj/item/gun/ballistic/automatic/sks
+	projectile_damage_multiplier = 1

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7072,6 +7072,7 @@
 #include "modular_nova\master_files\code\modules\projectiles\guns\energy.dm"
 #include "modular_nova\master_files\code\modules\projectiles\guns\ballistic\automatic.dm"
 #include "modular_nova\master_files\code\modules\projectiles\guns\ballistic\revolver.dm"
+#include "modular_nova\master_files\code\modules\projectiles\guns\ballistic\rifle.dm"
 #include "modular_nova\master_files\code\modules\projectiles\guns\ballistic\suppressor.dm"
 #include "modular_nova\master_files\code\modules\projectiles\guns\ballistic\bows\_bow.dm"
 #include "modular_nova\master_files\code\modules\projectiles\guns\ballistic\bows\bow_quivers.dm"


### PR DESCRIPTION
## About The Pull Request
buffs the sakhno SKS to a 1x damage multiplier
compare/contrast other comparable rifles, the sakhno/rengo and lanca:
sakhno/rengo:
- 1x damage mult
- bolt-action (inconvenient) but no delay other than click cooldown
- stripper clip fed (unless rengo, which is magfed)
- rengo is scoped

lanca:
- 1x damage mult
- semi-auto but increased fire delay
- magazine fed
- has a scope

sks pre-buff:
- 0.5x damage mult
- semi-auto
- stripper clip fed (inconvenient)
- no scope

## How This Contributes To The Nova Sector Roleplay Experience
funny

more seriously it's a rifle that you obtain by a sidequest that involves using the black market and then cobbling together random doodads. i think it's fine for it to hit harder because of the inconveniences associated with its obtainment and use

## Proof of Testing
![image](https://github.com/user-attachments/assets/e0516b6d-c4c3-4438-9224-629297f8235e)

## Changelog

:cl:
balance: The Sakhno SKS now has a 1x damage multiplier, up from 0.5x.
/:cl: