### PR TITLE
Hotfix for the heretic gateway [plz speedmerge]

### DIFF
--- a/_maps/RandomZLevels/heretic.dmm
+++ b/_maps/RandomZLevels/heretic.dmm
@@ -466,10 +466,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/awaymission/beach/heretic)
-"hI" = (
-/mob/living/basic/cult/engorge/devourdem,
-/turf/open/misc/beach/sand,
-/area/awaymission/beach/heretic)
 "hL" = (
 /obj/structure/railing{
 	dir = 5
@@ -2259,6 +2255,7 @@
 /area/awaymission/beach/heretic)
 "Kx" = (
 /obj/effect/heretic_rune/big,
+/mob/living/basic/cult/engorge/devourdem,
 /turf/open/floor/plating,
 /area/awaymission/beach/heretic)
 "Ky" = (
@@ -14563,7 +14560,7 @@ RM
 RM
 XV
 XV
-hI
+XV
 XV
 RM
 RM


### PR DESCRIPTION
Somebody moved the final boss of this area from somewhere he was supposed to be where somebody he is NOT supposed to be- or my dumbass did this.

And also the gateway sometimes breaks- so this also adds an emergency exit in the form of a salvation sign.

:cl:
fix: fixed the heretic final boss not being where its meant to, and added a backup exit.
/:cl: