### PR TITLE
Allows synth antennas to be used as mismatched parts

### DIFF
--- a/modular_nova/master_files/code/modules/client/preferences/mutant_parts.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/mutant_parts.dm
@@ -518,22 +518,13 @@
 		return ipc_screen_pref.is_accessible(preferences) // check if the associated type is even accessible
 
 /// IPC Antennas
-
 /datum/preference/choiced/mutant_choice/synth_antenna
 	savefile_key = "feature_ipc_antenna"
 	relevant_mutant_bodypart = MUTANT_SYNTH_ANTENNA
 	default_accessory_type = /datum/sprite_accessory/antenna/none
-	flexible_mismatch = FALSE
 
 /datum/preference/choiced/mutant_choice/synth_antenna/is_part_enabled(datum/preferences/preferences)
 	return TRUE
-
-/datum/preference/choiced/mutant_choice/synth_antenna/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
-	var/species_path = preferences?.read_preference(/datum/preference/choiced/species)
-	if(!ispath(species_path, /datum/species/synthetic)) // This is what we do so it doesn't show up on non-synthetics.
-		return
-
-	return ..()
 
 /datum/preference/tri_color/synth_antenna
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
@@ -543,13 +534,6 @@
 	check_mode = TRICOLOR_CHECK_ACCESSORY
 	type_to_check = /datum/preference/choiced/mutant_choice/synth_antenna
 
-/datum/preference/tri_color/synth_antenna/is_accessible(datum/preferences/preferences)
-	if (!..(preferences))
-		return FALSE
-	if(preferences.read_preference(type_to_check))
-		var/datum/preference/choiced/mutant_choice/synth_antenna/antenna_pref = GLOB.preference_entries[type_to_check]
-		return antenna_pref.is_accessible(preferences) // check if the associated type is even accessible
-
 /datum/preference/tri_bool/synth_antenna_emissive
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
 	savefile_identifier = PREFERENCE_CHARACTER
@@ -557,13 +541,6 @@
 	relevant_mutant_bodypart = MUTANT_SYNTH_ANTENNA
 	check_mode = TRICOLOR_CHECK_ACCESSORY
 	type_to_check = /datum/preference/choiced/mutant_choice/synth_antenna
-
-/datum/preference/tri_bool/synth_antenna_emissive/is_accessible(datum/preferences/preferences)
-	if (!..(preferences))
-		return FALSE
-	if(preferences.read_preference(type_to_check))
-		var/datum/preference/choiced/mutant_choice/synth_antenna/antenna_pref = GLOB.preference_entries[type_to_check]
-		return antenna_pref.is_accessible(preferences) // check if the associated type is even accessible
 
 /// IPC Chassis
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Partly reverts #5205 and adjusts IPC antenna code to make it work with the mismatch parts toggle.  Huge thank you to Mal for helping with this!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Customization good!  Non-IPCs can now use the antennas as normal.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  

https://github.com/user-attachments/assets/520246ae-7183-4f9b-8832-d351d3bd0e70


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Non-IPCs can now use synth antenna again with mismatch parts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
