### PR TITLE
[Removal] Ban Romerol from Antags TC shop

### DIFF
--- a/modular_nova/modules/traitor-uplinks/code/categories/stealthy_weapons.dm
+++ b/modular_nova/modules/traitor-uplinks/code/categories/stealthy_weapons.dm
@@ -6,3 +6,11 @@
 	surplus = 0
 	progression_minimum = 10 MINUTES
 	uplink_item_flags = NONE
+
+//In essence, this following code removes Romerol.
+/datum/uplink_item/stealthy_weapons/romerol_kit
+	item = /obj/item/bikehorn/rubberducky
+	purchasable_from = NONE
+	surplus = 0
+	progression_minimum = 777 MINUTES
+	cost = 500


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Modularly sets the romerol kit to being able to purchase from anyone, and if able, to be unlocked after 777 minutes, and if able to require 500 telecrystals, and if able to end up with a rubber duck instead of the romerol kit.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Ensures Romerol, something that breaks many of our policies by its existance when uncontroled and not part of an event, to not fall in players hands unless there is admin involvement. Hopefully.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/961ea453-81ec-4052-aa96-bbb19da69241)

![image](https://github.com/user-attachments/assets/dd230c89-6d81-462f-b65b-89050dbdadc2)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: After a brave SolFed raid on a Syndicate black site, the terrorist organization's Virology lab where it was rumored the deadly virus known as Romerol was destroyed. Authorities indicate that this deadly virus will no longer be found in this terrorist group operatives hands. The virus twisted creator has not been aprehended though, and SolFed confirms the search for them continues.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
