### PR TITLE
Adds an Undershirt version of the greyscale Fishnets

### DIFF
--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/underwear/undershirts.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/underwear/undershirts.dm
@@ -133,3 +133,14 @@
 	icon_state = "babydoll"
 	gender = FEMALE
 	use_static = FALSE
+
+//These are just copies of a bra sprite-accessory, but they layer over other bras instead.
+/datum/sprite_accessory/undershirt/fishnet_sleeves
+	name = "Fishnet - Sleeved (Greyscale)"
+	icon_state = "fishnet_sleeves_alt"
+	use_static = FALSE
+
+/datum/sprite_accessory/undershirt/fishnet_base
+	name = "Fishnet - Sleeveless (Greyscale)"
+	icon_state = "fishnet_body_alt"
+	use_static = FALSE


### PR DESCRIPTION

## About The Pull Request

Being forced to have these AS a bra sucks. What if I want a bra UNDER my fishnets? Huh? What about that punk?

Just adds an /undershirt/ version of the bra. That's it. That's the PR. 11 line change ~~(1 being a comment and 2 being whitespace so 8 functional lines)~~
## How This Contributes To The Nova Sector Roleplay Experience
This goes so hard feel free to screenshot
~~Makes me wish the fishnets weren't 100% opacity tbh. Feels a bit off.~~
![image](https://github.com/user-attachments/assets/c5da34bd-60c5-4a3b-8e56-19d5c06a373a)
## Proof of Testing
![image](https://github.com/user-attachments/assets/85511e0a-c7fa-4bd3-9b2a-f94dd442d5ec)



## Changelog
:cl:
add: Added Undershirt variants of the greyscale Fishnets (for wearing OVER bras, as opposed to wearing them AS bras)
/:cl:
