### PR TITLE
[QoL] Empaths no longer get depressed when examining an evil person, they still get shaken. 

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -514,7 +514,7 @@
 
 /datum/mood_event/encountered_evil
 	description = "I didn't want to believe it, but there are people out there that are genuinely evil."
-	mood_change = -4
+	mood_change = 0 // NOVA EDIT CHANGE - Original: -4 - This causes a mood debuf on people that get a positive quirk over examining someone with a neutral quirk otherwise.
 	timeout = 1 MINUTES
 
 /datum/mood_event/smoke_in_face


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Sets to 0 the mood debuff of examining an evil person, from a -4

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

First, they wanted to remove Fundamentally Evil, a quirk a good amount of people use, over it, and it has too many mechanics that actually pay attention to the Evil quirk to just remove like that on a whim.

Second, its true that empath is a high end positive quirk that you either spend a slot or 6 points to get, that gets heavily punished over people putting a neutral quirk over them, so I agree that needs to be removed, and only that.

It should encourage people to use empath again without fear to have a large debuff over examining people, and such people to have that minor examine 'protection', which is kinda silly.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/c2a2a83a-f3b8-40b4-9626-3e1f7da6d7b6)

![image](https://github.com/user-attachments/assets/8b2621c7-eca6-4947-983c-bfa8f16a9b24)

  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Empathic personel got so used to the high population of, for a better word, fundamentally evil crewmembers, that they had become jaded to their presence and no longer get a mood impact upon encountering one. They still get the shakes though.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
