### PR TITLE
Adds fake identity kit to midround contractor (along with other stuff)

### DIFF
--- a/modular_nova/modules/contractor/code/datums/midround/outfit.dm
+++ b/modular_nova/modules/contractor/code/datums/midround/outfit.dm
@@ -17,6 +17,7 @@
 	backpack_contents = list(
 		/obj/item/storage/box/survival/syndie,
 		/obj/item/storage/box/syndicate/contract_kit/midround,
+		/obj/item/storage/box/syndicate/stealth_contractor,
 		/obj/item/knife/combat/survival,
 		/obj/item/pinpointer/crew/contractor,
 	)

--- a/modular_nova/modules/contractor/code/items/boxes.dm
+++ b/modular_nova/modules/contractor/code/items/boxes.dm
@@ -23,7 +23,6 @@
 	new /obj/item/mod/control/pre_equipped/contractor(src)
 	. = ..() // so their MODSuit is first
 	new /obj/item/uplink/old_radio(src)
-	new /obj/item/jammer(src)
 
 /obj/item/storage/box/contractor/fulton_extraction/PopulateContents()
 	new /obj/item/extraction_pack/contractor(src)
@@ -58,9 +57,22 @@
 
 	// Paper guide
 	new /obj/item/paper/contractor_guide/midround(src)
+	new /obj/item/fake_identity_kit(src)
 	new /obj/item/reagent_containers/hypospray/medipen/atropine(src)
 	new /obj/item/jammer(src)
 	new /obj/item/storage/fancy/cigarettes/cigpack_syndicate(src)
 	new /obj/item/lighter(src)
 
 #undef SMALL_ITEM_AMOUNT
+
+/obj/item/storage/box/syndicate/stealth_contractor
+	name = "Stealth Kit"
+	desc = "It's just an ordinary box."
+	special_desc = "Supplied to Syndicate contractors. Intended to support stealthy operations."
+
+/obj/item/storage/box/syndicate/stealth_contractor/PopulateContents()
+	new /obj/item/fake_identity_kit(src)
+	new /obj/item/clothing/head/chameleon(src)
+	new /obj/item/clothing/mask/chameleon(src)
+	new /obj/item/clothing/under/chameleon(src)
+	new /obj/item/clothing/shoes/chameleon(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So not too long ago TG added fake identity kits which should make mulligan injector less useless by adding your new appearance to crew manifest and fool everyone with fake arrival announcement. Exactly the sort of thing contractors lacked in regard of blending with the crew. New item comes in its own box along with some chameleon clothing, so antags arent forced to rush to dorms and scramble for proper assistant outfit
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Contractors will be able to fake their identities which will allow them to actually try stealthing and not get valided by random sec who shiftclick everyone.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
(its actually red, im to lazy to recompile)

![image](https://github.com/user-attachments/assets/e9eb6c66-aea6-4022-8556-5ad5120f4d0c)

![image](https://github.com/user-attachments/assets/abace974-8984-4542-866d-fe39c4b3da32)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Added fake identity kit to midround contractor loadout
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
