### PR TITLE
webbing attachment & cargo uniform fixes

### DIFF
--- a/modular_nova/master_files/code/modules/clothing/under/jobs/cargo.dm
+++ b/modular_nova/master_files/code/modules/clothing/under/jobs/cargo.dm
@@ -39,14 +39,16 @@
 
 /obj/item/clothing/under/rank/cargo/tech/nova/turtleneck
 	name = "supply turtleneck"
-	desc = "A snug turtleneck sweater worn by the Supply department.."
+	desc = "A snug turtleneck sweater worn by the Supply department."
 	icon_state = "turtleneck_cargo"
+	alt_covers_chest = TRUE
 
 /obj/item/clothing/under/rank/cargo/tech/nova/turtleneck/skirt
 	name = "supply skirtleneck"
 	desc = "A snug turtleneck sweater worn by Supply, this time with a skirt attached!"
 	icon_state = "skirtleneck"
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
+	alt_covers_chest = TRUE
 
 /obj/item/clothing/under/rank/cargo/tech/nova/evil
 	name = "black cargo uniform"

--- a/modular_nova/modules/food_replicator/code/clothing.dm
+++ b/modular_nova/modules/food_replicator/code/clothing.dm
@@ -69,6 +69,7 @@
 	icon = 'modular_nova/modules/food_replicator/icons/clothing.dmi'
 	worn_icon = 'modular_nova/modules/food_replicator/icons/clothing_worn.dmi'
 	icon_state = "accessory_webbing"
+	attachment_slot = NONE
 
 /obj/item/clothing/accessory/colonial_webbing/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
The 3-pocket webbing now doesn't require chest coverage to attach to things, by virtue of being its own webbing vest thing.
Cargo uniforms that cover the chest when rolled up are now flagged appropriately. Probably.

## How This Contributes To The Nova Sector Roleplay Experience
muh storagecreep

## Changelog

:cl:
fix: Slim colonial webbings no longer require a uniform to cover the chest to attach.
fix: Cargo uniforms with alt styles that cover the chest now should... cover the chest when using those alt styles, as appropriate.
/:cl:
