### PR TITLE
Unties internal ears from ear sprite accessory (by making new external organ)

### DIFF
--- a/code/__DEFINES/~nova_defines/DNA.dm
+++ b/code/__DEFINES/~nova_defines/DNA.dm
@@ -46,6 +46,7 @@
 
 /// Organ slot external
 #define ORGAN_SLOT_EXTERNAL_CAP "cap"
+#define ORGAN_SLOT_EXTERNAL_EARS "ears_cosmetic"
 #define ORGAN_SLOT_EXTERNAL_FLUFF "fluff"
 #define ORGAN_SLOT_EXTERNAL_HEAD_ACCESSORY "head_accessory"
 #define ORGAN_SLOT_EXTERNAL_MOTH_MARKINGS "moth_markings"

--- a/modular_nova/master_files/code/modules/surgery/organs/_organ.dm
+++ b/modular_nova/master_files/code/modules/surgery/organs/_organ.dm
@@ -1,4 +1,0 @@
-/obj/item/organ
-	/// Whether or not we're a species-specific organ that will override
-	/// the ear choice on a certain species, while still applying its visuals.
-	var/overrides_sprite_datum_organ_type = FALSE

--- a/modular_nova/modules/ai_uplink_upload/the_thing.dm
+++ b/modular_nova/modules/ai_uplink_upload/the_thing.dm
@@ -3,6 +3,7 @@
 	/// not all of actual external organs have it. Better to double check in case someone messes up with flags or something.
 	var/static/list/ignored_organ_slots = list(
 		ORGAN_SLOT_EXTERNAL_CAP,
+		ORGAN_SLOT_EXTERNAL_EARS,
 		ORGAN_SLOT_EXTERNAL_FLUFF,
 		ORGAN_SLOT_EXTERNAL_FRILLS,
 		ORGAN_SLOT_EXTERNAL_HEAD_ACCESSORY,

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/ears.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/ears.dm
@@ -1,7 +1,7 @@
 /datum/sprite_accessory/ears
 	key = "ears"
 	generic = "Ears"
-	organ_type = /obj/item/organ/ears/mutant
+	organ_type = /obj/item/organ/ears_cosmetic
 	relevent_layers = list(BODY_BEHIND_LAYER, BODY_ADJ_LAYER, BODY_FRONT_LAYER)
 	color_src = USE_MATRIXED_COLORS
 	genetic = TRUE
@@ -42,7 +42,7 @@
 
 /datum/sprite_accessory/ears/mutant
 	icon = 'modular_nova/master_files/icons/mob/sprite_accessory/ears.dmi'
-	organ_type = /obj/item/organ/ears/mutant
+	organ_type = /obj/item/organ/ears_cosmetic
 	color_src = USE_MATRIXED_COLORS
 	recommended_species = list(SPECIES_MAMMAL, SPECIES_HUMAN, SPECIES_SYNTH, SPECIES_FELINE, SPECIES_HUMANOID, SPECIES_GHOUL)
 	uses_emissives = TRUE

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -108,8 +108,6 @@
 	name = "core audiosomes"
 	zone = BODY_ZONE_CHEST
 	organ_flags = ORGAN_UNREMOVABLE
-	overrides_sprite_datum_organ_type = TRUE
-	bodypart_overlay = /datum/bodypart_overlay/mutant/ears
 
 /obj/item/organ/tongue/jelly
 	zone = BODY_ZONE_CHEST

--- a/modular_nova/modules/customization/modules/surgery/organs/ears.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/ears.dm
@@ -1,13 +1,15 @@
-/obj/item/organ/ears/mutant
+/obj/item/organ/ears_cosmetic
 	name = "fluffy ears"
 	desc = "Wait, there's two pairs of these?"
 	icon = 'icons/obj/clothing/head/costume.dmi'
 	icon_state = "kitty"
+	mutantpart_key = "ears"
+	mutantpart_info = list(MUTANT_INDEX_NAME = "Cat", MUTANT_INDEX_COLOR_LIST = list("#FFFFFF", "#FFFFFF", "#FFFFFF"))
+	zone = BODY_ZONE_HEAD
+	slot = ORGAN_SLOT_EXTERNAL_EARS
+	organ_flags = ORGAN_EXTERNAL
+	preference = "feature_ears"
 	bodypart_overlay = /datum/bodypart_overlay/mutant/ears
-
-/obj/item/organ/ears/cat
-
-/obj/item/organ/ears/fox
 
 /datum/bodypart_overlay/mutant/ears
 	feature_key = "ears"

--- a/modular_nova/modules/customization/modules/surgery/organs/organ.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/organ.dm
@@ -5,11 +5,13 @@
 	var/sprite_accessory_flags = NONE
 	/// Relevant layer flags, as set by the organ's associated sprite_accessory, should there be one.
 	var/relevant_layers
-
-/obj/item/organ
 	///This is for associating an organ with a mutant bodypart. Look at tails for examples
 	var/mutantpart_key
+	/// A list with utant part preference name, its color and emissives if they exist (check code\__DEFINES\~nova_defines\DNA.dm)
 	var/list/list/mutantpart_info
+	/// Whether or not we're a species-specific organ that will override
+	/// the ear choice on a certain species, while still applying its visuals.
+	var/overrides_sprite_datum_organ_type = FALSE
 
 /obj/item/organ/Initialize(mapload)
 	. = ..()
@@ -17,10 +19,8 @@
 		color = mutantpart_info[MUTANT_INDEX_COLOR_LIST][1]
 
 /obj/item/organ/Remove(mob/living/carbon/organ_owner, special, movement_flags)
-	// NOVA EDIT ADDITION START
 	if(mutantpart_key)
 		transfer_mutantpart_info(organ_owner, special)
-	// NOVA EDIT ADDITION END
 	return ..()
 
 /// Copies the organ's mutantpart_info to the owner's mutant_bodyparts

--- a/modular_nova/modules/organs/code/ears.dm
+++ b/modular_nova/modules/organs/code/ears.dm
@@ -23,8 +23,6 @@
 	desc = "A set of four long rabbit-like ears, a Teshari's main tool while hunting. Naturally extremely sensitive to loud sounds."
 	damage_multiplier = 1.5
 	actions_types = list(/datum/action/cooldown/spell/teshari_hearing)
-	overrides_sprite_datum_organ_type = TRUE
-	bodypart_overlay = /datum/bodypart_overlay/mutant/ears
 
 /obj/item/organ/ears/teshari/on_mob_remove(mob/living/carbon/ear_owner)
 	. = ..()

--- a/modular_nova/modules/synths/code/bodyparts/ears.dm
+++ b/modular_nova/modules/synths/code/bodyparts/ears.dm
@@ -8,8 +8,6 @@
 	gender = PLURAL
 	maxHealth = 1 * STANDARD_ORGAN_THRESHOLD
 	organ_flags = ORGAN_ROBOTIC | ORGAN_SYNTHETIC_FROM_SPECIES
-	overrides_sprite_datum_organ_type = TRUE
-	bodypart_overlay = /datum/bodypart_overlay/mutant/ears
 
 /obj/item/organ/ears/synth/emp_act(severity)
 	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7119,7 +7119,6 @@
 #include "modular_nova\master_files\code\modules\surgery\surgery.dm"
 #include "modular_nova\master_files\code\modules\surgery\bodyparts\_bodyparts.dm"
 #include "modular_nova\master_files\code\modules\surgery\bodyparts\head.dm"
-#include "modular_nova\master_files\code\modules\surgery\organs\_organ.dm"
 #include "modular_nova\master_files\code\modules\surgery\organs\tongue.dm"
 #include "modular_nova\master_files\code\modules\surgery\organs\external\antennae.dm"
 #include "modular_nova\master_files\code\modules\surgery\organs\external\wings\functional_wings.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
~~Drinking game: take a shot each time you see "ear" word~~
So quite a while ago I noticed one of my characters missing its ears. It happened because I used augs+ to change them with cybernetic version, which doesn't have sprite_accessory attached to them. I've reverted it back to default ears for my characters and forgot about problem for quite a while until AI uplink brain came by and showed me some problems with how actualization shuffles around bodyparts and organs. If you use whisper sensitive or regular cybernetic ears - they will change to fluffy ears. Because of them, you're now considered organic and dropped out of you shell. If you try to change fluffy ears with other type of ears - you lose ears sprites.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
You can now augment you ears without fear of ruining you beautiful character sprite
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

I've forgotten to take screenshots, so probably DNM until i have time to actually make them (and test tesharies and species other than lizards and augments+ themselves)
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed ear sprite getting removed when you change you ears in augs+ or through surgery
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
