### PR TITLE
Minor alterations to DS-2

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
@@ -5151,6 +5151,16 @@
 	pixel_x = -30;
 	req_access = list("syndicate")
 	},
+/obj/structure/table,
+/obj/item/circuitboard/machine/syndiepad/syndicate,
+/obj/item/circuitboard/computer/syndiepad/syndicate{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/circuitboard/computer/cargo/express/interdyne/syndicate{
+	pixel_y = 4;
+	pixel_x = 4
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/nova/des_two/bridge/vault)
 "xr" = (
@@ -8601,9 +8611,6 @@
 /obj/machinery/airalarm/directional/west,
 /obj/structure/filingcabinet,
 /obj/item/folder/syndicate/red,
-/obj/item/circuitboard/computer/cargo/express/interdyne/syndicate,
-/obj/item/circuitboard/computer/syndiepad/syndicate,
-/obj/item/circuitboard/machine/syndiepad/syndicate,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/nova/des_two/bridge/vault)
 "MZ" = (
@@ -11352,6 +11359,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/vending/autodrobe,
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/nova/des_two/service/dorms)
 "ZQ" = (


### PR DESCRIPTION

## About The Pull Request

* Moves Syndie cargo boards to a table in the vault so they can be easily noticed and found

* Adds an autodrobe to DS-2 for fancy wears!
## How This Contributes To The Nova Sector Roleplay Experience
At occasional times on DS-2 I've wanted to have fancier clothing and attire but there was no autodrobe to do so! I think this would allow ds-2 members to have bit more fashion and glamour while operating on DS-2!
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/91b9fbce-6cff-4889-a9e9-3b2bb6979042)

![image](https://github.com/user-attachments/assets/11e7f0f9-1b9d-417a-bbc0-9a1556898baa)


</details>

## Changelog
:cl:
map: moves DS-2 cargo boards to a table in the vault
map: adds an autodrobe to ds-2 dormitories
/:cl:
