### PR TITLE
[Balance] Forged armor pieces adjustments, made better all around, reduced grind.

### DIFF
--- a/modular_nova/modules/reagent_forging/code/crafting_bench.dm
+++ b/modular_nova/modules/reagent_forging/code/crafting_bench.dm
@@ -27,6 +27,7 @@
 	var/list/allowed_choices = list(
 		/datum/crafting_bench_recipe/plate_helmet,
 		/datum/crafting_bench_recipe/plate_vest,
+		/datum/crafting_bench_recipe/chain_shirt,
 		/datum/crafting_bench_recipe/plate_gloves,
 		/datum/crafting_bench_recipe/plate_boots,
 		/datum/crafting_bench_recipe/ring,

--- a/modular_nova/modules/reagent_forging/code/crafting_bench_recipes.dm
+++ b/modular_nova/modules/reagent_forging/code/crafting_bench_recipes.dm
@@ -36,6 +36,14 @@
 	resulting_item = /obj/item/clothing/suit/armor/forging_plate_armor
 	required_good_hits = 12
 
+/datum/crafting_bench_recipe/chain_shirt
+	recipe_name = "chain shirt"
+	recipe_requirements = list(
+		/obj/item/forging/complete/chain = 6,
+	)
+	resulting_item = /obj/item/clothing/suit/armor/forging_chain_shirt
+	required_good_hits = 12
+
 /datum/crafting_bench_recipe/plate_gloves
 	recipe_name = "plate gloves"
 	recipe_requirements = list(

--- a/modular_nova/modules/reagent_forging/code/forge_clothing.dm
+++ b/modular_nova/modules/reagent_forging/code/forge_clothing.dm
@@ -102,7 +102,7 @@
 
 /obj/item/clothing/gloves/forging_plate_gloves/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/armor_plate, 1, /obj/item/stack/sheet/animalhide/goliath_hide, /datum/armor/armor_forging_upgrade)
+	AddComponent(/datum/component/armor_plate, 1, armor_mod = /datum/armor/armor_forging_upgrade)
 	AddComponent(/datum/component/reagent_clothing, ITEM_SLOT_GLOVES)
 	AddComponent(/datum/component/adjust_fishing_difficulty, 4)
 

--- a/modular_nova/modules/reagent_forging/code/forge_clothing.dm
+++ b/modular_nova/modules/reagent_forging/code/forge_clothing.dm
@@ -78,7 +78,7 @@
 
 /obj/item/clothing/suit/armor/forging_chain_shirt/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/armor_plate, 2, /obj/item/stack/sheet/animalhide/goliath_hide, /datum/armor/armor_forging_upgrade)
+	AddComponent(/datum/component/armor_plate, 2, armor_mod = /datum/armor/armor_forging_upgrade)
 	AddComponent(/datum/component/reagent_clothing, ITEM_SLOT_OCLOTHING)
 
 	allowed += /obj/item/forging/reagent_weapon

--- a/modular_nova/modules/reagent_forging/code/forge_clothing.dm
+++ b/modular_nova/modules/reagent_forging/code/forge_clothing.dm
@@ -20,14 +20,14 @@
 	wound = 20
 
 /datum/armor/armor_forging_light
-	melee = 20
-	bullet = 10
-	laser = 10
-	energy = 10
+	melee = 25
+	bullet = 15
+	laser = 15
+	energy = 15
 	bomb = 20
 	bio = 20
 	acid = 10
-	wound = 10
+	wound = 15
 
 /datum/armor/armor_forging_upgrade
 	melee = 5
@@ -101,7 +101,7 @@
 
 /obj/item/clothing/gloves/forging_plate_gloves/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/armor_plate, 2, /obj/item/stack/sheet/animalhide/goliath_hide, /datum/armor/armor_forging_upgrade)
+	AddComponent(/datum/component/armor_plate, 1, /obj/item/stack/sheet/animalhide/goliath_hide, /datum/armor/armor_forging_upgrade)
 	AddComponent(/datum/component/reagent_clothing, ITEM_SLOT_GLOVES)
 	AddComponent(/datum/component/adjust_fishing_difficulty, 4)
 
@@ -148,7 +148,7 @@
 
 /obj/item/clothing/shoes/forging_plate_boots/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/armor_plate, 2, /obj/item/stack/sheet/animalhide/goliath_hide, /datum/armor/armor_forging_upgrade)
+	AddComponent(/datum/component/armor_plate, 1, /obj/item/stack/sheet/animalhide/goliath_hide, /datum/armor/armor_forging_upgrade)
 	AddComponent(/datum/component/reagent_clothing, ITEM_SLOT_FEET)
 	AddComponent(/datum/component/adjust_fishing_difficulty, 2)
 

--- a/modular_nova/modules/reagent_forging/code/forge_clothing.dm
+++ b/modular_nova/modules/reagent_forging/code/forge_clothing.dm
@@ -1,6 +1,44 @@
+//Armor Datums
+
+/datum/armor/armor_forging_hard
+	melee = 40
+	bullet = 30
+	energy = 10
+	bomb = 50
+	fire = 50
+	acid = 20
+	wound = 20
+
+/datum/armor/armor_forging_medium
+	melee = 30
+	bullet = 20
+	laser = 10
+	energy = 20
+	bomb = 50
+	fire = 50
+	acid = 20
+	wound = 20
+
+/datum/armor/armor_forging_light
+	melee = 20
+	bullet = 10
+	laser = 10
+	energy = 10
+	bomb = 20
+	bio = 20
+	acid = 10
+	wound = 10
+
+/datum/armor/armor_forging_upgrade
+	melee = 5
+	bullet = 5
+	laser = 5
+	energy = 5
+	wound = 5
+
 // Vests
 /obj/item/clothing/suit/armor/forging_plate_armor
-	name = "reagent plate vest"
+	name = "plate vest"
 	desc = "An armor vest made of hammered, interlocking plates."
 	icon = 'modular_nova/modules/reagent_forging/icons/obj/forge_clothing.dmi'
 	worn_icon = 'modular_nova/modules/reagent_forging/icons/mob/clothing/forge_clothing.dmi'
@@ -11,18 +49,35 @@
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 	resistance_flags = FIRE_PROOF
 	obj_flags_nova = ANVIL_REPAIR
-	armor_type = /datum/armor/armor_forging_plate_armor
+	body_parts_covered = GROIN|CHEST
+	armor_type = /datum/armor/armor_forging_hard
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR
-
-/datum/armor/armor_forging_plate_armor
-	melee = 40
-	bullet = 40
-	fire = 50
-	wound = 30
 
 /obj/item/clothing/suit/armor/forging_plate_armor/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/armor_plate, 4)
+	AddComponent(/datum/component/armor_plate, 2, /obj/item/stack/sheet/animalhide/goliath_hide, /datum/armor/armor_forging_upgrade)
+	AddComponent(/datum/component/reagent_clothing, ITEM_SLOT_OCLOTHING)
+	AddComponent(/datum/component/adjust_fishing_difficulty, 4)
+
+	allowed += /obj/item/forging/reagent_weapon
+	allowed += /obj/item/kinetic_crusher
+
+/obj/item/clothing/suit/armor/forging_chain_shirt
+	name = "chain mail"
+	desc = "An armor made by weaved chain links, allowing blows to be evenly distributed."
+	icon_state = "chained_leather_armor"
+	icon = 'modular_nova/modules/primitive_catgirls/icons/objects.dmi'
+	worn_icon = 'modular_nova/modules/primitive_catgirls/icons/clothing_greyscale.dmi'
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+	resistance_flags = FIRE_PROOF
+	obj_flags_nova = ANVIL_REPAIR
+	body_parts_covered = GROIN|CHEST
+	armor_type = /datum/armor/armor_forging_medium
+	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR
+
+/obj/item/clothing/suit/armor/forging_chain_shirt/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/armor_plate, 2, /obj/item/stack/sheet/animalhide/goliath_hide, /datum/armor/armor_forging_upgrade)
 	AddComponent(/datum/component/reagent_clothing, ITEM_SLOT_OCLOTHING)
 
 	allowed += /obj/item/forging/reagent_weapon
@@ -30,7 +85,7 @@
 
 // Gloves
 /obj/item/clothing/gloves/forging_plate_gloves
-	name = "reagent plate gloves"
+	name = "plate gloves"
 	desc = "A set of leather gloves with protective armor plates connected to the wrists."
 	icon = 'modular_nova/modules/reagent_forging/icons/obj/forge_clothing.dmi'
 	worn_icon = 'modular_nova/modules/reagent_forging/icons/mob/clothing/forge_clothing.dmi'
@@ -40,24 +95,19 @@
 	icon_state = "plate_gloves"
 	resistance_flags = FIRE_PROOF
 	obj_flags_nova = ANVIL_REPAIR
-	armor_type = /datum/armor/gloves_forging_plate_gloves
+	armor_type = /datum/armor/armor_forging_medium
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR
 	body_parts_covered = HANDS|ARMS
 
-/datum/armor/gloves_forging_plate_gloves
-	melee = 40
-	bullet = 40
-	fire = 50
-	wound = 30
-
 /obj/item/clothing/gloves/forging_plate_gloves/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/armor_plate, 4)
+	AddComponent(/datum/component/armor_plate, 2, /obj/item/stack/sheet/animalhide/goliath_hide, /datum/armor/armor_forging_upgrade)
 	AddComponent(/datum/component/reagent_clothing, ITEM_SLOT_GLOVES)
+	AddComponent(/datum/component/adjust_fishing_difficulty, 4)
 
 // Helmets
 /obj/item/clothing/head/helmet/forging_plate_helmet
-	name = "reagent plate helmet"
+	name = "plate helmet"
 	desc = "A helmet out of hammered plates with a leather neck guard and chin strap."
 	icon = 'modular_nova/modules/reagent_forging/icons/obj/forge_clothing.dmi'
 	worn_icon = 'modular_nova/modules/reagent_forging/icons/mob/clothing/forge_clothing.dmi'
@@ -69,23 +119,17 @@
 	resistance_flags = FIRE_PROOF
 	flags_inv = null
 	obj_flags_nova = ANVIL_REPAIR
-	armor_type = /datum/armor/helmet_forging_plate_helmet
+	armor_type = /datum/armor/armor_forging_light
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR
-
-/datum/armor/helmet_forging_plate_helmet
-	melee = 40
-	bullet = 40
-	fire = 50
-	wound = 30
 
 /obj/item/clothing/head/helmet/forging_plate_helmet/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/armor_plate, 4)
+	AddComponent(/datum/component/armor_plate, 2, /obj/item/stack/sheet/animalhide/goliath_hide, /datum/armor/armor_forging_upgrade)
 	AddComponent(/datum/component/reagent_clothing, ITEM_SLOT_HEAD)
 
 // Boots
 /obj/item/clothing/shoes/forging_plate_boots
-	name = "reagent plate boots"
+	name = "plate boots"
 	desc = "A pair of leather boots with protective armor plates over the shins and toes."
 	icon = 'modular_nova/modules/reagent_forging/icons/obj/forge_clothing.dmi'
 	worn_icon = 'modular_nova/modules/reagent_forging/icons/mob/clothing/forge_clothing.dmi'
@@ -95,25 +139,22 @@
 	worn_icon_teshari = 'modular_nova/modules/reagent_forging/icons/mob/clothing/forge_clothing_teshari.dmi'
 	icon_state = "plate_boots"
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
-	armor_type = /datum/armor/shoes_forging_plate_boots
+	armor_type = /datum/armor/armor_forging_light
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR
 	resistance_flags = FIRE_PROOF
 	obj_flags_nova = ANVIL_REPAIR
 	fastening_type = SHOES_SLIPON
 	body_parts_covered = FEET|LEGS
 
-/datum/armor/shoes_forging_plate_boots
-	melee = 20
-	bullet = 20
-
 /obj/item/clothing/shoes/forging_plate_boots/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/armor_plate, 2)
+	AddComponent(/datum/component/armor_plate, 2, /obj/item/stack/sheet/animalhide/goliath_hide, /datum/armor/armor_forging_upgrade)
 	AddComponent(/datum/component/reagent_clothing, ITEM_SLOT_FEET)
+	AddComponent(/datum/component/adjust_fishing_difficulty, 2)
 
 // Misc
 /obj/item/clothing/gloves/ring/reagent_clothing
-	name = "reagent ring"
+	name = "ring"
 	desc = "A tiny ring, sized to wrap around a finger."
 	icon_state = "ringsilver"
 	worn_icon_state = "sring"
@@ -124,9 +165,10 @@
 /obj/item/clothing/gloves/ring/reagent_clothing/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/reagent_clothing, ITEM_SLOT_GLOVES)
+	AddComponent(/datum/component/adjust_fishing_difficulty, -4)
 
 /obj/item/clothing/neck/collar/reagent_clothing
-	name = "reagent collar"
+	name = "collar"
 	desc = "A collar that is ready to be worn for certain individuals."
 	icon = 'modular_nova/modules/modular_items/lewd_items/icons/obj/lewd_clothing/lewd_neck.dmi'
 	worn_icon = 'modular_nova/modules/modular_items/lewd_items/icons/mob/lewd_clothing/lewd_neck.dmi'
@@ -146,7 +188,7 @@
 	AddComponent(/datum/component/reagent_clothing, ITEM_SLOT_NECK)
 
 /obj/item/restraints/handcuffs/reagent_clothing
-	name = "reagent handcuffs"
+	name = "handcuffs"
 	desc = "A pair of handcuffs that are ready to keep someone captive."
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR
 	obj_flags_nova = ANVIL_REPAIR

--- a/modular_nova/modules/reagent_forging/code/forge_clothing.dm
+++ b/modular_nova/modules/reagent_forging/code/forge_clothing.dm
@@ -96,7 +96,7 @@
 	icon_state = "plate_gloves"
 	resistance_flags = FIRE_PROOF
 	obj_flags_nova = ANVIL_REPAIR
-	armor_type = /datum/armor/armor_forging_medium
+	armor_type = /datum/armor/armor_forging_light
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR
 	body_parts_covered = HANDS|ARMS
 

--- a/modular_nova/modules/reagent_forging/code/forge_clothing.dm
+++ b/modular_nova/modules/reagent_forging/code/forge_clothing.dm
@@ -4,7 +4,7 @@
 	melee = 40
 	bullet = 30
 	energy = 10
-	bomb = 50
+	bomb = 40
 	fire = 50
 	acid = 20
 	wound = 20
@@ -14,9 +14,9 @@
 	bullet = 20
 	laser = 10
 	energy = 20
-	bomb = 50
+	bomb = 70
 	fire = 50
-	acid = 20
+	acid = 40
 	wound = 20
 
 /datum/armor/armor_forging_light
@@ -24,9 +24,9 @@
 	bullet = 15
 	laser = 15
 	energy = 15
-	bomb = 20
+	bomb = 35
 	bio = 20
-	acid = 10
+	acid = 20
 	wound = 15
 
 /datum/armor/armor_forging_upgrade
@@ -35,6 +35,7 @@
 	laser = 5
 	energy = 5
 	wound = 5
+	bomb = 5
 
 // Vests
 /obj/item/clothing/suit/armor/forging_plate_armor

--- a/modular_nova/modules/reagent_forging/code/forge_clothing.dm
+++ b/modular_nova/modules/reagent_forging/code/forge_clothing.dm
@@ -125,7 +125,7 @@
 
 /obj/item/clothing/head/helmet/forging_plate_helmet/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/armor_plate, 2, /obj/item/stack/sheet/animalhide/goliath_hide, /datum/armor/armor_forging_upgrade)
+	AddComponent(/datum/component/armor_plate, 2, armor_mod = /datum/armor/armor_forging_upgrade)
 	AddComponent(/datum/component/reagent_clothing, ITEM_SLOT_HEAD)
 
 // Boots

--- a/modular_nova/modules/reagent_forging/code/forge_clothing.dm
+++ b/modular_nova/modules/reagent_forging/code/forge_clothing.dm
@@ -149,7 +149,7 @@
 
 /obj/item/clothing/shoes/forging_plate_boots/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/armor_plate, 1, /obj/item/stack/sheet/animalhide/goliath_hide, /datum/armor/armor_forging_upgrade)
+	AddComponent(/datum/component/armor_plate, 1, armor_mod = /datum/armor/armor_forging_upgrade)
 	AddComponent(/datum/component/reagent_clothing, ITEM_SLOT_FEET)
 	AddComponent(/datum/component/adjust_fishing_difficulty, 2)
 

--- a/modular_nova/modules/reagent_forging/code/forge_clothing.dm
+++ b/modular_nova/modules/reagent_forging/code/forge_clothing.dm
@@ -119,7 +119,7 @@
 	resistance_flags = FIRE_PROOF
 	flags_inv = null
 	obj_flags_nova = ANVIL_REPAIR
-	armor_type = /datum/armor/armor_forging_light
+	armor_type = /datum/armor/armor_forging_medium
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR
 
 /obj/item/clothing/head/helmet/forging_plate_helmet/Initialize(mapload)

--- a/modular_nova/modules/reagent_forging/code/forge_clothing.dm
+++ b/modular_nova/modules/reagent_forging/code/forge_clothing.dm
@@ -56,7 +56,7 @@
 
 /obj/item/clothing/suit/armor/forging_plate_armor/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/armor_plate, 2, /obj/item/stack/sheet/animalhide/goliath_hide, /datum/armor/armor_forging_upgrade)
+	AddComponent(/datum/component/armor_plate, 2, armor_mod = /datum/armor/armor_forging_upgrade)
 	AddComponent(/datum/component/reagent_clothing, ITEM_SLOT_OCLOTHING)
 	AddComponent(/datum/component/adjust_fishing_difficulty, 4)
 


### PR DESCRIPTION
## About The Pull Request
Adds a variant of the chest armor using the icecats chainshirt icons as placeholder until someone better with sprites comes and offer an alternative.

Adds three tiers of armor values, Heavy, Medium and Light

The Plated armor and heartkin chainshirt uses heavy, the chainshirt and helmet uses medium, the gloves and boots use light values.

The amount of goliath/bear plates to upgrade each type changed, to 2 max for heavy and medium and 1 to light types. The effect of the upgrade no longer gives 10 melee extra armor, but 5 to melee, energy, laser, bullet, wounding and bomb.

This all results in an overall stronger armor, without the final armor reaching Drake set tier of melee protection.

## How This Contributes To The Nova Sector Roleplay Experience
It makes forged armor more unique, more balanced for the use outside of just being on the lavaland/ice tundra, while needing elements of such to advance its tier.

The dynamic of needing parts from the mining areas to get it to full protective values separate it from being over the limit of regular sec armor, while being harder to make to justify some of its specialty values. Then to get it from the low mid tier to mid-high tier of protection, upgrade parts are needed which are only found in mining areas (or a specialty forgotten gatcha crate in cargo). Further, to reach modsuit levels with this armor sets, one needs to find tribals who need to be willing to enchant said armor, which is not a sure thing.

For tribals the benefits are higher, as making the armor more well rounded and needing less materials to upgrade it (from 12 to 6) means they can produce more if needed, or be 'online' earlier, while making their armor different enough from other possible choices they have that the choice which to pick goes beyond aesthetics.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
Plate:

![image](https://github.com/user-attachments/assets/3560f47a-1dd0-42c9-b79b-15fd879453bd)

![image](https://github.com/user-attachments/assets/fcd45537-217b-4ccb-b2b2-5609e481d23c)

Chain:

![image](https://github.com/user-attachments/assets/7be77c1d-39fe-4d5b-8d80-43af480a4d44)

![image](https://github.com/user-attachments/assets/a062afc8-d62c-459d-97fe-b7bc41a6111e)

Helmet:

![image](https://github.com/user-attachments/assets/25c5761a-9c97-4de5-b398-712518111303)

![image](https://github.com/user-attachments/assets/dc660d1e-ade6-4c49-b8be-363f5a9cf34e)

Gloves (Got mistaken and used Helmet stats, assume its the same as boots):

![image](https://github.com/user-attachments/assets/1d41a4fa-6a58-4455-9bb0-5e61d54df567)

![image](https://github.com/user-attachments/assets/3210d8ac-73bf-4064-9a35-b9fe308675ed)

Boots:

![image](https://github.com/user-attachments/assets/31f0e82b-ccf9-4a77-9094-056c06405a3d)

![image](https://github.com/user-attachments/assets/1fe1165a-eb2e-41c2-9df9-c3dde5d57b07)

Workbench:

![image](https://github.com/user-attachments/assets/ae5a4137-25ca-4cea-9891-32419a0eb32d)

</details>

## Changelog
:cl:
balance: Forged Armor was improved all around, made more significant and less grindy to upgrade (6 pieces for a full set vs 12).  While it no longer reachs Drake Armor levels of Melee protection, its other stats make it more formidable and useful for the day to day.
add: Chainshirt added to the forging workbench, as an alternative for the Plate mail, less focused on melee and bullets, more on energy types. Not to be confused with the Heartkin Chainshirt, which has the same stats as the platemail.
/:cl:
