### PR TITLE
[QoL] [Staff Request] Make the Shuttle transit times consistent (15 minutes), regardless of Alert

### DIFF
--- a/modular_nova/modules/alerts/code/security_level_datums.dm
+++ b/modular_nova/modules/alerts/code/security_level_datums.dm
@@ -1,15 +1,20 @@
+#define ALERT_COEFF_NOVA 1.5 // 1.5x the default value, normally 10 minutes, which give us 15 minutes.
+
 /**
  * Contains some overrides and our sec levels.
  */
 
 /datum/security_level/green
 	sound = 'modular_nova/modules/alerts/sound/security_levels/green.ogg'
+	shuttle_call_time_mod = ALERT_COEFF_NOVA
 
 /datum/security_level/blue
 	sound = 'modular_nova/modules/alerts/sound/security_levels/blue.ogg'
+	shuttle_call_time_mod = ALERT_COEFF_NOVA
 
 /datum/security_level/red
 	sound = 'modular_nova/modules/alerts/sound/security_levels/red.ogg'
+	shuttle_call_time_mod = ALERT_COEFF_NOVA
 
 /datum/security_level/delta
 	announcement_color = "pink"
@@ -18,6 +23,7 @@
 	sound = 'modular_nova/modules/alerts/sound/security_levels/delta.ogg'
 	looping_sound = 'modular_nova/modules/alerts/sound/misc/alarm_delta.ogg'
 	looping_sound_interval = 8 SECONDS
+	shuttle_call_time_mod = ALERT_COEFF_NOVA
 
 
 /**
@@ -35,7 +41,7 @@
 	lowering_to_configuration_key = /datum/config_entry/string/alert_violet_downto
 	elevating_to_configuration_key = /datum/config_entry/string/alert_violet_upto
 	sound = 'modular_nova/modules/alerts/sound/security_levels/violet.ogg'
-	shuttle_call_time_mod = 0.75
+	shuttle_call_time_mod = ALERT_COEFF_NOVA
 
 /**
  * Orange
@@ -52,7 +58,7 @@
 	lowering_to_configuration_key = /datum/config_entry/string/alert_orange_downto
 	elevating_to_configuration_key = /datum/config_entry/string/alert_orange_upto
 	sound = 'modular_nova/modules/alerts/sound/security_levels/orange.ogg'
-	shuttle_call_time_mod = 0.75
+	shuttle_call_time_mod = ALERT_COEFF_NOVA
 
 /**
  * Amber
@@ -70,7 +76,7 @@
 	lowering_to_configuration_key = /datum/config_entry/string/alert_amber_downto
 	elevating_to_configuration_key = /datum/config_entry/string/alert_amber_upto
 	sound = 'modular_nova/modules/alerts/sound/security_levels/amber.ogg'
-	shuttle_call_time_mod = 0.5
+	shuttle_call_time_mod = ALERT_COEFF_NOVA
 
 /**
  * Epsilon
@@ -87,7 +93,7 @@
 	fire_alarm_light_color = COLOR_BIOLUMINESCENCE_PURPLE
 	lowering_to_configuration_key = /datum/config_entry/string/alert_epsilon_downto
 	elevating_to_configuration_key = /datum/config_entry/string/alert_epsilon_upto
-	shuttle_call_time_mod = 0.15
+	shuttle_call_time_mod = ALERT_COEFF_NOVA
 	sound = 'modular_nova/modules/alerts/sound/security_levels/epsilon.ogg'
 	looping_sound = 'modular_nova/modules/alerts/sound/security_levels/epsilon_loop.ogg'
 	looping_sound_interval = 15 SECONDS
@@ -106,7 +112,7 @@
 	fire_alarm_light_color = COLOR_ASSEMBLY_PURPLE
 	lowering_to_configuration_key = /datum/config_entry/string/alert_gamma_downto
 	elevating_to_configuration_key = /datum/config_entry/string/alert_gamma_upto
-	shuttle_call_time_mod = 0.25
+	shuttle_call_time_mod = ALERT_COEFF_NOVA
 	sound = 'modular_nova/modules/alerts/sound/security_levels/gamma_alert.ogg'
 	looping_sound = 'modular_nova/modules/alerts/sound/security_levels/gamma_alert.ogg'
 	looping_sound_interval = 13 SECONDS
@@ -128,3 +134,6 @@
 	sound = 'modular_nova/modules/alerts/sound/security_levels/gamma_alert.ogg'
 	looping_sound = 'modular_nova/modules/alerts/sound/security_levels/gamma_alert.ogg'
 	looping_sound_interval = 13 SECONDS
+	shuttle_call_time_mod = ALERT_COEFF_NOVA
+
+#undef ALERT_COEFF_NOVA


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Changed the time mod on all the alert levels on a modular file to be 1.5, which makes it go to 15 minutes given the current tg config. (Is not wise to force it on a higher level, given the shuttle code.)

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Requested by Deadmon.

It's also I believe a very good change, since it gives consistency with the shuttle, doesnt force HoS and other command to change the alert levels based on the round end, but based on the real danger level. It allows everyone to know that roughly if everything goes well a round will last the same, from finish to end, barring round delays.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/74958641-0e0a-4dcb-be2a-435d3dd4a742)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: In compliance with SolFed safety regulations, we have disabled the overdrive from our escape shuttles, forcing us to replace the hyperdrives with TX2 models. These are roughly 30% faster to prepare, but safety meassures cannot be skipped from the startup, this means shuttles will take 12 minutes from 17 minutes to prepare, and will arrive 3 minutes after preparation, setting the time for our shuttles to arrive from CC to the station from 20 to 15 minutes, in all alert levels.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
