### PR TITLE
.35 Sol general rebalance

### DIFF
--- a/modular_nova/modules/company_imports/code/armament_datums/sol_defense.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/sol_defense.dm
@@ -97,7 +97,6 @@
 
 /datum/armament_entry/company_import/sol_defense/sidearm/wespe
 	item_type = /obj/item/gun/ballistic/automatic/pistol/sol
-	restricted = TRUE
 
 /datum/armament_entry/company_import/sol_defense/sidearm/type207
 	item_type = /obj/item/gun/ballistic/automatic/pistol/type207

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/ammo/pistol.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/ammo/pistol.dm
@@ -20,10 +20,10 @@
 
 /obj/projectile/bullet/c35sol
 	name = ".35 Sol Short bullet"
-	damage = 25
+	damage = 20
 
-	wound_bonus = 10 // Normal bullets are 20
-	bare_wound_bonus = 20
+	wound_bonus = 5 // Normal bullets are 20
+	bare_wound_bonus = 10
 
 
 /obj/item/ammo_box/c35sol

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/submachinegun.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/submachinegun.dm
@@ -27,8 +27,8 @@
 
 	suppressor_x_offset = 11
 
-	burst_size = 3
-	fire_delay = 0.2 SECONDS
+	burst_size = 1
+	fire_delay = 0.3 SECONDS
 
 	spread = 7.5
 
@@ -44,8 +44,10 @@
 /obj/item/gun/ballistic/automatic/sol_smg/give_manufacturer_examine()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_CARWO)
 
-/obj/item/gun/ballistic/automatic/sol_smg/no_mag
-	spawnwithmagazine = FALSE
+/obj/item/gun/ballistic/automatic/sol_smg/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/automatic_fire, fire_delay)
+
 
 // Sindano (evil)
 

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/trappiste_fabriek/pistol.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/trappiste_fabriek/pistol.dm
@@ -17,7 +17,7 @@
 	suppressor_x_offset = 0
 	suppressor_y_offset = 0
 
-	fire_delay = 0.3 SECONDS
+	fire_delay = 0.2 SECONDS
 
 	lore_blurb = "<i>The Guêpe is an evolution of an older pistol which has seen use for over a century, with incremental \
 		improvements keeping it up to date.<br><br>\
@@ -41,10 +41,6 @@
 
 /obj/item/gun/ballistic/automatic/pistol/sol/no_mag
 	spawnwithmagazine = FALSE
-
-/obj/item/gun/ballistic/automatic/pistol/sol/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/automatic_fire, fire_delay)
 
 // Sol pistol evil gun
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
35 sol, and the two guns (minus the renard) were a little overpeforming for their weight-class, too high of a DPS, too high of a reliability, and a bit too much favored-numbers,
so the round itself is down 5 damage, with a hefty-hit to wound-chance, and bare-wound chance,

the sindano loses it's burst, and is now full-auto, while the guepe is now semi-auto (space glock)

putting this up early to let people skim the numbers for feedback

## How This Contributes To The Nova Sector Roleplay Experience
there should be two guns that are kinda just better then most of the others in their weight-class, with no competition(and in the sindanos case, flatout better then most guns whole-stop)

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  not done yet
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: 35 sol nerfed in both damage and wound bonus
balance: The sindano is no longer burst, instead it's full auto and shoots about at guepe pace
balance: speaking of: the guepe is now semi-auto, and no longer restricted in cargo. (also shoots slightly faster)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
