### PR TITLE
Consistency tweaks to a certain preference toggle

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -345,7 +345,7 @@
 
 	if(client)
 		var/erp_status_pref = client.prefs.read_preference(/datum/preference/choiced/erp_status)
-		if(erp_status_pref && !CONFIG_GET(flag/disable_erp_preferences))
+		if(erp_status_pref && !CONFIG_GET(flag/disable_erp_preferences) && user.client.prefs.read_preference(/datum/preference/toggle/master_erp_preferences))
 			. += span_info("ERP Status: [span_revenboldnotice(erp_status_pref)]")
 
 	if (!CONFIG_GET(flag/disable_antag_opt_in_preferences))

--- a/code/modules/mob/living/silicon/ai/examine.dm
+++ b/code/modules/mob/living/silicon/ai/examine.dm
@@ -27,7 +27,7 @@
 		else if (!shunted && !client)
 			. += "[src]Core.exe has stopped responding! NTOS is searching for a solution to the problem..."
 	//NOVA EDIT ADDITION BEGIN - CUSTOMIZATION
-	. += get_silicon_flavortext()
+	. += get_silicon_flavortext(user)
 	//NOVA EDIT ADDITION END
 
 	. += ..()

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -47,7 +47,7 @@
 		if(DEAD)
 			. += span_deadsay("It looks like its system is corrupted and requires a reset.")
 	//NOVA EDIT ADDITION BEGIN - CUSTOMIZATION
-	. += get_silicon_flavortext()
+	. += get_silicon_flavortext(user)
 	//NOVA EDIT ADDITION END
 
 	. += ..()

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -159,7 +159,7 @@
 	. = ..()
 	. += "Its master ID string seems to be [(!master_name || emagged) ? "empty" : master_name]."
 	//NOVA EDIT ADDITION BEGIN - CUSTOMIZATION
-	. += get_silicon_flavortext()
+	. += get_silicon_flavortext(user)
 	//NOVA EDIT ADDITION END
 
 /mob/living/silicon/pai/get_status_tab_items()

--- a/modular_nova/master_files/code/modules/mob/living/examine_tgui.dm
+++ b/modular_nova/master_files/code/modules/mob/living/examine_tgui.dm
@@ -70,7 +70,7 @@
 
 	//  Handle OOC notes first
 	if(preferences)
-		if(preferences.read_preference(/datum/preference/toggle/master_erp_preferences))
+		if(user.client.prefs.read_preference(/datum/preference/toggle/master_erp_preferences))
 			var/e_prefs = preferences.read_preference(/datum/preference/choiced/erp_status)
 			var/e_prefs_hypno = preferences.read_preference(/datum/preference/choiced/erp_status_hypno)
 			var/e_prefs_v = preferences.read_preference(/datum/preference/choiced/erp_status_v)

--- a/modular_nova/modules/customization/modules/mob/living/silicon/examine.dm
+++ b/modular_nova/modules/customization/modules/mob/living/silicon/examine.dm
@@ -2,7 +2,7 @@
  *  Returns a list of lines containing silicon flavourtext, temporary flavourtext, ERP preferences and a link to "look closer" and open the examine panel.
  *  Intended to be appended at the end of examine() result.
  */
-/mob/living/silicon/proc/get_silicon_flavortext()
+/mob/living/silicon/proc/get_silicon_flavortext(mob/user)
 	. = list()
 	var/flavor_text_link
 	/// The first 1-FLAVOR_PREVIEW_LIMIT characters in the mob's client's silicon_flavor_text preference datum. FLAVOR_PREVIEW_LIMIT is defined in flavor_defines.dm.
@@ -18,8 +18,8 @@
 
 	if(client)
 		var/erp_status_pref = client.prefs.read_preference(/datum/preference/choiced/erp_status)
-		if(erp_status_pref && !CONFIG_GET(flag/disable_erp_preferences))
-			. += span_notice("ERP STATUS: [erp_status_pref]")
+		if(erp_status_pref && !CONFIG_GET(flag/disable_erp_preferences) && user.client.prefs.read_preference(/datum/preference/toggle/master_erp_preferences))
+			. += span_notice("ERP STATUS: [span_revenboldnotice(erp_status_pref)]")
 
 	if (!CONFIG_GET(flag/disable_antag_opt_in_preferences))
 		var/opt_in_status = mind?.get_effective_opt_in_level()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Tweaks the extreme roleplay toggle, it no longer hides your preferences from everyone if you have it disabled.

Instead, if you have the toggle off, you won't see others' preferences if you have the toggle off, they'll be hidden from both examine and the flavor text window.

I also added the purple text span that was missing for silicon's roleplay preferences.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
More of a consistency fix if anything. Hiding your own prefs entirely to everyone if you had the option toggled off seemed to be a bit unintended, and made it only look as if you weren't connected at all to others.

Additionally, if someone has this toggled off it usually means they want nothing to do with extreme roleplay and I doubt they'd be interested in knowing someone's extreme roleplay preferences while examining or looking on their OOC notes.

Not that OOC notes aren't already full of those, I'm tempted to separate OOC notes into separate SFW/NSFW tabs like The Final Night's but I'm busy (and lazy) for that to be honest.

## Proof of Testing
Tested this with two clients and it worked as intended but I also coded this at 4 am so I can't exactly guarantee much.
Also didn't leak out any funnies when it was disabled
<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

The bodies were still connected and it was taken through a different client that had the toggles set to off.

  Human

![image](https://github.com/user-attachments/assets/444b2a70-7f02-43ef-9e68-65af97025968)

 Silicon

![image](https://github.com/user-attachments/assets/2e5014f3-923e-403b-b5dc-86727aa13959)

 Silicon pref text fix
![image](https://github.com/user-attachments/assets/929c11b4-f682-4c9e-8a76-cb0814e8357a)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Hardly
code: changed some code
fix: silicon's roleplay preferences are now highlighted in purple
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
