### PR TITLE
Adds Two New Non-Suspicious D20s To The Loadout

### DIFF
--- a/modular_nova/master_files/code/game/objects/items/dice.dm
+++ b/modular_nova/master_files/code/game/objects/items/dice.dm
@@ -1,0 +1,9 @@
+/obj/item/dice/d20/nat1
+	rigged = DICE_BASICALLY_RIGGED
+	rigged_value = 1
+	special_desc = "There's a bit of extra heft to this die."
+
+/obj/item/dice/d20/nat20
+	rigged = DICE_BASICALLY_RIGGED
+	rigged_value = 20
+	special_desc = /obj/item/dice/d20/nat1::special_desc

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_toys.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_toys.dm
@@ -374,6 +374,14 @@
 	name = "D20"
 	item_path = /obj/item/dice/d20
 
+/datum/loadout_item/toys/dice/d20_weighted_low
+	name = "D20 (Weighted, Low)"
+	item_path = /obj/item/dice/d20/nat1
+
+/datum/loadout_item/toys/dice/d20_weighted_high
+	name = "D20 (Weighted, High)"
+	item_path = /obj/item/dice/d20/nat20
+
 /datum/loadout_item/toys/dice/d100
 	name = "D100"
 	item_path = /obj/item/dice/d100

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6850,6 +6850,7 @@
 #include "modular_nova\master_files\code\game\objects\items\AI_modules.dm"
 #include "modular_nova\master_files\code\game\objects\items\cards_ids.dm"
 #include "modular_nova\master_files\code\game\objects\items\cosmetics.dm"
+#include "modular_nova\master_files\code\game\objects\items\dice.dm"
 #include "modular_nova\master_files\code\game\objects\items\dualsaber.dm"
 #include "modular_nova\master_files\code\game\objects\items\dyekit.dm"
 #include "modular_nova\master_files\code\game\objects\items\emags.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds two new D20s available through the loadout only; absolutely normal and with no questionable qualities. *Were* they to have any questionable qualities; such as a weight placed inside to ensure more regularly rolling towards a certain number; completely hypothetically - one would target `1` most often, the other `20`, though it would not be guaranteed.

Of course; they're completely normal and can be used as normal. Because they're normal.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
I have a character who's got a dice just like these. Completely normal dice. You'll never guess which of those hypotheticals she more aligns with.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
In a moment; I'm compiling RN. I don't see any reason it wouldn't and I was actively in a call making a joke about making this PR ASAP so I'm posting it before I have that proof.
<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Weighted D20s are now available in the loadout! They're not guaranteed winners, but skew results fairly heavily.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
