### PR TITLE
re-add examinable effects for ashwalkers around evolutions.

### DIFF
--- a/modular_nova/modules/ashwalkers/code/species/Ashwalkers.dm
+++ b/modular_nova/modules/ashwalkers/code/species/Ashwalkers.dm
@@ -124,7 +124,7 @@
 	alert_type = null
 
 /datum/status_effect/age_evolve_ready/get_examine_text()
-	return span_warning("[owner.name] reached the age for evolving!")
+	return span_warning("[owner.name] has reached the age for evolving!")
 
 /datum/status_effect/ash_age
 	id = "ash_age"

--- a/modular_nova/modules/ashwalkers/code/species/Ashwalkers.dm
+++ b/modular_nova/modules/ashwalkers/code/species/Ashwalkers.dm
@@ -59,6 +59,7 @@
 	human_target = parent
 	// when the rune successfully completes the age ritual, it will send the signal... do the proc when we receive the signal
 	RegisterSignal(human_target, COMSIG_RUNE_EVOLUTION, PROC_REF(check_evolution))
+	RegisterSignal(human_target, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 
 /// Age Ritual handler
 /datum/component/ash_age/proc/check_evolution()
@@ -70,7 +71,6 @@
 
 	// since it was time, go up a stage and now we check what to add
 	current_stage++
-	human_target.remove_status_effect(/datum/status_effect/age_evolve_ready)
 	human_target.apply_status_effect(/datum/status_effect/ash_age)
 	var/datum/species/species_target = human_target.dna.species
 	switch(current_stage)
@@ -119,24 +119,19 @@
 /datum/movespeed_modifier/ash_aged
 	multiplicative_slowdown = -0.2
 
-/datum/status_effect/age_evolve_ready
-	id = "age_evolve_ready"
-	alert_type = null
-
-/datum/status_effect/age_evolve_ready/get_examine_text()
-	return span_warning("[owner.name] has reached the age for evolving!")
+/// Examines
+/datum/component/ash_age/proc/on_examine(atom/target_atom, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+	if(human_target.has_status_effect(/datum/status_effect/ash_age))
+		examine_list += span_notice("[human_target] has not yet reached the age for evolving.")
+		return
+	examine_list += span_warning("[human_target] has reached the age for evolving!")
 
 /datum/status_effect/ash_age
 	id = "ash_age"
 	duration = 15 MINUTES
 	show_duration = TRUE
 	alert_type = /atom/movable/screen/alert/status_effect/ash_age
-
-/datum/status_effect/ash_age/get_examine_text()
-	return span_notice("[owner.name] has not yet reached the age for evolving.")
-
-/datum/status_effect/ash_age/on_remove()
-	owner.apply_status_effect(/datum/status_effect/age_evolve_ready)
 
 /atom/movable/screen/alert/status_effect/ash_age
 	name = "Ashen Age Fatigue"

--- a/modular_nova/modules/ashwalkers/code/species/Ashwalkers.dm
+++ b/modular_nova/modules/ashwalkers/code/species/Ashwalkers.dm
@@ -70,6 +70,7 @@
 
 	// since it was time, go up a stage and now we check what to add
 	current_stage++
+	human_target.remove_status_effect(/datum/status_effect/age_evolve_ready)
 	human_target.apply_status_effect(/datum/status_effect/ash_age)
 	var/datum/species/species_target = human_target.dna.species
 	switch(current_stage)
@@ -118,11 +119,24 @@
 /datum/movespeed_modifier/ash_aged
 	multiplicative_slowdown = -0.2
 
+/datum/status_effect/age_evolve_ready
+	id = "age_evolve_ready"
+	alert_type = null
+
+/datum/status_effect/age_evolve_ready/get_examine_text()
+	return span_warning("[owner.name] reached the age for evolving!")
+
 /datum/status_effect/ash_age
 	id = "ash_age"
 	duration = 15 MINUTES
 	show_duration = TRUE
 	alert_type = /atom/movable/screen/alert/status_effect/ash_age
+
+/datum/status_effect/ash_age/get_examine_text()
+	return span_notice("[owner.name] has not yet reached the age for evolving.")
+
+/datum/status_effect/ash_age/on_remove()
+	owner.apply_status_effect(/datum/status_effect/age_evolve_ready)
 
 /atom/movable/screen/alert/status_effect/ash_age
 	name = "Ashen Age Fatigue"


### PR DESCRIPTION
## About The Pull Request
Re-adds the examine text placed on ash walkers when they are and are not able to evolve now that evolution is based on status effects. These were the "Ashie has not yet reached the age for evolving." and "Ashie has reached the age for evolving!" messages. ~~It appears slightly higher in the examine text due to when status effects get checked but the examine messages are the same as they were previously.~~ There is no longer a difference in where it is rendered and is a direct re-add of the old messages and placements.

## How This Contributes To The Nova Sector Roleplay Experience
Being able to at a glance tell if your fellow ashwalkers were ready to evolve was around for a very long time and helpful to organizing the group without asking variations of 'are you ready?' frequently. Less time figuring out age timers means more time to interact in other ways.

## Proof of Testing
- confirmed 'not ready to evolve' examine message was present during the run up to be able to evolve
- confirmed the red warning 'ready to evolve' replaced it when the ashen age fatigue effect wore off
- repeated this for a few evolutions

_note_: everything sporadically runs at a snail's pace (even without these changes) locally at byond 516 for me right now so can't confirm if there's any performance impact. This seems small enough where I don't think it introduces any risk.

<details>
<summary>Screenshots/Videos</summary>
  Examine texts before these messages were removed:

<img alt="prevolve" src="https://github.com/user-attachments/assets/7f3fadf7-a344-4b30-ab7b-61f7a9cdd8f4" />

![postvolve](https://github.com/user-attachments/assets/acd2fe51-da14-4828-8e27-ab2d39f18492)

  Examine texts with these changes:
![effect_prevolve](https://github.com/user-attachments/assets/1677f851-b2e6-4e37-95e5-7b4cbde402b7)

![effect_postvolve](https://github.com/user-attachments/assets/efee4c8c-513f-402e-9b08-705f9628a22c)

</details>

## Changelog

:cl:
qol: Ashwalker examine text now shows the observer if they are ready to evolve again or not.
/:cl:

