### PR TITLE
Action slots update for erp items

### DIFF
--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_clothing/bdsm_mask.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_clothing/bdsm_mask.dm
@@ -24,6 +24,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	flags_cover = MASKCOVERSMOUTH
 	flags_inv = HIDEFACIALHAIR|HIDESNOUT
+	action_slots = ALL
 	var/mask_on = FALSE
 	var/breath_status = TRUE
 	var/time_to_choke = 12	// How long can breath hold

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_clothing/deprivation_helmet.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_clothing/deprivation_helmet.dm
@@ -22,6 +22,7 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT|HIDEFACIALHAIR
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	clothing_flags = SNUG_FIT
+	action_slots = ALL
 	unique_reskin = list(
 		"Earred" = "dephelmet",
 		"Earless" = "dephelmet_earless"

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_clothing/dorms_headphones.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_clothing/dorms_headphones.dm
@@ -11,6 +11,7 @@
 	flags_1 = IS_PLAYER_COLORABLE_1
 	strip_delay = 15
 	custom_price = PAYCHECK_CREW * 2
+	action_slots = ALL
 	actions_types = list(/datum/action/item_action/toggle_dorms_headphones)
 	/// Are we playing music? Controls icon state and flavor text.
 	var/playing_music = FALSE


### PR DESCRIPTION
## About The Pull Request

Added the ability to use padded headphones/deprivation helmet/latex gasmask actions in any slot.

## How This Contributes To The Nova Sector Roleplay Experience

A small handy thing for players. Maybe someone will like it.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
  
![F](https://github.com/user-attachments/assets/41ebcd66-008b-42ce-a270-9f241e2df212)

</details>

## Changelog

:cl: mogeoko
qol: You can use padded headphones/deprivation helmet/latex gasmask in any possible slot now.
/:cl:
