### PR TITLE
Adds a cooking oil vat to SerenityStation's cold room.

### DIFF
--- a/_maps/map_files/SerenityStation/SerenityStation.dmm
+++ b/_maps/map_files/SerenityStation/SerenityStation.dmm
@@ -6119,7 +6119,7 @@
 /area/space/nearstation)
 "bLM" = (
 /obj/effect/turf_decal/weather/snow,
-/obj/structure/table,
+/obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "bLR" = (


### PR DESCRIPTION

## About The Pull Request

This, as the title may suggest, replaces a superfluous table in the lower level of SerenityStation's kitchen cold room with a cooking oil vat.

## How This Contributes To The Nova Sector Roleplay Experience

SerenityStation is the only map other than BirdShot, and the only map at all in Nova Sector's map rotation, that doesn't have a cooking oil vat in the cold room.

From what i can tell, the oil vat is more-or-less a standard fixture of the cold room, and its absence makes some things, like making beer batter for battered sausages, more difficult than they would be otherwise. It's theoretically possible to grind up soybean seeds for cooking oil, but i imagine people would rather get it from the vat, especially if they need large amounts.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![Screenshot_272](https://github.com/user-attachments/assets/c736eb1f-1508-420b-8e96-2f9c210cdc14)

</details>

## Changelog
:cl:
map: There is now a cooking oil vat in SerenityStation's cold room.
/:cl:
