### PR TITLE
QOL: Neutral Voice Actor Quirk

### DIFF
--- a/modular_nova/modules/voice_actor_quirk/code/voice_actor_quirk.dm
+++ b/modular_nova/modules/voice_actor_quirk/code/voice_actor_quirk.dm
@@ -5,7 +5,7 @@
 	gain_text = span_notice("You are reminded of how your other voice sounds.")
 	lose_text = span_warning("You suddenly forget what your other voice sounds like!")
 	medical_record_text = ""
-	value = 4
+	value = 0
 	quirk_flags = QUIRK_HUMAN_ONLY
 
 /datum/quirk_constant_data/voice_actor


### PR DESCRIPTION
## About The Pull Request

This PR sets the value of the Voice Actor quirk to 0, making it a "neutral" quirk. Based on player suggestions, the Voice Actor quirk's value was not expected by players because its effects are minor.

## How This Contributes To The Nova Sector Roleplay Experience

Will allow players to use the Voice Actor quirk as a neutral quirk, and not have it contribute to their positive quirk limit.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/4692380a-1cce-4674-b24c-3177b176d3db)

</details>

## Changelog

:cl:
qol: Changed the value of the Voice Actor quirk to 0, making it a neutral quirk.
/:cl:
