### PR TITLE
[Feature] Add Honeysuckle to the Lilies mutation list.

### DIFF
--- a/modular_nova/modules/customization/modules/hydroponics/grown/honeysuckle.dm
+++ b/modular_nova/modules/customization/modules/hydroponics/grown/honeysuckle.dm
@@ -1,3 +1,6 @@
+/obj/item/seeds/poppy/lily/
+	mutatelist = list(/obj/item/seeds/poppy/lily/trumpet, /obj/item/seeds/honeysuckle) //was originally gonna use New() to add it, but it ended up adding the mutation to trumpet too. - Original: list(/obj/item/seeds/poppy/lily/trumpet)
+
 // Honeysuckle
 /obj/item/seeds/honeysuckle
 	name = "honeysuckle seed pack"
@@ -15,6 +18,8 @@
 	icon_dead = "honeysuckle-dead"
 	genes = list(/datum/plant_gene/trait/preserved, /datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list(/datum/reagent/consumable/honey = 0.2, /datum/reagent/consumable/nutriment = 0.05)
+	rarity = 30 //same as trumpet
+	graft_gene = /datum/plant_gene/trait/preserved
 
 /obj/item/food/grown/honeysuckle
 	seed = /obj/item/seeds/honeysuckle


### PR DESCRIPTION

## About The Pull Request
Adds the Honeysuckle to the Lily Mutation list.

Adds minor stats (Rarity and graft gene) to the honeysuckle to keep consistency with station use.

## How This Contributes To The Nova Sector Roleplay Experience
It adds a different way to get honey that was already in the game and was exclusive of a faction that rarely, if ever, used it for trading. It also provides everyone a way to access it and even said faction a way to recover it in case its ever lost.

Additionally, it allows for the making of naturally fermented mead, something thats generally rare to see.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/f1ecd61d-91e4-420e-b150-d3363c317019)

![image](https://github.com/user-attachments/assets/4c80c41c-0ff2-4d4a-8186-28211e5f8a20)

</details>

## Changelog
:cl:
add: A mutation of Lilies has been rediscovered, the Honeysuckle, a flower formely believed native to Freyja, turned out in to be a bioengineered marvel produced by the heartkin forefathers. This wonderful plant is capable of producing honey and fermenting to mead, to the delight of colonist everywhere!
/:cl:
