### PR TITLE
Add: Silicon Headshots

### DIFF
--- a/modular_nova/master_files/code/modules/client/preferences/headshot.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/headshot.dm
@@ -5,7 +5,12 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "headshot"
 	maximum_value_length = MAX_MESSAGE_LEN
-	/// Assoc list of ckeys and their link, used to cut down on chat spam
+	///Assoc list of ckeys and their links, used to cut down on chat spam
+	///Example structure:
+	///list("myckey" = list(
+	///	"human" = list("http://website.com/human_image.png"),
+	///	"silicon" = list("http://website.com/silicon_image.png"),
+	///))
 	var/list/stored_link = list()
 	var/static/link_regex = regex("i.gyazo.com|files.byondhome.com|images2.imgbox.com")
 	var/static/list/valid_extensions = list("jpg", "png", "jpeg") // Regex works fine, if you know how it works
@@ -14,8 +19,7 @@
 	target?.dna.features["headshot"] = preferences?.headshot
 
 /datum/preference/text/headshot/is_valid(value)
-	if(!length(value)) // Just to get blank ones out of the way
-		usr?.client?.prefs?.headshot = null
+	if(!length(value))
 		return TRUE
 
 	var/find_index = findtext(value, "https://")
@@ -48,6 +52,11 @@
 		to_chat(usr, span_notice("If the photo doesn't show up properly in-game, ensure that it's a direct image link that opens properly in a browser."))
 		to_chat(usr, span_notice("Keep in mind that the photo will be downsized to 250x250 pixels, so the more square the photo, the better it will look."))
 		log_game("[usr] has set their Headshot image to '[value]'.")
-	stored_link[usr?.ckey] = value
-	usr?.client?.prefs.headshot = value
+	stored_link[usr?.ckey]["human"] = value
 	return TRUE
+
+/datum/preference/text/headshot/silicon
+	savefile_key = "silicon_headshot"
+
+/datum/preference/text/headshot/silicon/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return FALSE

--- a/modular_nova/master_files/code/modules/client/preferences_savefile.dm
+++ b/modular_nova/master_files/code/modules/client/preferences_savefile.dm
@@ -319,7 +319,6 @@
 	save_data["allow_advanced_colors"] = allow_advanced_colors
 	save_data["alt_job_titles"] = alt_job_titles
 	save_data["languages"] = languages
-	save_data["headshot"] = headshot
 	save_data["modular_version"] = MODULAR_SAVEFILE_VERSION_MAX
 	save_data["food_preferences"] = food_preferences
 

--- a/modular_nova/master_files/code/modules/mob/living/examine_tgui.dm
+++ b/modular_nova/master_files/code/modules/mob/living/examine_tgui.dm
@@ -98,7 +98,7 @@
 		custom_species = "Silicon"
 		custom_species_lore = "A cyborg unit."
 		ooc_notes += preferences.read_preference(/datum/preference/text/ooc_notes)
-		headshot += preferences.read_preference(/datum/preference/text/headshot)
+		headshot += preferences.read_preference(/datum/preference/text/headshot/silicon)
 
 	if(ishuman(holder))
 		var/mob/living/carbon/human/holder_human = holder

--- a/modular_nova/modules/character_directory/code/character_directory.dm
+++ b/modular_nova/modules/character_directory/code/character_directory.dm
@@ -230,7 +230,7 @@ GLOBAL_LIST_EMPTY(name_to_appearance)
 			species = READ_PREFS(silicon, choiced/brain_type)
 			//Load silicon flavor text in place of normal flavor text
 			flavor_text = READ_PREFS(silicon, text/silicon_flavor_text) || ""
-			headshot = READ_PREFS(silicon, text/headshot) || ""
+			headshot = READ_PREFS(silicon, text/headshot/silicon) || ""
 		// Don't show if they are not a human or a silicon
 		else
 			continue

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/headshot.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/headshot.tsx
@@ -1,13 +1,21 @@
 // THIS IS A NOVA SECTOR UI FILE
 import { Feature, FeatureShortTextInput } from '../../base';
 
+const description =
+  'Requires a link ending with .png, .jpeg, or .jpg, starting with \
+  https://, and hosted on Gyazo, ImgBox, or Byond Members files. \
+  Renders the image underneath your character preview in the examine \
+  more window. Image larger than 250x250 will be resized to 250x250. \
+  Aim for 250x250 whenever possible';
+
 export const headshot: Feature<string> = {
   name: 'Headshot',
-  description:
-    'Requires a link ending with .png, .jpeg, or .jpg, starting with \
-    https://, and hosted on Gyazo or Discord. Renders the image underneath \
-    your character preview in the examine more window. \
-    Image larger than 250x250 will be resized to 250x250. \
-    Aim for 250x250 whenever possible',
+  description: description,
+  component: FeatureShortTextInput,
+};
+
+export const silicon_headshot: Feature<string> = {
+  name: 'Headshot (Silicon)',
+  description: description,
   component: FeatureShortTextInput,
 };


### PR DESCRIPTION
## About The Pull Request

This is a quick PR that adds the option "Headshot (Silicon)" to the character preferences screen.

## How This Contributes To The Nova Sector Roleplay Experience

Cyborg and AI players will benefit from having a unique silicon headshot image that is separated from their normal headshot.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/257edf25-3e5b-4fbe-bef3-d2957ee0c69c)

![image](https://github.com/user-attachments/assets/eb4ccf50-0c57-4b82-a90a-14ee72a376f8) ![image](https://github.com/user-attachments/assets/338dd9d8-084a-4455-aac3-cb0949cbc9b7)

</details>

## Changelog

:cl:
add: Silicon Headshot character preference, to pick a unique AI/Cyborg headshot image.
/:cl:
