### PR TITLE
Janitorial work at its finest (code cleaning/organizing)

### DIFF
--- a/modular_nova/master_files/code/modules/clothing/base_clothes.dm
+++ b/modular_nova/master_files/code/modules/clothing/base_clothes.dm
@@ -4,32 +4,49 @@
 	var/icon/worn_icon_digi
 	/// The config type to use for greyscaled worn sprites for digitigrade characters. Both this and greyscale_colors must be assigned to work.
 	var/greyscale_config_worn_digi
+	/// Icon file for mob worn overlays, for characters with a muzzle sprite accessory.
+	var/worn_icon_muzzled
 	/// The config type to use for greyscaled worn sprites for characters with a muzzle sprite accessory. Both this and greyscale_colors must be assigned to work.
 	var/greyscale_config_worn_muzzled
+
+	/// Monkey
+
 	/// Icon file for mob worn overlays, if the user is a monkey.
 	var/icon/worn_icon_monkey
 	/// The config type to use for greyscale worn sprites for monkeys. Both this and greyscale_colors must be assigned to work.
 	var/greyscale_config_worn_monkey
-	/// Icon file for mob worn overlays, if the user is a vox.
-	var/icon/worn_icon_vox
-	/// Icon file for mob worn overlays, if the user is a better vox.
-	var/icon/worn_icon_better_vox
+
+	/// Teshari
+
 	/// Icon file for mob worn overlays, if the user is a teshari.
 	var/icon/worn_icon_teshari
 	/// The config type to use for greyscaled worn sprites for Teshari characters. Both this and greyscale_colors must be assigned to work.
 	var/greyscale_config_worn_teshari
+
+	/// Vox
+
+	/// Icon file for mob worn overlays, if the user is a vox.
+	var/icon/worn_icon_vox
+	/// Icon file for mob worn overlays, if the user is a better vox.
+	var/icon/worn_icon_better_vox
 	/// The config type to use for greyscaled worn sprites for vox characters. Both this and greyscale_colors must be assigned to work.
 	var/greyscale_config_worn_vox
 	/// The config type to use for greyscaled worn sprites for vox primalis characters. Both this and greyscale_colors must be assigned to work.
 	var/greyscale_config_worn_better_vox
 
-	var/worn_icon_taur_snake
-	var/worn_icon_taur_paw
-	var/worn_icon_taur_hoof
-	var/worn_icon_muzzled
+	/// Taurs
 
+	/// Icon file for mob worn overlays, for characters with a snake taur sprite accessory.
+	var/worn_icon_taur_snake
+	/// Icon file for mob worn overlays, for characters with a paw'd taur sprite accessory.
+	var/worn_icon_taur_paw
+	/// Icon file for mob worn overlays, for characters with a hoof'd taur sprite accessory.
+	var/worn_icon_taur_hoof
+	///  The config type to use for greyscaled worn sprites for characters using taur snake sprite accessory. Both this and greyscale_colors must be assigned to work.
 	var/greyscale_config_worn_taur_snake
+	///  The config type to use for greyscaled worn sprites for characters using taur paws sprite accessory. Both this and greyscale_colors must be assigned to work.
 	var/greyscale_config_worn_taur_paw
+	///  The config type to use for greyscaled worn sprites for characters using taur hoofs sprite accessory. Both this and greyscale_colors must be assigned to work.
 	var/greyscale_config_worn_taur_hoof
 
 	/// Used for BODYSHAPE_CUSTOM: Needs to follow this syntax: a list() with the x and y coordinates of the pixel you want to get the color from. Colors are filled in as GAGs values for fallback.


### PR DESCRIPTION
## About The Pull Request

Cleans-the-code-for-maintainers and contributors and adds missing documentation.

## How This Contributes To The Nova Sector Roleplay Experience

Physically it wont do shit for the main players as a whole, but will clean up enough for other contributors and maintainers to maybe enjoy

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: moved code around the nova modular file "base_clothes.dm" to make it look more cleaner, coherent and keeping everything together.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
