### PR TITLE
Fix teshari accessories being haunted and floating away

### DIFF
--- a/code/modules/surgery/bodyparts/worn_feature_offset.dm
+++ b/code/modules/surgery/bodyparts/worn_feature_offset.dm
@@ -44,7 +44,7 @@
 /datum/worn_feature_offset/proc/apply_offset(image/overlay)
 	var/list/offset = get_offset()
 	// NOVA EDIT ADDITION START
-	// TODO" A temporary hack until TG fixes this
+	// TODO A temporary hack until TG fixes this
 	if(feature_key == OFFSET_ACCESSORY)
 		// Reset our applied offset
 		overlay.pixel_w = 0


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/5171

## How This Contributes To The Nova Sector Roleplay Experience

No more haunted pins. This is a bandaid until TG fixes the issue upstream.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![dreamseeker_RrlsyRJ6MF](https://github.com/user-attachments/assets/6fabc183-2db8-4391-b0aa-4892dbb3892e)
  
</details>

## Changelog

:cl:
fix: accessories equipped on teshari will no longer run away from them over time
/:cl: