### PR TITLE
Fix cybernetic teshari head's eye icon and color

### DIFF
--- a/modular_nova/modules/tesh_augments/code/robot_bodyparts.dm
+++ b/modular_nova/modules/tesh_augments/code/robot_bodyparts.dm
@@ -97,7 +97,8 @@
 	brute_modifier = 1
 	burn_modifier = 0.9
 
-	head_flags = HEAD_EYESPRITES
+	head_flags = HEAD_EYESPRITES|HEAD_EYECOLOR
+	eyes_icon = 'modular_nova/modules/organs/icons/teshari_eyes.dmi'
 
 // teshari_ surplus
 


### PR DESCRIPTION
## About The Pull Request

The cybernetic teshari head did not have its `eyes_icon` set to the appropriate file and also lacked the `HEAD_EYECOLOR` bitflag, resulting in the eyes being very noticeably offset and the eye color selected in setup not appearing in-game.
Both of these issues have been fixed by assigning the correct file to `eyes_icon` and adding the missing bitflag to `head_flags`.

## How This Contributes To The Nova Sector Roleplay Experience

A robotic teshari's eyes will no longer be horribly offset from their face and will also be the color the player wanted them to be.

## Proof of Testing

<details>
<summary>Screenshots</summary>

**Before:**
![image](https://github.com/user-attachments/assets/0a01dfe7-e3f7-43bf-8c05-235890cd5897)

**After:**
![image](https://github.com/user-attachments/assets/96efdb65-73ab-4005-ba74-153513c73a92)

</details>

## Changelog

:cl:
fix: Raptoral cybernetic heads now have the correct eyes sprite, and also retain the eye color selected in character setup.
/:cl: