### PR TITLE
drops mold-core health by a lot

### DIFF
--- a/modular_nova/modules/mold/code/mold_structures.dm
+++ b/modular_nova/modules/mold/code/mold_structures.dm
@@ -60,7 +60,7 @@
 	icon = 'modular_nova/modules/mold/icons/blob_core.dmi'
 	icon_state = "blob_core"
 	layer = TABLE_LAYER
-	max_integrity = 1200
+	max_integrity = 450
 
 	/// The soundloop played by the core
 	var/datum/looping_sound/core_heartbeat/soundloop


### PR DESCRIPTION

## About The Pull Request

With this amount of health, it kinda just turns into a slug-fest even when you reach the core, to a very-long and awkward effect, this should make it seem alot less tedious to clean out a mold especially if the push to the core gets slowed down alot (firemold, spidermold, emp mold)


## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  numbers change
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: mold-core health is dropped to 450, from 1200, leaving it significantly easier to crush!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
