### PR TITLE
Fixes security belt

### DIFF
--- a/modular_nova/master_files/code/game/objects/items/storage/belt.dm
+++ b/modular_nova/master_files/code/game/objects/items/storage/belt.dm
@@ -1,9 +1,5 @@
-/obj/item/storage/belt/security
-	// new storage type designed to stop carrying multiple guns
-	storage_type = /datum/storage/secbelt
-
-/// type restricted storage datum to stop hoarding 5 guns
-/datum/storage/secbelt
+/// restricting security storage datum to prevent hoarding multiple weapons
+/datum/storage/security_belt
 	/// types we're stopping ourselves from holding multiple of
 	var/list/limited_hold_types = list(
 		/obj/item/gun,
@@ -14,17 +10,17 @@
 	/// how many restricted items do we want to keep, at maximum, in this belt (2, ideally, for a gun and baton, theoretically)
 	var/max_limited_store = 2
 
-/datum/storage/secbelt/handle_enter(datum/source, obj/item/arrived)
+/datum/storage/security_belt/handle_enter(datum/source, obj/item/arrived)
 	. = ..()
 	if(is_type_in_list(arrived, limited_hold_types))
 		limited_held++
 
-/datum/storage/secbelt/handle_exit(datum/source, obj/item/gone)
+/datum/storage/security_belt/handle_exit(datum/source, obj/item/gone)
 	. = ..()
 	if(is_type_in_list(gone, limited_hold_types))
 		limited_held = max(limited_held - 1, 0)
 
-/datum/storage/secbelt/can_insert(obj/item/to_insert, mob/user, messages, force)
+/datum/storage/security_belt/can_insert(obj/item/to_insert, mob/user, messages, force)
 	. = ..()
 	if(is_type_in_list(to_insert, limited_hold_types) && (limited_held >= max_limited_store))
 		user.balloon_alert(user, "no suitable space!")


### PR DESCRIPTION
## About The Pull Request
Security belt currently has 7 slots instead of 5 and seemed to be unrestricted in what it could hold so I've changed our modular ``secbelt`` storage datum to instead make use of TG's existing ``security_belt`` storage datum while still keeping the gun belt restrictions in place.

Security webbings are unaffected.


## How This Contributes To The Nova Sector Roleplay Experience
Fixes what appears to be an oversight as regular security belts can usually only carry 5 security items at a time (with webbing carrying more)

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
 
![dreamseeker_LqSdMBv8BS](https://github.com/user-attachments/assets/16ba5b5f-0516-45a6-944a-93a43f7f11fd)

![dreamseeker_iYfgdaiVRG](https://github.com/user-attachments/assets/1cde19bb-87de-440f-b1b6-71558b01478d)

</details>

## Changelog
:cl: Hardly
fix: fixes security belt so it has 5 slots and item restrictions again
/:cl:
