### PR TITLE
System Shock Update

### DIFF
--- a/modular_nova/modules/system_shock/code/system_shock_quirk.dm
+++ b/modular_nova/modules/system_shock/code/system_shock_quirk.dm
@@ -23,10 +23,10 @@
 
 /datum/quirk/system_shock/proc/on_electrocute()
 	SIGNAL_HANDLER
-	var/knockout_length = 0.9 SECONDS + rand(0 SECONDS, 0.5 SECONDS)
+	var/knockout_length = 7 SECONDS + rand(1 SECONDS, 3 SECONDS)
 	quirk_holder.set_static_vision(knockout_length)
 	quirk_holder.balloon_alert(quirk_holder, "system rebooting")
-	to_chat(quirk_holder, span_danger("CRIT&!AL ERR%R: S#STEM REBO#TING."))
+	to_chat(quirk_holder, span_danger("POWER INSTABILITY: SYSTEM RECALIBRATING."))
 	addtimer(CALLBACK(src, PROC_REF(knock_out), knockout_length - 0.4 SECONDS), 2 SECONDS)
 	//The intent with the 0.4 seconds is so that the visual static effect lasts longer than the actual knockout/sleeping effect.
 


### PR DESCRIPTION
Adjusts the quirk to it's original design intention of being a heavy sleeper for synthetics. Original knockout length was almost inconsequential.