### PR TITLE
this money dead as hell: reintroduces the collar bomb into the black market

### DIFF
--- a/code/modules/cargo/markets/market_items/clothing.dm
+++ b/code/modules/cargo/markets/market_items/clothing.dm
@@ -103,7 +103,7 @@
 	price_max = CARGO_CRATE_VALUE
 	stock_max = 3
 	availability_prob = 40
-/** Nova Edit Removal
+
 /datum/market_item/clothing/collar_bomb
 	name = "Collar Bomb Kit"
 	desc = "An unpatented and questionably ethical kit consisting of a low-yield explosive collar and a remote to trigger it."
@@ -112,4 +112,4 @@
 	price_max = CARGO_CRATE_VALUE * 4.5
 	stock_max = 3
 	availability_prob = 60
-**/
+

--- a/modular_nova/master_files/code/modules/clothing/neck/collar_bomb.dm
+++ b/modular_nova/master_files/code/modules/clothing/neck/collar_bomb.dm
@@ -1,0 +1,33 @@
+/obj/item/clothing/neck/collar_bomb/explosive_countdown(ticks_left)
+	active = TRUE
+	if(ticks_left > 0)
+		playsound(src, 'sound/items/timer.ogg', 30, FALSE)
+		balloon_alert_to_viewers("[ticks_left]")
+		ticks_left--
+		addtimer(CALLBACK(src, PROC_REF(explosive_countdown), ticks_left), 1 SECONDS)
+		return
+
+	playsound(src, 'sound/effects/snap.ogg', 75, TRUE)
+	if(!ishuman(loc))
+		balloon_alert_to_viewers("dud...")
+		active = FALSE
+		return
+	var/mob/living/carbon/human/brian = loc
+	if(brian.get_item_by_slot(ITEM_SLOT_NECK) != src)
+		balloon_alert_to_viewers("dud...")
+		active = FALSE
+		return
+	// everything above this line is just copy-pasted as of 4/27/2025 m/d/y
+	visible_message(span_warning("[src] goes off, horrifically maiming [brian]!"), span_hear("You hear a boom!"))
+	playsound(src, SFX_EXPLOSION, 30, TRUE)
+	var/obj/item/bodypart/head/dome = brian.get_bodypart(BODY_ZONE_HEAD)
+	// max damage to the head is 250 and we want to hit crit slash/crit bone/crit burn
+	dome.receive_damage(brute = 75, sharpness = SHARP_EDGED)
+	dome.receive_damage(brute = 75, sharpness = SHARP_EDGED)
+	dome.receive_damage(burn = 100)
+	var/datum/wound/cranial_fissure/crit_wound = new()
+	crit_wound.apply_wound(dome)
+	brian.investigate_log("has been blasted by [src].", INVESTIGATE_DEATHS)
+	// everything below this line is just copy-pasted as of 4/27/2025 m/d/y
+	flash_color(brian, flash_color = COLOR_RED, flash_time = 1 SECONDS)
+	qdel(src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6965,6 +6965,7 @@
 #include "modular_nova\master_files\code\modules\clothing\head\monkey_magnification_helmet.dm"
 #include "modular_nova\master_files\code\modules\clothing\masks\_masks.dm"
 #include "modular_nova\master_files\code\modules\clothing\neck\_neck.dm"
+#include "modular_nova\master_files\code\modules\clothing\neck\collar_bomb.dm"
 #include "modular_nova\master_files\code\modules\clothing\outfits\ert.dm"
 #include "modular_nova\master_files\code\modules\clothing\outfits\standard.dm"
 #include "modular_nova\master_files\code\modules\clothing\shoes\bananashoes.dm"


### PR DESCRIPTION
## About The Pull Request
Uncomments the collar bomb kit from the black market uplink.
"Nerfs" the collar bomb so that it grievously wounds you (and, obviously, kills you) instead of outright decapitating you.

## How This Contributes To The Nova Sector Roleplay Experience
There's a bomb strapped to your neck.

## Proof of Testing
![image](https://github.com/user-attachments/assets/e3887006-b109-47bd-a21f-c3cdede98936)

## Changelog

:cl:
add: For reasons unknown, the collar bomb box from the black market uplink is back in stock.
balance: The explosive yield of collar bombs have been changed so that they don't outright decapitate the victim. Instead, they are horrifically maimed in the process of being killed.
/:cl: