### PR TITLE
Fixes silicon flavor text appearing wrong

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/species_features.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/species_features.tsx
@@ -47,14 +47,14 @@ export const flavor_text_nsfw: Feature<string> = {
 };
 
 export const silicon_flavor_text: Feature<string> = {
-  name: 'Flavor Text (Silicon, NSFW)',
+  name: 'Flavor Text (Silicon)',
   description:
     "Only appears if you're playing as a borg/AI. Do not put sexual things in here—move those to Flavor Text (Silicon, NSFW).",
   component: FeatureTextInput,
 };
 
 export const silicon_flavor_text_nsfw: Feature<string> = {
-  name: 'NSFW Flavor Text (Silicon)',
+  name: 'Flavor Text (Silicon, NSFW)',
   description:
     'Same as Silicon Flavor Text but requires you to click a tab to view.',
   component: FeatureTextInput,


### PR DESCRIPTION

## About The Pull Request
aw man
![image](https://github.com/user-attachments/assets/999ec2f5-001f-4ba6-9f9c-eef28a4fc94c)
## How This Contributes To The Nova Sector Roleplay Experience
No confusion
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: Fixed both silicon flavor text fields in preferences appearing as NSFW
/:cl:
