### PR TITLE
de-fixes (removes) low-sanity hallucations

### DIFF
--- a/code/datums/mood.dm
+++ b/code/datums/mood.dm
@@ -607,11 +607,11 @@
 			mob_parent.add_actionspeed_modifier(/datum/actionspeed_modifier/high_sanity)
 			sanity_level = SANITY_LEVEL_GREAT
 
-	// Crazy or insane = add some uncommon hallucinations
+	/* // Crazy or insane = add some uncommon hallucinations // NOVA EDIT - Removes low-sanity halluctinations
 	if(sanity_level >= SANITY_LEVEL_CRAZY)
 		mob_parent.apply_status_effect(/datum/status_effect/hallucination/sanity)
 	else
-		mob_parent.remove_status_effect(/datum/status_effect/hallucination/sanity)
+		mob_parent.remove_status_effect(/datum/status_effect/hallucination/sanity) */
 
 	update_mood_icon()
 


### PR DESCRIPTION


## About The Pull Request

Disables the hallucations given by low-sanity, for a long list of reasons including:
It can be disruptive to long-running RP situations where people aren't mid-talk wolfing down a giant sandwhich
The mood system is 'finnicky' at best with what it decides tanks your mood
<details>

![image](https://github.com/user-attachments/assets/2b07c872-3c07-4c48-8aa5-8f88b15e8b7b)

</details>
there's pretty much no upside at all to this

## How This Contributes To The Nova Sector Roleplay Experience

Doesn't cause the mood system to unnecessarily intervene in the round for the sake of it.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  IDK what to put here
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Sanity hallucinations were put back to bed, RIP.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
