### PR TITLE
Fixes Interdyne Biohazard suits being stocked in Virology instead of in Interdyne

### DIFF
--- a/modular_nova/master_files/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/modular_nova/master_files/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -244,7 +244,7 @@
 /obj/structure/closet/l3closet/interdyne
 	name = "Interdyne level 3 biohazard gear closet"
 
-/obj/structure/closet/l3closet/virology/PopulateContents()
+/obj/structure/closet/l3closet/interdyne/PopulateContents()
 	new /obj/item/storage/bag/bio(src)
 	new /obj/item/clothing/suit/bio_suit/interdyne(src)
 	new /obj/item/clothing/head/bio_hood/interdyne(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Real simple. The PopulateContents was copy-pasted from Virology's when it was made so they had the gear list to start with... but the actual typepath wasn't changed. So when the items inside were set up, it just overrode Virology.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Fixes an unintentional override that gave the station a biosuit that's meant to be ghostrole-exclusive. 
... and gives the ghostrole the biosuit they're meant to have now too.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>COMPLETED:</summary>
  
  Station lockers ("Virology" lockers)
![image](https://github.com/user-attachments/assets/dab27c71-9cc1-4948-88aa-a3e640af95e7)

Interdyne lockers actually get the intended suit now too. Because they didn't.
![image](https://github.com/user-attachments/assets/83ec7fe7-2a43-470c-9f19-0d8e30205dca)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed Interdyne biosuits being stocked in Virology, instead of Interdyne
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
