### PR TITLE
Tamaya Donator Item Fix

### DIFF
--- a/modular_nova/modules/ahabs_spear/code/trophies_misc.dm
+++ b/modular_nova/modules/ahabs_spear/code/trophies_misc.dm
@@ -14,6 +14,7 @@
 	name = "crusher Ahab's harpoon retool kit"
 	desc = "A toolkit for changing the crusher's appearance without affecting the device's function. This one will make it look like Ahab's harpoon, the weapon of legends."
 	icon = 'modular_nova/modules/ahabs_spear/icons/ahabs_spear.dmi'
+	retool_projectile_icon_file = 'modular_nova/modules/ahabs_spear/icons/projectiles.dmi'
 	icon_state = "ahab_retool"
 	forced_skin = /datum/crusher_skin/ahabs_harpoon
 


### PR DESCRIPTION
## About The Pull Request

As of [#90742](https://github.com/tgstation/tgstation/pull/90742) being mirrored the `retool_projectile_icon_file` var got moved to the retool kit item and when things were being updated it was not adjusted accordingly and as a result the  `retool_projectile_icon_file` var never got altered for this item. Invisible projectiles are less than ideal.

## How This Contributes To The Nova Sector Roleplay Experience

Donator gets their item working correctly again.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
Before:

![image](https://github.com/user-attachments/assets/d1670b27-55ba-4d0b-b56b-b2eb532147a1)

After:

![image](https://github.com/user-attachments/assets/8b44f27a-dd43-463a-b094-2de8aa0d999a)



</details>

## Changelog

:cl: Chestlet
fix: Tamaya donator item has a projectile icon again.
/:cl: