### PR TITLE
Adds handheld grenades to Imports

### DIFF
--- a/modular_nova/modules/company_imports/code/armament_datums/vitezstvi_ammo.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/vitezstvi_ammo.dm
@@ -180,25 +180,45 @@
 /datum/armament_entry/company_import/vitezstvi/shot_shells/confetti
 	item_type = /obj/item/ammo_box/advanced/s12gauge/honkshot
 
-// Boxes of kiboko launcher ammo
+// Grenades like grenades and boxes of kiboko launcher ammo (which are grenades)
 
-/datum/armament_entry/company_import/vitezstvi/grenade_shells
-	subcategory = "Grenade Shells"
+/datum/armament_entry/company_import/vitezstvi/grenades
+	subcategory = "Grenades"
 	cost = PAYCHECK_COMMAND
 
-/datum/armament_entry/company_import/vitezstvi/grenade_shells/practice
+/datum/armament_entry/company_import/vitezstvi/grenades/frag
+	item_type = /obj/item/grenade/frag
+	restricted = TRUE
+
+/datum/armament_entry/company_import/vitezstvi/grenades/smoke
+	item_type = /obj/item/grenade/smokebomb
+
+/datum/armament_entry/company_import/vitezstvi/grenades/stingbang
+	item_type = /obj/item/grenade/stingbang
+
+/datum/armament_entry/company_import/vitezstvi/grenades/ninebang
+	item_type = /obj/item/grenade/primer
+
+/datum/armament_entry/company_import/vitezstvi/grenades/ninestingbang
+	item_type = /obj/item/grenade/primer/stingbang
+
+/datum/armament_entry/company_import/vitezstvi/grenades/antigravity
+	item_type = /obj/item/grenade/antigravity
+	cost = PAYCHECK_COMMAND * 2
+
+/datum/armament_entry/company_import/vitezstvi/grenades/kiboko_practice
 	item_type = /obj/item/ammo_box/c980grenade
 
-/datum/armament_entry/company_import/vitezstvi/grenade_shells/smoke
+/datum/armament_entry/company_import/vitezstvi/grenades/kiboko_smoke
 	item_type = /obj/item/ammo_box/c980grenade/smoke
 
-/datum/armament_entry/company_import/vitezstvi/grenade_shells/riot
+/datum/armament_entry/company_import/vitezstvi/grenades/kiboko_riot
 	item_type = /obj/item/ammo_box/c980grenade/riot
 
-/datum/armament_entry/company_import/vitezstvi/grenade_shells/shrapnel
+/datum/armament_entry/company_import/vitezstvi/grenades/kiboko_shrapnel
 	item_type = /obj/item/ammo_box/c980grenade/shrapnel
 	restricted = TRUE
 
-/datum/armament_entry/company_import/vitezstvi/grenade_shells/phosphor
+/datum/armament_entry/company_import/vitezstvi/grenades/kiboko_phosphor
 	item_type = /obj/item/ammo_box/c980grenade/shrapnel/phosphor
 	restricted = TRUE

--- a/modular_nova/modules/company_imports/code/armament_datums/vitezstvi_ammo.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/vitezstvi_ammo.dm
@@ -189,6 +189,7 @@
 /datum/armament_entry/company_import/vitezstvi/grenades/frag
 	item_type = /obj/item/grenade/frag
 	restricted = TRUE
+	cost = PAYCHECK_COMMAND * 2
 
 /datum/armament_entry/company_import/vitezstvi/grenades/smoke
 	item_type = /obj/item/grenade/smokebomb
@@ -204,7 +205,7 @@
 
 /datum/armament_entry/company_import/vitezstvi/grenades/antigravity
 	item_type = /obj/item/grenade/antigravity
-	cost = PAYCHECK_COMMAND * 2
+	cost = PAYCHECK_COMMAND * 3
 
 /datum/armament_entry/company_import/vitezstvi/grenades/kiboko_practice
 	item_type = /obj/item/ammo_box/c980grenade

--- a/modular_nova/modules/company_imports/code/armament_datums/vitezstvi_ammo.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/vitezstvi_ammo.dm
@@ -182,44 +182,48 @@
 
 // Grenades like grenades and boxes of kiboko launcher ammo (which are grenades)
 
-/datum/armament_entry/company_import/vitezstvi/grenades
-	subcategory = "Grenades"
+/datum/armament_entry/company_import/vitezstvi/grenades_hand
+	subcategory = "Hand Grenades"
 	cost = PAYCHECK_COMMAND
 
-/datum/armament_entry/company_import/vitezstvi/grenades/frag
+/datum/armament_entry/company_import/vitezstvi/grenades_hand/frag
 	item_type = /obj/item/grenade/frag
 	restricted = TRUE
 	cost = PAYCHECK_COMMAND * 2
 
-/datum/armament_entry/company_import/vitezstvi/grenades/smoke
+/datum/armament_entry/company_import/vitezstvi/grenades_hand/smoke
 	item_type = /obj/item/grenade/smokebomb
 
-/datum/armament_entry/company_import/vitezstvi/grenades/stingbang
+/datum/armament_entry/company_import/vitezstvi/grenades_hand/stingbang
 	item_type = /obj/item/grenade/stingbang
 
-/datum/armament_entry/company_import/vitezstvi/grenades/ninebang
+/datum/armament_entry/company_import/vitezstvi/grenades_hand/ninebang
 	item_type = /obj/item/grenade/primer
 
-/datum/armament_entry/company_import/vitezstvi/grenades/ninestingbang
+/datum/armament_entry/company_import/vitezstvi/grenades_hand/ninestingbang
 	item_type = /obj/item/grenade/primer/stingbang
 
-/datum/armament_entry/company_import/vitezstvi/grenades/antigravity
+/datum/armament_entry/company_import/vitezstvi/grenades_hand/antigravity
 	item_type = /obj/item/grenade/antigravity
 	cost = PAYCHECK_COMMAND * 3
 
-/datum/armament_entry/company_import/vitezstvi/grenades/kiboko_practice
+/datum/armament_entry/company_import/vitezstvi/grenades_kiboko
+	subcategory = "Grenade Shells"
+	cost = PAYCHECK_COMMAND
+
+/datum/armament_entry/company_import/vitezstvi/grenades_kiboko/kiboko_practice
 	item_type = /obj/item/ammo_box/c980grenade
 
-/datum/armament_entry/company_import/vitezstvi/grenades/kiboko_smoke
+/datum/armament_entry/company_import/vitezstvi/grenades_kiboko/kiboko_smoke
 	item_type = /obj/item/ammo_box/c980grenade/smoke
 
-/datum/armament_entry/company_import/vitezstvi/grenades/kiboko_riot
+/datum/armament_entry/company_import/vitezstvi/grenades_kiboko/kiboko_riot
 	item_type = /obj/item/ammo_box/c980grenade/riot
 
-/datum/armament_entry/company_import/vitezstvi/grenades/kiboko_shrapnel
+/datum/armament_entry/company_import/vitezstvi/grenades_kiboko/kiboko_shrapnel
 	item_type = /obj/item/ammo_box/c980grenade/shrapnel
 	restricted = TRUE
 
-/datum/armament_entry/company_import/vitezstvi/grenades/kiboko_phosphor
+/datum/armament_entry/company_import/vitezstvi/grenades_kiboko/kiboko_phosphor
 	item_type = /obj/item/ammo_box/c980grenade/shrapnel/phosphor
 	restricted = TRUE


### PR DESCRIPTION

## About The Pull Request
Adds conventional frags, smokes, and stingbang grenades to Vitezstvi ammo.
Adds unconventional rotfrag and rotsting grenades too. The more you click it, the more shrapnel it spits out.
Adds very-unconventional antigravity grenades as a dessert.
![image](https://github.com/user-attachments/assets/3108b225-0c22-410a-8370-b2d2291f5716)
## How This Contributes To The Nova Sector Roleplay Experience
It's only fair to spice up any of our encounters even more with how much other quite-cool-actually things we've added, from easily available weapons and armor and medicine. Yet somehow grenades were exempt from that list; after some genuinely-extensive testing, I've come to this list as none of the nades here seem to be particularly egregious.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/565a5d19-143d-4ad5-8cb5-252542073abc)
![image](https://github.com/user-attachments/assets/c336c08a-87dc-4161-80b3-ce9c9a5f227d)

</details>

## Changelog
:cl: Stalkeros
add: Lots of various interesting grenades have been added to Vitezstvi ammo.
/:cl:
