### PR TITLE
ashie ritual tweaks

### DIFF
--- a/modular_nova/modules/ashwalkers/code/effects/ash_rituals.dm
+++ b/modular_nova/modules/ashwalkers/code/effects/ash_rituals.dm
@@ -260,34 +260,35 @@
 /// Summon specific lavaland critter
 /datum/ash_ritual/summon_lavaland_creature
 	name = "Summon Lavaland Creature"
-	desc = "Summons a random, wild monster from another region in space."
+	desc = "Summons two random, wild monsters from another region in space."
 	required_components = list(
 		"north" = /obj/item/organ/monster_core/regenerative_core,
-		"south" = /mob/living/basic/mining/ice_whelp,
+		"south" = /obj/item/stack/sheet/animalhide/ashdrake,
 		"east" = /obj/item/stack/ore/bluespace_crystal,
 		"west" = /obj/item/stack/ore/bluespace_crystal,
 	)
 	consumed_components = list(
 		/obj/item/organ/monster_core/regenerative_core,
-		/mob/living/basic/mining/ice_whelp,
-		/obj/item/stack/ore/bluespace_crystal,
+		/obj/item/stack/sheet/animalhide/ashdrake,
 	)
 
 /datum/ash_ritual/summon_lavaland_creature/ritual_success(obj/effect/ash_rune/success_rune)
 	. = ..()
-	var/mob_type = pick(
-		/mob/living/basic/mining/goliath,
-		/mob/living/basic/mining/legion,
-		/mob/living/basic/mining/brimdemon,
-		/mob/living/basic/mining/watcher,
-		/mob/living/basic/mining/lobstrosity/lava,
-	)
-	new mob_type(success_rune.loc)
+	for(var/iterate in 1 to 2)
+		var/mob_type = pick(
+			/mob/living/basic/mining/goliath,
+			/mob/living/basic/mining/legion,
+			/mob/living/basic/mining/brimdemon,
+			/mob/living/basic/mining/watcher,
+			/mob/living/basic/mining/lobstrosity/lava,
+			/mob/living/basic/mining/bileworm,
+		)
+		new mob_type(success_rune.loc)
 
 /// Colder versions of critters to summon
 /datum/ash_ritual/summon_icemoon_creature
 	name = "Summon Icemoon Creature"
-	desc = "Summons a random, wild monster from another region in space."
+	desc = "Summons two random, wild monsters from another region in space."
 	required_components = list(
 		"north" = /obj/item/organ/monster_core/regenerative_core,
 		"south" = /obj/item/food/grown/surik,
@@ -297,19 +298,19 @@
 	consumed_components = list(
 		/obj/item/organ/monster_core/regenerative_core,
 		/obj/item/food/grown/surik,
-		/obj/item/stack/ore/bluespace_crystal,
 	)
 
 /datum/ash_ritual/summon_icemoon_creature/ritual_success(obj/effect/ash_rune/success_rune)
 	. = ..()
-	var/mob_type = pick(
-		/mob/living/basic/mining/ice_demon,
-		/mob/living/basic/mining/ice_whelp,
-		/mob/living/basic/mining/lobstrosity,
-		/mob/living/simple_animal/hostile/asteroid/polarbear,
-		/mob/living/basic/mining/wolf,
-	)
-	new mob_type(success_rune.loc)
+	for(var/iterate in 1 to 2)
+		var/mob_type = pick(
+			/mob/living/basic/mining/ice_demon,
+			/mob/living/basic/mining/ice_whelp,
+			/mob/living/basic/mining/lobstrosity,
+			/mob/living/simple_animal/hostile/asteroid/polarbear,
+			/mob/living/basic/mining/wolf,
+		)
+		new mob_type(success_rune.loc)
 
 /// Xenobio Ritual
 /datum/ash_ritual/uncover_rocks
@@ -322,7 +323,6 @@
 		"west" = /obj/item/xenoarch/useless_relic,
 	)
 	consumed_components = list(
-		/obj/item/stack/ore/bluespace_crystal,
 		/obj/item/stack/sheet/animalhide/goliath_hide,
 		/obj/item/xenoarch/useless_relic,
 	)
@@ -407,7 +407,7 @@
 
 	var/list/yes_voters = SSpolling.poll_candidates("Do you wish to banish [find_banished]?", poll_time = 10 SECONDS, group = asked_voters)
 
-	if(length(yes_voters) < length(asked_voters))
+	if(length(yes_voters) <= (length(asked_voters) * 0.5)) // you need a simple majority (ex: 10 people vote, need 6)
 		find_banished.balloon_alert_to_viewers("banishment failed!")
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
if a ritual was using a bluespace crystal, I made the choice to not have it consume the bluespace crystal-- it is a limited material and desired from both ashies and crew.
changed the summon lavaland monsters to be the hide of a whelp-- because some time ago, they made it to where you couldn't drag whelps, which the whole body was an ingredient to the ritual.
changed the summon lavaland monsters to include the bileworm-- because they are limited and don't have a tendril
changed the summon lavaland and icemoon to summon two of the creatures instead of one
banishment now only requires a simple majority-- used to require 100% agreement from everyone
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
you actually couldn't complete the summon lavaland creature because it required a mob that could no longer be dragged, so you'd need to kill it on the correct tile-- changing it to the hide of the whelp is better for this.
because there is a ritual that uses the bileworm's spewlet, I made bileworms summonable from the lavaland creature ritual-- which should help everyone (ashies and crew)
with limited bs crystals, it isn't fun being limited in the amount of times you can do the ritual-- also, with bs crystals not being consumed, it allows people to steal the crystals from the ashies
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
screen shot was prior to when I changed to the hide
![image](https://github.com/user-attachments/assets/137cb5b1-42fc-4669-86c9-c5a6430e4145)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: ashies can now actually complete the "summon lavaland creatures" ritual
fix: the banishment ritual now actually requires a simple majority (rather than requiring the whole tribe to vote yes)
qol: all current ashie rituals no longer consume the bs crystal component-- still required to be present
balance: summon lavaland/icemoon creatures now summon two instead of one
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
