### PR TITLE
add syndie nunchuks to traitor uplink & opfor

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -1004,9 +1004,9 @@
 	cooldown = CLICK_CD_MELEE
 	knockdown_time = 0.25 SECONDS
 	demolition_mod = 1.5
-	stamina_damage = 30 // 4 hit stamcrit
+	stamina_damage = 35 // 4 hit stamcrit
 	stun_armour_penetration = 30 // bronze-silver telescopic
-	force = 16 // 7 hit crit
+	force = 21 // 7 hit crit
 	bare_wound_bonus = 5
 
 /obj/item/melee/baton/nunchaku/proc/randomize_state()
@@ -1038,3 +1038,13 @@
 		melee_attack_chain(owner, attacker, LEFT_CLICK)
 
 	return ..()
+
+
+// NOVA EDIT
+/obj/item/melee/baton/nunchaku
+	stamina_damage = 35 // 4 hit stamcrit
+	force = 21 // 7 hit crit
+	special_desc_requirement = EXAMINE_CHECK_SYNDICATE
+	special_desc = "A Syndicate fitness equipment used in training and spec-ops.\
+					It is painted in the syndicate's colors and has the organization's logo."
+// NOVA EDIT

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -52,6 +52,15 @@
 	cost = 6
 	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
 
+/datum/uplink_item/dangerous/nunchaku
+	name = "Syndie Fitness Nunchuks"
+	desc = "Heavyweight titanium nunchucks that can be used to knock out and harm your opponent quickly and easily.\
+			In close combat, it allows you to block all melee attacks and throws, punishing the offender."
+	item = /obj/item/melee/baton/nunchaku
+	cost = 7
+	purchasable_from = ~UPLINK_SPY //spy get their own tg version
+	uplink_item_flags = SYNDIE_ILLEGAL_TECH | SYNDIE_TRIPS_CONTRABAND
+
 /datum/uplink_item/dangerous/rapid
 	name = "Gloves of the North Star"
 	desc = "These gloves let the user punch people very fast. Does not improve weapon attack speed or the meaty fists of a hulk."

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -52,15 +52,6 @@
 	cost = 6
 	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
 
-/datum/uplink_item/dangerous/nunchaku
-	name = "Syndie Fitness Nunchuks"
-	desc = "Heavyweight titanium nunchucks that can be used to knock out and harm your opponent quickly and easily.\
-			In close combat, it allows you to block all melee attacks and throws, punishing the offender."
-	item = /obj/item/melee/baton/nunchaku
-	cost = 7
-	purchasable_from = ~UPLINK_SPY //spy get their own tg version
-	uplink_item_flags = SYNDIE_ILLEGAL_TECH | SYNDIE_TRIPS_CONTRABAND
-
 /datum/uplink_item/dangerous/rapid
 	name = "Gloves of the North Star"
 	desc = "These gloves let the user punch people very fast. Does not improve weapon attack speed or the meaty fists of a hulk."

--- a/modular_nova/modules/opposing_force/code/equipment/melee.dm
+++ b/modular_nova/modules/opposing_force/code/equipment/melee.dm
@@ -65,6 +65,8 @@
 	description = "An extremely sharp and robust sword perfect to cleave through any opposition. Also highly illegal."
 	admin_note = "WARNING: 30 force, 35 armor pen."
 
+/datum/opposing_force_equipment/melee/nunchaku
+	item_type = /obj/item/melee/baton/nunchaku
 
 /datum/opposing_force_equipment/melee_stealth
 	category = OPFOR_EQUIPMENT_CATEGORY_MELEE_STEALTH

--- a/modular_nova/modules/traitor-uplinks/code/categories/dangerous.dm
+++ b/modular_nova/modules/traitor-uplinks/code/categories/dangerous.dm
@@ -26,6 +26,16 @@
 	cost = 1 // 1 whole dolar
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
+/datum/uplink_item/dangerous/nunchaku
+	name = "Syndie Fitness Nunchuks"
+	desc = "Heavyweight titanium nunchucks that can be used to knock out and harm your opponent quickly and easily.\
+			In close combat, it allows you to block all melee attacks and throws, punishing the offender."
+	item = /obj/item/melee/baton/nunchaku
+	cost = 7
+	purchasable_from = ~UPLINK_SPY //spy get their own tg version
+	uplink_item_flags = SYNDIE_ILLEGAL_TECH | SYNDIE_TRIPS_CONTRABAND
+
+
 // TG Overrides - Raises cost of this by 2x
 /datum/uplink_item/role_restricted/his_grace
 	cost = 40 // forces you to murderbone, so we're taking two antags out for one if they try it


### PR DESCRIPTION
## About The Pull Request

Lore accurated merge new syndie melee weapon

## How This Contributes To The Nova Sector Roleplay Experience

Adds nunchucks to the traitors uplink/opfor and tweak stats to TG values. That why the spy is almost never used.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/6c95069f-de76-408b-ba0b-a109bf6b3dbf)
![image](https://github.com/user-attachments/assets/d534a546-0731-4fe1-8ec0-3d6870ed30a0)

</details>

## Changelog

:cl: Blackjack (Syndie Maid)
balance: adding nunchuks to traitor uplink (7 TC) and opfor, tweak stats to TG values.
/:cl:
