### PR TITLE
buff naga leg

### DIFF
--- a/modular_nova/modules/bodyparts/code/taur_bodyparts.dm
+++ b/modular_nova/modules/bodyparts/code/taur_bodyparts.dm
@@ -4,6 +4,9 @@
 	bodypart_flags = BODYPART_UNREMOVABLE
 	can_be_surgically_removed = FALSE
 	bodyshape = parent_type::bodyshape | BODYSHAPE_TAUR
+	brute_modifier = 0.8
+	burn_modifier = 0.8
+	wound_resistance = 20
 
 /obj/item/bodypart/leg/right/taur/generate_icon_key()
 	RETURN_TYPE(/list)
@@ -16,6 +19,9 @@
 	bodypart_flags = BODYPART_UNREMOVABLE
 	can_be_surgically_removed = FALSE
 	bodyshape = parent_type::bodyshape | BODYSHAPE_TAUR
+	brute_modifier = 0.8
+	burn_modifier = 0.8
+	wound_resistance = 20
 
 /obj/item/bodypart/leg/left/taur/generate_icon_key()
 	RETURN_TYPE(/list)
@@ -29,6 +35,9 @@
 	can_be_surgically_removed = FALSE
 	bodyshape = parent_type::bodyshape | BODYSHAPE_TAUR
 	damage_examines = list(BRUTE = ROBOTIC_BRUTE_EXAMINE_TEXT, BURN = ROBOTIC_BURN_EXAMINE_TEXT)
+	brute_modifier = 0.8
+	burn_modifier = 0.8
+	wound_resistance = 20
 
 /obj/item/bodypart/leg/right/synth/taur/generate_icon_key()
 	RETURN_TYPE(/list)
@@ -42,6 +51,9 @@
 	can_be_surgically_removed = FALSE
 	bodyshape = parent_type::bodyshape | BODYSHAPE_TAUR
 	damage_examines = list(BRUTE = ROBOTIC_BRUTE_EXAMINE_TEXT, BURN = ROBOTIC_BURN_EXAMINE_TEXT)
+	brute_modifier = 0.8
+	burn_modifier = 0.8
+	wound_resistance = 20
 
 /obj/item/bodypart/leg/left/Synth/taur/generate_icon_key()
 	RETURN_TYPE(/list)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
makes the naga "legs" more protected. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Because nagas cannot wear shoes, their legs/feet are exposed without armor. This means that they get some pretty brutal wounds and almost forces nagas out of combat. Nagas (usually/typically) are depicted with scales, which one could argue should provide some line of defense.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/a6b871d2-1fb6-4a61-9eaa-4b2a1f45c33b)
compiled-- looked over other instances of how the vars should be used.
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: naga tails (legs) are less prone to wounds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
