### PR TITLE
[Balance] - Gives All advanced diseases and Hemopages health regen indicators when they heal

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -31,6 +31,7 @@
 	return power
 
 /datum/symptom/heal/proc/Heal(mob/living/M, datum/disease/advance/A, actual_power)
+	new /obj/effect/temp_visual/heal(get_turf(M), "#EC1C24") // NOVA EDIT ADD - adds visual effects to virus healing, only runs when healing.
 	return TRUE
 
 /datum/symptom/heal/proc/passive_message_condition(mob/living/M)
@@ -160,6 +161,8 @@
 
 	if(!parts.len)
 		return
+
+	new /obj/effect/temp_visual/heal(get_turf(M), "#EC1C24") // NOVA EDIT ADD - adds visual effects to virus healing, only runs when healing.
 
 	for(var/obj/item/bodypart/bodypart in parts)
 		if(bodypart.heal_damage(heal_amt/parts.len, heal_amt/parts.len, required_bodytype = BODYTYPE_ORGANIC))
@@ -300,6 +303,8 @@
 	if(!parts.len)
 		return
 
+	new /obj/effect/temp_visual/heal(get_turf(M), "#EC1C24") // NOVA EDIT ADD - adds visual effects to virus healing, only runs when healing.
+	
 	if(prob(5))
 		to_chat(M, span_notice("The darkness soothes and mends your wounds."))
 
@@ -405,6 +410,9 @@
 	if(!parts.len)
 		return
 
+	if (!deathgasp) // NOVA EDIT ADD - We ask for the stealth effect specifically as this is the only effect where the whole joke is to pass as dead, so you shouldnt be seen as being healing.
+		new /obj/effect/temp_visual/heal(get_turf(M), "#EC1C24") // NOVA EDIT ADD - adds visual effects to virus healing, only runs when healing.
+
 	for(var/obj/item/bodypart/bodypart in parts)
 		if(bodypart.heal_damage(heal_amt/parts.len, heal_amt/parts.len, required_bodytype = BODYTYPE_ORGANIC))
 			M.update_damage_overlays()
@@ -465,6 +473,8 @@
 
 	if(!parts.len)
 		return
+
+	new /obj/effect/temp_visual/heal(get_turf(M), "#EC1C24") // NOVA EDIT ADD - adds visual effects to virus healing, only runs when healing.
 
 	if(prob(5))
 		to_chat(M, span_notice("You feel yourself absorbing the water around you to soothe your damaged skin."))
@@ -575,6 +585,8 @@
 	if(prob(5))
 		to_chat(M, span_notice("You feel yourself absorbing plasma inside and around you..."))
 
+	new /obj/effect/temp_visual/heal(get_turf(M), "#EC1C24") // NOVA EDIT ADD - adds visual effects to virus healing, only runs when healing.
+
 	var/target_temp = M.get_body_temp_normal()
 	if(M.bodytemperature > target_temp)
 		M.adjust_bodytemperature(-20 * temp_rate * TEMPERATURE_DAMAGE_COEFFICIENT, target_temp)
@@ -641,6 +653,8 @@
 
 	if(!parts.len)
 		return
+
+	new /obj/effect/temp_visual/heal(get_turf(M), "#EC1C24") // NOVA EDIT ADD - adds visual effects to virus healing, only runs when healing.
 
 	if(prob(4))
 		to_chat(M, span_notice("Your skin glows faintly, and you feel your wounds mending themselves."))

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_status_effects.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_status_effects.dm
@@ -136,6 +136,7 @@
 		return
 
 	regenerator.blood_volume = max(regenerator.blood_volume - blood_used, MINIMUM_VOLUME_FOR_REGEN)
+	new /obj/effect/temp_visual/heal(get_turf(regenerator), "#EC1C24")
 
 
 /datum/movespeed_modifier/hemophage_dormant_state


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds a health regen effect used in many other places to signify healing for  when each advanced virus sympton that heals does the same.  For Regenerative Coma, added a check in case the virus is on stealth mode, if it is, the indicator wont show.

Added the same indicator to the hemopage healing.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

This allows both the people affected and onlookers to note when someone is healing, something that would definitively be apparent to anyone seeing wounds close and severe bruising / burning dissapear, which I believe is quite important, both on a mechanical level and for roleplay.

It also prevents a form of abuse on which passive healer players try to stall for their healing capabilities to kick in. With this change it will be tacit for everyone involved.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
starlight:
![image](https://github.com/user-attachments/assets/a7c741f9-88ed-44fe-a09c-4752f0c7e8ec)

nocturnal:
![image](https://github.com/user-attachments/assets/e65a4720-cb2e-4c36-a538-489dde619cd0)

hemopage:
![image](https://github.com/user-attachments/assets/a0a1bb60-b424-44b1-9023-26ada5707cde)

Stealth Coma (no regen show):
![image](https://github.com/user-attachments/assets/9d837a7b-a110-4539-9bf2-39e7c56131ea)

Regular Coma:
![image](https://github.com/user-attachments/assets/04247261-fd04-4677-8492-30a607e4eb44)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Makes all Virology viruses get a health indicator when they regen, with a notable exception of the stealth version of Regenerative Coma, for obvious reasons.
balance: Makes Hemopages regen get a health indicator when they regen. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
