### PR TITLE
better open bolt support for ammo counter

### DIFF
--- a/modular_nova/modules/gunhud/code/gun_hud_component.dm
+++ b/modular_nova/modules/gunhud/code/gun_hud_component.dm
@@ -67,7 +67,10 @@
 	if(istype(the_gun, /obj/item/gun/ballistic/bow))
 		return the_gun.get_ammo(countchambered = FALSE)
 
-	return the_gun.get_ammo(countchambered = TRUE)
+	if(the_gun.bolt_type == BOLT_TYPE_OPEN)
+		return the_gun.get_ammo(countchambered = FALSE)
+	else
+		return the_gun.get_ammo(countchambered = TRUE)
 
 
 /datum/component/ammo_hud/proc/update_hud()


### PR DESCRIPTION
## About The Pull Request
ammo counter no longer erroneously counts bullets twice for open-bolt SMGs

## How This Contributes To The Nova Sector Roleplay Experience
numbers
## Proof of Testing

![image](https://github.com/user-attachments/assets/8620408d-0357-47e5-a686-d9ee2bcef344)

## Changelog

:cl:
fix: The ammo counter HUD element now accounts for open bolt weapons (e.g. the Sindano).
/:cl:
