### PR TITLE
[QoL] Medical Pills and Bandages storage improvement.

### DIFF
--- a/modular_nova/modules/modular_items/code/storage.dm
+++ b/modular_nova/modules/modular_items/code/storage.dm
@@ -9,3 +9,21 @@
 
 /obj/item/storage/backpack/messenger/explorer 
 	resistance_flags = FIRE_PROOF
+
+/obj/item/storage/fancy/nugget_box
+	spawn_count = 7
+
+/obj/item/storage/fancy/nugget_box/Initialize(mapload)
+	. = ..()
+	atom_storage.max_slots = 7
+	atom_storage.max_total_storage = WEIGHT_CLASS_TINY * 7
+
+/obj/item/storage/box/bandages/Initialize(mapload)
+	. = ..()
+	atom_storage.max_slots = 14
+	atom_storage.max_total_storage = WEIGHT_CLASS_TINY * 14
+
+/obj/item/storage/pill_bottle/Initialize(mapload)
+	. = ..()
+	atom_storage.max_slots = 21
+	atom_storage.max_total_storage = WEIGHT_CLASS_TINY * 21


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Increased the max slots and weight values for the pill bottles, bandage boxes and nugget boxes.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

It was requested by medical veterans on the discord. The logic behind it is that its more a quality of life for people that work with these, to hold more in wharever thing doctors get into. Any powergarmer would already have different, more effective, methods to deal with healing as was outlined in discord, as dental implants and similars, or simply having 3 boxes-pill bottles.

The nugget one was me needing an excuse for the change, it bothered me for ages it was 6 and not 7 like everything else in the game.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/a1fea398-16ca-4c2c-b301-5572aff4be94)

![image](https://github.com/user-attachments/assets/fad1f167-53b4-4d04-8eb9-f80b54131d41)

![image](https://github.com/user-attachments/assets/09f8e0d0-30e7-4a73-b157-2536b24b0c30)

![image](https://github.com/user-attachments/assets/7a16e190-c2b4-4e74-9e98-4d2dc78e2dbe)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Pill Bottles capacity was increased from 7 to 21. Bandage boxes were increased from 7 to 14. Nugget boxes were increased from 6 to 7.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
