### PR TITLE
[MODULAR] Slows the bleedrate on pretty much all of the bleeding wounds

### DIFF
--- a/modular_nova/master_files/code/datums/wounds/pierce.dm
+++ b/modular_nova/master_files/code/datums/wounds/pierce.dm
@@ -1,0 +1,8 @@
+/datum/wound/pierce/bleed/moderate
+	initial_flow = 1
+
+/datum/wound/pierce/bleed/severe
+	initial_flow = 1.75
+
+/datum/wound/pierce/bleed/critical
+	initial_flow = 2.3

--- a/modular_nova/master_files/code/datums/wounds/slash.dm
+++ b/modular_nova/master_files/code/datums/wounds/slash.dm
@@ -1,0 +1,11 @@
+/datum/wound/slash/flesh/moderate
+	initial_flow = 1.5
+	minimum_flow = 0.3
+
+/datum/wound/slash/flesh/severe
+	initial_flow = 2.25
+	minimum_flow = 1.755
+
+/datum/wound/slash/flesh/critical
+	initial_flow = 3
+	minimum_flow = 2.85

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6768,6 +6768,8 @@
 #include "modular_nova\master_files\code\datums\traits\neutral.dm"
 #include "modular_nova\master_files\code\datums\votes\_vote_datum.dm"
 #include "modular_nova\master_files\code\datums\votes\map_vote.dm"
+#include "modular_nova\master_files\code\datums\wounds\pierce.dm"
+#include "modular_nova\master_files\code\datums\wounds\slash.dm"
 #include "modular_nova\master_files\code\game\atoms.dm"
 #include "modular_nova\master_files\code\game\sound.dm"
 #include "modular_nova\master_files\code\game\area\areas\ruins\lavaland.dm"


### PR DESCRIPTION


## About The Pull Request
Despite bloodloss being changed, bleeding wounds are pretty much unequivocally a death sentence, especially for off-station people (tarkov, contractors, ninjas, w/e) unless you stack up on epi-pens, so this aims to slow it down a _little_ bit to buy more time before you're in the official 'you're fucked' range.

## How This Contributes To The Nova Sector Roleplay Experience
Less people bleeding out quietly in a corner of the map because they got knicked by one buckshot pellet and got a weeping avulsion somehow.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  SOON TM
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Bleed wounds across the board 'bleed less,' due to biological changes in the local-sector!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
