### PR TITLE
Adds a new room to the ghost cafe's hotel orb

### DIFF
--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -170,6 +170,8 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 		load_from = ghost_cafe_rooms_apartment
 	else if(chosen_room == "Beach Condo")
 		load_from = ghost_cafe_rooms_beach_condo
+	else if(chosen_room == "Shuttle")
+		load_from = ghost_cafe_rooms_shuttle
 	//NOVA EDIT ADDITION END
 
 	load_from.load(bottom_left)

--- a/modular_nova/master_files/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/modular_nova/master_files/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -1,16 +1,19 @@
 // GHOST HOTEL UPDATE
 /obj/item/hilbertshotel
-	var/static/list/hotel_maps = list("Generic", "Apartment", "Beach Condo")
+	var/static/list/hotel_maps = list("Generic", "Apartment", "Beach Condo", "Shuttle")
 	//standard - hilbert's hotel room
 	//apartment - see /datum/map_template/ghost_cafe_rooms
 	var/datum/map_template/ghost_cafe_rooms/apartment/ghost_cafe_rooms_apartment
 	var/datum/map_template/ghost_cafe_rooms/beach_condo/ghost_cafe_rooms_beach_condo
+	var/datum/map_template/ghost_cafe_rooms/shuttle/ghost_cafe_rooms_shuttle
+
 
 // GHOST HOTEL UPDATE
 /obj/item/hilbertshotel/prepare_rooms()
 	. = ..()
 	ghost_cafe_rooms_apartment = new()
 	ghost_cafe_rooms_beach_condo = new()
+	ghost_cafe_rooms_shuttle = new()
 
 // GHOST HOTEL UPDATE
 /area/misc/hilbertshotel

--- a/modular_nova/modules/ghostcafe/code/hilbertshotel_ghost.dm
+++ b/modular_nova/modules/ghostcafe/code/hilbertshotel_ghost.dm
@@ -20,3 +20,7 @@
 /datum/map_template/ghost_cafe_rooms/beach_condo
 	name = "Beach Condo"
 	mappath = "modular_nova/modules/hotel_rooms/beach_condo.dmm"
+
+/datum/map_template/ghost_cafe_rooms/shuttle
+	name = "Shuttle"
+	mappath = "modular_nova/modules/hotel_rooms/smallship.dmm"

--- a/modular_nova/modules/hotel_rooms/smallship.dmm
+++ b/modular_nova/modules/hotel_rooms/smallship.dmm
@@ -1,0 +1,713 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"av" = (
+/turf/closed/indestructible/fakedoor{
+	name = "Maintenance"
+	},
+/area/misc/hilbertshotel)
+"cy" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/sign/painting/large/library{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/right,
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"cZ" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/misc/hilbertshotel)
+"eo" = (
+/obj/structure/window/reinforced/shuttle/indestructible,
+/turf/open/indestructible/plating,
+/area/misc/hilbertshotel)
+"fb" = (
+/turf/closed/indestructible/hoteldoor{
+	icon_state = "door_closed";
+	icon = 'icons/obj/doors/puzzledoor/default.dmi'
+	},
+/area/misc/hilbertshotel)
+"fI" = (
+/turf/closed/indestructible/fakedoor{
+	name = "Bridge"
+	},
+/area/misc/hilbertshotel)
+"hB" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"hQ" = (
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"jM" = (
+/turf/closed/indestructible/titanium,
+/area/misc/hilbertshotel)
+"lq" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/misc/hilbertshotel)
+"lw" = (
+/turf/open/floor/plating,
+/area/misc/hilbertshotel)
+"my" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 5;
+	pixel_y = 14
+	},
+/turf/open/floor/carpet/royalblue,
+/area/misc/hilbertshotel)
+"nQ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/machinery/light_switch/directional/north,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"ot" = (
+/obj/structure/chair,
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"qy" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"qK" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"qL" = (
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron/white/small,
+/area/misc/hilbertshotel)
+"qQ" = (
+/obj/structure/sign/painting,
+/turf/closed/indestructible/titanium,
+/area/misc/hilbertshotel)
+"rl" = (
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool/cobble/corner{
+	dir = 1
+	},
+/area/misc/hilbertshotel)
+"rv" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 9
+	},
+/turf/open/floor/iron/kitchen,
+/area/misc/hilbertshotel)
+"sl" = (
+/obj/structure/closet/firecloset/wall,
+/turf/closed/indestructible/titanium/nodiagonal,
+/area/misc/hilbertshotel)
+"sr" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/chair,
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"su" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen,
+/area/misc/hilbertshotel)
+"tL" = (
+/turf/closed/indestructible/titanium/nodiagonal,
+/area/misc/hilbertshotel)
+"tW" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"uk" = (
+/turf/open/space/bluespace,
+/area/misc/hilbertshotel)
+"uF" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 10
+	},
+/turf/open/floor/iron/kitchen,
+/area/misc/hilbertshotel)
+"uI" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"vy" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 5
+	},
+/turf/open/floor/iron/kitchen,
+/area/misc/hilbertshotel)
+"we" = (
+/obj/machinery/door/morgue,
+/turf/open/floor/iron/white/small,
+/area/misc/hilbertshotel)
+"xt" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/carpet/royalblue,
+/area/misc/hilbertshotel)
+"xy" = (
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"yw" = (
+/turf/closed/indestructible/fakedoor{
+	name = "Engineering"
+	},
+/area/misc/hilbertshotel)
+"yP" = (
+/obj/structure/sink/kitchen/directional/east,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen,
+/area/misc/hilbertshotel)
+"yW" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Ship Maintenance"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/hilbertshotel)
+"zL" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/closet/firecloset/wall,
+/turf/closed/indestructible/titanium/nodiagonal,
+/area/misc/hilbertshotel)
+"zS" = (
+/turf/open/floor/iron/white/small,
+/area/misc/hilbertshotel)
+"Ad" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/structure/table/wood,
+/obj/item/pizzabox/margherita{
+	pixel_y = 11
+	},
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"AH" = (
+/obj/machinery/door/airlock/silver/glass,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/hilbertshotel)
+"BP" = (
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"Cp" = (
+/obj/structure/closet/secure_closet/freezer/kitchen/all_access,
+/obj/effect/spawner/random/food_or_drink/three_course_meal,
+/obj/effect/spawner/random/food_or_drink/three_course_meal,
+/obj/effect/spawner/random/food_or_drink/three_course_meal,
+/obj/effect/spawner/random/food_or_drink/three_course_meal,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen,
+/area/misc/hilbertshotel)
+"Dg" = (
+/obj/structure/closet/firecloset/wall,
+/turf/closed/indestructible/titanium,
+/area/misc/hilbertshotel)
+"Eh" = (
+/obj/structure/curtain,
+/obj/item/soap/deluxe,
+/obj/machinery/shower/directional/west,
+/turf/open/floor/iron/white/small,
+/area/misc/hilbertshotel)
+"FR" = (
+/obj/machinery/light/warm/directional/north,
+/turf/open/floor/iron/white/small,
+/area/misc/hilbertshotel)
+"Gx" = (
+/obj/machinery/light/cold/directional/north,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"GC" = (
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool/cobble/side{
+	dir = 1
+	},
+/area/misc/hilbertshotel)
+"GR" = (
+/obj/structure/sign/painting/library,
+/turf/closed/indestructible/titanium,
+/area/misc/hilbertshotel)
+"Hy" = (
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool/cobble,
+/area/misc/hilbertshotel)
+"Iu" = (
+/obj/effect/spawner/liquids_spawner,
+/obj/machinery/light/warm/directional/south,
+/turf/open/floor/iron/pool/cobble/corner{
+	dir = 8
+	},
+/area/misc/hilbertshotel)
+"JV" = (
+/obj/structure/bed/double/pod{
+	dir = 4
+	},
+/obj/effect/spawner/random/bedsheet/any/double{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/misc/hilbertshotel)
+"Kv" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating,
+/area/misc/hilbertshotel)
+"Mc" = (
+/obj/effect/spawner/liquids_spawner,
+/obj/item/toy/plush/shark,
+/turf/open/floor/iron/pool/cobble,
+/area/misc/hilbertshotel)
+"Mo" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/misc/hilbertshotel)
+"Nv" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"NK" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/light/warm/directional/south,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/rag,
+/obj/item/pizzabox/margherita{
+	pixel_y = 11
+	},
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"Oo" = (
+/obj/structure/window/reinforced/shuttle/indestructible,
+/turf/open/floor/plating,
+/area/misc/hilbertshotel)
+"Pu" = (
+/obj/machinery/computer{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/misc/hilbertshotel)
+"Qo" = (
+/obj/machinery/light/cold/directional/north,
+/turf/open/floor/carpet/royalblue,
+/area/misc/hilbertshotel)
+"QH" = (
+/obj/machinery/power/smes,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/misc/hilbertshotel)
+"Rj" = (
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool/cobble/side{
+	dir = 4
+	},
+/area/misc/hilbertshotel)
+"Rz" = (
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool/cobble/corner,
+/area/misc/hilbertshotel)
+"RJ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/light/warm/directional/north,
+/obj/structure/chair/sofa/corp,
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"Sx" = (
+/turf/closed/indestructible/fakedoor/glass_airlock,
+/area/misc/hilbertshotel)
+"Ub" = (
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool/cobble/corner{
+	dir = 4
+	},
+/area/misc/hilbertshotel)
+"Uk" = (
+/obj/structure/sink/directional/south,
+/turf/open/floor/iron/white/small,
+/area/misc/hilbertshotel)
+"Ur" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/item/flashlight/lamp/green{
+	pixel_x = 5;
+	pixel_y = 14
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"VD" = (
+/obj/item/hairbrush{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/serviette_pack,
+/obj/structure/closet/cabinet,
+/turf/open/floor/carpet/royalblue,
+/area/misc/hilbertshotel)
+"VG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/structure/chair/sofa/corp/corner,
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"VQ" = (
+/obj/structure/table/reinforced,
+/obj/item/knife/kitchen,
+/obj/machinery/light/warm/directional/west,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen,
+/area/misc/hilbertshotel)
+"Wb" = (
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron/white/small,
+/area/misc/hilbertshotel)
+"Xd" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 6
+	},
+/turf/open/floor/iron/kitchen,
+/area/misc/hilbertshotel)
+"Xk" = (
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool/cobble/side{
+	dir = 8
+	},
+/area/misc/hilbertshotel)
+"Xz" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"XI" = (
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/carpet/royalblue,
+/area/misc/hilbertshotel)
+"XW" = (
+/obj/structure/chair/comfy/teal{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/misc/hilbertshotel)
+"Yq" = (
+/obj/machinery/light/warm/directional/west,
+/turf/open/floor/iron/white/small,
+/area/misc/hilbertshotel)
+"YF" = (
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool/cobble/side,
+/area/misc/hilbertshotel)
+"Zk" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet/royalblue,
+/area/misc/hilbertshotel)
+"Zl" = (
+/turf/open/floor/carpet/royalblue,
+/area/misc/hilbertshotel)
+
+(1,1,1) = {"
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+"}
+(2,1,1) = {"
+tL
+jM
+eo
+eo
+eo
+jM
+eo
+fb
+tL
+jM
+jM
+jM
+jM
+jM
+tL
+"}
+(3,1,1) = {"
+fI
+xy
+xy
+xy
+xy
+xy
+xy
+xy
+jM
+FR
+zS
+zS
+zS
+zS
+av
+"}
+(4,1,1) = {"
+qQ
+Nv
+xy
+xy
+xy
+BP
+hB
+xy
+jM
+qL
+rl
+Xk
+Xk
+Iu
+jM
+"}
+(5,1,1) = {"
+jM
+jM
+jM
+AH
+jM
+sl
+xy
+xy
+jM
+Wb
+GC
+Mc
+Hy
+YF
+jM
+"}
+(6,1,1) = {"
+jM
+JV
+my
+Zl
+Zk
+jM
+hQ
+xy
+GR
+zS
+Rz
+Rj
+Rj
+Ub
+jM
+"}
+(7,1,1) = {"
+jM
+XI
+Zl
+Zl
+xt
+GR
+xy
+xy
+jM
+AH
+jM
+jM
+jM
+jM
+jM
+"}
+(8,1,1) = {"
+jM
+Qo
+Zl
+Zl
+xt
+jM
+Gx
+xy
+AH
+rv
+yP
+Cp
+VQ
+uF
+jM
+"}
+(9,1,1) = {"
+jM
+Mo
+Zl
+Zl
+xt
+jM
+hB
+uI
+GR
+vy
+su
+su
+su
+Xd
+yw
+"}
+(10,1,1) = {"
+jM
+Pu
+XW
+Zl
+VD
+jM
+jM
+yW
+jM
+nQ
+tW
+tW
+tW
+qy
+jM
+"}
+(11,1,1) = {"
+jM
+jM
+jM
+we
+tL
+zL
+cZ
+lq
+jM
+cy
+aa
+aa
+aa
+qK
+jM
+"}
+(12,1,1) = {"
+jM
+Uk
+Yq
+zS
+jM
+QH
+lw
+lw
+jM
+RJ
+aa
+aa
+ot
+NK
+jM
+"}
+(13,1,1) = {"
+jM
+Eh
+zS
+zS
+jM
+QH
+Kv
+lw
+Dg
+VG
+Xz
+Ur
+sr
+Ad
+jM
+"}
+(14,1,1) = {"
+tL
+jM
+Oo
+Oo
+jM
+jM
+Oo
+Sx
+tL
+jM
+eo
+eo
+eo
+jM
+tL
+"}
+(15,1,1) = {"
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+"}
+(16,1,1) = {"
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+uk
+"}

--- a/modular_nova/modules/hotel_rooms/smallship.dmm
+++ b/modular_nova/modules/hotel_rooms/smallship.dmm
@@ -1,200 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"aa" = (
-/turf/open/floor/wood,
-/area/misc/hilbertshotel)
-"av" = (
-/turf/closed/indestructible/fakedoor{
-	name = "Maintenance"
-	},
-/area/misc/hilbertshotel)
-"cy" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/sign/painting/large/library{
-	dir = 1
-	},
-/obj/structure/chair/sofa/corp/right,
-/turf/open/floor/wood,
-/area/misc/hilbertshotel)
-"cZ" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/misc/hilbertshotel)
-"eo" = (
-/obj/structure/window/reinforced/shuttle/indestructible,
-/turf/open/indestructible/plating,
-/area/misc/hilbertshotel)
-"fb" = (
-/turf/closed/indestructible/hoteldoor{
-	icon_state = "door_closed";
-	icon = 'icons/obj/doors/puzzledoor/default.dmi'
-	},
-/area/misc/hilbertshotel)
-"fI" = (
-/turf/closed/indestructible/fakedoor{
-	name = "Bridge"
-	},
-/area/misc/hilbertshotel)
-"hB" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/misc/hilbertshotel)
-"hQ" = (
+"ak" = (
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/misc/hilbertshotel)
-"jM" = (
-/turf/closed/indestructible/titanium,
-/area/misc/hilbertshotel)
-"lq" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/misc/hilbertshotel)
-"lw" = (
-/turf/open/floor/plating,
-/area/misc/hilbertshotel)
-"my" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 5;
-	pixel_y = 14
-	},
-/turf/open/floor/carpet/royalblue,
-/area/misc/hilbertshotel)
-"nQ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/machinery/light_switch/directional/north,
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood,
-/area/misc/hilbertshotel)
-"ot" = (
-/obj/structure/chair,
-/turf/open/floor/wood,
-/area/misc/hilbertshotel)
-"qy" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/misc/hilbertshotel)
-"qK" = (
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/misc/hilbertshotel)
-"qL" = (
-/obj/structure/sign/poster/random/directional/north,
-/turf/open/floor/iron/white/small,
-/area/misc/hilbertshotel)
-"qQ" = (
-/obj/structure/sign/painting,
-/turf/closed/indestructible/titanium,
-/area/misc/hilbertshotel)
-"rl" = (
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool/cobble/corner{
-	dir = 1
-	},
-/area/misc/hilbertshotel)
-"rv" = (
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 9
-	},
-/turf/open/floor/iron/kitchen,
-/area/misc/hilbertshotel)
-"sl" = (
-/obj/structure/closet/firecloset/wall,
-/turf/closed/indestructible/titanium/nodiagonal,
-/area/misc/hilbertshotel)
-"sr" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/chair,
-/turf/open/floor/wood,
-/area/misc/hilbertshotel)
-"su" = (
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 4
-	},
-/turf/open/floor/iron/kitchen,
-/area/misc/hilbertshotel)
-"tL" = (
-/turf/closed/indestructible/titanium/nodiagonal,
-/area/misc/hilbertshotel)
-"tW" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/misc/hilbertshotel)
-"uk" = (
-/turf/open/space/bluespace,
-/area/misc/hilbertshotel)
-"uF" = (
-/obj/structure/table/reinforced,
-/obj/machinery/microwave{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 10
-	},
-/turf/open/floor/iron/kitchen,
-/area/misc/hilbertshotel)
-"uI" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/misc/hilbertshotel)
-"vy" = (
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 5
-	},
-/turf/open/floor/iron/kitchen,
-/area/misc/hilbertshotel)
-"we" = (
-/obj/machinery/door/morgue,
-/turf/open/floor/iron/white/small,
-/area/misc/hilbertshotel)
-"xt" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/carpet/royalblue,
-/area/misc/hilbertshotel)
-"xy" = (
-/turf/open/floor/iron,
-/area/misc/hilbertshotel)
-"yw" = (
-/turf/closed/indestructible/fakedoor{
-	name = "Engineering"
-	},
-/area/misc/hilbertshotel)
-"yP" = (
-/obj/structure/sink/kitchen/directional/east,
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 8
-	},
-/turf/open/floor/iron/kitchen,
-/area/misc/hilbertshotel)
-"yW" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Ship Maintenance"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/hilbertshotel)
-"zL" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/structure/closet/firecloset/wall,
-/turf/closed/indestructible/titanium/nodiagonal,
-/area/misc/hilbertshotel)
-"zS" = (
-/turf/open/floor/iron/white/small,
-/area/misc/hilbertshotel)
-"Ad" = (
+"bH" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
@@ -204,15 +13,145 @@
 	},
 /turf/open/floor/wood,
 /area/misc/hilbertshotel)
-"AH" = (
-/obj/machinery/door/airlock/silver/glass,
-/turf/open/floor/iron/dark/textured_large,
+"cw" = (
+/obj/machinery/power/smes,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/misc/hilbertshotel)
-"BP" = (
-/obj/machinery/light/cold/directional/east,
+"cG" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/carpet/royalblue,
+/area/misc/hilbertshotel)
+"cU" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"dY" = (
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool/cobble,
+/area/misc/hilbertshotel)
+"eD" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/sign/painting/large/library{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp/right,
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"gg" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/closed/indestructible/titanium/nodiagonal,
+/area/misc/hilbertshotel)
+"gp" = (
 /turf/open/floor/iron,
 /area/misc/hilbertshotel)
-"Cp" = (
+"gu" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"gF" = (
+/turf/open/space/bluespace,
+/area/misc/hilbertshotel)
+"hE" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet/royalblue,
+/area/misc/hilbertshotel)
+"it" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/misc/hilbertshotel)
+"iu" = (
+/obj/structure/sign/painting,
+/turf/closed/indestructible/titanium,
+/area/misc/hilbertshotel)
+"iF" = (
+/obj/structure/curtain,
+/obj/item/soap/deluxe,
+/obj/machinery/shower/directional/west,
+/turf/open/floor/iron/white/small,
+/area/misc/hilbertshotel)
+"js" = (
+/obj/structure/sink/directional/south,
+/turf/open/floor/iron/white/small,
+/area/misc/hilbertshotel)
+"jD" = (
+/turf/closed/indestructible/titanium/nodiagonal,
+/area/misc/hilbertshotel)
+"jG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/chair,
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"jX" = (
+/obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/plating,
+/area/misc/hilbertshotel)
+"lN" = (
+/obj/machinery/light/warm/directional/north,
+/turf/open/floor/iron/white/small,
+/area/misc/hilbertshotel)
+"nx" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/misc/hilbertshotel)
+"nC" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 9
+	},
+/turf/open/floor/iron/kitchen,
+/area/misc/hilbertshotel)
+"nK" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating,
+/area/misc/hilbertshotel)
+"ow" = (
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool/cobble/corner,
+/area/misc/hilbertshotel)
+"oF" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 5
+	},
+/turf/open/floor/iron/kitchen,
+/area/misc/hilbertshotel)
+"oK" = (
+/turf/open/floor/plating,
+/area/misc/hilbertshotel)
+"qr" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"qz" = (
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool/cobble/side{
+	dir = 4
+	},
+/area/misc/hilbertshotel)
+"sC" = (
+/turf/closed/indestructible/fakedoor{
+	name = "Bridge"
+	},
+/area/misc/hilbertshotel)
+"sQ" = (
+/turf/closed/indestructible/hoteldoor{
+	icon_state = "door_closed";
+	icon = 'icons/obj/doors/puzzledoor/default.dmi'
+	},
+/area/misc/hilbertshotel)
+"sZ" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/all_access,
 /obj/effect/spawner/random/food_or_drink/three_course_meal,
 /obj/effect/spawner/random/food_or_drink/three_course_meal,
@@ -225,134 +164,69 @@
 	},
 /turf/open/floor/iron/kitchen,
 /area/misc/hilbertshotel)
-"Dg" = (
-/obj/structure/closet/firecloset/wall,
-/turf/closed/indestructible/titanium,
-/area/misc/hilbertshotel)
-"Eh" = (
-/obj/structure/curtain,
-/obj/item/soap/deluxe,
-/obj/machinery/shower/directional/west,
-/turf/open/floor/iron/white/small,
-/area/misc/hilbertshotel)
-"FR" = (
-/obj/machinery/light/warm/directional/north,
-/turf/open/floor/iron/white/small,
-/area/misc/hilbertshotel)
-"Gx" = (
-/obj/machinery/light/cold/directional/north,
-/turf/open/floor/iron,
-/area/misc/hilbertshotel)
-"GC" = (
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool/cobble/side{
-	dir = 1
+"tc" = (
+/turf/closed/indestructible/fakedoor{
+	name = "Engineering"
 	},
 /area/misc/hilbertshotel)
-"GR" = (
-/obj/structure/sign/painting/library,
-/turf/closed/indestructible/titanium,
-/area/misc/hilbertshotel)
-"Hy" = (
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool/cobble,
-/area/misc/hilbertshotel)
-"Iu" = (
+"tI" = (
 /obj/effect/spawner/liquids_spawner,
 /obj/machinery/light/warm/directional/south,
 /turf/open/floor/iron/pool/cobble/corner{
 	dir = 8
 	},
 /area/misc/hilbertshotel)
-"JV" = (
-/obj/structure/bed/double/pod{
-	dir = 4
-	},
-/obj/effect/spawner/random/bedsheet/any/double{
-	dir = 4
-	},
+"ue" = (
 /turf/open/floor/carpet/royalblue,
 /area/misc/hilbertshotel)
-"Kv" = (
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/plating,
+"up" = (
+/obj/machinery/light/warm/directional/west,
+/turf/open/floor/iron/white/small,
 /area/misc/hilbertshotel)
-"Mc" = (
+"ut" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/machinery/light_switch/directional/north,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"vt" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"vv" = (
+/turf/closed/indestructible/fakedoor/glass_airlock,
+/area/misc/hilbertshotel)
+"vy" = (
+/obj/machinery/light/cold/directional/north,
+/turf/open/floor/carpet/royalblue,
+/area/misc/hilbertshotel)
+"wt" = (
+/obj/machinery/door/airlock/silver/glass,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/hilbertshotel)
+"wB" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 10
+	},
+/turf/open/floor/iron/kitchen,
+/area/misc/hilbertshotel)
+"wO" = (
 /obj/effect/spawner/liquids_spawner,
 /obj/item/toy/plush/shark,
 /turf/open/floor/iron/pool/cobble,
 /area/misc/hilbertshotel)
-"Mo" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/carpet/royalblue,
-/area/misc/hilbertshotel)
-"Nv" = (
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/iron,
-/area/misc/hilbertshotel)
-"NK" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/light/warm/directional/south,
-/obj/structure/table/wood,
-/obj/item/reagent_containers/cup/rag,
-/obj/item/pizzabox/margherita{
-	pixel_y = 11
-	},
-/turf/open/floor/wood,
-/area/misc/hilbertshotel)
-"Oo" = (
+"xD" = (
 /obj/structure/window/reinforced/shuttle/indestructible,
 /turf/open/floor/plating,
 /area/misc/hilbertshotel)
-"Pu" = (
-/obj/machinery/computer{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblue,
-/area/misc/hilbertshotel)
-"Qo" = (
-/obj/machinery/light/cold/directional/north,
-/turf/open/floor/carpet/royalblue,
-/area/misc/hilbertshotel)
-"QH" = (
-/obj/machinery/power/smes,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/misc/hilbertshotel)
-"Rj" = (
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool/cobble/side{
-	dir = 4
-	},
-/area/misc/hilbertshotel)
-"Rz" = (
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool/cobble/corner,
-/area/misc/hilbertshotel)
-"RJ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/light/warm/directional/north,
-/obj/structure/chair/sofa/corp,
-/turf/open/floor/wood,
-/area/misc/hilbertshotel)
-"Sx" = (
-/turf/closed/indestructible/fakedoor/glass_airlock,
-/area/misc/hilbertshotel)
-"Ub" = (
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool/cobble/corner{
-	dir = 4
-	},
-/area/misc/hilbertshotel)
-"Uk" = (
-/obj/structure/sink/directional/south,
-/turf/open/floor/iron/white/small,
-/area/misc/hilbertshotel)
-"Ur" = (
+"Bi" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
@@ -363,48 +237,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/misc/hilbertshotel)
-"VD" = (
-/obj/item/hairbrush{
-	pixel_x = 2;
-	pixel_y = 3
+"Dp" = (
+/obj/structure/chair/comfy/teal{
+	dir = 8
 	},
-/obj/item/serviette_pack,
-/obj/structure/closet/cabinet,
 /turf/open/floor/carpet/royalblue,
 /area/misc/hilbertshotel)
-"VG" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/structure/chair/sofa/corp/corner,
-/turf/open/floor/wood,
-/area/misc/hilbertshotel)
-"VQ" = (
-/obj/structure/table/reinforced,
-/obj/item/knife/kitchen,
-/obj/machinery/light/warm/directional/west,
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 8
-	},
-/turf/open/floor/iron/kitchen,
-/area/misc/hilbertshotel)
-"Wb" = (
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron/white/small,
-/area/misc/hilbertshotel)
-"Xd" = (
-/obj/effect/turf_decal/siding/thinplating_new/light{
-	dir = 6
-	},
-/turf/open/floor/iron/kitchen,
-/area/misc/hilbertshotel)
-"Xk" = (
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool/cobble/side{
-	dir = 8
-	},
-/area/misc/hilbertshotel)
-"Xz" = (
+"DW" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
@@ -413,301 +252,459 @@
 	},
 /turf/open/floor/wood,
 /area/misc/hilbertshotel)
-"XI" = (
+"Ed" = (
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool/cobble/corner{
+	dir = 4
+	},
+/area/misc/hilbertshotel)
+"Fu" = (
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron/white/small,
+/area/misc/hilbertshotel)
+"GM" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 5;
+	pixel_y = 14
+	},
+/turf/open/floor/carpet/royalblue,
+/area/misc/hilbertshotel)
+"Ib" = (
+/obj/structure/sign/painting/library,
+/turf/closed/indestructible/titanium,
+/area/misc/hilbertshotel)
+"IL" = (
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron/white/small,
+/area/misc/hilbertshotel)
+"IR" = (
+/obj/structure/table/reinforced,
+/obj/item/knife/kitchen,
+/obj/machinery/light/warm/directional/west,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen,
+/area/misc/hilbertshotel)
+"Jg" = (
+/turf/closed/indestructible/fakedoor{
+	name = "Maintenance"
+	},
+/area/misc/hilbertshotel)
+"Jx" = (
+/turf/open/floor/iron/white/small,
+/area/misc/hilbertshotel)
+"Jz" = (
+/obj/structure/window/reinforced/shuttle/indestructible,
+/turf/open/indestructible/plating,
+/area/misc/hilbertshotel)
+"Ki" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/light/warm/directional/north,
+/obj/structure/chair/sofa/corp,
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"Kj" = (
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"LN" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 6
+	},
+/turf/open/floor/iron/kitchen,
+/area/misc/hilbertshotel)
+"LQ" = (
+/obj/item/hairbrush{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/serviette_pack,
+/obj/structure/closet/cabinet,
+/turf/open/floor/carpet/royalblue,
+/area/misc/hilbertshotel)
+"Mc" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"Ni" = (
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool/cobble/side{
+	dir = 1
+	},
+/area/misc/hilbertshotel)
+"NL" = (
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool/cobble/side{
+	dir = 8
+	},
+/area/misc/hilbertshotel)
+"Qq" = (
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen,
+/area/misc/hilbertshotel)
+"QR" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"Rr" = (
+/obj/structure/chair,
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"Sq" = (
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"Sw" = (
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool/cobble/corner{
+	dir = 1
+	},
+/area/misc/hilbertshotel)
+"SO" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Ship Maintenance"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/hilbertshotel)
+"Ui" = (
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool/cobble/side,
+/area/misc/hilbertshotel)
+"UB" = (
+/obj/structure/sink/kitchen/directional/east,
+/obj/effect/turf_decal/siding/thinplating_new/light{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen,
+/area/misc/hilbertshotel)
+"UI" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/light/warm/directional/south,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/rag,
+/obj/item/pizzabox/margherita{
+	pixel_y = 11
+	},
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"WL" = (
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/carpet/royalblue,
 /area/misc/hilbertshotel)
-"XW" = (
-/obj/structure/chair/comfy/teal{
+"WY" = (
+/obj/structure/bed/double/pod{
+	dir = 4
+	},
+/obj/effect/spawner/random/bedsheet/any/double{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/misc/hilbertshotel)
+"Xy" = (
+/obj/machinery/door/morgue,
+/turf/open/floor/iron/white/small,
+/area/misc/hilbertshotel)
+"XG" = (
+/obj/machinery/light/cold/directional/north,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"Yl" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/structure/chair/sofa/corp/corner,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/wood,
+/area/misc/hilbertshotel)
+"YT" = (
+/turf/closed/indestructible/titanium,
+/area/misc/hilbertshotel)
+"Zj" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"Zv" = (
+/obj/machinery/computer{
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblue,
 /area/misc/hilbertshotel)
-"Yq" = (
-/obj/machinery/light/warm/directional/west,
-/turf/open/floor/iron/white/small,
-/area/misc/hilbertshotel)
-"YF" = (
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool/cobble/side,
-/area/misc/hilbertshotel)
-"Zk" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/royalblue,
-/area/misc/hilbertshotel)
-"Zl" = (
-/turf/open/floor/carpet/royalblue,
-/area/misc/hilbertshotel)
 
 (1,1,1) = {"
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
 "}
 (2,1,1) = {"
-tL
-jM
-eo
-eo
-eo
-jM
-eo
-fb
-tL
-jM
-jM
-jM
-jM
-jM
-tL
+jD
+YT
+Jz
+Jz
+Jz
+YT
+Jz
+sQ
+jD
+YT
+xD
+xD
+xD
+YT
+jD
 "}
 (3,1,1) = {"
-fI
-xy
-xy
-xy
-xy
-xy
-xy
-xy
-jM
-FR
-zS
-zS
-zS
-zS
-av
+sC
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+YT
+lN
+Jx
+Jx
+Jx
+Jx
+Jg
 "}
 (4,1,1) = {"
-qQ
-Nv
-xy
-xy
-xy
-BP
-hB
-xy
-jM
-qL
-rl
-Xk
-Xk
-Iu
-jM
+iu
+QR
+gp
+gp
+gp
+Kj
+Zj
+gp
+YT
+IL
+Sw
+NL
+NL
+tI
+YT
 "}
 (5,1,1) = {"
-jM
-jM
-jM
-AH
-jM
-sl
-xy
-xy
-jM
-Wb
-GC
-Mc
-Hy
-YF
-jM
+YT
+YT
+YT
+wt
+YT
+jD
+gu
+gp
+YT
+Fu
+Ni
+wO
+dY
+Ui
+YT
 "}
 (6,1,1) = {"
-jM
-JV
-my
-Zl
-Zk
-jM
-hQ
-xy
-GR
-zS
-Rz
-Rj
-Rj
-Ub
-jM
+YT
+WY
+GM
+ue
+hE
+YT
+ak
+gp
+Ib
+Jx
+ow
+qz
+qz
+Ed
+YT
 "}
 (7,1,1) = {"
-jM
-XI
-Zl
-Zl
-xt
-GR
-xy
-xy
-jM
-AH
-jM
-jM
-jM
-jM
-jM
+YT
+WL
+ue
+ue
+cG
+Ib
+gp
+gp
+YT
+wt
+YT
+YT
+YT
+YT
+YT
 "}
 (8,1,1) = {"
-jM
-Qo
-Zl
-Zl
-xt
-jM
-Gx
-xy
-AH
-rv
-yP
-Cp
-VQ
-uF
-jM
+YT
+vy
+ue
+ue
+cG
+YT
+XG
+gp
+wt
+nC
+UB
+sZ
+IR
+wB
+YT
 "}
 (9,1,1) = {"
-jM
-Mo
-Zl
-Zl
-xt
-jM
-hB
-uI
-GR
-vy
-su
-su
-su
-Xd
-yw
+YT
+it
+ue
+ue
+cG
+YT
+Zj
+vt
+Ib
+oF
+Qq
+Qq
+Qq
+LN
+tc
 "}
 (10,1,1) = {"
-jM
-Pu
-XW
-Zl
-VD
-jM
-jM
-yW
-jM
-nQ
-tW
-tW
-tW
-qy
-jM
+YT
+Zv
+Dp
+ue
+LQ
+YT
+YT
+SO
+YT
+ut
+qr
+qr
+qr
+cU
+YT
 "}
 (11,1,1) = {"
-jM
-jM
-jM
-we
-tL
-zL
-cZ
-lq
-jM
-cy
-aa
-aa
-aa
-qK
-jM
+YT
+YT
+YT
+Xy
+jD
+gg
+jX
+nx
+YT
+eD
+Sq
+Sq
+Sq
+Mc
+YT
 "}
 (12,1,1) = {"
-jM
-Uk
-Yq
-zS
-jM
-QH
-lw
-lw
-jM
-RJ
-aa
-aa
-ot
-NK
-jM
+YT
+js
+up
+Jx
+YT
+cw
+oK
+oK
+YT
+Ki
+Sq
+Sq
+Rr
+UI
+YT
 "}
 (13,1,1) = {"
-jM
-Eh
-zS
-zS
-jM
-QH
-Kv
-lw
-Dg
-VG
-Xz
-Ur
-sr
-Ad
-jM
+YT
+iF
+Jx
+Jx
+YT
+cw
+nK
+oK
+YT
+Yl
+DW
+Bi
+jG
+bH
+YT
 "}
 (14,1,1) = {"
-tL
-jM
-Oo
-Oo
-jM
-jM
-Oo
-Sx
-tL
-jM
-eo
-eo
-eo
-jM
-tL
+jD
+YT
+xD
+xD
+YT
+YT
+xD
+vv
+jD
+YT
+Jz
+Jz
+Jz
+YT
+jD
 "}
 (15,1,1) = {"
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
 "}
 (16,1,1) = {"
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
-uk
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
+gF
 "}


### PR DESCRIPTION

## About The Pull Request
As the tile says adds a new room to the hotel's ghost rooms, it couldn't be bigger as the size of the ghost room's max limit, bricks the system somewhat.

## How This Contributes To The Nova Sector Roleplay Experience

I think this allows for a new setting to roleplay in, giving the place a bit of comfort!
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/0a670124-e2fc-4a28-8c08-a7d01d0ceb84)

</details>

## Changelog
:cl:
map: added a new ghost room called "shuttle" for ghost cafe's "ghost dojo/hotel"
/:cl:
