### PR TITLE
Adds golem-mining-stuff to interdyne's mining vendor

### DIFF
--- a/modular_nova/modules/mapping/code/interdyne_mining.dm
+++ b/modular_nova/modules/mapping/code/interdyne_mining.dm
@@ -15,6 +15,7 @@
 		CATEGORY_TOYS_DRONE,
 		CATEGORY_PKA,
 		CATEGORY_INTERDYNE,
+		CATEGORY_GOLEM,
 	)
 
 // This is honestly quite terrible but, replaces voucher spawned mining drones with the interdyne subtype at this console


### PR DESCRIPTION
## About The Pull Request

TL;DR, lets them get the liberator's legacy with some mining points,
originally they didn't have this to encourage them to work with DS2, but that never panned out, so they're getting it back

## How This Contributes To The Nova Sector Roleplay Experience
It's like half a ghost-role without this, and generally leads to them having to go up and down from ds2 20x to get things set up

## Proof of Testing

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Interdyne now get's the liberator's legacy in their mining vendor, giving them access to a full R-N-D lathe and circuit printer, even off icebox
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
