### PR TITLE
Gives auto update on security level change to status displays

### DIFF
--- a/modular_nova/master_files/code/game/machinery/status_display.dm
+++ b/modular_nova/master_files/code/game/machinery/status_display.dm
@@ -29,6 +29,38 @@ GLOBAL_LIST_INIT(alert_picture_options_nova, list(
 	. = ..()
 	set_picture("default")
 
+/obj/machinery/status_display/evac
+	var/static/list/alert_list = list(
+		"greenalert",
+		"bluealert",
+		"violetalert",
+		"orangealert",
+		"amberalert",
+		"redalert",
+		"deltaalert",
+		"gammaalert",
+		"epsilonalert",
+		"federalalert",
+	)
+
+/obj/machinery/status_display/evac/Initialize(mapload, ndir, building)
+	. = ..()
+	RegisterSignal(SSsecurity_level, COMSIG_SECURITY_LEVEL_CHANGED, PROC_REF(on_sec_level_change))
+
+/obj/machinery/status_display/evac/Destroy()
+	. = ..()
+	UnregisterSignal(SSsecurity_level, COMSIG_SECURITY_LEVEL_CHANGED)
+
+/obj/machinery/status_display/evac/proc/on_sec_level_change(datum/source, new_level)
+	SIGNAL_HANDLER
+	if(current_mode != SD_PICTURE)
+		return
+	if(!(current_picture in alert_list))
+		return
+
+	var/datum/security_level/alert_level = SSsecurity_level.available_levels[SSsecurity_level.number_level_to_text(new_level)]
+	set_picture(alert_level.status_display_icon_state)
+
 /obj/machinery/status_display/syndie
 	name = "syndicate status display"
 

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole/Main.tsx
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole/Main.tsx
@@ -159,8 +159,7 @@ export function PageMain(props) {
               color={engineeringOverride ? 'bad' : undefined}
               onClick={() => act('toggleEngOverride')}
             >
-              {engineeringOverride ? 'Disable' : 'Enable'}
-              Engineering Override Access
+              {engineeringOverride ? 'Disable' : 'Enable'} Engineering Override Access
             </Button.Confirm>
           )}
           {/* NOVA EDIT ADDITION END */}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Somebody made a suggestion to code it, so why not. Works only if you set it to show current alert level.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Somebody asked this and while seeing smiley green planets funny during something like blob hazard, it would be better if it just autoupdates itself. After all, its a whole point of those displays.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

  ![dreamseeker_xr8jrZgmXO](https://github.com/user-attachments/assets/1dd2acd2-9cb4-44b5-b2e1-84c9dfd0dc33)
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Status displays will now update their picture according to current security level. No need to do it manually anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
