### PR TITLE
Enhanced language prefs and tweaks job language reqs a little

### DIFF
--- a/modular_nova/master_files/code/modules/client/preferences/middleware/languages.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/middleware/languages.dm
@@ -26,8 +26,10 @@
 	/// A associative list of language names to their typepath
 	var/static/list/name_to_language = list()
 	action_delegations = list(
-		"give_language" = PROC_REF(give_language),
-		"remove_language" = PROC_REF(remove_language),
+		"speak_language" = PROC_REF(speak_language),
+		"understand_language" = PROC_REF(understand_language),
+		"forget_speak_language" = PROC_REF(forget_speak_language),
+		"forget_understand_language" = PROC_REF(forget_understand_language)
 	)
 
 /datum/preference_middleware/languages/apply_to_human(mob/living/carbon/human/target, datum/preferences/preferences, visuals_only = FALSE)
@@ -87,7 +89,8 @@
 			selected_languages += list(list(
 				"description" = language.desc,
 				"name" = language.name,
-				"icon" = sanitize_css_class_name(language.name)
+				"icon" = sanitize_css_class_name(language.name),
+				"speaking" = !!(preferences.languages[language.type] == LANGUAGE_SPOKEN),
 			))
 		else
 			unselected_languages += list(list(
@@ -112,35 +115,55 @@
 		name_to_language[language.name] = language_name
 
 /**
- * Proc that gives a language to a character, granted that they don't already have too many
- * of them, based on their maximum amount of languages.
- *
- * Arguments:
- * * params - List of parameters, given to us by the `act()` method from TGUI. Needs to
- * contain a value under `"language_name"`.
+ * Proc that gives understanding and speaking capabilities of a language to a character,
+ * granted that they don't already have too many of them, based on their maximum amount of languages.
  *
  * Returns TRUE all the time, to ensure that the UI is updated.
  */
-/datum/preference_middleware/languages/proc/give_language(list/params)
+/datum/preference_middleware/languages/proc/speak_language(list/params, mob/user)
 	var/language_name = params["language_name"]
-	var/max_languages = preferences.all_quirks.Find(TRAIT_LINGUIST) ? MAX_LANGUAGES_LINGUIST : MAX_LANGUAGES_NORMAL
 
-	if(preferences.languages && preferences.languages.len == max_languages) // too many languages
+	var/max_languages = preferences.all_quirks.Find(TRAIT_LINGUIST) ? MAX_LANGUAGES_LINGUIST : MAX_LANGUAGES_NORMAL
+	if(preferences.languages && !(name_to_language[language_name] in preferences.languages) && preferences.languages.len == max_languages) // this is a new language and we're at the limit
+		to_chat(user, span_warning("You have too many languages learned!"))
 		return TRUE
 
 	preferences.languages[name_to_language[language_name]] = LANGUAGE_SPOKEN
 	return TRUE
 
 /**
- * Proc that removes a language from a character.
- *
- * Arguments:
- * * params - List of parameters, given to us by the `act()` method from TGUI. Needs to
- * contain a value under `"language_name"`.
+ * Proc that gives understanding capabilities only of a language to a character,
+ * granted that they don't already have too many of them, based on their maximum amount of languages.
  *
  * Returns TRUE all the time, to ensure that the UI is updated.
  */
-/datum/preference_middleware/languages/proc/remove_language(list/params)
+/datum/preference_middleware/languages/proc/understand_language(list/params, mob/user)
+	var/language_name = params["language_name"]
+
+	var/max_languages = preferences.all_quirks.Find(TRAIT_LINGUIST) ? MAX_LANGUAGES_LINGUIST : MAX_LANGUAGES_NORMAL
+	if(preferences.languages && !(name_to_language[language_name] in preferences.languages) && preferences.languages.len == max_languages) // this is a new language and we're at the limit
+		to_chat(user, span_warning("You have too many languages learned!"))
+		return TRUE
+
+	preferences.languages[name_to_language[language_name]] = LANGUAGE_UNDERSTOOD
+	return TRUE
+
+/**
+ * Proc that takes away speaking capabilities of a language from a character.
+ *
+ * Returns TRUE all the time, to ensure that the UI is updated.
+ */
+/datum/preference_middleware/languages/proc/forget_speak_language(list/params, mob/user)
+	var/language_name = params["language_name"]
+	preferences.languages[name_to_language[language_name]] = LANGUAGE_UNDERSTOOD
+	return TRUE
+
+/**
+ * Proc that takes away speaking and understanding capabilities of a language from a character.
+ *
+ * Returns TRUE all the time, to ensure that the UI is updated.
+ */
+/datum/preference_middleware/languages/proc/forget_understand_language(list/params, mob/user)
 	var/language_name = params["language_name"]
 	preferences.languages -= name_to_language[language_name]
 	return TRUE

--- a/modular_nova/master_files/code/modules/language/language_holder.dm
+++ b/modular_nova/master_files/code/modules/language/language_holder.dm
@@ -36,7 +36,7 @@ GLOBAL_DATUM_INIT(language_holder_adjustor, /datum/language_holder_adjustor, new
 	remove_languages_by_source(list(LANGUAGE_MIND, LANGUAGE_ATOM, LANGUAGE_SPECIES))
 
 	for(var/lang_path in preferences.languages)
-		grant_language(lang_path)
+		grant_language(lang_path, (preferences.languages[lang_path] == LANGUAGE_SPOKEN ? ALL : UNDERSTOOD_LANGUAGE))
 
 	get_selected_language()
 

--- a/modular_nova/modules/customization/modules/jobs/_job.dm
+++ b/modular_nova/modules/customization/modules/jobs/_job.dm
@@ -14,7 +14,7 @@
 	//Blacklist of species for this job.
 	var/list/species_blacklist
 	/// Which languages does the job require, associative to LANGUAGE_UNDERSTOOD or LANGUAGE_SPOKEN
-	var/list/required_languages = list(/datum/language/common = LANGUAGE_SPOKEN)
+	var/list/required_languages = list(/datum/language/common = LANGUAGE_UNDERSTOOD)
 
 	///Is this job veteran only? If so, then this job requires the player to be in the veteran_players.txt
 	var/veteran_only = FALSE
@@ -71,31 +71,37 @@
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
 	banned_augments = list(SEC_RESTRICTED_AUGMENTS)
 	species_blacklist = list(SPECIES_ABDUCTORWEAK = TRUE)
+	required_languages = list(/datum/language/common = LANGUAGE_SPOKEN)
 
 /datum/job/detective
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
 	banned_augments = list(SEC_RESTRICTED_AUGMENTS)
+	required_languages = list(/datum/language/common = LANGUAGE_SPOKEN)
 
 /datum/job/warden
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
 	banned_augments = list(SEC_RESTRICTED_AUGMENTS)
 	species_blacklist = list(SPECIES_ABDUCTORWEAK = TRUE)
+	required_languages = list(/datum/language/common = LANGUAGE_SPOKEN)
 
 /datum/job/blueshield
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
 	banned_augments = list(SEC_RESTRICTED_AUGMENTS)
 	species_blacklist = list(SPECIES_ABDUCTORWEAK = TRUE)
+	required_languages = list(/datum/language/common = LANGUAGE_SPOKEN)
 
 /datum/job/corrections_officer
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS)
 	banned_augments = list(SEC_RESTRICTED_AUGMENTS)
 	species_blacklist = list(SPECIES_ABDUCTORWEAK = TRUE)
+	required_languages = list(/datum/language/common = LANGUAGE_SPOKEN)
 
 // Command
 /datum/job/captain
 	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)
 	banned_augments = list(HEAD_RESTRICTED_AUGMENTS)
 	species_blacklist = list(SPECIES_ABDUCTORWEAK = TRUE)
+	required_languages = list(/datum/language/common = LANGUAGE_SPOKEN)
 
 /datum/job/nanotrasen_consultant
 	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)
@@ -106,28 +112,34 @@
 	banned_quirks = list(SEC_RESTRICTED_QUIRKS, HEAD_RESTRICTED_QUIRKS)
 	banned_augments = list(SEC_RESTRICTED_AUGMENTS)
 	species_blacklist = list(SPECIES_ABDUCTORWEAK = TRUE)
+	required_languages = list(/datum/language/common = LANGUAGE_SPOKEN)
 
 /datum/job/chief_medical_officer
 	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)
 	banned_augments = list(HEAD_RESTRICTED_AUGMENTS)
 	species_blacklist = list(SPECIES_ABDUCTORWEAK = TRUE)
+	required_languages = list(/datum/language/common = LANGUAGE_SPOKEN)
 
 /datum/job/chief_engineer
 	banned_quirks = list(HEAD_RESTRICTED_QUIRKS, "Paraplegic" = TRUE)
 	banned_augments = list(HEAD_RESTRICTED_AUGMENTS)
 	species_blacklist = list(SPECIES_ABDUCTORWEAK = TRUE)
+	required_languages = list(/datum/language/common = LANGUAGE_SPOKEN)
 
 /datum/job/research_director
 	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)
 	banned_augments = list(HEAD_RESTRICTED_AUGMENTS)
+	required_languages = list(/datum/language/common = LANGUAGE_SPOKEN)
 
 /datum/job/head_of_personnel
 	banned_quirks = list(HEAD_RESTRICTED_QUIRKS)
 	banned_augments = list(HEAD_RESTRICTED_AUGMENTS)
+	required_languages = list(/datum/language/common = LANGUAGE_SPOKEN)
 
 /datum/job/quartermaster
 	banned_quirks = list(HEAD_RESTRICTED_QUIRKS_QM)
 	banned_augments = list(HEAD_RESTRICTED_AUGMENTS)
+	required_languages = list(/datum/language/common = LANGUAGE_SPOKEN)
 
 //Silicon
 /datum/job/ai
@@ -155,18 +167,23 @@
 
 /datum/job/orderly
 	banned_quirks = list(GUARD_RESTRICTED_QUIRKS)
+	required_languages = list(/datum/language/common = LANGUAGE_SPOKEN)
 
 /datum/job/science_guard
 	banned_quirks = list(GUARD_RESTRICTED_QUIRKS)
+	required_languages = list(/datum/language/common = LANGUAGE_SPOKEN)
 
 /datum/job/customs_agent
 	banned_quirks = list(GUARD_RESTRICTED_QUIRKS)
+	required_languages = list(/datum/language/common = LANGUAGE_SPOKEN)
 
 /datum/job/bouncer
 	banned_quirks = list(GUARD_RESTRICTED_QUIRKS)
+	required_languages = list(/datum/language/common = LANGUAGE_SPOKEN)
 
 /datum/job/engineering_guard
 	banned_quirks = list(GUARD_RESTRICTED_QUIRKS)
+	required_languages = list(/datum/language/common = LANGUAGE_SPOKEN)
 
 /datum/job/proc/has_required_languages(datum/preferences/pref)
 	if(!required_languages)

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/LanguagesMenu.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/LanguagesMenu.tsx
@@ -2,16 +2,9 @@
 import { useBackend } from 'tgui/backend';
 import { BlockQuote, Box, Button, Section, Stack } from 'tgui-core/components';
 
-import { PreferencesMenuData } from '../types';
+import { Language, PreferencesMenuData } from '../types';
 
-export function KnownLanguage(props: {
-  language: {
-    name: string;
-    description: string;
-    icon: string;
-    speaking: boolean;
-  };
-}) {
+export function KnownLanguage(props: { language: Language }) {
   const { act } = useBackend<PreferencesMenuData>();
   return (
     <Stack.Item>
@@ -30,25 +23,25 @@ export function KnownLanguage(props: {
         }
       >
         <BlockQuote>{props.language.description}</BlockQuote>
-        <Button.Checkbox
+        <Button
+          color="bad"
           icon="brain"
-          selected
-          tooltip="Removing your ability to understand the language will also prevent you from speaking it."
+          tooltip="Forgetting how to understand the language will also prevent you from speaking it."
           onClick={() =>
             act('forget_understand_language', {
               language_name: props.language.name,
             })
           }
         >
-          Can understand
-        </Button.Checkbox>
-        <Button.Checkbox
+          Forget
+        </Button>
+        <Button
+          color={props.language.speaking ? 'good' : 'default'}
           icon={props.language.speaking ? 'comment' : 'comment-slash'}
-          selected={props.language.speaking}
           tooltip={
             props.language.speaking
-              ? 'Lose the ability to speak the language, but you keep your understanding of it.'
-              : 'Gives you the ability to speak the language.'
+              ? 'Forget how to speak the language, but you keep your understanding of it.'
+              : 'Learn to speak the language.'
           }
           onClick={() =>
             act(
@@ -59,21 +52,17 @@ export function KnownLanguage(props: {
             )
           }
         >
-          Can{!props.language.speaking && "'t"} speak
-        </Button.Checkbox>
+          Can {props.language.speaking ? 'speak' : 'only understand'}
+        </Button>
       </Section>
     </Stack.Item>
   );
 }
 
-export function UnknownLanguage(props: {
-  language: {
-    name: string;
-    description: string;
-    icon: string;
-  };
-}) {
-  const { act } = useBackend<PreferencesMenuData>();
+export function UnknownLanguage(props: { language: Language }) {
+  const { act, data } = useBackend<PreferencesMenuData>();
+  const noPoints =
+    data.selected_languages.length === data.total_language_points;
   return (
     <Stack.Item>
       <Section
@@ -92,35 +81,37 @@ export function UnknownLanguage(props: {
       >
         <BlockQuote>{props.language.description}</BlockQuote>
         <Button
+          color={!noPoints ? 'good' : 'grey'}
           icon="comment"
-          tooltip="Gives you the ability to speak and understand the language."
+          tooltip="Learn to speak and understand the language."
           onClick={() =>
             act('speak_language', { language_name: props.language.name })
           }
         >
-          Learn speech
+          Speak
         </Button>
         <Button
+          color={!!noPoints && 'grey'}
           icon="brain"
-          tooltip="Gives you the ability to understand the language but not speak it."
+          tooltip="Learn to understand the language but not speak it."
           onClick={() =>
             act('understand_language', { language_name: props.language.name })
           }
         >
-          Learn understanding only
+          Understand
         </Button>
       </Section>
     </Stack.Item>
   );
 }
 
-export const LanguagesPage = (props) => {
+export function LanguagesPage() {
   const { data } = useBackend<PreferencesMenuData>();
   return (
     <>
       <Section textAlign="center">
-        Here, you can add languages to your character using a point system. The{' '}
-        <b>Linguist</b> neutral quirk will give you one extra point.
+        Here, you can learn languages using a point system. The <b>Linguist</b>{' '}
+        neutral quirk will give you one extra point.
         <br />
         Languages may be either <b>spoken and understood</b> or{' '}
         <b>just understood.</b>
@@ -128,11 +119,13 @@ export const LanguagesPage = (props) => {
         One language is worth <b>1 point,</b> even if that language is only
         understood and not spoken.
         <br />
+        You must have at least one known language, and you must understand Sol
+        Common to play most station jobs. <br />
         It does not cost points to toggle speech of a language—it only costs
         points to add an entirely new language.
       </Section>
       <Stack>
-        <Stack.Item minWidth="33%">
+        <Stack.Item minWidth="50%">
           <Section
             title={
               <Box fontSize="150%">
@@ -147,7 +140,7 @@ export const LanguagesPage = (props) => {
             </Stack>
           </Section>
         </Stack.Item>
-        <Stack.Item minWidth="33%">
+        <Stack.Item minWidth="50%">
           <Section
             title={
               <Box fontSize="150%">
@@ -166,4 +159,4 @@ export const LanguagesPage = (props) => {
       </Stack>
     </>
   );
-};
+}

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/LanguagesMenu.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/LanguagesMenu.tsx
@@ -1,86 +1,169 @@
 // THIS IS A NOVA SECTOR UI FILE
 import { useBackend } from 'tgui/backend';
-import { Box, Button, Section, Stack } from 'tgui-core/components';
+import { BlockQuote, Box, Button, Section, Stack } from 'tgui-core/components';
 
 import { PreferencesMenuData } from '../types';
 
-export const KnownLanguage = (props) => {
+export function KnownLanguage(props: {
+  language: {
+    name: string;
+    description: string;
+    icon: string;
+    speaking: boolean;
+  };
+}) {
   const { act } = useBackend<PreferencesMenuData>();
   return (
     <Stack.Item>
-      <Section title={props.language.name}>
-        {props.language.description}
-        <br />
-        <Button
-          mt={1.5}
-          color="bad"
+      <Section
+        title={
+          <>
+            <Box
+              // Manually putting the icon here instead of using the buttons prop cause it looks better
+              mr="2px"
+              mb="-4px"
+              inline
+              className={'languages16x16 ' + props.language.icon}
+            />
+            <Box inline>{props.language.name}</Box>
+          </>
+        }
+      >
+        <BlockQuote>{props.language.description}</BlockQuote>
+        <Button.Checkbox
+          icon="brain"
+          selected
+          tooltip="Removing your ability to understand the language will also prevent you from speaking it."
           onClick={() =>
-            act('remove_language', { language_name: props.language.name })
+            act('forget_understand_language', {
+              language_name: props.language.name,
+            })
           }
         >
-          Forget <Box className={'languages16x16 ' + props.language.icon} />
-        </Button>
+          Can understand
+        </Button.Checkbox>
+        <Button.Checkbox
+          icon={props.language.speaking ? 'comment' : 'comment-slash'}
+          selected={props.language.speaking}
+          tooltip={
+            props.language.speaking
+              ? 'Lose the ability to speak the language, but you keep your understanding of it.'
+              : 'Gives you the ability to speak the language.'
+          }
+          onClick={() =>
+            act(
+              props.language.speaking
+                ? 'forget_speak_language'
+                : 'speak_language',
+              { language_name: props.language.name },
+            )
+          }
+        >
+          Can{!props.language.speaking && "'t"} speak
+        </Button.Checkbox>
       </Section>
     </Stack.Item>
   );
-};
+}
 
-export const UnknownLanguage = (props) => {
+export function UnknownLanguage(props: {
+  language: {
+    name: string;
+    description: string;
+    icon: string;
+  };
+}) {
   const { act } = useBackend<PreferencesMenuData>();
   return (
     <Stack.Item>
-      <Section title={props.language.name}>
-        {props.language.description}
-        <br />
+      <Section
+        title={
+          <>
+            <Box
+              // Manually putting the icon here instead of using the buttons prop cause it looks better
+              mr="2px"
+              mb="-3px"
+              inline
+              className={'languages16x16 ' + props.language.icon}
+            />
+            <Box inline>{props.language.name}</Box>
+          </>
+        }
+      >
+        <BlockQuote>{props.language.description}</BlockQuote>
         <Button
-          mt={1.5}
-          color="good"
+          icon="comment"
+          tooltip="Gives you the ability to speak and understand the language."
           onClick={() =>
-            act('give_language', { language_name: props.language.name })
+            act('speak_language', { language_name: props.language.name })
           }
         >
-          Learn <Box className={'languages16x16 ' + props.language.icon} />
+          Learn speech
+        </Button>
+        <Button
+          icon="brain"
+          tooltip="Gives you the ability to understand the language but not speak it."
+          onClick={() =>
+            act('understand_language', { language_name: props.language.name })
+          }
+        >
+          Learn understanding only
         </Button>
       </Section>
     </Stack.Item>
   );
-};
+}
 
 export const LanguagesPage = (props) => {
   const { data } = useBackend<PreferencesMenuData>();
   return (
-    <Stack>
-      <Stack.Item minWidth="33%">
-        <Section title="Available Languages">
-          <Stack vertical>
-            {data.unselected_languages.map((val) => (
-              <UnknownLanguage key={val.icon} language={val} />
-            ))}
-          </Stack>
-        </Section>
-      </Stack.Item>
-      <Stack.Item minWidth="33%">
-        <Section
-          title={
-            'Points: ' +
-            data.selected_languages.length +
-            '/' +
-            data.total_language_points
-          }
-        >
-          Here, you can purchase languages using a point buy system. Each
-          Language is worth 1 point.
-        </Section>
-      </Stack.Item>
-      <Stack.Item minWidth="33%">
-        <Section title="Known Languages">
-          <Stack vertical>
-            {data.selected_languages.map((val) => (
-              <KnownLanguage key={val.icon} language={val} />
-            ))}
-          </Stack>
-        </Section>
-      </Stack.Item>
-    </Stack>
+    <>
+      <Section textAlign="center">
+        Here, you can add languages to your character using a point system. The{' '}
+        <b>Linguist</b> neutral quirk will give you one extra point.
+        <br />
+        Languages may be either <b>spoken and understood</b> or{' '}
+        <b>just understood.</b>
+        <br />
+        One language is worth <b>1 point,</b> even if that language is only
+        understood and not spoken.
+        <br />
+        It does not cost points to toggle speech of a language—it only costs
+        points to add an entirely new language.
+      </Section>
+      <Stack>
+        <Stack.Item minWidth="33%">
+          <Section
+            title={
+              <Box fontSize="150%">
+                {data.unselected_languages.length} available languages
+              </Box>
+            }
+          >
+            <Stack vertical>
+              {data.unselected_languages.map((val) => (
+                <UnknownLanguage key={val.icon} language={val} />
+              ))}
+            </Stack>
+          </Section>
+        </Stack.Item>
+        <Stack.Item minWidth="33%">
+          <Section
+            title={
+              <Box fontSize="150%">
+                {data.selected_languages.length}/{data.total_language_points}{' '}
+                known languages
+              </Box>
+            }
+          >
+            <Stack vertical>
+              {data.selected_languages.map((val) => (
+                <KnownLanguage key={val.icon} language={val} />
+              ))}
+            </Stack>
+          </Section>
+        </Stack.Item>
+      </Stack>
+    </>
   );
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/types.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/types.ts
@@ -105,6 +105,7 @@ export type Language = {
   description: string;
   name: string;
   icon: string;
+  speaking: boolean;
 };
 
 export type Marking = {


### PR DESCRIPTION
## About The Pull Request
You can now toggle being able to speak a language (and still understand it!) in your preferences, as probably intended from a long time ago.

Non-guard/sec and non-command jobs now only require being able to *understand* Sol Common. Guard/sec and command jobs still require being able to *speak* it.
## How This Contributes To The Nova Sector Roleplay Experience
More buttons to press to make characters that are probably more interesting, I've wanted this since forever.

Guard/sec and command jobs don't allow you to play as a mute without the signer quirk, so they obviously shouldn't allow you to play without being able to *speak* Common. 

The rest of the jobs in the game don't care about mutes, though, so I think it's fine to let them be played as long as you can *understand* Common.

Mute changes how you are mechanically allowed to interact with others and not being able to speak Common will have almost the same effect until you run into someone who shares a spoken language with you, so we should apply that logic here too. Jobs that allow mutes should also allow people who can't *speak* Common but are still able to *understand* it.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/ae2f5e32-03cd-49b1-8192-a30195dff2a3)
![image](https://github.com/user-attachments/assets/f2335017-e15c-48a1-8f1e-8a3a8416e807)
![image](https://github.com/user-attachments/assets/91413b6a-cc04-4802-bcf2-a35878e3405e)

</details>

## Changelog
:cl:
qol: You can now toggle being able to speak a language in your preferences, so you can understand a language but not be able to speak it.
/:cl:
