### PR TITLE
Makes 'pellet' shells for shotguns weak against armor again.

### DIFF
--- a/modular_nova/modules/shotgunrebalance/code/shotgun.dm
+++ b/modular_nova/modules/shotgunrebalance/code/shotgun.dm
@@ -87,6 +87,7 @@
 	projectile_type = /obj/projectile/bullet/pellet/shotgun_buckshot
 	pellets = 12 // 5 * 12 for 60 damage if every pellet hits, we want to keep lethal shells ~50 damage
 	variance = 20
+	weak_against_armour = TRUE
 
 /obj/item/ammo_casing/shotgun/buckshot/old
 	name = "old buckshot shell"


### PR DESCRIPTION
## About The Pull Request
Turns out, they slowly became over-performing as higher-firerate versions of shotguns came out, so this makes them perform poorly against armor.

## How This Contributes To The Nova Sector Roleplay Experience

Guns should be primarily a character flavor choice, instead of one suddenly becoming objectively the best in nearly any situation, which is where buckshot's sitting currently.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  i'll do it super-soon
</details>

## Changelog
:cl:
balance: 'Pellet' shells for shotguns, including buckshot and rubbershot now fair worse against armor all-around!
/:cl:
