### PR TITLE
Fixes bump teleporter

### DIFF
--- a/code/game/objects/effects/bump_teleporter.dm
+++ b/code/game/objects/effects/bump_teleporter.dm
@@ -29,7 +29,6 @@
 /obj/effect/bump_teleporter/singularity_pull(atom/singularity, current_size)
 	return
 
-/* NOVA EDIT REMOVAL  - MOVED TO BLACK_MESA
 /obj/effect/bump_teleporter/Bumped(atom/movable/bumper)
 	if(!validate_setup(bumper))
 		return
@@ -40,7 +39,6 @@
 			return
 
 	stack_trace("Bump_teleporter [src] could not find a teleporter with id [id_target]!")
-*/
 
 /// Check to see if our teleporter was set up correctly mapside. Return TRUE if everything is fine, FALSE if not.
 /obj/effect/bump_teleporter/proc/validate_setup(atom/movable/checkable)


### PR DESCRIPTION
## About The Pull Request

Black mesa got removed a while ago but this removal was never undone.

## How This Contributes To The Nova Sector Roleplay Experience

Bump teleporter functional again

## Changelog

:cl:
fix: the bump teleporter effect functions again
/:cl: