### PR TITLE
Italicizes examine_mores, fixes plasma globs, etc etc

### DIFF
--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/bolt_fabrications/longarm.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/bolt_fabrications/longarm.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/ballistic/automatic/type213
 	name = "\improper Type 213 Kinetic Submachine Gun"
-	desc = "A completely nonlethal longarm used by Sol Fed Peacekeeping forces. It uses kinetic rounds to temporarily disable adversaries. Made as a companion to the Type 207 Kinetic Pistol."
+	desc = "A completely nonlethal longarm used by SolFed Peacekeeping forces, using kinetic rounds to temporarily disable adversaries. Made as a companion to the Type 207 Kinetic Pistol."
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/company_and_or_faction_based/bolt_fabrications/type213.dmi'
 	icon_state = "type213"
 	lefthand_file = 'modular_nova/modules/modular_weapons/icons/mob/company_and_or_faction_based/bolt_fabrications/guns_lefthand.dmi'

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/bolt_fabrications/magazine.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/bolt_fabrications/magazine.dm
@@ -1,5 +1,5 @@
 /obj/item/ammo_box/magazine/kineticballs
-	name = "kinetic balls pistol magazine"
+	name = "kinetic ball pistol magazine"
 	desc = "A gun magazine filled with balls. The kind that makes makes people stop, holds twelve rounds."
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/company_and_or_faction_based/bolt_fabrications/type207magazine.dmi'
 	icon_state = "type207mag"
@@ -15,7 +15,7 @@
 // Magazine for the Type 213
 
 /obj/item/ammo_box/magazine/kineticballsbig
-	name = "\improper Kinetic Submachine Gun magazine"
+	name = "kinetic submachine gun magazine"
 	desc = "A large magazine for a Type 213 Submachine Gun. Holds 24 rounds of ammunition."
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/company_and_or_faction_based/bolt_fabrications/type213magazine.dmi'
 	icon_state = "type213mag"
@@ -54,4 +54,4 @@
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2,
 		/datum/material/plastic = SHEET_MATERIAL_AMOUNT * 2,
 	)
-	max_ammo = 26
+	max_ammo = 27

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/advert.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/advert.dm
@@ -7,12 +7,11 @@
 /obj/structure/sign/poster/official/carwo_grenade/examine_more(mob/user)
 	. = ..()
 
-	. += "Small text details that certain types of grenades may not be available in your \
+	. += "<i>Small text details that certain types of grenades may not be available in your \
 		region depending on local weapons regulations. Suspiciously, however, if you squint at \
 		it a bit, the background colors of the image come together vaguely in the shape of \
-		a computer board and a multitool. What did they mean by this?"
-
-	return .
+		a computer board and a multitool.<br><br>\
+		What did they mean by this?</i>"
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/carwo_grenade, 32)
 
@@ -26,11 +25,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/carwo_grenade, 3
 /obj/structure/sign/poster/official/carwo_magazine/examine_more(mob/user)
 	. = ..()
 
-	. += "Small text details that certain types of magazines may not be available in your \
+	. += "<i>Small text details that certain types of magazines may not be available in your \
 		region depending on local weapons regulations. Suspiciously, however, if you squint at \
 		it a bit, the background colors of the image come together vaguely in the shape of \
-		a computer board and a multitool. What did they mean by this?"
-
-	return .
+		a computer board and a multitool. What did they mean by this?</i>"
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/carwo_magazine, 32)

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/grenade_launcher.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/grenade_launcher.dm
@@ -49,18 +49,18 @@
 /obj/item/gun/ballistic/automatic/sol_grenade_launcher/examine_more(mob/user)
 	. = ..()
 
-	. += "The Kiboko is one of the strangest weapons Carwo offers. A grenade launcher, \
-		though not in the standard grenade size. The much lighter .980 Tydhouer grenades \
-		developed for the weapon offered many advantages over standard grenade launching \
-		ammunition. For a start, it was significantly lighter, and easier to carry large \
-		amounts of. What it also offered, however, and the reason SolFed funded the \
-		project: Variable time fuze. Using the large and expensive ranging sight on the \
-		launcher, its user can set an exact distance for the grenade to self detonate at. \
-		The dream of militaries for decades, finally realized. The smaller shells do not, \
-		however, make the weapon any more enjoyable to fire. The kick is only barely \
-		manageable thanks to the massive muzzle brake at the front."
-
-	return .
+	. += "<i>The Kiboko, a light grenade launcher, is one of the strangest weapons Carwo offers, \
+	and is noteworthy for its lighter, nonstandard grenade size.<br><br>\
+	The much lighter .980 Tydhouer grenades developed for the weapon offer many advantages \
+	over other conventional launcher grenade systems. \
+	For a start, Tydhouer grenades are significantly lighter, and easier to carry large \
+	amounts of. The main reason SolFed funded the project, though, \
+	was its reliable, on-the-fly programmable variable time fuze. \
+	Using the large (and expensive, to the chagrin of quartermasters) ranging sight on the \
+	launcher, users can set an exact distance for the grenade to self-detonate at; \
+	the decades-held dream of militaries, finally realized. \
+	The smaller shells do not, however, make the weapon any more enjoyable to fire. \
+	The kick is only barely manageable thanks to the massive muzzle brake at the front.</i>"
 
 /obj/item/gun/ballistic/automatic/sol_grenade_launcher/examine(mob/user)
 	. = ..()

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/rifle.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/rifle.dm
@@ -2,7 +2,7 @@
 
 /obj/item/gun/ballistic/automatic/sol_rifle
 	name = "\improper MMR-2543E"
-	desc = "A heavy assault rifle chambered in .40Sol, with a comically fast fire-rate for weapons of it's class."
+	desc = "A heavy assault rifle chambered in .40 Sol Long, with a decent rate of fire for weapons of its class. Accepts any standard SolFed rifle magazine."
 
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/company_and_or_faction_based/carwo_defense_systems/guns48x.dmi'
 	icon_state = "infanterie"
@@ -35,12 +35,19 @@
 	suppressor_y_offset = 1
 
 	burst_size = 1
-	fire_delay = 0.30 SECONDS
+	fire_delay = 0.2 SECONDS
 	actions_types = list()
 
 	spread = 2
 	projectile_wound_bonus = 10
 	projectile_damage_multiplier = 0.75
+
+	/// Lore specific to this type of gun.
+	var/model_specific_lore = "This variant is the Espatier model and is the standard weapon for SolFed’s Espatier Corps. \
+	It features a slim and compact design optimized for the close-range engagements \
+	Espatiers typically find themselves in, while still retaining effectiveness at long range. \
+	A computerized sight allows for quick and easy adjustment for engagements at different ranges, \
+	and in a wide range of environments, while a swappable internal heatsink protects the weapon from overheating whilst firing in a vacuum."
 
 /obj/item/gun/ballistic/automatic/sol_rifle/Initialize(mapload)
 	. = ..()
@@ -61,16 +68,14 @@
 /obj/item/gun/ballistic/automatic/sol_rifle/examine_more(mob/user)
 	. = ..()
 
-	. += "The MMR-2543 is the current standard service rifle for all branches of the Sol Federation Armed Forces. \
-		The MMR-2543 was initially created for use by the Sagittarian Triumvirate’s military, \
-		with its adoption by SolFed coming a few years later. Thanks to both the prestige the weapon gained from being adopted \
-		by two of the most prominent military forces in SolFed, \
-		and its modular design making it easily adapted to different requirements, it is currently the most widely adopted rifle in SolFed with a wide range of different users. \
-		This variant is the Espatier model and is the standard weapon for SolFed’s Espatier Corps. It features a slim and compact design optimized for the close-range engagements \
-		Espatiers typically find themselves in, while still retaining effectiveness at long range. A computerized sight allows for quick and easy adjustment for engagements at different ranges, \
-		and in a wide range of environments, while a swappable internal heatsink protects the weapon from overheating whilst firing in a vacuum."
+	// core lore - linebreak - backstory - linebreak - model-specific
+	. += "<i>The MMR-2543 is the current standard service rifle for all branches of the Sol Federation Armed Forces.<br><br>\
+		Initially created for use by the Sagittarian Triumvirate’s military, its adoption by SolFed came a few years later. \
+		Thanks to both the prestige the weapon gained from being adopted by two of the most prominent military forces in SolFed, \
+		and its modular design making it easily adapted to different requirements, \
+		it is currently the most widely adopted rifle in SolFed with a wide range of different users.<br></i>"
 
-	return .
+	. += "<i>[model_specific_lore]</i>"
 
 /obj/item/gun/ballistic/automatic/sol_rifle/no_mag
 	spawnwithmagazine = FALSE
@@ -79,7 +84,7 @@
 
 /obj/item/gun/ballistic/automatic/sol_rifle/marksman
 	name = "\improper MMR-2543I"
-	desc = "A heavy marksman rifle commonly seen in the hands of SolFed military types. Accepts any standard SolFed rifle magazine."
+	desc = "A heavy marksman rifle chambered in .40 Sol Long, commonly seen in the hands of SolFed military types. Accepts any standard SolFed rifle magazine."
 
 	icon_state = "elite"
 	worn_icon_state = "elite"
@@ -87,8 +92,11 @@
 
 	spawn_magazine_type = /obj/item/ammo_box/magazine/c40sol_rifle
 
-	fire_delay = 0.4 SECONDS
-	
+	fire_delay = 1.6 SECONDS
+	burst_delay = 0.1 SECONDS
+
+	actions_types = list(/datum/action/item_action/toggle_firemode)
+
 	suppressor_x_offset = 1
 	suppressor_y_offset = 1
 
@@ -96,6 +104,10 @@
 	spread = 5.5
 	projectile_damage_multiplier = 1
 	projectile_wound_bonus = 3
+
+	model_specific_lore = "This variant is the Infantry model and is the primary rifle \
+	for both the SolFed Hydro Corps and Atmospheric Corps. It features excellent accuracy and durability, \
+	and a specialized three-shot burst designed to complete before recoil can impact the shooter."
 
 /obj/item/gun/ballistic/automatic/sol_rifle/marksman/Initialize(mapload)
 	. = ..()
@@ -105,21 +117,6 @@
 /obj/item/gun/ballistic/automatic/sol_rifle/marksman/give_autofire()
 	return
 
-/obj/item/gun/ballistic/automatic/sol_rifle/marksman/examine_more(mob/user)
-	. = ..()
-
-	. = "The MMR-2543 is the current standard service rifle for all branches of the Sol Federation Armed Forces. \
-		The MMR-2543 was initially created for use by the Sagittarian Triumvirate’s military, \
-		with its adoption by SolFed coming a few years later. Thanks to both the prestige the weapon gained from \
-		being adopted by two of the most prominent military forces in SolFed, and its modular \
-		design making it easily adapted to different requirements, it is currently the most widely adopted rifle \
-		in SolFed with a wide range of different users. This variant is the Infantry model and is the primary rifle \
-		for both the SolFed Hydro Corps and Atmospheric Corps. It features excellent accuracy and durability, \
-		a specialized two shot burst designed to fire off two rounds before recoil can impact the shooter, \
-		and a more moderate rate of automatic fire to help preserve ammunition during long engagements."
-
-	return .
-
 /obj/item/gun/ballistic/automatic/sol_rifle/marksman/no_mag
 	spawnwithmagazine = FALSE
 
@@ -127,7 +124,7 @@
 
 /obj/item/gun/ballistic/automatic/sol_rifle/machinegun
 	name = "\improper Qarad Light Machinegun"
-	desc = "A hefty machinegun commonly seen in the hands of SolFed military types. Accepts any standard SolFed rifle magazine."
+	desc = "A hefty machine gun chambered in .40 Sol Long, commonly seen in the hands of SolFed military types. Accepts any standard SolFed rifle magazine."
 
 	icon_state = "qarad"
 	worn_icon_state = "qarad"
@@ -143,18 +140,12 @@
 	spread = 12.5
 	projectile_wound_bonus = -20
 
-/obj/item/gun/ballistic/automatic/sol_rifle/machinegun/examine_more(mob/user)
-	. = ..()
-
-	. += "The 'Qarad' variant of the rifle, what you are looking at now, \
-		is a modification to turn the weapon into a passable, if sub-optimal \
-		light machinegun. To support the machinegun role, the internals were \
-		converted to make the gun into an open bolt, faster firing machine. These \
-		additions, combined with a battle rifle not meant to be used fully auto \
-		much to begin with, made for a relatively unwieldy weapon. A machinegun, \
-		however, is still a machinegun, no matter how hard it is to keep on target."
-
-	return .
+	model_specific_lore = "The 'Qarad' variant of the MMR-2543 platform converts the rifle into \
+	a passable, if suboptimal, light machine gun. To support its new, fully-automatic role, \
+	the firing system was converted into a faster, open-bolt configuration. \
+	These modifications, combined with a battle rifle platform not meant to be used \
+	much in full-auto to begin with, made for a relatively unwieldy weapon.<br><br>\
+	A machinegun, however, is still a machinegun, no matter how hard it is to keep on target."
 
 /obj/item/gun/ballistic/automatic/sol_rifle/machinegun/no_mag
 	spawnwithmagazine = FALSE

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/shotgun.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/shotgun.dm
@@ -2,7 +2,7 @@
 
 /obj/item/gun/ballistic/shotgun/riot/sol
 	name = "\improper M64 Shotgun"
-	desc = "A twelve gauge shotgun with a six shell capacity... ontop? Made for and used by SolFed's various military branches."
+	desc = "A robust twelve-gauge shotgun with an eight-shell, top-mounted magazine tube. Made for and used by SolFed's various military and police forces."
 
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/company_and_or_faction_based/carwo_defense_systems/guns48x.dmi'
 	icon_state = "renoster"
@@ -25,6 +25,7 @@
 	can_suppress = TRUE
 	rack_delay = 0.5 SECONDS
 	fire_delay = 0.5 SECONDS // Turns out, this is actually pretty fairly balanced
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/sol
 	suppressor_x_offset = 7
 	suppressor_y_offset = -3
 
@@ -41,15 +42,13 @@
 /obj/item/gun/ballistic/shotgun/riot/sol/examine_more(mob/user)
 	. = ..()
 
-	. += "The M64 was designed at its core as a police shotgun. \
-		As consequence, it holds all the qualities a police force would want \
-		in one. Large shell capacity, sturdy frame, while holding enough \
-		capacity for modification to satiate even the most overfunded of \
-		peacekeeper forces. Inevitably, the weapon made its way into civilian \
-		markets alongside its sale to several military branches that also \
-		saw value in having a heavy shotgun."
-
-	return .
+	. += "<i>The M64 was designed, at its core, as a police shotgun.<br><br>\
+	As a consequence, it holds all the qualities a police force would want \
+	in a shotgun; a large capacity, robust frame, and enough modularity \
+	to satiate even the most overfunded of peacekeeper forces. \
+	Inevitably, it made its way into civilian markets, \
+	alongside its sale to several military branches that also \
+	saw value in having a heavy shotgun.</i>"
 
 /obj/item/gun/ballistic/shotgun/riot/sol/update_appearance(updates)
 	if(sawn_off)
@@ -58,26 +57,27 @@
 
 	. = ..()
 
-/obj/item/ammo_box/magazine/internal/shot/riot
-	max_ammo = 8 // putting this here, because this is the only one we have on station at the start.
+/obj/item/ammo_box/magazine/internal/shot/sol
+	ammo_type = /obj/item/ammo_casing/shotgun/rubbershot
+	max_ammo = 8
 
 /obj/item/gun/ballistic/shotgun/riot/sol/thunderdome
-	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/riot/sol_thunderdome
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/sol/thunderdome
 
-/obj/item/ammo_box/magazine/internal/shot/riot/sol_thunderdome
+/obj/item/ammo_box/magazine/internal/shot/sol/thunderdome
 	ammo_type = /obj/item/ammo_casing/shotgun/beehive
 
 // Shotgun but EVIL!
 
 /obj/item/gun/ballistic/shotgun/riot/sol/evil
-	desc = "A twleve guage shotgun with an eight shell capacity... on top? This one is painted in a tacticool black."
+	desc = parent_type::desc + "This one is painted in a tacticool black."
 
 	icon_state = "renoster_evil"
 	worn_icon_state = "renoster_evil"
 	inhand_icon_state = "renoster_evil"
 
 /obj/item/gun/ballistic/shotgun/riot/sol/evil/thunderdome
-	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/riot/sol_thunderdome/evil
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/sol/thunderdome/evil
 
-/obj/item/ammo_box/magazine/internal/shot/riot/sol_thunderdome/evil
+/obj/item/ammo_box/magazine/internal/shot/sol/thunderdome/evil
 	ammo_type = /obj/item/ammo_casing/shotgun/flechette

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/submachinegun.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/submachinegun.dm
@@ -2,7 +2,7 @@
 
 /obj/item/gun/ballistic/automatic/sol_smg
 	name = "\improper Sindano Submachine Gun"
-	desc = "A small submachine gun firing .35 Sol. Commonly seen in the hands of PMCs and other unsavory corpos. Accepts any standard Sol pistol magazine."
+	desc = "A small submachine gun firing .35 Sol Short. Commonly seen in the hands of PMCs and other unsavory corpos. Accepts any standard Sol pistol magazine."
 
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/company_and_or_faction_based/carwo_defense_systems/guns32x.dmi'
 	icon_state = "sindano"
@@ -42,15 +42,14 @@
 /obj/item/gun/ballistic/automatic/sol_smg/examine_more(mob/user)
 	. = ..()
 
-	. += "The Sindano submachinegun was originally produced for military contract. \
-		These guns were seen in the hands of anyone from medics, ship techs, logistics officers, \
-		and shuttle pilots often had several just to show off. Due to SolFed's quest to \
-		extend the lifespans of their logistics officers and quartermasters, the weapon \
-		uses the same standard pistol cartridge that most other miltiary weapons of \
-		small caliber use. This results in interchangeable magazines between pistols \
-		and submachineguns, neat!"
+	. += "<i>The Sindano submachinegun was originally produced for a military contract.<br><br>\
+	Thanks to that, they could be found in the hands of any SolFed second-line force; \
+	from medics, to ship techs, to logistics officers. Funnily enough, shuttle pilots often had several just to show off. \
+	Due to SolFed's quest to extend the lifespans of their logistics officers and quartermasters, \
+	the Sindano uses the same standard pistol cartridge that most other SolFed military weapons of \
+	small caliber do.<br><br>\
+	This results in interchangeable magazines between pistols and submachineguns. Neat!</i>"
 
-	return .
 
 /obj/item/gun/ballistic/automatic/sol_smg/no_mag
 	spawnwithmagazine = FALSE
@@ -58,7 +57,7 @@
 // Sindano (evil)
 
 /obj/item/gun/ballistic/automatic/sol_smg/evil
-	desc = "A small submachinegun, this one is painted in tacticool black. Accepts any standard Sol pistol magazine."
+	desc = parent_type::desc + "This one is painted in a tacticool black."
 
 	icon_state = "sindano_evil"
 	inhand_icon_state = "sindano_evil"

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armouries/submachinegun.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armouries/submachinegun.dm
@@ -22,12 +22,12 @@ This is a Blueshield weapon. It's for the Blueshield. If this ends up in Cargo I
 /obj/item/gun/ballistic/automatic/nt20/examine_more(mob/user)
 	. = ..()
 
-	. += "The Nanotrasen Armories NT20 is a recent release from NT's esteemed private arms division, \
+	. += "<i>The Nanotrasen Armories NT20 is a recent release from NT's esteemed private arms division, \
 		and it's received a warm welcome from the Shield teams and other NT armed forces who have been \
-		issued it in the ongoing rollout. \
+		issued it in its ongoing rollout.<br><br>\
 		Though certain rival manufacturers have dismissed the NT20 as a \"fake\" or a \"blatant bootleg,\"  \
 		the inimitable .460 Ceres round and a patent-pending multi-stage delayed blowback system \
-		make the NT20 powerful, reliable, accurate, and shockingly comfortable to fire."
+		make the NT20 powerful, reliable, accurate, and shockingly comfortable to fire.</i>"
 
 /obj/item/gun/ballistic/automatic/nt20/give_manufacturer_examine()
     AddElement(/datum/element/manufacturer_examine, COMPANY_NANOTRASEN)

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/saibasan/laser_guns.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/saibasan/laser_guns.dm
@@ -70,11 +70,14 @@
 	var/datum/component/soulcatcher/tracked_soulcatcher
 	/// What is this gun's extended examine, we only have to do this because the carbine is a subtype
 	var/expanded_examine_text = "The Hyeseong rifle is the first line of man-portable Marsian weapons platforms \
-		from Cybersun Industries. Like her younger sister weapon, the Hoshi carbine, CI used funding aid provided \
-		by SolFed to develop a portable weapon fueled by a proprietary generator rumored to be fueled by superstable plasma. \
-		A rugged and hefty weapon, the Hyeseong stars in applications anywhere from medium to long ranges, though struggling \
-		in CQB. Her onboard machine intelligence, at first devised to support the operator and manage the internal reactor, \
-		is shipped with a more professional and understated personality-- since influenced by 'negligence' from users in \
+		from Cybersun Industries.<br><br>\
+		Like her younger sister weapon, the Hoshi carbine, CI used funding aid provided \
+		by SolFed to develop a portable weapon fueled by a proprietary generator \
+		rumored to be fueled by superstable plasma. \
+		A rugged and hefty weapon, the Hyeseong stars in applications anywhere from medium to long ranges, though it struggles \
+		in CQB.<br><br>\
+		Her onboard machine intelligence, at first devised to support the operator and manage the internal reactor, \
+		is shipped with a more professional and understated personality—since influenced by 'negligence' from users in \
 		wiping the intelligence's memory before resale or transport."
 	/// A cooldown for when the weapon has last spoken, prevents messages from getting turbo spammed
 	COOLDOWN_DECLARE(last_speech)
@@ -96,8 +99,7 @@
 
 /obj/item/gun/energy/modular_laser_rifle/examine_more(mob/user)
 	. = ..()
-	. += expanded_examine_text
-	return .
+	. += "<i>[expanded_examine_text]</i>"
 
 /obj/item/gun/energy/modular_laser_rifle/Destroy()
 	QDEL_NULL(tracked_soulcatcher)
@@ -274,11 +276,13 @@
 	default_selected_mode = "Incinerate"
 	speech_json_file = SHORT_MOD_LASER_SPEECH
 	expanded_examine_text = "The Hoshi carbine is the latest line of man-portable Marsian weapons platforms from \
-		Cybersun Industries. Like her older sister weapon, the Hyeseong rifle, CI used funding aid provided by SolFed \
-		to develop a portable weapon fueled by a proprietary generator rumored to be fueled by superstable plasma. A \
-		lithe and mobile weapon, the Hoshi stars in close-quarters battle, trickshots, and area-of-effect blasts; though \
-		ineffective at ranged combat. Her onboard machine intelligence, at first devised to support the operator and \
-		manage the internal reactor, was originally shipped with a more energetic personality-- since influenced by 'negligence' \
+		Cybersun Industries.<br><br>\
+		Like her older sister weapon, the Hyeseong rifle, CI used funding aid provided by SolFed \
+		to develop a portable weapon fueled by a proprietary generator rumored to be fueled by superstable plasma. \
+		A lithe and mobile weapon, the Hoshi stars in close-quarters battle, trickshots, and area-of-effect blasts, \
+		at the cost of longer-ranged combat performance.<br><br>\
+		Her onboard machine intelligence, at first devised to support the operator and manage the internal reactor, \
+		was originally shipped with a more energetic personality—since influenced by 'negligence' \
 		from users in wiping the intelligence's memory before resale or transport."
 
 /obj/item/gun/energy/modular_laser_rifle/carbine/emp_act(severity)

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/ammo/plasma.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/ammo/plasma.dm
@@ -14,7 +14,7 @@
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/company_and_or_faction_based/szot_dynamica/ammo.dmi'
 	icon_state = "plasma_glob"
 	damage = 10
-	speed = 0.66
+	speed = 1.5
 	bare_wound_bonus = 40
-	wound_bonus = -20 // Not to great at wounding through armor.
+	wound_bonus = -20 // Not too great at wounding through armor.
 	pass_flags = PASSTABLE | PASSGRILLE // His ass does NOT pass through glass!

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/magazines.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/magazines.dm
@@ -38,7 +38,7 @@
 
 /obj/item/ammo_box/magazine/napad
 	name = "\improper Napad submachinegun magazine"
-	desc = "A massive magazine for the Napadayuschiy Submachine gun. Holds fifty rounds of 10mm ammunition."
+	desc = "A massive magazine for the Napadayuschiy submachine gun. Holds fifty rounds of 10mm ammunition."
 
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/company_and_or_faction_based/szot_dynamica/ammo.dmi'
 	icon_state = "napad_mag"

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/pistol.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/pistol.dm
@@ -37,14 +37,12 @@
 /obj/item/gun/ballistic/automatic/pistol/plasma_thrower/examine_more(mob/user)
 	. = ..()
 
-	. += "Originally started as the best means to deterring large crowds, it quickly found a second life \
-		as a frontier all-arounder on account of it's cheap-and-rechargable packs, full auto capabilities, \
-		and one hell of an intimidation factor. \
-		Earlier claims by competitors passed it off as terrible against armor,  \
-		but in reality, it's about as effective as any ballistic you could get your hands on! \
-		As long as your sector, and local-command permits automatic weapons, that is... and grevious wounds."
-
-	return .
+	. += "<i>The Słońce Plasma Projector is an exercise in magnetically-agitated volume of plasmic fire.<br><br>\
+	Originally started as a means to deter large crowds, it quickly found a second life \
+	as a frontier all-rounder on account of it's cheap and rechargable packs, full-auto capabilities, \
+	and the intimidation factor of throwing a wall of searing plasma in the vague direction of what it's pointed at. \
+	Earlier iterations had some performance issues against layers of armor, \
+	but refinements to the magnetic chamber mitigated previous plasma adherence issues, mitigating that issue.</i>"
 
 // Plasma sharpshooter pistol
 // Shoots single, strong plasma blasts at a slow rate
@@ -71,7 +69,7 @@
 	spread = 2.5
 
 	projectile_damage_multiplier = 3 // 30 damage a shot
-	projectile_wound_bonus = 10 // +55 of the base projectile, burn baby burn
+	projectile_wound_bonus = 20 // base projectile has -20 wound bonus, this brings it back up to 0. burns are pretty schnasty though
 
 /obj/item/gun/ballistic/automatic/pistol/plasma_marksman/give_manufacturer_examine()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_SZOT)
@@ -83,20 +81,20 @@
 /obj/item/gun/ballistic/automatic/pistol/plasma_marksman/examine_more(mob/user)
 	. = ..()
 
-	. += "The 'Gwiazda' is a further refinement of the 'Słońce' design. with improved \
-		energy cycling, magnetic launchers built to higher precision, and an overall more \
-		ergonomic design. Early reports speak highly of it's ability to shoot in a straight line. \
-		Why it's ended up here is anyone's guess, but the best one would be: 'Testing market sustainability.'"
-
-	return .
+	. += "<i>The 'Gwiazda' is a further refinement of the 'Słońce' design, \
+		serving as an exercise in magnetically-agitated precision of plasmic fire. \
+		Sharing its predecessor's cheap and rechargable power packs, this iteration trades \
+		in the intimidation factor of its haphazard automatic mode for much better per-glob performance. \
+		With improved energy cycling, a better-tuned \"precision\" magnetic chamber, and an overall more \
+		ergonomic design, end-users report that it is actually capable of shooting in a line straighter than other variants.</i>"
 
 // A revolver, but it can hold shotgun shells
 // Woe, buckshot be upon ye
 
 /obj/item/gun/ballistic/revolver/shotgun_revolver
 	name = "\improper Bóbr 12 GA revolver"
-	desc = "A dated attempt at upsizing a revolver to a 'servicable' caliber for frontier-and-distance planets. \
-		A revolver type design with a four shell cylinder. That's right, shell, this one shoots twelve guage."
+	desc = "A dated attempt at upsizing a revolver to a 'servicable' caliber for frontier and/or otherwise distant planets. \
+	Evidently, the conclusion of those efforts was a four-shell cylinder made for twelve gauge shells."
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/cylinder/rev12ga
 	recoil = SAWN_OFF_RECOIL
 	weapon_weight = WEAPON_MEDIUM
@@ -111,20 +109,20 @@
 /obj/item/gun/ballistic/revolver/shotgun_revolver/examine_more(mob/user)
 	. = ..()
 
-	. += "The 'Bóbr' started development as a limited run sporting weapon before \
-		quickly being eaten up by both militias and the general populace on most frontiers, \
-		Especially favored by cargo-runners, and pirates due to the ease of finding more 12G. \
-		Unlike the silver and wood sporting variants, this is the pure survival model replacing the grip with a \
-		standard rubberized pistol grip and weather resistant finish. While the 'Bóbr' isn't the most appealing \
-		weapon to grace someone's hands, it might be the most practical."
-
-	return .
+	. += "<i>The 'Bóbr' is a twelve gauge shotgun in the somewhat comical form-factor of a revolver, \
+		which doesn't prove particularly conducive to controlling recoil.<br><br>\
+		The Bóbr started development as a limited run sporting weapon, \
+		before quickly finding a place with both colonial militias and the general populace of rougher frontiers. \
+		It's been favored by cargo-runners on both sides of the law, due to the ease of finding or reloading ammunition. \
+		Unlike the silver and wood sporting variants, this is the pure survival model, which uses a \
+		standard, rubberized pistol grip, and weather-resistant finish. \
+		While the 'Bóbr' isn't the most appealing weapon to grace someone's hands, it's at least somewhat practical.</i>"
 
 // A 10mm pistol that shoots slow as all get out, but has that deep dish magazine going on
 
 /obj/item/gun/ballistic/automatic/pistol/zashch
-	name = "\improper 'Zashch' self-loading pistol"
-	desc = "A hulking self-loading handgun designated 'Zashchitnik'. Feeds from large 18 round box magazines. Chambered for 10mm."
+	name = "\improper 'Zashch' heavy pistol"
+	desc = "A hulking, self-loading 10mm handgun, designated 'Zashchitnik'. Feeds from large 18 round box magazines."
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/company_and_or_faction_based/szot_dynamica/guns_32.dmi'
 	icon_state = "zashch"
 	lefthand_file = 'modular_nova/modules/modular_weapons/icons/mob/company_and_or_faction_based/szot_dynamica/guns_lefthand.dmi'
@@ -153,11 +151,11 @@
 /obj/item/gun/ballistic/automatic/pistol/zashch/examine_more(mob/user)
 	. = ..()
 
-	. += "The Zashchitnik self-loading pistol was designed as a police and security sidearm for ballistic favoring forces. \
-		Choosing to chamber the 10mm cartridge for its exceptional stopping power, \
-		the hulking pistol is known to be a powerful firearm, albeit maligned by some units for the sheer size. \
+	. += "<i>The 'Zashchitnik' self-loading pistol is a hefty handgun with a focus on reliability and magazine size.<br><br>\
+		Originally designed as a police and security sidearm for ballistic-favoring forces, \
+		Szot Dynamica chose to chamber it for the 10mm cartridge for its exceptional stopping power. \
+		The hulking pistol is known to be a powerful firearm with a surprisingly tame recoil, thanks to \
+		the sheer bulk of it; a trait that some find satisfying while others find suboptimal for aiming consecutive shots. \
 		The size was dictated necessary for several reasons during the design, not the least so that it can load expansive \
-		magazines flush to the grip that allow for exceptionally large amounts of fire power. \
-		It has found niche use with security forces both corporate and state sponsored in more middling economic locations."
-
-	return .
+		magazines flush to the grip that allow for exceptionally large amounts of firepower. \
+		It has found niche use with security forces both corporate and state-sponsored in more middling economic locations.</i>"

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/rifle.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/rifle.dm
@@ -57,17 +57,17 @@
 /obj/item/gun/ballistic/automatic/miecz/examine_more(mob/user)
 	. = ..()
 
-	. += "The Miecz is one of the staple weapons of the frontier; simple, effective, and based on \
-		a figuratively 'tested' design, (though you couldn't be sure which one that is). \
-		Fires the .27-54 'intermediary' caliber round, if only to dodge its classification as a rifle. \
-		Overall, it's decently accurate, lightweight, reeks of gun-grease,  \
-		and might feel a little more homely then the next gun over... or, at least that's what the label says. \
-		The Wood-Substitute material is known to have various side-effects, please contact your local health department before use."
+	. += "<i>The Miecz is one of the staple weapons of the frontier; simple, effective, and based on \
+	a figuratively 'tested' design, though you couldn't be sure which one.<br><br>\
+	It fires the .27-54 'intermediary' caliber round, if only to dodge classification as a rifle. \
+	Overall, it's decently accurate, lightweight, reeks of gun-grease, \
+	and might feel a little more homely then the next gun over... allegedly, anyway.<br><br>\
+	The wood-substitute material is known to have various side-effects. Contact your local health department before use.</i>"
 
 /obj/item/gun/ballistic/automatic/miecz/no_mag
 	spawnwithmagazine = FALSE
 
-// Semi-automatic rifle firing .310 with reduced damage compared to a Sakhno
+// Semi-automatic rifle firing .310 with reduced firerate compared to a Sakhno
 
 /obj/item/gun/ballistic/automatic/lanca
 	name = "\improper Lanca Battle Rifle"
@@ -124,17 +124,13 @@
 /obj/item/gun/ballistic/automatic/lanca/examine_more(mob/user)
 	. = ..()
 
-	. += "The Lanca started as an attempt to replace the confusing position of the Miecz, \
-		Originally started as an attempt to upscale the Miecz to a marksman caliber. \
-		It eventually ended up as little more then an odd cousin to it's starting frame. \
-		Upscaled heavily from the classic 7.62x24mm catridge, to a full size .310, which \
-		Necessitated a redoing of the entire bolt, and upper receiver, coupled with a much stronger recoil spring. \
-		Then, to make up for all the added weight, the stock was replaced with a lighter skeletonized one, \
-		and the barrel assembly was changed out for a minimalist design. \
-		All in all, you get less rifle, for the priveledge of a bigger caliber. \
-		...And a scope."
-
-	return .
+	. += "<i>The Lanca started as an attempt to replace the confusing position of the Miecz.<br><br>\
+	Originally designed as an attempt to upscale the Miecz to a marksman caliber, \
+	it eventually ended up as little more then an odd cousin to it's starting frame. \
+	Initial efforts to upscale from the Miecz's .27-caliber cartridge, to a full-size .310 \
+	necessitated a rework of the entire bolt, updated upper receiver, and a much stronger recoil spring. \
+	To make up for the added weight, the stock was skeletonized, and the barrel assembly was changed out for a minimalist design.<br><br>\
+	All in all, you get less rifle for the somewhat paradoxical privilege of a bigger bang.</i>"
 
 /obj/item/gun/ballistic/automatic/lanca/no_mag
 	spawnwithmagazine = FALSE
@@ -192,11 +188,10 @@
 /obj/item/gun/ballistic/automatic/wylom/examine_more(mob/user)
 	. = ..()
 
-	. += "The 'Wyłom' AMR was a weapon not originally made for unaided human hands. \
-		The original rifle had mounting points for a specialized suit attachment system, \
-		but that quickly fell through once it was announced, as exosuit hunting, isnt a common trend on the frontier. \
-		This is the spitting image of anti-armo-... anti-anything.  \
-		There's a laser etched warning label, informing users of the weapon to be wary of side-blast. \
-		...And to not use it if you arent of appropriate size, but the sizing chart is no where to be seen."
-
-	return .
+	. += "<i>The 'Wyłom' AMR was not originally made for unaided human hands. \
+	The original rifle had mounting points for a specialized suit attachment system, \
+	but that quickly fell through once it was announced, as exosuit hunting isn't exactly a common frontier pastime. \
+	Generally considered a strong contender for the definition of \"anti-armor\", \
+	a strong argument exists to consider it closer to \"anti-anything\".<br><br>\
+	A laser-etched warning label warns users of the weapon to be wary of side-blast from the muzzle brake... \
+	and to not fire unsupported if one is not of appropriate mass to \"wrestle\" the recoil.</i>"

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/submachinegun.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/submachinegun.dm
@@ -2,8 +2,7 @@
 
 /obj/item/gun/ballistic/automatic/napad
 	name = "\improper 'Napad' Submachine Gun"
-	desc = "A bulky submachine gun holding a close relation to the Zashchitnik pistol. Designated 'Napadayuschiy'. \
-		It holds a notable fifty rounds of 10mm in the magazine."
+	desc = "A bulky, 10mm submachine gun with sizeable magazines holding a close relation to the Zashchitnik pistol. Designated 'Napadayuschiy'."
 
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/company_and_or_faction_based/szot_dynamica/guns_48.dmi'
 	icon_state = "napad"
@@ -49,15 +48,16 @@
 /obj/item/gun/ballistic/automatic/napad/examine_more(mob/user)
 	. = ..()
 
-	. += "The Napadayuschiy was made for the inevitable situation of the Zashchitnik not being enough firepower \
-		for the job. The Napadayuschiy sports a colossal magazine and a familiarly oversized stature to the Zashchitnik. \
-		The massive magazine is a point of contention, being a stick magazine, it sticks far from the gun, \
-		making it easy to catch on surfaces and door frames. Regardless, the weapon is reliable, \
-		though if you do not place the charging handle into the loading notch before inserting a fresh magazine, \
-		the spring pressure of the weapon's fully loaded magazine will make operating the charging handle require \
-		a herculean feat of strength."
-
-	return .
+	. += "<i>The 'Napadayuschiy' is a heavy sub-machine gun with a focus on reliability and a very large magazine size. \
+		Originally, it was designed for the inevitable situation of its sibling, the Zashchitnik handgun, \
+		not bringing enough to bear for any given situation. \
+		It sports a colossal magazine and a oversized stature familiar to the Zashchitnik. \
+		However, the sheer size of the magazine is a point of contention; its simple, angular construction means \
+		it sticks far from the gun, making it easy to catch on surfaces and door frames. \
+		Regardless, the weapon is reliable, albeit with a small quirk regarding the manual of arms; \
+		if the charging handle isn't placed into the loading notch before inserting a fresh magazine, \
+		the spring pressure of fifty 10mm rounds will make operating the charging handle require \
+		a herculean feat of strength.</i>"
 
 /obj/item/gun/ballistic/automatic/napad/no_mag
 	spawnwithmagazine = FALSE

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/trappiste_fabriek/advert.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/trappiste_fabriek/advert.dm
@@ -10,12 +10,10 @@
 /obj/structure/sign/poster/official/trappiste_suppressor/examine_more(mob/user)
 	. = ..()
 
-	. += "It was hard to notice before, but now that you really look at it... \
+	. += "<i>It was hard to notice before, but now that you really look at it... \
 		This thing is completely covered in micro scale text telling you in just about \
 		every human language and then some that Trappiste isn't liable for ear damage \
-		caused by their weapons, suppressed or not."
-
-	return .
+		caused by their weapons, suppressed or not.</i>"
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/trappiste_suppressor, 32)
 
@@ -31,11 +29,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/trappiste_suppre
 /obj/structure/sign/poster/official/trappiste_ammunition/examine_more(mob/user)
 	. = ..()
 
-	. += "Small text details that this information may also be transferrable \
+	. += "<i>Small text details that this information may also be transferrable \
 		to other types of SolFed ammunition, but that you should check the box \
-		the bullets come in just to be sure. Trappiste is, of course,\
-		not liable for excess harm caused by misreading color identification systems."
-
-	return .
+		the bullets come in just to be sure. Trappiste is, of course, \
+		not liable for excess harm caused by misreading color identification systems.</i>"
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/official/trappiste_ammunition, 32)

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/trappiste_fabriek/pistol.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/trappiste_fabriek/pistol.dm
@@ -2,7 +2,7 @@
 
 /obj/item/gun/ballistic/automatic/pistol/sol
 	name = "\improper Guêpe Pistol"
-	desc = "The standard issue service pistol of SolFed's various military branches. Uses .35 Sol and comes with an attached light."
+	desc = "The standard issue service pistol of SolFed's various military branches. Uses .35 Sol, and comes with an attached light."
 
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/company_and_or_faction_based/trappiste_fabriek/guns32x.dmi'
 	icon_state = "wespe"
@@ -35,17 +35,16 @@
 /obj/item/gun/ballistic/automatic/pistol/sol/examine_more(mob/user)
 	. = ..()
 
-	. += "The Guêpe is an evolution of an older pistol which has seen use for over a century, with incremental \
-		improvements keeping it up to date. The first models proved incredibly popular with law enforcement throughout SolFed, \
-		due to their ease of use, repair, and that the low-caliber bullets lead to a heavily reduced chance of collateral damage. \
- 		As the decades passed the proven design was steadily adopted into various militaries as well, most notably by the \
- 		Sol Federation Armed Forces who took it on as their first service pistol just after their founding in 2492 with more modern variants \
-		 remaining the SFAF's primary service pistol to this day. \
-		In the civilian market the Guêpe is particularly popular among spacers who appreciate the hidden simplicity and surplus of spare parts. \
-		Less savory individuals also appreciate just how easy it is get in full-auto, simply by traveling to a less-restrictive jurisdiction and either \
-		buying a full-auto variant or having it converted."
-
-	return .
+	. += "<i>The Guêpe is an evolution of an older pistol which has seen use for over a century, with incremental \
+	improvements keeping it up to date.<br><br>\
+	The first models proved incredibly popular with law enforcement throughout SolFed, \
+	due to their ease of use, maintainability, and its low-caliber bullets heavily reducing the chance of collateral damage. \
+	As the decades passed, the proven design was steadily adopted into various militaries as well; most notably, by the \
+	Sol Federation Armed Forces, who took it on as their first service pistol, just after their founding in 2492, \
+	with more modern variants remaining the SFAF's primary service pistol to this day. \
+	In the civilian market, the Guêpe is particularly popular among spacers who appreciate its simplicity and surplus of spare parts.<br><br>\
+	Less savory individuals also appreciate just how easy it is get in full-auto, simply by traveling to a less restrictive jurisdiction, and either \
+	buying a full-auto variant or having it converted.</i>"
 
 /obj/item/gun/ballistic/automatic/pistol/sol/no_mag
 	spawnwithmagazine = FALSE
@@ -98,14 +97,18 @@
 /obj/item/gun/ballistic/automatic/pistol/trappiste/examine_more(mob/user)
 	. = ..()
 
-	. += "The Défenestreur is the embodiment of a handcannon; a ridiculously oversized and overloaded pistol round crammed into a just-as-obscene gun to match it. \
-		Entered production around 2496, not long after the release of the Défonce revolver, to fill a market niche between anti-material rifle and personal defense weapon. \
-		Presented as an anti-wildlife weapon, it's more common-use is ensuring that whatever--or whoever--you open fire at, is gone well-before they have time to realize who did it. \
-		A long, almost one piece slide leads back into a rotating bolt/slide combination, loaded from the underside with a ten round magazine as the rounds themselves were far to big \
-		to ever fit within a reasonably sized grip. Despite its size, the slide and sheer weight of the gun keep the recoil about as low as anyone could realistically expect. \
-		What a beauty."
+	. += "<i>The Défenestreur is the embodiment of a hand cannon; a ridiculously oversized and overloaded pistol round, \
+	crammed into a just-as-obscene gun to match it.<br><br>\
+	It entered production around 2496, not long after the release of the Défonce revolver, \
+	to fill a market niche between anti-materiel rifle and personal defense weapon. \
+	Presented as an anti-wildlife weapon, its more common use is ensuring that \
+	whatever, or whoever, you open fire at, is gone, well-before they have time to realize who did it. \
+	A long, near-monolithic barrel assembly leads back into a rotating bolt and slide combination, \
+	loaded from the underside with a ten-round magazine, as the rounds themselves were far too big \
+	to ever fit within a reasonably sized grip. \
+	Despite its size, the slide and sheer weight of the gun keep the recoil about as low as anyone could realistically expect.<br><br>\
+	Some consider it a beauty; others consider it a beast. Either way, it has a very distinct identity.</i>"
 
-	return .
 
 /obj/item/gun/ballistic/automatic/pistol/trappiste/no_mag
 	spawnwithmagazine = FALSE

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/trappiste_fabriek/revolver.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/trappiste_fabriek/revolver.dm
@@ -26,17 +26,16 @@
 /obj/item/gun/ballistic/revolver/sol/examine_more(mob/user)
 	. = ..()
 
-	. += "The Renard is exactly as simple as it looks, lacking almost any of the functionality or technology you'd expect from a Trappiste weapon, \
-		having shaved it all away for the convenience of its remarkably small size.\
-		Originally, it was seen as an acceptable backup for SolFed's police forces, able to be stashed in any manner of pouch, pocket, \
-		or even just stuck into your waistband, while still coming loaded with eight .35 sol rounds. \
-		As they modernized, it started living a second life with executives, bodyguards, and criminals, due to its ease of concealment. \
-		If bang for your buck was the focus, you can't do much better then the bare minimum in both cost and size. \
-		There's not alot to be said about the actual function of the gun either, with a centerline barrel and being shot from the lowest chamber relative to the sights, \
-		the recoil is non-existant, just like the user's safety. The only out-of-place feature is that the chamber is pressed forward during firing, \
-		forming a seal in a manner that still allows it to be suppressed, whatever the use of that could be."
-
-	return .
+	. += "<i>The Renard is as simple as it looks, trimming down Trappiste's typical extravagance for the sake of its small size.<br><br>\
+	Originally, it was seen as an acceptable backup for SolFed's police forces, \
+	able to be stashed in any manner of pouch, pocket, or even just stuck into your waistband, \
+	while still coming loaded with eight .35 Sol Short rounds. \
+	As SolFed's myriad forces modernized, the Renard began living a second life with executives, bodyguards, and criminals due to its ease of concealment. \
+	If bang for your buck was the focus, you can't do much better then the bare minimum in both cost and size. \
+	There's not a lot to be said about the actual function of the gun either; thanks to a centerline barrel \
+	and being shot from the lowest chamber of the cylinder, the recoil is non-existent, much like the user's safety. \
+	The only out-of-place feature for a budget revolver like this is that the chamber is pressed forward during firing, \
+	forming a seal between cylinder and barrel in a manner that still allows it to be suppressed.</i>"
 
 /obj/item/ammo_box/magazine/internal/cylinder/c35sol
 	ammo_type = /obj/item/ammo_casing/c35sol
@@ -74,14 +73,14 @@
 /obj/item/gun/ballistic/revolver/takbok/examine_more(mob/user)
 	. = ..()
 
-	. += "The Defoncé was designed to fulfil a request by the Sol Federation Armed Forces for a maintainable high caliber pistol. \
-		While the Guêpe served well to deal with human sized targets it would struggle to take down large fauna. \
-		The Defoncé was made to fill that capability gap and enable backline SFAF personnel to easily defend themselves against dangerous creatures when serving in the wilderness of alien worlds. \
-		The resulting pistol perfectly filled the SFAF's requirements, and as such has remained in service ever since its adoption in 2495. \
-		The durable, simple and easy to maintain design of the Defoncé combined with its high power has also made it popular in some parts of the civilian firearms market; \
-		primarily with frontier settlers and hunters who appreciate its maintainability and the ease with which it can take down large creatures."
-
-	return .
+	. += "<i>The Defoncé was designed to fulfill a request by the Sol Federation Armed Forces for a maintainable high caliber pistol.<br><br>\
+	While the Guêpe served well to deal with human sized targets, it struggled against large fauna. \
+	The Defoncé was made to fill that capability gap, enabling second-line SFAF personnel to easily defend themselves \
+	against dangerous creatures when serving in the wilderness of alien worlds. \
+	The resulting pistol perfectly filled the SFAF's requirements, and, as such, has remained in service ever since its adoption in 2495. \
+	The durable, simple, and easy-to-maintain design of the Defoncé, combined with its high power, \
+	has also made it popular in some parts of the civilian firearms market; \
+	primarily with frontier settlers and hunters who appreciate its maintainability, and the ease with which it can take down large creatures.</i>"
 
 /obj/item/ammo_box/magazine/internal/cylinder/c585trappiste
 	ammo_type = /obj/item/ammo_casing/c585trappiste

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/xhihao_light_arms/rifle.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/xhihao_light_arms/rifle.dm
@@ -37,13 +37,18 @@
 /obj/item/gun/ballistic/rifle/sporterized/examine_more(mob/user)
 	. = ..()
 
-	. += "The Xhihao 'Rengo' conversion rifle. Initially a set of chassis parts sold in a single kit by Xhihao Light Arms, \
-		which can be swapped out with many of the outdated or simply old parts on a typical Sakhno rifle. \
-		While not necessarily increasing performance in any way, the magazine is slightly longer. The weapon \
-		is also overall a bit shorter, making it easier to handle for some people. Cannot be sawn off, cutting \
-		really any part of this weapon off would make it non-functional."
-
-	return .
+	. += "<i>The Xhihao 'Rengo' rifle is a conversion of the venerable Sakhno Precision Rifle, \
+		with \"modern\" features such as an accessory rail and detachable magazines.<br><br>\
+		Initially a set of chassis parts sold in a single kit by Xhihao Light Arms, \
+		the 'Rengo' kit is designed to replace much of the furniture on a typical Sakhno \
+		in order to improve the ergonomics, reduce the weight, and overall improve the end-user experience. \
+		While not necessarily increasing performance in any way, the magazine's cross-compatibility with Lanca magazines \
+		allows for greater capacity than the five-round internal magazines that come standard with Sakhnos, and the \
+		scope included with the kit, originally for use with the Lanca, is quite usable thanks to the shared chambering. \
+		The weapon is also overall a bit shorter, making it easier to handle for smaller shooters and/or \
+		in uncomfortably close quarters for a precision weapon. \
+		Due to the reduced space between components, the Rengo cannot be sawn off; \
+		cutting... any part of this weapon off, really, would make it either hazardous to fire or non-functional.</i>"
 
 /obj/item/gun/ballistic/rifle/sporterized/empty
 	bolt_locked = TRUE // so the bolt starts visibly open

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/xhihao_light_arms/submachinegun.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/xhihao_light_arms/submachinegun.dm
@@ -48,16 +48,16 @@
 /obj/item/gun/ballistic/automatic/xhihao_smg/examine_more(mob/user)
 	. = ..()
 
-	. += "The Bogseo submachinegun is seen in highly different lights based on \
-		who you ask. Ask a Jovian, and they'll go off all day about how they \
-		love the thing so. A big weapon for shooting big targets, like the \
-		fuel-stat raiders in their large suits of armor. Ask a space pirate, however \
-		and you'll get a different story. That is thanks to many SolFed anti-piracy \
-		units picking the Bogseo as their standard boarding weapon. What better \
-		to ruin a brigand's day than a bullet large enough to turn them into \
-		mist at full auto, after all?"
-
-	return .
+	. += "<i>The Bogseo submachinegun, chambered in the monstrous .585 Trappiste, \
+	is an exercise in shoulder-bruising close-quarters brutality.<br><br>\
+		Depending on who you ask, it's seen in very different lights; \
+		ask a Jovian, and they'll go off all day about how they \
+		love the thing so, thanks to its efficacy against large targets, like \
+		fuel-stat raiders in large suits of armor. \
+		Ask a space pirate, however, and you'll get a different story, \
+		thanks to many SolFed anti-piracy units picking the Bogseo as their standard boarding weapon.<br><br>\
+		What better option to ruin a brigand's day than a hail of bullets \
+		large enough to turn them into mist at full auto, after all?</i>"
 
 /obj/item/gun/ballistic/automatic/xhihao_smg/no_mag
 	spawnwithmagazine = FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8418,7 +8418,7 @@
 #include "modular_nova\modules\modular_weapons\code\company_and_or_faction_based\carwo_defense_systems\ammo\grenade.dm"
 #include "modular_nova\modules\modular_weapons\code\company_and_or_faction_based\carwo_defense_systems\ammo\pistol.dm"
 #include "modular_nova\modules\modular_weapons\code\company_and_or_faction_based\carwo_defense_systems\ammo\rifle.dm"
-#include "modular_nova\modules\modular_weapons\code\company_and_or_faction_based\nanotrasen_armouries\rifle.dm"
+#include "modular_nova\modules\modular_weapons\code\company_and_or_faction_based\nanotrasen_armouries\submachinegun.dm"
 #include "modular_nova\modules\modular_weapons\code\company_and_or_faction_based\saibasan\laser_guns.dm"
 #include "modular_nova\modules\modular_weapons\code\company_and_or_faction_based\saibasan\mode_datums.dm"
 #include "modular_nova\modules\modular_weapons\code\company_and_or_faction_based\saibasan\projectiles.dm"


### PR DESCRIPTION
## About The Pull Request
Tweaks a bunch of `examine_more()`s to be italicized like other examines. Mostly on guns. Sometimes on posters.
Also moves the NT20 to `submachinegun.dm` because it's not a rifle even if you can't stow it like one, or something. Maybe. Probably.
## How This Contributes To The Nova Sector Roleplay Experience
The lore
## Changelog

:cl:
spellcheck: examine_more()s on a bunch of Nova guns have been somewhat tweaked to be stylistically consistent (read: italicised).
fix: Plasma globs are no longer torturously slow. (They're just regular slow.)
/:cl: