### PR TITLE
optional limited mentoring books

### DIFF
--- a/modular_nova/modules/mentoring/mentoring.dm
+++ b/modular_nova/modules/mentoring/mentoring.dm
@@ -32,6 +32,12 @@
 	///if selected, will teach sign-language-- because it isn't a language...?
 	var/teach_sign = FALSE
 
+	/// whether the book should have a limited amount of uses
+	var/limit_uses = FALSE
+
+	/// if limit_use is true, how many times should we be able to be used before disappearing
+	var/allowed_uses = 1
+
 	///the list of sentences sent to the author as they write the book
 	var/static/list/writing_sentences = list(
 		"You philosophize the pedagogical approach for this term...",
@@ -51,17 +57,11 @@
 		"You jot down some notes in the book, then scribble it out...",
 	)
 
-/obj/item/mentoring_book/Initialize(mapload)
+/obj/item/mentoring_book/limited
+	limit_uses = TRUE
+
+/obj/item/mentoring_book/examine(mob/user)
 	. = ..()
-	RegisterSignal(src, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
-
-/obj/item/mentoring_book/Destroy(force)
-	UnregisterSignal(src, COMSIG_ATOM_EXAMINE)
-	return ..()
-
-/obj/item/mentoring_book/proc/on_examine(datum/source, mob/user, list/examine_list)
-	SIGNAL_HANDLER
-
 	var/level_name
 	if(author_level)
 		switch(author_level)
@@ -81,15 +81,31 @@
 				level_name = "master"
 
 	if(taught_skill)
-		examine_list += "This book can teach you to become a(n) [level_name] [initial(taught_skill.title)]."
+		. += span_notice("This book can teach you to become a(n) [level_name] [initial(taught_skill.title)].")
 
 	if(taught_language)
-		examine_list += "This book can teach you to become fluent in [initial(taught_language.name)]."
+		. += span_notice("This book can teach you to become fluent in [initial(taught_language.name)].")
 
 	if(teach_sign)
-		examine_list += "This book can teach you sign language."
+		. += span_notice("This book can teach you sign language.")
 
-	examine_list += "Using a pen will allow you to impart your knowledge about language or skills to the book!"
+	. += span_notice("Using a pen will allow you to impart your knowledge about language or skills to the book!")
+
+	if(limit_uses)
+		. += span_warning("This book can only be used [allowed_uses] more time(s)!")
+
+/// will lower the use by one (if allowed) and check if it should be destroyed
+/obj/item/mentoring_book/proc/check_limit(mob/user)
+	if(!limit_uses)
+		return
+
+	allowed_uses -= 1
+	if(allowed_uses > 0)
+		to_chat(user, span_notice("[src] looks a little more damaged..."))
+		return
+
+	to_chat(user, span_warning("[src] tears and breaks!"))
+	qdel(src)
 
 /// when given a message and an amount of time, requires the user to stand still while receiving the message
 /obj/item/mentoring_book/proc/timed_sentence(mob/user, var/sent_message, var/time_amount)
@@ -122,12 +138,14 @@
 		var/learning_exp = 10
 		while(user_level < author_level)
 			if(!timed_sentence(user, pick(learning_sentences), 6 SECONDS))
+				check_limit(user)
 				return
 			user.mind?.adjust_experience(taught_skill, learning_exp)
 			user_level = user.mind?.get_skill_level(taught_skill)
 			learning_exp += 5 //this means that it won't take 40 minutes to get from beginner to master... I definitely wouldn't know ;-;
 
 		to_chat(user, span_notice("You have learned all you can learn from [src]."))
+		check_limit(user)
 		return
 
 	if(taught_language)
@@ -142,6 +160,7 @@
 		user.remove_blocked_language(taught_language, source = LANGUAGE_BABEL)
 		user.grant_language(taught_language, source = LANGUAGE_BABEL)
 		to_chat(user, span_notice("You have fully learned [initial(taught_language.name)]"))
+		check_limit(user)
 		return
 
 	if(teach_sign)
@@ -157,6 +176,7 @@
 
 			living_user.add_quirk(/datum/quirk/item_quirk/signer)
 			to_chat(living_user, span_notice("You have fully learned sign language!"))
+			check_limit(user)
 			return
 
 		else
@@ -170,6 +190,7 @@
 
 			user.AddComponent(/datum/component/sign_language)
 			to_chat(user, span_notice("You have fully learned sign language!"))
+			check_limit(user)
 			return
 
 	return ..()
@@ -258,6 +279,8 @@
 				return ITEM_INTERACT_SUCCESS
 
 	return ..()
+
+/obj/item/mentoring_book
 
 #undef AUTHOR_LEVEL_NOVICE
 #undef AUTHOR_LEVEL_APPRENTICE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds a new variable to mentoring books that allow people to create subtypes that will be destroyed after a certain amount of uses
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
this allows other contributors, both code and mapping, to make limited mentoring books for whatever they want (such as ruin rewards, or whatever). More flexible content allows for more variety and less of the same gameplay loop.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/257b8098-fd86-4119-a7a9-d00052710524)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: added a limited version of the mentoring book, so other contributors (and stuff in game) can modify it for whatever reason
code: removed the examine signal and just used the default examine proc... I should have done that before
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
