### PR TITLE
Tones down the magfed shotguns

### DIFF
--- a/modular_nova/master_files/code/modules/projectiles/boxes_magazines/external/shotgun.dm
+++ b/modular_nova/master_files/code/modules/projectiles/boxes_magazines/external/shotgun.dm
@@ -20,7 +20,7 @@
 	base_icon_state = "spikewall_mag"
 	ammo_type = /obj/item/ammo_casing/shotgun
 	caliber = CALIBER_SHOTGUN
-	max_ammo = 12
+	max_ammo = 10
 	casing_phrasing = "shell"
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 
@@ -43,7 +43,7 @@
 	base_icon_state = "marauder_mag"
 	ammo_type = /obj/item/ammo_casing/shotgun
 	caliber = CALIBER_SHOTGUN
-	max_ammo = 8
+	max_ammo = 7
 
 /obj/item/ammo_box/magazine/jager/rubbershot
 	ammo_type = /obj/item/ammo_casing/shotgun/rubbershot
@@ -53,7 +53,7 @@
 	desc = "A magazine of shotgun shells, suitable for the 'Jager' combat shotgun."
 	icon_state = "marauder_mag_large"
 	base_icon_state = "marauder_mag_large"
-	max_ammo = 10
+	max_ammo = 9
 
 /obj/item/ammo_box/magazine/jager/large/empty
 	start_empty = TRUE
@@ -69,7 +69,7 @@
 	base_icon_state = "shitzu_mag"
 	ammo_type = /obj/item/ammo_casing/shotgun
 	caliber = CALIBER_SHOTGUN
-	max_ammo = 12
+	max_ammo = 10
 	casing_phrasing = "shell"
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 

--- a/modular_nova/master_files/code/modules/projectiles/boxes_magazines/external/shotgun.dm
+++ b/modular_nova/master_files/code/modules/projectiles/boxes_magazines/external/shotgun.dm
@@ -53,7 +53,7 @@
 	desc = "A magazine of shotgun shells, suitable for the 'Jager' combat shotgun."
 	icon_state = "marauder_mag_large"
 	base_icon_state = "marauder_mag_large"
-	max_ammo = 12
+	max_ammo = 10
 
 /obj/item/ammo_box/magazine/jager/large/empty
 	start_empty = TRUE

--- a/modular_nova/master_files/code/modules/projectiles/boxes_magazines/external/shotgun.dm
+++ b/modular_nova/master_files/code/modules/projectiles/boxes_magazines/external/shotgun.dm
@@ -20,7 +20,7 @@
 	base_icon_state = "spikewall_mag"
 	ammo_type = /obj/item/ammo_casing/shotgun
 	caliber = CALIBER_SHOTGUN
-	max_ammo = 16
+	max_ammo = 12
 	casing_phrasing = "shell"
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armouries/shotgun.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armouries/shotgun.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/ballistic/shotgun/katyusha
 	name = "\improper Katyusha Shotgun"
-	desc = "A 2-round burst fire, mag-fed shotgun for combat in narrow corridors, \
+	desc = "A mag-fed shotgun for combat in narrow corridors, \
 		nicknamed 'Katyusha' by the blueshields for its versatility. Compatible only with specialized 16-shell drum magazines."
 
 	icon = 'modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armouries/ballistic48x.dmi'
@@ -18,17 +18,13 @@
 	inhand_x_dimension = 32
 	inhand_y_dimension = 32
 	obj_flags = UNIQUE_RENAME
-	projectile_damage_multiplier = 1.2
 	weapon_weight = WEAPON_MEDIUM
 	accepted_magazine_type = /obj/item/ammo_box/magazine/katyusha
 	spawn_magazine_type = /obj/item/ammo_box/magazine/katyusha/buckshot
 
 	can_suppress = FALSE
-	burst_size = 2
-	fire_delay = 0.85 SECONDS // Bulldog Stat Original: fire_delay = 1
-	burst_delay = 0.35 SECONDS
+	fire_delay = 5.5
 	fire_sound = 'modular_nova/master_files/sound/weapons/shotgun_nova.ogg' // Meatier shotgun sound
-	actions_types = list(/datum/action/item_action/toggle_firemode)
 
 	mag_display = TRUE
 	empty_indicator = TRUE
@@ -38,13 +34,12 @@
 	semi_auto = TRUE
 	internal_magazine = FALSE
 	tac_reloads = TRUE
-	burst_fire_selection = TRUE
 
 	lore_blurb =  "The Nanotrasen Armories Katyusha Magfed Shotgun is a recent release from NT's esteemed private arms division, \
 		and it's received a warm welcome from the Shield teams and other NT armed forces who have been \
 		issued it in the ongoing rollout. \
 		Though certain rival manufacturers have dismissed the Katyusha as a \"fake\" or a \"blatant bootleg,\"  \
-		the inimitable burst fire and a patent-pending multi-stage delayed blowback system \
+		the inimitable firepower and a patent-pending multi-stage delayed blowback system \
 		make the Katyusha powerful, reliable, accurate, and shockingly comfortable to fire."
 
 /obj/item/gun/ballistic/shotgun/katyusha/give_manufacturer_examine()
@@ -61,22 +56,19 @@
 
 /obj/item/gun/ballistic/shotgun/katyusha/jager
 	name = "\improper Jäger Shotgun"
-	desc = "A 2-round burst fire, mag-fed shotgun for combat in narrow corridors, \
+	desc = "A mag-fed shotgun for combat in narrow corridors, \
 		nicknamed 'Jäger' by the Solar Federation Marines for its versatility in clearing tight corridors, and special operations in hunting individuals."
 
 	icon_state = "marauder"
 	worn_icon_state = "marauder"
 	inhand_icon_state = "marauder"
 
-	projectile_damage_multiplier = 1
-	fire_delay = 1.5 SECONDS
-	burst_delay = 0.45 SECONDS
 	accepted_magazine_type = /obj/item/ammo_box/magazine/jager
 	spawn_magazine_type = /obj/item/ammo_box/magazine/jager/rubbershot
 	lore_blurb = "The Solar Federation Surplus 'Jäger' Magfed Shotgun is a recent release from Solar Federation Surplus. \
 		and it's received a warm welcome from the Solar Federation Marines and S.W.A.T. Teams. \
 		issued it in the ongoing rollout. \
-		the inimitable burst fire and multi-shell compatibility \
+		the inimitable firepower and multi-shell compatibility \
 		makes the Jäger powerful, reliable, accurate, and shockingly comfortable to fire."
 
 /obj/item/gun/ballistic/shotgun/katyusha/jager/give_manufacturer_examine()

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/syndicate_armaments/shotgun.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/syndicate_armaments/shotgun.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/ballistic/shotgun/katyusha/shitzu // Pulls from katyusha Shotgun
 	name = "\improper Shitzu Shotgun"
-	desc = "A Suspicious 2-round burst fire, mag-fed shotgun for combat in narrow corridors, \
+	desc = "A suspicious mag-fed shotgun for combat in narrow corridors, \
 		nicknamed 'Shitzu' by other agents for its versatility in clearing tight corridors and its ability to disbatch of threats."
 
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/company_and_or_faction_based/syndicate_armaments/ballistic48x.dmi'
@@ -13,10 +13,6 @@
 	icon_state = "shitzu"
 	inhand_icon_state = "shitzu"
 
-	projectile_damage_multiplier = 1
-	burst_delay = 0.35 SECONDS // Burst and Fire delay are different
-	// burst_delay = time between shots in burst
-	// fire_delay = time betweeen single fire (semi-auto)
 	accepted_magazine_type = /obj/item/ammo_box/magazine/shitzu
 	spawn_magazine_type = /obj/item/ammo_box/magazine/shitzu/milspec
 	lore_blurb = "The Syndicate Surplus 'Shitzu' Magfed Shotgun is a addition and remodification of the bulldog. \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Nerfs Katyusha, Jager and Shitzu by adjusting the following;
* Removes the 2-burst for all the variants
* Fire of rate has been increased for all the variants to be slightly slower than a combat shotgun's
* Katyusha no longer gets a 1.2x damage multiplier, instead having the same as every other non-antag shotgun
* Katyusha's max ammo for the drum mag is now 10 from 16
* Shitzu's max ammo for it's mag is now 10 from 12
* Jager's max ammo for large mag is now 9 from 12
* Jager's max ammo for regular mag is now 7 from 8

This does not change the ability to print milspec ammo as someone is already working on that.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

The shotgun currently overshadows every other shotgun in the game, its DPS (assuming slugs) being quite high as well as a shotgun with a burst system being too powerful to have as a station shotgun, allowing it to not only mow down anyone in a few seconds but also causing some unintended, unbalanced behavior such as stardust shells being able to double tase someone and stunning someone almost instantly, regardless of the armor.

The magazine changes might look harsh but its important to consider that even Bulldog only has a max ammo of 9 for a nukie weapon, with the reloading being easy to do thanks to it being magfed. ~~Tactical reloading is your best friend.~~

Katyusha's stats were questionable. While Bulldog's drum mags have 9, Katyusha would get an drum mag of a whopping 16 shells and a damage multiplier of 1.2x. Combined with buckshot's 60 damage (assuming pellets hit) brings it up to 72 while slugs would go from 50 to 60, effectively giving them the same damage as their milspec variants.

The point of this is not to nerf the shotgun down to irrelevancy, but to make it match the DPS and stats of our current shotguns more. It's still a great choice to have as proof of testing shows.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
Shooting with riot shotgun

https://github.com/user-attachments/assets/70129ea4-58b5-4f97-aa97-9e1cc46bcb1e

Shooting with Jager

https://github.com/user-attachments/assets/1152a6ee-de1c-413b-aac3-a2ca55b7e4ef


  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Hardly
balance: Magfed shotguns (Katyusha, Jager, Shitzu) no longer fire in bursts.
balance: Removes 1.2x damage multiplier from Katyusha
balance: Katyusha and Shitzu's magazine is now 10 from 16
balance: Jager's large magazine is now 9 from 12, with regular magazine being 7 from 8
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
