### PR TITLE
[NON-MODULAR]

### DIFF
--- a/code/game/objects/items/implants/implant_freedom.dm
+++ b/code/game/objects/items/implants/implant_freedom.dm
@@ -31,9 +31,15 @@
 	if(!uses)
 		addtimer(CALLBACK(carbon_imp_in, TYPE_PROC_REF(/atom, balloon_alert), carbon_imp_in, "implant degraded!"), 1 SECONDS)
 		qdel(src)
+		// if being tased, removes the status on use, and detaches the electrode.
+
+	carbon_imp_in.remove_status_effect(/datum/status_effect/tased)
 
 /obj/item/implant/freedom/proc/can_trigger(mob/living/carbon/implanted_in)
 	if(implanted_in.handcuffed || implanted_in.legcuffed)
+		return TRUE
+
+	if(implanted_in.has_status_effect(/datum/status_effect/tased))
 		return TRUE
 
 	var/obj/item/clothing/shoes/shoes = implanted_in.shoes

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -184,10 +184,19 @@
 				"NNNNNNNNGGGGGGGGHH!",
 				";AAAAAAARRRGH!",
 			), forced = "hulk")
+		if(HAS_TRAIT(owner, TRAIT_BATON_RESISTANCE)) // If you have baton resistance while being tased, significantly decreases the stamina damage.
+			to_chat(owner, span_notice("You feel a slight shock, and attempt to shrug it off."))
+			stamina_per_second = 5
+			owner.remove_movespeed_modifier(/datum/movespeed_modifier/being_tased)
+		if(HAS_TRAIT(owner, TRAIT_SHOCKIMMUNE)) // genetics mutation insulated protects from taser shock, as well as voltaic heart
+			to_chat(owner, span_notice("The electrode hits you, but it only tickles."))
+			stamina_per_second = 0
+			owner.remove_movespeed_modifier(/datum/movespeed_modifier/being_tased)
 	if(ishuman(owner))
 		var/mob/living/carbon/human/human_owner = owner
 		human_owner.force_say()
 	return TRUE
+
 
 /datum/status_effect/tased/on_remove()
 	if(istype(taser, /obj/machinery/porta_turret))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes taser slightly less OP against nukies and such.
Tunes down 			stamina_per_second to value of 5 instead of 20 if target is owner of TRAIT_BATON_RESISTANCE.
Making nukie/stimmed up antag take 65 stamina damage per one hit vs 80 stamina damage against anyone without this trait.
 TRAIT_SHOCKIMMUNE completely immune to shock damage.
 
 Both also gain major bonus of not being slowed down as being tased. allowing to retreat.
 
 Allows freedom implant to shurg off electrode by activating it while being tased.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Tasers are borken af right now. anyone dies to lol lmao get tased idiot. shouldn't be this way
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
scweenshots
<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

1. https://discord.com/channels/1171566433923239977/1172988592658841680/1352396870017613946 
5. https://discord.com/channels/1171566433923239977/1172988592658841680/1352396920177561781

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Freedom implant now allows you to escape taser electrode
add: Added more things
balance: owners of TRAIT_BATON_RESISTANCE gain less stamina damage while getting tased
balance: owners of  TRAIT_SHOCKIMMUNE gain nostamina damage while getting tased
balance :owners of  TRAIT_SHOCKIMMUNE of  TRAIT_BATON_RESISTANCE gain no slowdown as they are tased.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
