### PR TITLE
actually makes buckshot/rubbershot weak against armor for real this time

### DIFF
--- a/modular_nova/modules/shotgunrebalance/code/shotgun.dm
+++ b/modular_nova/modules/shotgunrebalance/code/shotgun.dm
@@ -87,7 +87,6 @@
 	projectile_type = /obj/projectile/bullet/pellet/shotgun_buckshot
 	pellets = 12 // 5 * 12 for 60 damage if every pellet hits, we want to keep lethal shells ~50 damage
 	variance = 20
-	weak_against_armour = TRUE
 
 /obj/item/ammo_casing/shotgun/buckshot/old
 	name = "old buckshot shell"
@@ -96,6 +95,7 @@
 
 /obj/projectile/bullet/pellet/shotgun_buckshot
 	damage = 5
+	weak_against_armour = TRUE
 
 /obj/item/ammo_casing/shotgun/buckshot/milspec
 	desc = "A hot-loaded 12 gauge milspec buckshot shell, used by various paramilitaries and mercenary forces. Probably not legal to use under corporate regulations."
@@ -109,6 +109,7 @@
 	wound_falloff_tile = -0.25
 	speed = 1.5
 	armour_penetration = 5
+	// weak_against_armour = FALSE // Probably don't uncomment this unless you have a really compelling reason.
 
 /obj/projectile/bullet/shotgun_slug
 	damage = 50 // based on old stats
@@ -134,6 +135,7 @@
 /obj/projectile/bullet/pellet/shotgun_rubbershot
 	stamina = 10
 	speed = 1
+	weak_against_armour = TRUE
 
 /obj/item/ammo_casing/shotgun/magnum
 	name = "magnum blockshot shell"


### PR DESCRIPTION
## About The Pull Request
NovaSector/NovaSector#5241 but actually applied to the projectile defines and not the casings

## How This Contributes To The Nova Sector Roleplay Experience
nerfs should probably actually nerf the projectiles huh

## Changelog

:cl:
fix: A previous balance change made buckshot and rubber shot weak against armor, but accidentally only set that condition for the casing. This has been rectified, and buckshot/rubber shot is now properly mitigated by ballistic protection.
/:cl:
