### PR TITLE
[Feature] [Staff Request] Gas Miners DLC: Admins Shenanigans

### DIFF
--- a/modular_nova/modules/modular_items/code/summon_beacon.dm
+++ b/modular_nova/modules/modular_items/code/summon_beacon.dm
@@ -137,6 +137,9 @@
 	allowed_areas = list(
 		/area/station/engineering/atmos,
 		/area/station/engineering/atmospherics_engine,
+		/area/ruin/space/has_grav/nova/des_two/engineering, //ds2
+		/area/ruin/space/has_grav/port_tarkon/atmos, //tarkon
+		/area/centcom/tdome/arena, //thunderdome
 	)
 
 	selectable_atoms = list(
@@ -145,7 +148,56 @@
 		/obj/machinery/atmospherics/miner/nitrogen,
 		/obj/machinery/atmospherics/miner/oxygen,
 		/obj/machinery/atmospherics/miner/plasma,
+		/obj/machinery/atmospherics/miner/water_vapor,
 	)
 
 	area_string = "atmospherics"
-	supply_pod_stay = TRUE
+
+/obj/item/summon_beacon/gas_miner/hacked
+	name = "hacked gas miner beacon"
+	desc = parent_type::desc + " It seems the area detector is hardcoded to TRUE. Huh."
+
+	area_string = "any"
+
+	list/allowed_areas = list(
+		/area,
+	)
+
+/obj/item/summon_beacon/gas_miner/expanded
+	name = "expanded gas miner beacon"
+	desc = parent_type::desc + " This one seems to have its selection expanded."
+
+	selectable_atoms = list(
+		/obj/machinery/atmospherics/miner/carbon_dioxide,
+		/obj/machinery/atmospherics/miner/n2o,
+		/obj/machinery/atmospherics/miner/nitrogen,
+		/obj/machinery/atmospherics/miner/oxygen,
+		/obj/machinery/atmospherics/miner/plasma,
+		/obj/machinery/atmospherics/miner/bz,
+		/obj/machinery/atmospherics/miner/water_vapor,
+		/obj/machinery/atmospherics/miner/freon,
+		/obj/machinery/atmospherics/miner/halon,
+		/obj/machinery/atmospherics/miner/healium,
+		/obj/machinery/atmospherics/miner/hydrogen,
+		/obj/machinery/atmospherics/miner/hypernoblium,
+		/obj/machinery/atmospherics/miner/miasma,
+		/obj/machinery/atmospherics/miner/nitrium,
+		/obj/machinery/atmospherics/miner/pluoxium,
+		/obj/machinery/atmospherics/miner/proto_nitrate,
+		/obj/machinery/atmospherics/miner/tritium,
+		/obj/machinery/atmospherics/miner/zauker,
+		/obj/machinery/atmospherics/miner/helium,
+		/obj/machinery/atmospherics/miner/antinoblium,
+	)
+
+/obj/item/summon_beacon/gas_miner/expanded/debug
+	name = "debug gas miner beacon"
+	desc = "You better know what you are doing with this."
+
+	area_string = "any"
+	
+	uses = 99
+	
+	list/allowed_areas = list(
+		/area,
+	)

--- a/modular_nova/modules/modular_items/code/summon_beacon.dm
+++ b/modular_nova/modules/modular_items/code/summon_beacon.dm
@@ -159,7 +159,7 @@
 
 	area_string = "any"
 
-	list/allowed_areas = list(
+	allowed_areas = list(
 		/area,
 	)
 
@@ -198,6 +198,6 @@
 	
 	uses = 99
 	
-	list/allowed_areas = list(
+	allowed_areas = list(
 		/area,
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Makes the base Gas miner able to pick H2O in addition to the previous gasses.

Makes the base Gas miner able to be used in tarkon atmos, ds2 engineering and the CC thunderdome.

Makes three admin spawnable only Gas miner variants, for use on events and admin tests:

hacked - Meant for the Drone event, and other Build your Station types, its just the base miner with the area restriction gone.  There is a great potential for grief with all it uses, with plasma and co2 being in particular terryfing on the station, so monitor their use.

expanded - Left In case admins can give it an use, it has the areas restricted but allows to pick any of the gas miners in existence. It has the same area limitation as regular Gas Miners, so it can be a '''little''' more controled than the expanded one, but as it has more dangerous gasses, would still keep it out of reach unless there is a good reason.

debug - no limit of area or limit on their gas selection, it also has 99 uses. Should be useful for administrative showcases of gas effects and debugging issues with atmos.

I also removed the flag that left the supply pod since I though it was ugly.

Expands 

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Consulted with various vet engineers to make sure adding h2o wouldnt be a problem, adding it was more a thing of consistency as the miner can easily mine things as plasma or n2o, but h2o was left out in an ugly situation where we ended up using things like tritinium production or saunas to harvest it, felt weird and inconsistent.

Added the areas of tarkon, ds2 to future proof the miners and give it a bit of consistency to these areas, in case mapers decide to make more of them and not prepare everything for them in a silver plate, again, consistency.

Added thunderdome to allow admins to test stuff if needed so.

Regarding the three new Gas miners that dont affect the players because they are admin only.

They are tools for events or debugging, in particular this PR was made specifically because of the Mother Drone event, to have gas miners ready to use for it that would actually feel like the ones that are in the station. I dont know if the other two will be ever be used on another event or if admins will use them to try stuff in the thunderdome, but I felt it a good idea to leave one more tool at their disposal, as it was just a few lines more of effort.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

new h2o call:  
![image](https://github.com/user-attachments/assets/1d57786a-d45a-44ef-8483-6644a2aee1a0)

regular still cant be called in improper areas:
![image](https://github.com/user-attachments/assets/57d0220b-c1de-4ae6-b031-da9e239209e3)

![image](https://github.com/user-attachments/assets/375322dd-fa3c-41a0-8aac-0db700e5ed3f)

![image](https://github.com/user-attachments/assets/27cd014b-1c3c-49dd-909c-3d2db2e174ad)

![image](https://github.com/user-attachments/assets/4fd0ce6c-f5d7-43b5-befe-48524afd11ed)

![image](https://github.com/user-attachments/assets/100c5cb8-e0dd-4032-919b-974124cb2b0d)

![image](https://github.com/user-attachments/assets/d26f6b8a-694e-4a8d-9cdf-0897aa61d32e)

![image](https://github.com/user-attachments/assets/c73cf28d-0669-429e-a569-eb8f63c63972)

![image](https://github.com/user-attachments/assets/6b2f94d6-8ab7-4377-898b-d6135a8a1851)

![image](https://github.com/user-attachments/assets/a2a76a42-3317-46b0-9947-3adde413e0bc)

![image](https://github.com/user-attachments/assets/d8a747c7-3ace-4ed7-953a-a1ecf0d56ea6)

![image](https://github.com/user-attachments/assets/afea978d-cf81-4748-a3ae-78bd3443b1c5)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: We deployed a bluespace beacon in a Gas Giant made of pure H2O, and now all our gas miners can beam its extracted resources to our stations if needed!
add:  In preparation for comercialization of the Gas Miners, places such as Tarkon atmos, DS2 engineering and CC Thunderdome can now use Gas miners!
admin: Admins get three new debug/event Gas miners to use! Hacked: can be used in any area - Expanded: Can pick any gas! - Debug: Any Area, Any Gas, Any number of times!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
