### PR TITLE
Lets security jobs spawn with the police-whistle

### DIFF
--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_masks.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_masks.dm
@@ -99,7 +99,10 @@
 *	JOB-LOCKED
 */
 
-// Ain't a damn thing
+/datum/loadout_item/mask/whistlesec
+	name = "Police Whistle"
+	item_path = /obj/item/clothing/mask/whistle
+	restricted_roles = list(JOB_WARDEN, JOB_DETECTIVE, JOB_SECURITY_OFFICER, JOB_HEAD_OF_SECURITY, JOB_CORRECTIONS_OFFICER)
 
 /*
 *	MASQUERADE MASKS


### PR DESCRIPTION


## About The Pull Request
Adds the police whistle for sec-jobs to the loadout, pretty much that's it


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Security officers can spawn with a whistle, for whistling, in their mask slot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
