### PR TITLE
Certain Footwear No Longer Assumes Digi

### DIFF
--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_clothing/lewd_shoes.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_clothing/lewd_shoes.dm
@@ -8,7 +8,7 @@
 	greyscale_colors = "#383840"
 	greyscale_config = /datum/greyscale_config/ballet_heel
 	greyscale_config_worn = /datum/greyscale_config/ballet_heel/worn
-	greyscale_config_worn = /datum/greyscale_config/ballet_heel/worn/digi
+	greyscale_config_worn_digi = /datum/greyscale_config/ballet_heel/worn/digi
 	flags_1 = IS_PLAYER_COLORABLE_1
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
 
@@ -39,6 +39,6 @@
 	greyscale_colors = "#383840"
 	greyscale_config = /datum/greyscale_config/latex_socks
 	greyscale_config_worn = /datum/greyscale_config/latex_socks/worn
-	greyscale_config_worn = /datum/greyscale_config/latex_socks/worn/digi
+	greyscale_config_worn_digi = /datum/greyscale_config/latex_socks/worn/digi
 	flags_1 = IS_PLAYER_COLORABLE_1
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION


### PR DESCRIPTION
This got bungled in the conversion; oops.

:cl:
fix: Ballet Heels and Latex Socks now use the proper icon state for non-digis.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
