### PR TITLE
Add: Voice Actor Chat Color

### DIFF
--- a/modular_nova/modules/voice_actor_quirk/code/alter_voice_action.dm
+++ b/modular_nova/modules/voice_actor_quirk/code/alter_voice_action.dm
@@ -8,15 +8,21 @@
 	var/primary_voice
 	/// The pitch of the primary voice
 	var/primary_pitch = 0
+	/// The chat color of the primary voice
+	var/primary_color = COLOR_WHITE
 	/// The secondary voice that can be swapped to/from at will
 	var/secondary_voice
 	/// The secondary voice's pitch
 	var/secondary_pitch = 0
+	/// The chat color of the secondary voice
+	var/secondary_color = COLOR_WHITE
 
 ///Sets up the voice and pitch variables.
 /datum/action/innate/alter_voice/proc/setup_second_voice(mob/actor)
 	if(!actor.client)
 		return
+	// Set up secondary color
+	secondary_color = actor.client.prefs.read_preference(/datum/preference/color/voice_actor_color)
 	// Set up secondary pitch
 	secondary_pitch = actor.client.prefs.read_preference(/datum/preference/numeric/voice_actor_pitch)
 	// Set up secondary voice
@@ -43,11 +49,14 @@
 		to_chat(owner, span_userdanger("You can't remember your second voice at the moment. (Please consider reporting this on github!)"))
 		return
 	active = !active
+	var/mob/living/carbon/human/owner_human = owner
 	if(active)
+		owner_human.apply_preference_chat_color(secondary_color)
 		owner.voice = secondary_voice
 		owner.pitch = secondary_pitch
 		to_chat(owner, span_green("You are now voice acting."))
 	else
+		owner_human.apply_preference_chat_color(primary_color)
 		owner.voice = primary_voice
 		owner.pitch = primary_pitch
 		to_chat(owner, span_green("You have stopped voice acting."))
@@ -58,6 +67,8 @@
 	. = ..()
 	if(grant_to != owner)
 		return
+	// Set up primary runechat color
+	primary_color = grant_to.chat_color
 	// Set up primary pitch
 	if(SStts.pitch_enabled)
 		primary_pitch = grant_to.pitch

--- a/modular_nova/modules/voice_actor_quirk/code/voice_actor_preferences.dm
+++ b/modular_nova/modules/voice_actor_quirk/code/voice_actor_preferences.dm
@@ -41,3 +41,14 @@
 
 /datum/preference/numeric/voice_actor_pitch/create_default_value()
 	return 0
+
+/datum/preference/color/voice_actor_color
+	savefile_key = "voice_actor_color"
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_identifier = PREFERENCE_CHARACTER
+
+/datum/preference/color/voice_actor_color/apply_to_human()
+	return
+
+/datum/preference/color/voice_actor_color/create_default_value()
+	return process_chat_color("#[random_color()]")

--- a/modular_nova/modules/voice_actor_quirk/code/voice_actor_quirk.dm
+++ b/modular_nova/modules/voice_actor_quirk/code/voice_actor_quirk.dm
@@ -1,6 +1,6 @@
 /datum/quirk/voice_actor
 	name = "Voice Actor"
-	desc = "You are able to swap between two different TTS voices."
+	desc = "You can swap between two TTS voices and chat colors."
 	icon = FA_ICON_MICROPHONE_LINES
 	gain_text = span_notice("You are reminded of how your other voice sounds.")
 	lose_text = span_warning("You suddenly forget what your other voice sounds like!")
@@ -10,7 +10,11 @@
 
 /datum/quirk_constant_data/voice_actor
 	associated_typepath = /datum/quirk/voice_actor
-	customization_options = list(/datum/preference/choiced/voice_actor, /datum/preference/numeric/voice_actor_pitch)
+	customization_options = list(
+		/datum/preference/choiced/voice_actor,
+		/datum/preference/numeric/voice_actor_pitch,
+		/datum/preference/color/voice_actor_color,
+	)
 
 /datum/quirk/voice_actor/add(client/client_source)
 	var/datum/action/innate/alter_voice/voice_action = new

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/voice_actor.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/voice_actor.tsx
@@ -1,5 +1,10 @@
 // THIS IS A NOVA SECTOR UI FILE
-import { Feature, FeatureChoiced, FeatureNumberInput } from '../../base';
+import {
+  Feature,
+  FeatureChoiced,
+  FeatureColorInput,
+  FeatureNumberInput,
+} from '../../base';
 import { FeatureDropdownInput } from '../../dropdowns';
 
 export const voice_actor: FeatureChoiced = {
@@ -10,4 +15,9 @@ export const voice_actor: FeatureChoiced = {
 export const voice_actor_pitch: Feature<number> = {
   name: 'Second Pitch',
   component: FeatureNumberInput,
+};
+
+export const voice_actor_color: Feature<string> = {
+  name: 'Second Chat Color',
+  component: FeatureColorInput,
 };


### PR DESCRIPTION
## About The Pull Request

The PR adds a secondary runechat color to the Voice Actor quirk's preferences.

## How This Contributes To The Nova Sector Roleplay Experience

Allows players to change their runechat color when they swap their Voice Actor voice.

The changes make the quirk more useful, especially when the TTS server isn't working properly.

## Proof of Testing

Testing TBD

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl:
qol: Adds a secondary runechat color option to the Voice Actor quirk. 
/:cl:
