### PR TITLE
Fix quirk weirdness in ghost cafe

### DIFF
--- a/modular_nova/modules/ghostcafe/code/ghost_role_spawners.dm
+++ b/modular_nova/modules/ghostcafe/code/ghost_role_spawners.dm
@@ -54,6 +54,7 @@
 	flavour_text = "You are off-duty and have decided to visit your favourite cafe. Enjoy yourself."
 	random_appearance = FALSE
 	loadout_enabled = TRUE
+	quirks_enabled = TRUE
 
 /obj/effect/mob_spawn/ghost_role/human/ghostcafe/special(mob/living/carbon/human/new_spawn)
 	. = ..()
@@ -66,9 +67,8 @@
 		ADD_TRAIT(new_spawn, TRAIT_FREE_GHOST, TRAIT_GHOSTROLE)
 		ADD_TRAIT(new_spawn, TRAIT_NOBREATH, TRAIT_GHOSTROLE)
 		to_chat(new_spawn,span_warning("<b>Ghosting is free!</b>"))
-		var/datum/action/toggle_dead_chat_mob/D = new(new_spawn)
-		SSquirks.AssignQuirks(new_spawn, new_spawn.client, TRUE, TRUE, null, FALSE, new_spawn)
-		D.Grant(new_spawn)
+		var/datum/action/toggle_dead_chat_mob/dchat_toggle_ability = new(new_spawn)
+		dchat_toggle_ability.Grant(new_spawn)
 
 /mob/living/proc/on_using_radio(atom/movable/talking_movable)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request
Fixes some inconsistencies with quirks in the ghost cafe, seemingly caused by quirks being loaded before normal preferences- the spawner had its own way of loading in quirks rather than just enabling it for the mob spawner to handle
Fixes #4858
Fixes #4510
## How This Contributes To The Nova Sector Roleplay Experience
feex
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  I've been sitting on this for a while so I don't have the original screenshots i took but here's some second hand proof i solicited from our lovely internetizen

![image](https://github.com/user-attachments/assets/687327e4-fb21-4b3f-ada2-9da647c97827)

</details>

## Changelog
:cl:
fix: Voice actor and oversized now work properly in the ghost cafe
/:cl:
