### PR TITLE
[S]TEST MERGE ONLY - Disable lethals in cargo imports for a few days

### DIFF
--- a/modular_nova/master_files/code/modules/cargo/goodies.dm
+++ b/modular_nova/master_files/code/modules/cargo/goodies.dm
@@ -1,3 +1,4 @@
+/*
 /datum/supply_pack/goody/dumdum38
 	access_view = FALSE
 	special = TRUE
@@ -48,3 +49,4 @@
 
 /datum/supply_pack/goody/double_barrel
 	access_view = FALSE
+*/

--- a/modular_nova/modules/company_imports/code/armament_datums/deforest_medical.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/deforest_medical.dm
@@ -245,7 +245,7 @@
 /datum/armament_entry/company_import/deforest/cyber_implants
 	subcategory = "Cybernetic Implants"
 	cost = PAYCHECK_COMMAND * 3
-
+/*
 /datum/armament_entry/company_import/deforest/cyber_implants/razorwire
 	name = "Razorwire Spool Implant"
 	item_type = /obj/item/organ/cyberimp/arm/razorwire
@@ -253,7 +253,7 @@
 /datum/armament_entry/company_import/deforest/cyber_implants/shell_launcher
 	name = "Shell Launch System Implant"
 	item_type = /obj/item/organ/cyberimp/arm/shell_launcher
-
+*/
 /datum/armament_entry/company_import/deforest/cyber_implants/sandy
 	name = "Qani-Laaca Sensory Computer Implant"
 	item_type = /obj/item/organ/cyberimp/sensory_enhancer

--- a/modular_nova/modules/company_imports/code/armament_datums/microstar_energy.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/microstar_energy.dm
@@ -14,7 +14,7 @@
 /datum/armament_entry/company_import/microstar/basic_energy_weapons/advtaser
 	item_type = /obj/item/gun/energy/e_gun/advtaser
 	cost = PAYCHECK_CREW * 7 // slightly more expensive because of style points, and being a taser/disabler combo
-
+/*
 /datum/armament_entry/company_import/microstar/basic_energy_weapons/disabler_smg
 	item_type = /obj/item/gun/energy/disabler/smg
 	cost = PAYCHECK_CREW * 7 // slightly more expensive due to ease of use/full auto
@@ -74,3 +74,4 @@
 /datum/armament_entry/company_import/microstar/experimental_energy/tesla_cannon
 	item_type = /obj/item/gun/energy/tesla_cannon
 	restricted = TRUE
+*/

--- a/modular_nova/modules/company_imports/code/armament_datums/nri_military_surplus.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/nri_military_surplus.dm
@@ -104,7 +104,7 @@
 /datum/armament_entry/company_import/nri_surplus/misc/nri_flag
 	item_type = /obj/item/sign/flag/nri
 	cost = PAYCHECK_CREW * 0.5
-
+/*
 /datum/armament_entry/company_import/nri_surplus/firearm
 	subcategory = "Firearms"
 	cost = PAYCHECK_COMMAND * 6
@@ -180,3 +180,4 @@
 /datum/armament_entry/company_import/nri_surplus/firearm_ammo/amr_magazine
 	item_type = /obj/item/ammo_box/magazine/wylom
 	cost = PAYCHECK_CREW * 3
+*/

--- a/modular_nova/modules/company_imports/code/armament_datums/sol_defense.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/sol_defense.dm
@@ -84,7 +84,7 @@
 /datum/armament_entry/company_import/sol_defense/case/carwo
 	item_type = /obj/item/storage/toolbox/guncase/nova/carwo_large_case/empty
 	cost = PAYCHECK_COMMAND * 2
-
+/*
 /datum/armament_entry/company_import/sol_defense/sidearm
 	subcategory = "Sidearms"
 	cost = PAYCHECK_COMMAND * 4
@@ -118,10 +118,10 @@
 
 /datum/armament_entry/company_import/sol_defense/longarm/sindano
 	item_type = /obj/item/gun/ballistic/automatic/sol_smg
-
+*/
 /datum/armament_entry/company_import/sol_defense/longarm/type213
 	item_type = /obj/item/gun/ballistic/automatic/type213
-
+/*
 /datum/armament_entry/company_import/sol_defense/longarm/br38
 	item_type = /obj/item/gun/ballistic/automatic/battle_rifle
 	cost = PAYCHECK_COMMAND * 8
@@ -145,7 +145,7 @@
 /* //
 datum/armament_entry/company_import/sol_defense/longarm/outomaties
 	item_type = /obj/item/gun/ballistic/automatic/sol_rifle/machinegun
-	cost = PAYCHECK_COMMAND * 23 
+	cost = PAYCHECK_COMMAND * 23
 */ //Commented out due to a severe lack of balance regarding it.
 
 /datum/armament_entry/company_import/sol_defense/longarm/kiboko
@@ -170,13 +170,13 @@ datum/armament_entry/company_import/sol_defense/longarm/outomaties
 
 /datum/armament_entry/company_import/sol_defense/magazines/br38
 	item_type = /obj/item/ammo_box/magazine/m38/empty
-
+*/
 /datum/armament_entry/company_import/sol_defense/magazines/kineticballs
 	item_type = /obj/item/ammo_box/magazine/kineticballs/starts_empty
 
 /datum/armament_entry/company_import/sol_defense/magazines/kineticballsbig
 	item_type = /obj/item/ammo_box/magazine/kineticballsbig/starts_empty
-
+/*
 /datum/armament_entry/company_import/sol_defense/magazines/sol_rifle_standard
 	item_type = /obj/item/ammo_box/magazine/c40sol_rifle/standard/starts_empty
 	cost = PAYCHECK_COMMAND
@@ -199,3 +199,4 @@ datum/armament_entry/company_import/sol_defense/longarm/outomaties
 	item_type = /obj/item/ammo_box/magazine/jager/large/empty
 	cost = PAYCHECK_CREW * 3
 	restricted = TRUE
+*/

--- a/modular_nova/modules/company_imports/code/armament_datums/sol_defense.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/sol_defense.dm
@@ -94,10 +94,10 @@
 
 /datum/armament_entry/company_import/sol_defense/sidearm/wespe
 	item_type = /obj/item/gun/ballistic/automatic/pistol/sol
-
+*/
 /datum/armament_entry/company_import/sol_defense/sidearm/type207
 	item_type = /obj/item/gun/ballistic/automatic/pistol/type207
-
+/*
 /datum/armament_entry/company_import/sol_defense/sidearm/skild
 	item_type = /obj/item/gun/ballistic/automatic/pistol/trappiste
 	cost = PAYCHECK_COMMAND * 6

--- a/modular_nova/modules/company_imports/code/armament_datums/vitezstvi_ammo.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/vitezstvi_ammo.dm
@@ -24,10 +24,10 @@
 /datum/armament_entry/company_import/vitezstvi/accessory
 	subcategory = "Weapon Accessories"
 	cost = PAYCHECK_COMMAND
-
+/*
 /datum/armament_entry/company_import/vitezstvi/accessory/suppressor
 	item_type = /obj/item/suppressor/standard
-
+*/
 /datum/armament_entry/company_import/vitezstvi/accessory/seclight
 	item_type = /obj/item/flashlight/seclite
 
@@ -53,7 +53,7 @@
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes
 	subcategory = "Ammunition Boxes"
 	cost = PAYCHECK_CREW
-
+/*
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes/peacekeeper_lethal
 	item_type = /obj/item/ammo_box/c9mm
 
@@ -62,10 +62,10 @@
 
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes/peacekeeper_ap
 	item_type = /obj/item/ammo_box/c9mm/ap
-
+*/
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes/peacekeeper_rubber
 	item_type = /obj/item/ammo_box/c9mm/rubber
-
+/*
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes/auto10mm_lethal
 	item_type = /obj/item/ammo_box/c10mm
 
@@ -122,10 +122,10 @@
 
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes/trappiste585_incendiary
 	item_type = /obj/item/ammo_box/c585trappiste/incendiary
-
+*/
 /datum/armament_entry/company_import/vitezstvi/ammo_boxes/kineticballs
 	item_type = /obj/item/ammo_box/advanced/kineticballs
-
+/*
 // Revolver speedloaders
 
 /datum/armament_entry/company_import/vitezstvi/speedloader
@@ -202,3 +202,4 @@
 /datum/armament_entry/company_import/vitezstvi/grenade_shells/phosphor
 	item_type = /obj/item/ammo_box/c980grenade/shrapnel/phosphor
 	restricted = TRUE
+*/

--- a/modular_nova/modules/modular_weapons/code/cargo_crates/surplus_crates.dm
+++ b/modular_nova/modules/modular_weapons/code/cargo_crates/surplus_crates.dm
@@ -24,7 +24,7 @@
 	desc = "A collection of surplus equipment sourced from the Coalition of Independent Nations' military stockpiles. \
 	Likely to contain old and outdated equipment, as is the nature of surplus."
 	contraband = TRUE
-	cost = CARGO_CRATE_VALUE * 20
+	cost = CARGO_CRATE_VALUE * 10
 	contains = list(
 		// Clothing
 		/obj/item/clothing/under/syndicate/rus_army/cin_surplus/random_color = ITEM_WEIGHT_CLOTHING,
@@ -43,6 +43,7 @@
 		/obj/item/clothing/head/helmet/nri_police = ITEM_WEIGHT_ARMOR,
 		/obj/item/clothing/suit/armor/vest/nri_police = ITEM_WEIGHT_ARMOR,
 		// Weapons
+		/*
 		/obj/item/gun/ballistic/revolver/shotgun_revolver = ITEM_WEIGHT_GUN_COMMON,
 		/obj/item/gun/ballistic/automatic/pistol/plasma_thrower = ITEM_WEIGHT_GUN_COMMON,
 		/obj/item/gun/ballistic/automatic/pistol/plasma_marksman = ITEM_WEIGHT_GUN_COMMON,
@@ -63,6 +64,7 @@
 		/obj/item/ammo_box/strilka310 = ITEM_WEIGHT_AMMO_SINGLE,
 		/obj/item/ammo_box/magazine/lanca/spawns_empty = ITEM_WEIGHT_AMMO_SINGLE,
 		/obj/item/ammo_box/magazine/wylom = ITEM_WEIGHT_AMMO_SINGLE,
+		*/
 		// Other items
 		/obj/item/sign/flag/nri = ITEM_WEIGHT_MISC,
 		/obj/item/trench_tool = ITEM_WEIGHT_MISC,


### PR DESCRIPTION

## About The Pull Request

This is a test for the server to receive feedback on weapons freely available to crew, we'll TM this for a couple of days then post a survery after. 

Opting to leave in the self defense weapons, and melee ones for the test period

## How This Contributes To The Nova Sector Roleplay Experience

The vocal annoyance with the ability to easily get weapons is getting harder to ignore, and in a realistic RP setting you would never be able to purchase these in a pressurized space station to begin with. It compounded with suggestions to balance changes that had to factor in 'is the station armed from cargo' rather than not having to worry about that.

Making lethal weapons a rarity again will let us see how crew re-adapt to a more normal server environment, giving traitors a better round at hostages or general intimidation since the cat in atmos wont pull a shotgun out of her cat pocket and blow his face off.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/1018f419-3396-4825-86c5-f5c8293cdfbc)

![image](https://github.com/user-attachments/assets/578c201e-c1c0-45eb-985f-19e3466a2cc9)

</details>

## Changelog
:cl:

/:cl:
