### PR TITLE
Fixes prefs not hiding themselves when their associated parts are not available (IPC screens), fixes IPC antennae being stuck on non-IPCs

### DIFF
--- a/modular_nova/master_files/code/modules/client/preferences/mutant_parts.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/mutant_parts.dm
@@ -594,13 +594,6 @@
 
 	return data
 
-/datum/preference/choiced/mutant_choice/synth_chassis/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
-	var/species_path = preferences?.read_preference(/datum/preference/choiced/species)
-	if(!ispath(species_path, /datum/species/synthetic)) // This is what we do so it doesn't show up on non-synthetics.
-		return
-
-	return ..()
-
 /datum/preference/color/mutant/synth_chassis
 	category = PREFERENCE_CATEGORY_SUPPLEMENTAL_FEATURES
 	savefile_identifier = PREFERENCE_CHARACTER
@@ -635,13 +628,6 @@
 	data[SUPPLEMENTAL_FEATURE_KEY] = "ipc_head_color"
 
 	return data
-
-/datum/preference/choiced/mutant_choice/synth_head/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
-	var/species_path = preferences?.read_preference(/datum/preference/choiced/species)
-	if(!ispath(species_path, /datum/species/synthetic)) // This is what we do so it doesn't show up on non-synthetics.
-		return
-
-	return ..()
 
 /datum/preference/color/mutant/synth_head
 	category = PREFERENCE_CATEGORY_SUPPLEMENTAL_FEATURES


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/5161

These IPC prefs are an odd duck in that they do not have an associated toggle. The toggle is normally what determines whether or not these get hidden so with a lack of one we have to add some special handling.

## How This Contributes To The Nova Sector Roleplay Experience

Less clutter in the prefs menu is a good thing.

## Proof of Testing

<details>
<summary>IPC antenna goes away now</summary>
  
![uomTj1sM7z](https://github.com/user-attachments/assets/df15df4a-bfb4-4a8a-8d74-91134b4568ab)

</details>

## Changelog

:cl:
fix: fixes IPC prefs cluttering the prefs menu for non-synths. fixes an bug where the ipc antennae would persist upon changing species from ipc to something else and be unchangeable until you went back to ipc.
/:cl: