### PR TITLE
Adds the big-guncase as a backpack item

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -110,6 +110,7 @@ GLOBAL_LIST_INIT(security_depts_prefs, sort_list(list(
 #define TPACKB "Beltpack"
 #define TPACKA "Waistpack"
 #define TPACKC "Chest pack"
+#define GUNCASE "Guncase"
 // NOVA EDIT ADDITION END
 GLOBAL_LIST_INIT(backpacklist, list(
 	DBACKPACK,
@@ -125,6 +126,7 @@ GLOBAL_LIST_INIT(backpacklist, list(
 	TPACKB,
 	TPACKA,
 	TPACKC,
+	GUNCASE,
 	// NOVA EDIT ADDITION END
 ))
 

--- a/code/modules/client/preferences/clothing.dm
+++ b/code/modules/client/preferences/clothing.dm
@@ -35,6 +35,7 @@
 		TPACKB,
 		TPACKA,
 		TPACKC,
+		GUNCASE,
 		// NOVA EDIT ADDITION END
 	)
 /datum/preference/choiced/backpack/create_default_value()
@@ -59,6 +60,8 @@
 			return /obj/item/storage/backpack/tinypaka
 		if (TPACKC)
 			return /obj/item/storage/backpack/tinypakc
+		if (GUNCASE)
+			return /obj/item/storage/toolbox/guncase/nova
 		// NOVA EDIT ADDITION END
 
 		// In a perfect world, these would be your department's backpack.

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -401,6 +401,8 @@
 				back = /obj/item/storage/backpack/tinypaka
 			if(TPACKC)
 				back = /obj/item/storage/backpack/tinypakc
+			if(GUNCASE)
+				back = /obj/item/storage/toolbox/guncase/nova
 			// NOVA EDIT ADDITION START
 			else
 				back = backpack //Department backpack


### PR DESCRIPTION

## About The Pull Request

Tin, it's the grey-one

## How This Contributes To The Nova Sector Roleplay Experience

Another backpack option, that was an inhand option, for some reason. (still left it there for people not intending to wear it)

## Proof of Testing

# Soon TM, just putting this up early

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: guncases (large) are now a backpack slot item in the loadout!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
