### PR TITLE
Adds veteran status to OOC notes in player panel + character directory

### DIFF
--- a/modular_nova/master_files/code/modules/mob/living/examine_tgui.dm
+++ b/modular_nova/master_files/code/modules/mob/living/examine_tgui.dm
@@ -65,6 +65,7 @@
 	var/custom_species_lore
 	var/obscured
 	var/ooc_notes = ""
+	var/veteran_status
 	var/ideal_antag_optin_status
 	var/current_antag_optin_status
 	var/headshot = ""
@@ -91,6 +92,8 @@
 				antag_prefs = preferences.read_preference(/datum/preference/choiced/antag_opt_in_status)
 			current_antag_optin_status = GLOB.antag_opt_in_strings[num2text(effective_opt_in_level)]
 			ideal_antag_optin_status = GLOB.antag_opt_in_strings[num2text(antag_prefs)]
+
+		veteran_status = GLOB.veteran_list[user.ckey]
 
 	// Now we handle silicon and/or human, order doesn't really matter
 	// If other variants of mob/living need to be handled at some point, put them here
@@ -121,6 +124,8 @@
 	data["custom_species"] = custom_species
 	data["custom_species_lore"] = custom_species_lore
 	data["headshot"] = headshot
+
+	data["veteran_status"] = veteran_status
 
 	data["ideal_antag_optin_status"] = ideal_antag_optin_status
 	data["current_antag_optin_status"] = current_antag_optin_status

--- a/modular_nova/modules/character_directory/code/character_directory.dm
+++ b/modular_nova/modules/character_directory/code/character_directory.dm
@@ -205,6 +205,7 @@ GLOBAL_LIST_EMPTY(name_to_appearance)
 	var/vore
 	var/noncon
 	var/hypno
+	var/veteran_status
 	var/character_ad
 	var/headshot
 	var/ref
@@ -255,6 +256,7 @@ GLOBAL_LIST_EMPTY(name_to_appearance)
 		hypno = READ_PREFS(mob, choiced/erp_status_hypno) || "Ask"
 		character_ad = READ_PREFS(mob, text/character_ad) || ""
 		ooc_notes = READ_PREFS(mob, text/ooc_notes) || ""
+		veteran_status = GLOB.veteran_list[mob.ckey]
 		// And finally, we want to get the mob's name, taking into account disguised names.
 		name = mob.real_name ? mob.name : mob.real_name
 
@@ -269,6 +271,7 @@ GLOBAL_LIST_EMPTY(name_to_appearance)
 			"vore" = vore,
 			"noncon" = noncon,
 			"hypno" = hypno,
+			"veteran_status" = veteran_status,
 			"character_ad" = character_ad,
 			"flavor_text" = flavor_text,
 			"headshot" = headshot,

--- a/tgui/packages/tgui/interfaces/ExaminePanel.jsx
+++ b/tgui/packages/tgui/interfaces/ExaminePanel.jsx
@@ -44,6 +44,7 @@ export const ExaminePanel = (props) => {
     custom_species,
     custom_species_lore,
     headshot,
+    veteran_status,
     ideal_antag_optin_status,
     current_antag_optin_status,
     opt_in_colors = { optin, color },
@@ -109,6 +110,19 @@ export const ExaminePanel = (props) => {
                       title="OOC Notes"
                       preserveWhitespace
                     >
+                      {veteran_status && (
+                        <Stack.Item>
+                          <span
+                            style={{
+                              color: 'gold',
+                              fontWeight: 'bold',
+                            }}
+                          >
+                            Player is a Veteran.
+                          </span>
+                          {'\n\n'}
+                        </Stack.Item>
+                      )}
                       {ideal_antag_optin_status && (
                         <Stack.Item>
                           Current Antag Opt-In Status:{' '}

--- a/tgui/packages/tgui/interfaces/NovaCharacterDirectory.jsx
+++ b/tgui/packages/tgui/interfaces/NovaCharacterDirectory.jsx
@@ -204,31 +204,15 @@ const ViewCharacter = (props) => {
                   title="OOC Notes"
                   preserveWhitespace
                 >
-                  {overlay.ideal_antag_optin_status && (
+                  {overlay.veteran_status && (
                     <Stack.Item>
-                      Current Antag Opt-In Status:{' '}
                       <span
                         style={{
+                          color: 'gold',
                           fontWeight: 'bold',
-                          color:
-                            overlay.opt_in_colors[
-                              overlay.current_antag_optin_status
-                            ],
                         }}
                       >
-                        {overlay.current_antag_optin_status}
-                      </span>
-                      {'\n'}
-                      Antag Opt-In Status {'(Preferences)'}:{' '}
-                      <span
-                        style={{
-                          color:
-                            overlay.opt_in_colors[
-                              overlay.ideal_antag_optin_status
-                            ],
-                        }}
-                      >
-                        {overlay.ideal_antag_optin_status}
+                        Player is a Veteran.
                       </span>
                       {'\n\n'}
                     </Stack.Item>


### PR DESCRIPTION
## About The Pull Request

Tin.

## How This Contributes To The Nova Sector Roleplay Experience

Adds a way for players to more easily identify veteran crew players in game.

## Proof of Testing

<details>
<summary>Seen in-game</summary>

![image](https://github.com/user-attachments/assets/ade1beb7-bcc9-4bfe-90b2-42846fcdbd1b)

![image](https://github.com/user-attachments/assets/865e602d-a32b-4d5e-8e92-38106b0ca8d9)

  
</details>

## Changelog

:cl:
qol: adds veteran status to OOC notes in player panel + character directory
/:cl:
