### PR TITLE
Loadout Tactical Maid Uniform Has Suit Sensors

### DIFF
--- a/modular_nova/modules/tacti_maid_loadout/tactimaid.dm
+++ b/modular_nova/modules/tacti_maid_loadout/tactimaid.dm
@@ -17,6 +17,7 @@
 /obj/item/clothing/under/syndicate/nova/maid/loadout_maid
 	name = "tactical maid outfit"
 	desc = "A 'tactical' skirtleneck fashioned to the likeness of a maid outfit"
+	has_sensor = HAS_SENSORS
 	icon_state = "syndimaid"
 	armor_type = /datum/armor/clothing_under/none
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The base tactical maid uniform with armor that is exclusive to <s>naughty</s> syndicated roles inherits no-sensors, the loadout-approved, non-armored version does the same - thus, a round-start uniform has no suit sensors. This change adjusts that - just like you she adjust your suit sensors.

## How This Contributes To The Nova Sector Roleplay Experience

Central approved clothing should typically come with these - this permits our pretty new loadout uniform to be worn without compromising on basic suit-sensors.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing


<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
</details>
  It is a single line-change web-edit based off of Interdyne's 'Syndicate' uniforms having suit sensors. If you REALLY want me to spin it up local and test it, I will.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Domestic servants wearing red uniforms have no time to bleed out in dark maintenance tunnels - their uniforms have been modified with standard issue suit sensors to combat inefficiency. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
