### PR TITLE
Removes the visual overlay from the Breathing Tube Implant

### DIFF
--- a/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_internal.dm
@@ -355,7 +355,7 @@
 	icon_state = "implant_mask"
 	slot = ORGAN_SLOT_BREATHING_TUBE
 	w_class = WEIGHT_CLASS_TINY
-	aug_overlay = "breathing_tube"
+	aug_overlay = "breathing_tube" //NOVA EDIT - ICON OVERRIDDEN IN AESTHETICS MODULE
 
 /obj/item/organ/cyberimp/mouth/breathing_tube/emp_act(severity)
 	. = ..()

--- a/modular_nova/modules/aesthetics/implanter/implanter.dm
+++ b/modular_nova/modules/aesthetics/implanter/implanter.dm
@@ -6,3 +6,6 @@
 
 /obj/item/implantcase
 	icon = 'modular_nova/modules/aesthetics/implanter/implanter.dmi'
+
+/obj/item/organ/cyberimp/mouth/breathing_tube
+	aug_overlay = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the visual overlay from the Breathing Tube Implant
That... that's it. Not sure what else to say here.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
I'm actually super happy with implants getting visuals. Being able to see toolset implants and thrusters and pumps is dope.

But this implant just doesn't have enough of a benefit to warrant the visual.
Other implants give proper boons, flat stat buffs or access to items... this one lets you use internals without a mask (which everyone spawns with, so it's not HARD to get). It ends up balance-wise just being an alternative to a mask.
And the visual is rather bulky for a mask alternative, to the point it dissuades use more than anything. 

Anyways, yeah. Not like security needs to see that you have this. What are you gonna do, breathe without their permission?

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

Gimme 5

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed the visual overlay of the Breathing Tube implant.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
