### PR TITLE
Makes it so Paradox Clone can actually spawn in correctly.

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm
@@ -975,6 +975,7 @@
 		if (!opt_in_disabled && player.mind?.get_effective_opt_in_level() < OPT_IN_YES_ROUND_REMOVE)
 			continue
 		// NOVA EDIT ADDITION END
+		possible_targets += player
 
 	if(possible_targets.len)
 		return pick(possible_targets)


### PR DESCRIPTION
## About The Pull Request

Turns out it's actually important to add players to a list of possible targets. How could we have known.

## How This Contributes To The Nova Sector Roleplay Experience

Antagonists spawning correctly is good.

## Proof of Testing

Can't really test it. Code matches TG's so it should work.

https://github.com/tgstation/tgstation/blob/3ff737f3f88a82c6c34245e822bb5fc70562c738/code/controllers/subsystem/dynamic/dynamic_rulesets_midround.dm#L953

## Changelog

:cl:
fix: Paradox clones can actually spawn in now.
/:cl: