### PR TITLE
Fixes oversize possibly resetting unarmed bonuses, fixes a coder moment in ghost ore vents

### DIFF
--- a/modular_nova/modules/ghost_mining/code/ghost_vent.dm
+++ b/modular_nova/modules/ghost_mining/code/ghost_vent.dm
@@ -301,11 +301,9 @@
 
 /obj/structure/ore_vent/ghost_mining/boss/reset_vent()
 	. = ..()
-	var/list/boss_pool = defending_mobs
-	var/old_boss = summoned_boss
-	boss_pool -= old_boss //avoid repeats.
+	var/list/boss_pool = defending_mobs.Copy()
+	boss_pool -= summoned_boss // Avoid repeats.
 	summoned_boss = pick(boss_pool)
-	boss_pool += old_boss // system stupid, need to reintroduce so no empty list. Yes, the list empties without this somehow.
 
 /obj/structure/ore_vent/ghost_mining/boss/start_wave_defense() //Stolen from original boss vent code
 	if(!COOLDOWN_FINISHED(src, wave_cooldown))

--- a/modular_nova/modules/oversized/code/oversized_quirk.dm
+++ b/modular_nova/modules/oversized/code/oversized_quirk.dm
@@ -45,19 +45,19 @@
 
 	var/obj/item/bodypart/arm/left/left_arm = human_holder.get_bodypart(BODY_ZONE_L_ARM)
 	if(left_arm)
-		left_arm.unarmed_damage_high = initial(left_arm.unarmed_damage_high)
+		left_arm.unarmed_damage_high -= OVERSIZED_HARM_DAMAGE_BONUS
 
 	var/obj/item/bodypart/arm/right/right_arm = human_holder.get_bodypart(BODY_ZONE_R_ARM)
 	if(right_arm)
-		right_arm.unarmed_damage_high = initial(right_arm.unarmed_damage_high)
+		right_arm.unarmed_damage_high -= OVERSIZED_HARM_DAMAGE_BONUS
 
 	var/obj/item/bodypart/leg/left_leg = human_holder.get_bodypart(BODY_ZONE_L_LEG)
-	if (left_leg)
-		left_leg.unarmed_effectiveness = initial(left_leg.unarmed_effectiveness)
+	if(left_leg)
+		left_leg.unarmed_effectiveness -= OVERSIZED_KICK_EFFECTIVENESS_BONUS
 
 	var/obj/item/bodypart/leg/right_leg = human_holder.get_bodypart(BODY_ZONE_R_LEG)
-	if (right_leg)
-		right_leg.unarmed_effectiveness = initial(right_leg.unarmed_effectiveness)
+	if(right_leg)
+		right_leg.unarmed_effectiveness -= OVERSIZED_KICK_EFFECTIVENESS_BONUS
 
 	for(var/obj/item/bodypart/bodypart as anything in human_holder.bodyparts)
 		bodypart.name = replacetext(bodypart.name, "oversized ", "")
@@ -91,14 +91,14 @@
 	// Oversized arms have a higher damage maximum. Pretty simple.
 	if(istype(gained, /obj/item/bodypart/arm))
 		var/obj/item/bodypart/arm/new_arm = gained
-		new_arm.unarmed_damage_high = initial(new_arm.unarmed_damage_high) + OVERSIZED_HARM_DAMAGE_BONUS
+		new_arm.unarmed_damage_high += OVERSIZED_HARM_DAMAGE_BONUS
 
 	// Before this, we never actually did anything with Oversized legs.
 	// This brings their unarmed_effectiveness up to 20 from 15, which is on par with mushroom legs.
 	// Functionally, this makes their prone kicks more accurate and increases the chance of extending prone knockdown... but only while the victim is already prone.
 	else if(istype(gained, /obj/item/bodypart/leg))
 		var/obj/item/bodypart/leg/new_leg = gained
-		new_leg.unarmed_effectiveness = initial(new_leg.unarmed_effectiveness) + OVERSIZED_KICK_EFFECTIVENESS_BONUS
+		new_leg.unarmed_effectiveness += OVERSIZED_KICK_EFFECTIVENESS_BONUS
 
 	gained.name = "oversized " + gained.name
 


### PR DESCRIPTION

## About The Pull Request

- Makes tha oversized quirk properly remove its given bonuses to the limbs
(A bit of things add and subtract to limb damage, setting it to initial would break several of them and allow them to go negative)

- Fixes the ore vents having weird code for randomizing their vent bosses
(I have no idea how this got past maintainers, what it is right now is taking the list, defining it as a list and then removing/adding bosses to the what is supposed to be read-only variable. This PR properly just copies it and picks what we need)

## How This Contributes To The Nova Sector Roleplay Experience

Less buggy code is more good

## Proof of Testing

Got a screenshot of it compiling:tm: and that i killed 2 megafauna without the vent going empty, both unnecessary because i explained it above but might aswell

<details>
<summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/b8a2181a-45a3-4b6d-ad13-308c3bcfe242)

![image](https://github.com/user-attachments/assets/d3db689f-c310-463a-b2a7-f7b03096bc77)

</details>

## Changelog

:cl:
fix: fixed an extremelly rare edge case of the oversized quirk improperly removing limb damage if the quirk is ever removed
/:cl:
