### PR TITLE
Snowglobe Ice Cream Machine

### DIFF
--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -17878,9 +17878,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/obj/structure/chair/sofa/left/brown{
-	dir = 1
-	},
+/obj/machinery/food_cart,
 /turf/open/floor/wood/tile,
 /area/station/service/kitchen/diner)
 "eQq" = (
@@ -43257,6 +43255,10 @@
 	pixel_x = -13;
 	pixel_y = 0
 	},
+/obj/item/storage/bag/chemistry{
+	pixel_x = 1;
+	pixel_y = -6
+	},
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/virology)
 "lBO" = (
@@ -50118,9 +50120,7 @@
 "nxH" = (
 /obj/structure/window/spawner/directional/south,
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/chair/sofa/right/brown{
-	dir = 1
-	},
+/obj/machinery/icecream_vat,
 /turf/open/floor/wood/tile,
 /area/station/service/kitchen/diner)
 "nxL" = (
@@ -248115,7 +248115,7 @@ dOY
 xCF
 kYF
 fdf
-goZ
+nxH
 qmr
 dgr
 oyQ
@@ -248372,7 +248372,7 @@ nEu
 nEu
 uBr
 oKV
-nxH
+lZd
 dmw
 iJQ
 rSU


### PR DESCRIPTION
## About The Pull Request

Another tiny pr for Snowglobe. This one adds the ice cream machine and the food cart to the cafeteria. Also, a single chem bag in virology to save virologists a boring trip upstairs if they are in the zone.

## How This Contributes To The Nova Sector Roleplay Experience

Someone spent way too long looking for the ice cream machine only to find it did not exist. It really should exist. This PR makes it exist. Serendipitous. 

## Proof of Testing

<details>
The ice cream and food cart in question.

![test1](https://github.com/user-attachments/assets/e74e8da8-8172-431e-abea-2f3f7920d833)

polite roundstart bag to haul pills up to the public fridge for viro.
![test2](https://github.com/user-attachments/assets/e1d47e7f-09a7-446e-becd-5decd7cc54d5)

</details>

## Changelog

:cl:
add: Added Ice cream cart and Food Cart to Snowglobe. And a round start viro chem bag.
/:cl:

