### PR TITLE
[TEST MERGE ONLY DO NOT MERGE THIS UNDER ANY CIRCUMSTANCES] CQC returns to traitors, but they also forget how to use guns.

### DIFF
--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -414,3 +414,4 @@
 #undef RESTRAIN_COMBO
 #undef PRESSURE_COMBO
 #undef CONSECUTIVE_COMBO
+#undef CQC_TRAIT "CQC trait"

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -3,6 +3,7 @@
 #define RESTRAIN_COMBO "GG"
 #define PRESSURE_COMBO "DG"
 #define CONSECUTIVE_COMBO "DDH"
+#define CQC_TRAIT "CQC trait" // This is just here for the testmerge to keep outside file edits to a minimum.
 
 /datum/martial_art/cqc
 	name = "CQC"

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -414,4 +414,4 @@
 #undef RESTRAIN_COMBO
 #undef PRESSURE_COMBO
 #undef CONSECUTIVE_COMBO
-#undef CQC_TRAIT "CQC trait"
+#undef CQC_TRAIT

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -14,15 +14,16 @@
 	VAR_PRIVATE/datum/weakref/restraining_mob
 	/// Probability of successfully blocking attacks while on throw mode
 	var/block_chance = 75
+	var/list/cqc_traits = list(TRAIT_NOGUNS)
 
 /datum/martial_art/cqc/on_teach(mob/living/new_holder)
 	. = ..()
+	new_holder.add_traits(cqc_traits, CQC_TRAIT)
 	RegisterSignal(new_holder, COMSIG_ATOM_ATTACKBY, PROC_REF(on_attackby))
 	RegisterSignal(new_holder, COMSIG_LIVING_CHECK_BLOCK, PROC_REF(check_block))
 
 /datum/martial_art/cqc/on_remove(mob/living/remove_from)
-	UnregisterSignal(remove_from, list(COMSIG_ATOM_ATTACKBY, COMSIG_LIVING_CHECK_BLOCK))
-	return ..()
+	remove_from.remove_traits(cqc_traits, CQC_TRAIT)
 
 ///Signal from getting attacked with an item, for a special interaction with touch spells
 /datum/martial_art/cqc/proc/on_attackby(mob/living/cqc_user, obj/item/attack_weapon, mob/attacker, params)

--- a/modular_nova/modules/traitor-uplinks/code/categories/stealthy_weapons.dm
+++ b/modular_nova/modules/traitor-uplinks/code/categories/stealthy_weapons.dm
@@ -9,8 +9,8 @@
 
 /datum/uplink_item/stealthy_weapons/CQC
 	name = "CQC Manual"
-	item_type = /obj/item/book/granter/martial/cqc
-	description = "A manual that teaches a single user tactical Close-Quarters Combat before self-destructing. WARNING: Causes the user to think guns 'the basics to CQC' are more important then 'using guns.'"
+	item = /obj/item/book/granter/martial/cqc
+	desc = "A manual that teaches a single user tactical Close-Quarters Combat before self-destructing. WARNING: Causes the user to think guns 'the basics to CQC' are more important then 'using guns.'"
 	progression_minimum = 30 MINUTES
 	population_minimum = TRAITOR_POPULATION_LOWPOP
 	cost = 17

--- a/modular_nova/modules/traitor-uplinks/code/categories/stealthy_weapons.dm
+++ b/modular_nova/modules/traitor-uplinks/code/categories/stealthy_weapons.dm
@@ -6,3 +6,13 @@
 	surplus = 0
 	progression_minimum = 10 MINUTES
 	uplink_item_flags = NONE
+
+/datum/uplink_item/stealthy_weapons/CQC
+	name = "CQC Manual"
+	item_type = /obj/item/book/granter/martial/cqc
+	description = "A manual that teaches a single user tactical Close-Quarters Combat before self-destructing. WARNING: Causes the user to think guns 'the basics to CQC' are more important then 'using guns.'"
+	progression_minimum = 30 MINUTES
+	population_minimum = TRAITOR_POPULATION_LOWPOP
+	cost = 17
+	surplus = 0
+	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS


### PR DESCRIPTION


## About The Pull Request

Read the nutritional label for important health facts.

Lets traitors buy 'CQC' again, but it now comes with the caveat of not letting you use guns while having it.

## How This Contributes To The Nova Sector Roleplay Experience

Hrgghhh... colonel...

## Proof of Testing
# I did not test this donut testmerge until i'm sure the no-guns works
## Changelog
:cl:
balance: CQC has ended up in the hands of Syndicate Agents again, they've finally remembered the basics.
/:cl:
