### PR TITLE
lowers the roundstart slime burn resist

### DIFF
--- a/modular_nova/modules/bodyparts/code/roundstartslime_bodyparts.dm
+++ b/modular_nova/modules/bodyparts/code/roundstartslime_bodyparts.dm
@@ -10,43 +10,49 @@
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
 	biological_state = (BIO_FLESH|BIO_BLOODED)
 	teeth_count = 0
+	burn_modifier = 0.8
 
 /obj/item/bodypart/chest/jelly/slime/roundstart
 	is_dimorphic = TRUE
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
 	biological_state = (BIO_FLESH|BIO_BLOODED)
+	burn_modifier = 0.8
 
 /obj/item/bodypart/arm/left/jelly/slime/roundstart
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
 	biological_state = (BIO_FLESH|BIO_BLOODED)
+	burn_modifier = 0.8
 
 /obj/item/bodypart/arm/right/jelly/slime/roundstart
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
 	biological_state = (BIO_FLESH|BIO_BLOODED)
+	burn_modifier = 0.8
 
 /obj/item/bodypart/leg/left/jelly/slime/roundstart
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
 	biological_state = (BIO_FLESH|BIO_BLOODED)
 	digitigrade_type = /obj/item/bodypart/leg/left/digitigrade/jelly/slime/roundstart
+	burn_modifier = 0.8
 
 /obj/item/bodypart/leg/right/jelly/slime/roundstart
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
 	biological_state = (BIO_FLESH|BIO_BLOODED)
 	digitigrade_type = /obj/item/bodypart/leg/right/digitigrade/jelly/slime/roundstart
+	burn_modifier = 0.8
 
 /obj/item/bodypart/leg/left/digitigrade/jelly/slime/roundstart
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
 	base_limb_id = SPECIES_SLIMEPERSON
 	biological_state = (BIO_FLESH|BIO_BLOODED)
 	dmg_overlay_type = null
-	burn_modifier = 0.5 // = 1/2x generic burn damage
+	burn_modifier = 0.8
 
 /obj/item/bodypart/leg/right/digitigrade/jelly/slime/roundstart
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
 	base_limb_id = SPECIES_SLIMEPERSON
 	biological_state = (BIO_FLESH|BIO_BLOODED)
 	dmg_overlay_type = null
-	burn_modifier = 0.5 // = 1/2x generic burn damage
+	burn_modifier = 0.8
 
 /obj/item/bodypart/head/jelly/drop_limb(special, dismembered, move_to_floor = FALSE)
 	if(special)


### PR DESCRIPTION


## About The Pull Request

It's currently 0.5 across the board from the parent type, this raises to to 0.8 of the total burn damage when received, giving them only a slight reduction

## How This Contributes To The Nova Sector Roleplay Experience

https://discord.com/channels/1171566433923239977/1362905660186038523/1362905660186038523

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: roundstart slimes have 30% less resistance to burns across their entire body, owch!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
