### PR TITLE
 Nukes forced walking in gunpoint

### DIFF
--- a/modular_nova/modules/gunpoint/code/gunpoint_datum.dm
+++ b/modular_nova/modules/gunpoint/code/gunpoint_datum.dm
@@ -26,10 +26,12 @@
 	source.face_atom(target)
 	source.visible_message(span_danger("[source.name] aims at [target.name] with the [aimed_gun.name]!"))
 
-///	was_running = (source.move_intent == MOVE_INTENT_RUN) /// Nova edit - allows you to run while aiming
-///	if(was_running)
-///		source.toggle_move_intent()
-///	ADD_TRAIT(source, TRAIT_NORUNNING, "gunpoint")
+	/* // NOVA EDIT REMOVAL START
+	was_running = (source.move_intent == MOVE_INTENT_RUN)
+	if(was_running)
+		source.toggle_move_intent()
+	ADD_TRAIT(source, TRAIT_NORUNNING, "gunpoint")
+	*/ // NOVA EDIT REMOVAL END
 
 	if(!target.gp_effect)
 		target.gp_effect = new


### PR DESCRIPTION

## About The Pull Request
Removes forced WALK trait as you take someone at gunpoint. without it's mechanical features it is absolutely useless.
And only allows other party forfiet roleplay and run away while you are hindered.
## How This Contributes To The Nova Sector Roleplay Experience
Makes roleplay feature actually roleplay friendly and not hinderance that could be abused by anyone who cares about roleplay lesser than you do in thes cene
## Proof of Testing
https://youtu.be/FzfIElyBZpw

</details>

## Changelog
:cl:
code: removed forced WALK on gunpoint. now you run
/:cl:
