### PR TITLE
Fixes non-primary SMs setting off the Delamination Suppression System

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -566,7 +566,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 	final_countdown = TRUE
 
-	SEND_GLOBAL_SIGNAL(COMSIG_MAIN_SM_DELAMINATING, final_countdown) // NOVA EDIT ADDITION - DELAM_SCRAM
+	if(is_main_engine) // NOVA EDIT ADDITION - DELAM_SCRAM
+		SEND_GLOBAL_SIGNAL(COMSIG_MAIN_SM_DELAMINATING, final_countdown) // NOVA EDIT ADDITION - DELAM_SCRAM
 	notify_ghosts(
 		"[src] has begun the delamination process!",
 		source = src,


### PR DESCRIPTION
## About The Pull Request
During a delam, ALL `/obj/machinery/power/supermatter_crystal` sent the signal to the suppression system.

Now only the Station's Supermatter should send the signal.
(`is_main_engine = TRUE` - _the only one that can have Slivers stolen and Cascade_)
## How This Contributes To The Nova Sector Roleplay Experience
A happy engineering team with a spontaneously-exploding supermatter is no longer a happy engineering team.
## Proof of Testing
Off-station shard popped tf off
![image](https://github.com/user-attachments/assets/ee83dfbc-083f-4f6d-aebe-a3d6277ed0b8)

## Changelog
:cl:
fix: NT has sliiiightly tweaked the sensitivity of the Delamination Suppression System. It should no longer go off when there's a delamination in the range of 50,000 kilometers, instead only working around 500 meters.
/:cl:
