### PR TITLE
Removes the MALF requirement for additional VOX

### DIFF
--- a/code/modules/antagonists/malf_ai/malf_ai.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai.dm
@@ -35,12 +35,6 @@
 	owner.special_role = job_rank
 	if(give_objectives)
 		forge_ai_objectives()
-	// NOVA EDIT START - Moving voice changing to Malf only
-#ifdef AI_VOX
-	var/mob/living/silicon/ai/malf_ai = owner.current
-	malf_ai.vox_voices += VOX_MIL
-#endif
-	// NOVA EDIT END
 
 	employer = pick(GLOB.ai_employers)
 	if(!employer)
@@ -64,12 +58,7 @@
 		var/mob/living/silicon/ai/malf_ai = owner.current
 		malf_ai.set_zeroth_law("")
 		malf_ai.remove_malf_abilities()
-		// NOVA EDIT START - Moving voice changing to Malf only
-#ifdef AI_VOX
-		malf_ai.vox_voices -= VOX_MIL
-		malf_ai.vox_type = VOX_NORMAL
-#endif
-		// NOVA EDIT END
+
 		QDEL_NULL(malf_ai.malf_picker)
 
 	owner.special_role = null

--- a/modular_nova/modules/alt_vox/code/vox_procs.dm
+++ b/modular_nova/modules/alt_vox/code/vox_procs.dm
@@ -5,7 +5,7 @@
 	/// The currently selected VOX Announcer voice.
 	var/vox_type = VOX_BMS
 	/// The list of available VOX Announcer voices to choose from.
-	var/list/vox_voices = list(VOX_HL, VOX_NORMAL, VOX_BMS)
+	var/list/vox_voices = list(VOX_HL, VOX_NORMAL, VOX_BMS, VOX_MIL)
 	/// The VOX word(s) that were previously inputed.
 	var/vox_word_string
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Just undoes the age-old restriction on the VOX we have, all it does is give meta-knowledge that the AI is malf and as such it's basically wasting space in our repo.

## How This Contributes To The Nova Sector Roleplay Experience

More variety beeps n boops

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
  
![image](https://github.com/user-attachments/assets/b427670e-88ba-4189-a887-4692bf1bfd24)

  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: unrestricts additional Vox voices away from being malf only
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
