### PR TITLE
[Not modular] adds nova alerts handling for modular computers

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -1004,6 +1004,25 @@
 		if(SEC_LEVEL_GREEN) // no threats, no concerns
 			return ALERT_RELEVANCY_SAFE
 
+		// NOVA EDIT START. ADDITION - ALERTS
+		if(SEC_LEVEL_EPSILON, SEC_LEVEL_GAMMA)
+			return ALERT_RELEVANCY_PERTINENT
+		if(SEC_LEVEL_AMBER, SEC_LEVEL_FEDERAL)
+			if(ACCESS_SECURITY in computer_id_slot.access)
+				return ALERT_RELEVANCY_PERTINENT
+			else
+				return ALERT_RELEVANCY_WARN
+		if(SEC_LEVEL_VIOLET)
+			if(ACCESS_MEDICAL in computer_id_slot.access)
+				return ALERT_RELEVANCY_PERTINENT
+			else
+				return ALERT_RELEVANCY_WARN
+		if(SEC_LEVEL_ORANGE)
+			if(ACCESS_ENGINEERING in computer_id_slot.access)
+				return ALERT_RELEVANCY_PERTINENT
+			else
+				return ALERT_RELEVANCY_WARN
+		// NOVA EDIT END
 	return 0
 
 #undef ALERT_RELEVANCY_SAFE

--- a/modular_nova/modules/alerts/code/security_level_datums.dm
+++ b/modular_nova/modules/alerts/code/security_level_datums.dm
@@ -27,6 +27,7 @@
  */
 /datum/security_level/violet
 	name = "violet"
+	name_shortform = "VLT"
 	announcement_color = "purple"
 	number_level = SEC_LEVEL_VIOLET
 	status_display_icon_state = "violetalert"
@@ -43,6 +44,7 @@
  */
 /datum/security_level/orange
 	name = "orange"
+	name_shortform = "ORNG"
 	announcement_color = "orange"
 	number_level = SEC_LEVEL_ORANGE
 	status_display_icon_state = "orangealert"
@@ -60,6 +62,7 @@
 
 /datum/security_level/amber
 	name = "amber"
+	name_shortform = "AMBR"
 	announcement_color = "yellow"
 	number_level = SEC_LEVEL_AMBER
 	status_display_icon_state = "amberalert"
@@ -77,6 +80,7 @@
 
 /datum/security_level/epsilon
 	name = "epsilon"
+	name_shortform = "ε"
 	announcement_color = "purple"
 	number_level = SEC_LEVEL_EPSILON
 	status_display_icon_state = "epsilonalert"
@@ -95,6 +99,7 @@
  */
 /datum/security_level/gamma
 	name = "gamma"
+	name_shortform = "γ"
 	announcement_color = "pink"
 	number_level = SEC_LEVEL_GAMMA
 	status_display_icon_state = "gammaalert"
@@ -114,6 +119,7 @@
 
 /datum/security_level/federal
 	name = "federal"
+	name_shortform = "FED"
 	announcement_color = "blue"
 	number_level = SEC_LEVEL_FEDERAL
 	status_display_icon_state = "federalalert"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
https://github.com/tgstation/tgstation/pull/89173 added this somewhat useful feature but we havent handled our security level leaving it as "not set" every time orange or amber being set. I've added a short names for them and its "relevancy levels". Don't know how i feel about greek letters though. Delta code has capital letter for it (a triangle) but epsilon and gamma are just E and Г. Lowercased gamma and epsilon still look kinda ugly though (but so does capital delta)

Can be fully modular if you wish. I don't want to override this proc though, it seems unnecessary 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
oh no its infamous not set alert level! we all are going to die! or be fired? or is it just sol president coming aboard?
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/0474d751-aca0-4ef1-9491-91bef7c0fa67)

(text is blinking here)

![image](https://github.com/user-attachments/assets/e22afe97-0604-4341-aa34-1e40881d4c94)

![image](https://github.com/user-attachments/assets/72ac3101-74d6-4726-9986-356308bc8d30)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: amber, violet, orange and some other alert levels are now rendered properly in PDAs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
