### PR TITLE
[Balance] Limits the Colossus death bolt range to 21 tiles

### DIFF
--- a/modular_nova/modules/modular_creatures/code/megafauna.dm
+++ b/modular_nova/modules/modular_creatures/code/megafauna.dm
@@ -1,0 +1,2 @@
+/obj/projectile/colossus
+	range = 21 //reduce the shoot to 3 screens lenght to reduce devastation

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8283,6 +8283,7 @@
 #include "modular_nova\modules\modsuit_pai\code\mod_pai.dm"
 #include "modular_nova\modules\modular_creatures\code\carp.dm"
 #include "modular_nova\modules\modular_creatures\code\creature.dm"
+#include "modular_nova\modules\modular_creatures\code\megafauna.dm"
 #include "modular_nova\modules\modular_creatures\code\sweaterfox.dm"
 #include "modular_nova\modules\modular_creatures\code\telegraph_overrides.dm"
 #include "modular_nova\modules\modular_ert\code\engineer\engineer.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Sets on a modular file the adjustment to the Colossus death bolt to 21 range, roughly 3 screens.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

While other solutions are still being debated, the colossus has been one of the main reasons for interdyne total destruction. We are still working on a solution but someone doing a megafauna a few screens over shouldnt fuck over an entire ghost role.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
Tested in local, dissapeared from the back of the chosen one arena to the entrance.

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Colossus death bolts (the ones that destroy structures) range were reduced from infinite to 21 tiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
