### PR TITLE
Makes blue security glasses separate.

### DIFF
--- a/modular_nova/modules/blueshield/code/blueshield.dm
+++ b/modular_nova/modules/blueshield/code/blueshield.dm
@@ -51,7 +51,7 @@
 	id = /obj/item/card/id/advanced/centcom/station
 	shoes = /obj/item/clothing/shoes/jackboots
 	ears = /obj/item/radio/headset/headset_bs/alt
-	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
+	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/blue
 	implants = list(/obj/item/implant/mindshield)
 	backpack_contents = list(
 		/obj/item/choice_beacon/blueshield = 1,

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_glasses.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_glasses.dm
@@ -158,6 +158,11 @@
 	item_path = /obj/item/clothing/glasses/hud/eyepatch/meson
 	restricted_roles = list(JOB_QUARTERMASTER, JOB_CARGO_TECHNICIAN, JOB_SHAFT_MINER, JOB_CUSTOMS_AGENT, JOB_CHIEF_ENGINEER, JOB_STATION_ENGINEER, JOB_ATMOSPHERIC_TECHNICIAN, JOB_ENGINEERING_GUARD)
 
+/datum/loadout_item/glasses/sechud_sunglasses_blue
+	name = "Blue Security Sunglasses"
+	item_path = /obj/item/clothing/glasses/hud/security/sunglasses/blue
+	restricted_roles = list(JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_HEAD_OF_SECURITY, JOB_CORRECTIONS_OFFICER, JOB_BOUNCER, JOB_ORDERLY, JOB_SCIENCE_GUARD, JOB_CUSTOMS_AGENT, JOB_ENGINEERING_GUARD, JOB_BLUESHIELD, JOB_DETECTIVE)
+
 /datum/loadout_item/glasses/secpatch
 	name = "Security HUD Eyepatch"
 	item_path = /obj/item/clothing/glasses/hud/eyepatch/sec

--- a/modular_nova/modules/sec_haul/code/misc/vending.dm
+++ b/modular_nova/modules/sec_haul/code/misc/vending.dm
@@ -17,7 +17,6 @@
 		/obj/item/melee/baton/security/stun_gun/stun_knife = 3,
 	)
 	premium = list(
-		/obj/item/clothing/glasses/hud/security/sunglasses/blue = 3,
 		/obj/item/storage/belt/security/webbing = 5,
 		/obj/item/coin/antagtoken = 1,
 		/obj/item/clothing/head/helmet/blueshirt = 3,
@@ -68,6 +67,7 @@
 			"name" = "Alternate",
 			"icon" = "shield-halved",
 			"products" = list(
+		/obj/item/clothing/glasses/hud/security/sunglasses/blue = 3,
 				/obj/item/clothing/head/beret/sec/nova = 4,
 				/obj/item/clothing/head/security_cap = 4,
 				/obj/item/clothing/head/helmet/sec/white = 3,

--- a/modular_nova/modules/sec_haul/code/misc/vending.dm
+++ b/modular_nova/modules/sec_haul/code/misc/vending.dm
@@ -17,6 +17,7 @@
 		/obj/item/melee/baton/security/stun_gun/stun_knife = 3,
 	)
 	premium = list(
+		/obj/item/clothing/glasses/hud/security/sunglasses/blue = 3,
 		/obj/item/storage/belt/security/webbing = 5,
 		/obj/item/coin/antagtoken = 1,
 		/obj/item/clothing/head/helmet/blueshirt = 3,

--- a/modular_nova/modules/sec_haul/code/security_clothing/sec_clothing_overrides.dm
+++ b/modular_nova/modules/sec_haul/code/security_clothing/sec_clothing_overrides.dm
@@ -175,24 +175,8 @@
 	)
 
 /obj/item/clothing/glasses/hud/security/sunglasses
-	unique_reskin = list(
-		"Dark-Tint Red Sunglasses" = list(
-			RESKIN_ICON_STATE = "sunhudsec",
-			RESKIN_WORN_ICON_STATE = "sunhudsec"
-		),
-		"Dark-Tint Blue Sunglasses" = list(
-			RESKIN_ICON = 'modular_nova/master_files/icons/obj/clothing/glasses.dmi',
-			RESKIN_ICON_STATE = "security_hud_blue_black",
-			RESKIN_WORN_ICON = 'modular_nova/master_files/icons/mob/clothing/eyes.dmi',
-			RESKIN_WORN_ICON_STATE = "security_hud_blue_black"
-		),
-		"Light-Tint Blue Sunglasses" = list(
-			RESKIN_ICON = 'modular_nova/master_files/icons/obj/clothing/glasses.dmi',
-			RESKIN_ICON_STATE = "security_hud_blue",
-			RESKIN_WORN_ICON = 'modular_nova/master_files/icons/mob/clothing/eyes.dmi',
-			RESKIN_WORN_ICON_STATE = "security_hud_blue"
-		),
-	)
+	uses_advanced_reskins = FALSE
+	unique_reskin = null
 
 /obj/item/clothing/glasses/hud/security/sunglasses/blue
 	icon = 'modular_nova/master_files/icons/obj/clothing/glasses.dmi',

--- a/modular_nova/modules/sec_haul/code/security_clothing/sec_clothing_overrides.dm
+++ b/modular_nova/modules/sec_haul/code/security_clothing/sec_clothing_overrides.dm
@@ -194,6 +194,21 @@
 		),
 	)
 
+/obj/item/clothing/glasses/hud/security/sunglasses/blue
+	icon = 'modular_nova/master_files/icons/obj/clothing/glasses.dmi',
+	worn_icon = 'modular_nova/master_files/icons/mob/clothing/eyes.dmi',
+	icon_state = 'security_hud_blue_black'
+	unique_reskin = list(
+		"Dark-Tint Blue Sunglasses" = list(
+			RESKIN_ICON_STATE = "security_hud_blue_black",
+			RESKIN_WORN_ICON_STATE = "security_hud_blue_black"
+		),
+		"Light-Tint Blue Sunglasses" = list(
+			RESKIN_ICON_STATE = "security_hud_blue",
+			RESKIN_WORN_ICON_STATE = "security_hud_blue"
+		),
+	)
+
 /obj/item/clothing/glasses/hud/security/night
 	uses_advanced_reskins = FALSE
 	unique_reskin = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Removes the blue sec glasses from the reskin options and instead makes it a separate item, making blueshields spawn with it while making it an option in secdrobe and loadout.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
Blueshields and bluesec players demand to have their glasses blue by default, and that reskinning the glasses overall seems weirdly hit or miss seeing reports that the icon keeps disppearing and then returning.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
I actually haven't tested this yet because my Windows 11 boot keeps breaking.
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Hardly
add: Adds blue security sunglasses and gives it to the blueshields, secoffs and guards can also get it through secdrobe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
