### PR TITLE
Expands crushers to reagent forged armor list

### DIFF
--- a/modular_nova/modules/reagent_forging/code/forge_clothing.dm
+++ b/modular_nova/modules/reagent_forging/code/forge_clothing.dm
@@ -26,6 +26,7 @@
 	AddComponent(/datum/component/reagent_clothing, ITEM_SLOT_OCLOTHING)
 
 	allowed += /obj/item/forging/reagent_weapon
+	allowed += /obj/item/kinetic_crusher
 
 // Gloves
 /obj/item/clothing/gloves/forging_plate_gloves


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does exactly what it says on the tin. Crushers have been added to the list of items that can be worn with the reagent-forged armor, except for the crusher-spear and crusher-hammer variants, which are too large by default to be worn on explorer suits.

## How This Contributes To The Nova Sector Roleplay Experience

People want the ability to carry their crushers alongside their regular clothing equipment. Being forced to wear bulky gear, like a goliath cloak or explorer suit, defeats the purpose, as these outfits cover most of one's clothing, limiting flexibility.

From a gameplay perspective, cargo often has people working in a forge. Miners can either make it themselves or ask a cargo technician to do it, giving another option in protecting one's self in the wastes. While the forged armor is effective when reinforced, it lacks fire protection, leaving the choice up to the miner whether or not they want to take that risk.
## Proof of Testing




<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/97f44279-18cd-4502-87c8-55e4b31f4d11)

![image](https://github.com/user-attachments/assets/6f28acaa-a3f5-4883-bf00-69bd1fc36fda)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:qol: Makes crushers wearable on reagent armor/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
