### PR TITLE
[Modular][Feature] Hearthkin relic salvage.

### DIFF
--- a/modular_nova/modules/primitive_catgirls/code/spawner.dm
+++ b/modular_nova/modules/primitive_catgirls/code/spawner.dm
@@ -301,6 +301,7 @@
 		/datum/crafting_recipe/runic_greatsword,
 		/datum/crafting_recipe/runic_greataxe,
 		/datum/crafting_recipe/runic_spear,
+		/datum/crafting_recipe/hearthkin_ship_fragment_inactive,
 	)
 
 /datum/antagonist/primitive_catgirl/Destroy()

--- a/modular_nova/modules/tribal_extended/code/recipes.dm
+++ b/modular_nova/modules/tribal_extended/code/recipes.dm
@@ -148,3 +148,14 @@
 	)
 	tool_behaviors = list(TOOL_HAMMER)
 	result = /obj/item/kinetic_crusher/spear/runic_spear
+
+/datum/crafting_recipe/hearthkin_ship_fragment_inactive
+	name = "Useless Relic Salvage"
+	category = CAT_MISC
+	//recipe given to hearthkins as part of their spawner/team setting
+	crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_MUST_BE_LEARNED
+	reqs = list(
+		/obj/item/xenoarch/useless_relic = 10,
+	)
+	tool_behaviors = list(TOOL_HAMMER)
+	result = /obj/item/hearthkin_ship_fragment_inactive


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As per popular request, adds a Hearthkin only recipe letting them turn 10 useless relics into an inactive fragment of the Stjarndrakkr. You can imagine it as them salvaging bits of old icecat tech from those relics and assembling those into something that works.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
In short, this adds a pity system to getting one of these fragments. Avoiding situation where an Hearthkin who really wants one spend more than half of the round trying to get one.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![Craft Exists](https://github.com/user-attachments/assets/f187d8f9-e4a6-4089-b003-647c39f41a74)

https://github.com/user-attachments/assets/669f3404-90c8-4448-bb7c-d02a8f46f0c6


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added a new Hearthkin only recipe "Useless Relic Salvage". Turn 10 useless relic into an inactive Stjarndrakkr fragment.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
