### PR TITLE
Remove TRAIT_BALLMER_SCIENTIST from RD and Scientist livers

### DIFF
--- a/modular_nova/modules/ballmer_fix/research_director.dm
+++ b/modular_nova/modules/ballmer_fix/research_director.dm
@@ -1,0 +1,2 @@
+/datum/job/research_director
+	liver_traits = list(TRAIT_ROYAL_METABOLISM)

--- a/modular_nova/modules/ballmer_fix/scientist.dm
+++ b/modular_nova/modules/ballmer_fix/scientist.dm
@@ -1,0 +1,2 @@
+/datum/job/scientist
+	liver_traits = null

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7261,6 +7261,8 @@
 #include "modular_nova\modules\awaymissions_nova\mothership_astrum\mob.dm"
 #include "modular_nova\modules\awaymissions_nova\mothership_astrum\mob_spawn.dm"
 #include "modular_nova\modules\awaymissions_nova\mothership_astrum\spawners.dm"
+#include "modular_nova\modules\ballmer_fix\research_director.dm"
+#include "modular_nova\modules\ballmer_fix\scientist.dm"
 #include "modular_nova\modules\banning\code\nova_bans.dm"
 #include "modular_nova\modules\barricades\code\barricade.dm"
 #include "modular_nova\modules\barsigns\code\barsigns.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the `TRAIT_BALLMER_SCIENTIST` flag from the RD and Scientist livers. This is the most permanent temporary fix, the ideal would probably be a preference or an actual trait you can select for specifically a research job but that's up to someone else to decide.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
There's a neat lil suggestion on the Discord that wanted the force-say for ballmer's peak removed due to the roleplay experience. This complies pretty heccin well.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: RD and Scientists no longer have a ballmer's peak by default
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
