### PR TITLE
[Balance] Lifts the restrictions on Armor, except for the Vokshod Modsuit kit

### DIFF
--- a/modular_nova/modules/company_imports/code/armament_datums/nri_military_surplus.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/nri_military_surplus.dm
@@ -20,22 +20,18 @@
 /datum/armament_entry/company_import/nri_surplus/clothing/helmet
 	item_type = /obj/item/clothing/head/helmet/cin_surplus_helmet/random_color
 	cost = PAYCHECK_COMMAND
-	restricted = TRUE
 
 /datum/armament_entry/company_import/nri_surplus/clothing/vest
 	item_type = /obj/item/clothing/suit/armor/vest/cin_surplus_vest
 	cost = PAYCHECK_COMMAND
-	restricted = TRUE
 
 /datum/armament_entry/company_import/nri_surplus/clothing/space_suit
 	item_type = /obj/item/clothing/suit/space/voskhod
 	cost = PAYCHECK_COMMAND*3
-	restricted = TRUE
 
 /datum/armament_entry/company_import/nri_surplus/clothing/space_helmet
 	item_type = /obj/item/clothing/head/helmet/space/voskhod
 	cost = PAYCHECK_COMMAND
-	restricted = TRUE
 
 /datum/armament_entry/company_import/nri_surplus/clothing/police_uniform
 	item_type = /obj/item/clothing/under/colonial/nri_police
@@ -45,7 +41,6 @@
 
 /datum/armament_entry/company_import/nri_surplus/clothing/police_jacket
 	item_type = /obj/item/clothing/suit/armor/vest/nri_police_jacket
-	restricted = TRUE
 
 /datum/armament_entry/company_import/nri_surplus/clothing/police_suit_jacket
 	item_type = /obj/item/clothing/suit/armor/vest/nri_police_jacket/suit
@@ -65,12 +60,10 @@
 /datum/armament_entry/company_import/nri_surplus/clothing/police_vest
 	item_type = /obj/item/clothing/head/helmet/nri_police
 	cost = PAYCHECK_COMMAND
-	restricted = TRUE
 
 /datum/armament_entry/company_import/nri_surplus/clothing/police_helmet
 	item_type = /obj/item/clothing/suit/armor/vest/nri_police
 	cost = PAYCHECK_COMMAND
-	restricted = TRUE
 
 // Random surplus store tier stuff, flags, old rations, multitools you'll never use, so on
 

--- a/modular_nova/modules/company_imports/code/armament_datums/sol_defense.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/sol_defense.dm
@@ -19,7 +19,6 @@
 /datum/armament_entry/company_import/sol_defense/armor
 	subcategory = "Ballistic Armor"
 	cost = PAYCHECK_CREW * 3
-	restricted = TRUE
 
 /datum/armament_entry/company_import/sol_defense/armor/ballistic_helmet
 	item_type = /obj/item/clothing/head/helmet/sf_peacekeeper/debranded
@@ -44,12 +43,10 @@
 	name = "Combat Boots"
 	cost = PAYCHECK_CREW * 4
 	item_type = /obj/item/clothing/shoes/combat
-	restricted = FALSE
 
 /datum/armament_entry/company_import/sol_defense/armor_hardened
 	subcategory = "Hardened Armor"
 	cost = PAYCHECK_CREW * 3
-	restricted = TRUE
 
 /datum/armament_entry/company_import/sol_defense/armor_hardened/enclosed_helmet
 	item_type = /obj/item/clothing/head/helmet/toggleable/sf_hardened
@@ -140,7 +137,6 @@
 /datum/armament_entry/company_import/sol_defense/longarm/jager
 	item_type = /obj/item/gun/ballistic/shotgun/katyusha/jager
 	cost = PAYCHECK_COMMAND * 20
-	restricted = TRUE
 
 /datum/armament_entry/company_import/sol_defense/longarm/infanterie
 	item_type = /obj/item/gun/ballistic/automatic/sol_rifle


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Lift all the restricted tags on Armor sets. Leaves the vokshod repowering kit restricted as it is still a powerful combat modsuit.

Also removed the double restriction on the Jaeger since it was unnesesary, it was already restricted by being a long arm child.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Armor was momentarily restricted by a policy which was changed. At the moment of this PR armor is allowed but it will add onto the crimes executed by the person wearing it.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  It just works ™ (Values change, verified but lost the screens)
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Armor is no longer restricted on Cargo Imports. Vokshod Modsuit kit is still restricted, but not the depowered version.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
