### PR TITLE
[Staff Request] [Balance] Mining Blood Jaunt rework, Mining Crushers adjustments, SEVA exploit fixed

### DIFF
--- a/code/modules/unit_tests/kinetic_crusher.dm
+++ b/code/modules/unit_tests/kinetic_crusher.dm
@@ -4,6 +4,7 @@
 /datum/unit_test/crusher_projectile/Run()
 	var/mob/living/carbon/human/consistent/attacker = EASY_ALLOCATE()
 	var/obj/item/kinetic_crusher/crusher = EASY_ALLOCATE()
+	crusher.allowed_areas_to_fire = list(/area) // NOVA EDIT ADDITION - Our crushers are limited by default in their area to shoot, so this makes the testing crusher able to shoot anywhere.
 
 	attacker.put_in_active_hand(crusher, forced = TRUE)
 	crusher.attack_self(attacker) // wields the crusher

--- a/modular_nova/modules/clothing_improvements/code/functional_toggle.dm
+++ b/modular_nova/modules/clothing_improvements/code/functional_toggle.dm
@@ -108,3 +108,6 @@ Use CTRL + SHIFT + LEFT CLICK to turn them on and off.
 
 /obj/item/clothing/suit/utility/
 	only_functional = TRUE
+
+/obj/item/clothing/suit/hooded/seva
+	only_functional = TRUE

--- a/modular_nova/modules/mining_crushers/code/miningweapons.dm
+++ b/modular_nova/modules/mining_crushers/code/miningweapons.dm
@@ -19,7 +19,7 @@
 	if (!is_type_in_list(get_area(user), allowed_areas_to_fire))
 		user.balloon_alert(user, "destabilizer cannot be used in [get_area(user)]!")
 		return
-	. = ..()
+	return ..()
 
 /obj/item/kinetic_crusher/examine(mob/living/user)
 	. = ..()

--- a/modular_nova/modules/mining_crushers/code/miningweapons.dm
+++ b/modular_nova/modules/mining_crushers/code/miningweapons.dm
@@ -1,8 +1,31 @@
 /obj/item/kinetic_crusher
 	/// This var is used to imitate being weilded if it's one handed
 	var/acts_as_if_wielded
-	/// AHABS_SPEAR Module Change - This var is used by retool kits when changing the crusher's projectile appearance
+	/// This var is used by retool kits when changing the crusher's projectile appearance
 	var/projectile_icon_file = 'icons/obj/weapons/guns/projectiles.dmi'
+	/// This var is used to list the areas where the destabilizer is allowed to shoot.
+	var/list/allowed_areas_to_fire = list(
+			/area/forestplanet,
+			/area/icemoon,
+			/area/lavaland,
+			/area/ocean/generated,
+			/area/ruin,
+			/area/mine,
+	)
+
+/obj/item/kinetic_crusher/fire_kinetic_blast(atom/target, mob/living/user, list/modifiers)
+	if(!istype(user))
+		return
+	if (!is_type_in_list(get_area(user), allowed_areas_to_fire))
+		user.balloon_alert(user, "destabilizer cannot be used in this area!")
+		return
+	. = ..()
+
+/obj/item/kinetic_crusher/examine(mob/living/user)
+	. = ..()
+	. += span_notice("The destabilizer only works on planetary surfaces, and specially stabilized mining areas.")
+	. += span_notice("The destabilizer can be enhanced by pushing it from behind while using a style meter, this will increase the \
+					destablization power and make backstab count from any direction")
 
 /obj/item/kinetic_crusher/machete
 	icon = 'modular_nova/modules/mining_crushers/icons/items_and_weapons.dmi'

--- a/modular_nova/modules/mining_crushers/code/miningweapons.dm
+++ b/modular_nova/modules/mining_crushers/code/miningweapons.dm
@@ -17,7 +17,7 @@
 	if(!istype(user))
 		return
 	if (!is_type_in_list(get_area(user), allowed_areas_to_fire))
-		user.balloon_alert(user, "destabilizer cannot be used in this area!")
+		user.balloon_alert(user, "destabilizer cannot be used in [get_area(user)]!")
 		return
 	. = ..()
 

--- a/modular_nova/modules/mining_crushers/code/miningweapons.dm
+++ b/modular_nova/modules/mining_crushers/code/miningweapons.dm
@@ -25,7 +25,7 @@
 	. = ..()
 	. += span_notice("The destabilizer only works on planetary surfaces, and specially stabilized mining areas.")
 	. += span_notice("The destabilizer can be enhanced by pushing it from behind while using a style meter, this will increase the \
-					destablization power and make backstab count from any direction")
+					destablization power and make backstab count from any direction.")
 
 /obj/item/kinetic_crusher/machete
 	icon = 'modular_nova/modules/mining_crushers/icons/items_and_weapons.dmi'

--- a/modular_nova/modules/mining_pka/code/kinetic_accelerator.dm
+++ b/modular_nova/modules/mining_pka/code/kinetic_accelerator.dm
@@ -74,12 +74,14 @@
 	special_desc = "During the crusher design pizza party, one member of the Mining Research and Development team brought out a real riot shotgun, and killed three \
 	other research members with one blast. The MR&D Director immediately thought of a genius idea, creating the proto-kinetic shotgun moments later, which he \
 	immediately used to execute the research member who brought the real shotgun. The proto-kinetic shotgun trades off some mod capacity and cooldown in favor \
-	of firing three shots at once with reduce range and power. The total damage of all three shots is higher than a regular PKA but the individual shots are weaker."
+	of firing three shots at once with reduce range and power. The total damage of all three shots is higher than a regular PKA but the individual shots are weaker. \
+	Looks like you need both hands to use it effectively."
 	icon = 'modular_nova/modules/mining_pka/icons/pka.dmi'
 	icon_state = "kineticshotgun"
 	base_icon_state = "kineticshotgun"
 	inhand_icon_state = "kineticgun"
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic/shotgun)
+	weapon_weight = WEAPON_HEAVY
 	max_mod_capacity = 65
 	randomspread = 0
 

--- a/modular_nova/modules/mining_pka/code/modkit.dm
+++ b/modular_nova/modules/mining_pka/code/modkit.dm
@@ -1,2 +1,20 @@
+/obj/item/borg/upgrade/modkit
+	/// Variable to keep in check the max number of cooldown modkits.
+	var/max_same = 99
+
+/obj/item/borg/upgrade/modkit/cooldown
+	max_same = 4
+
+/obj/item/borg/upgrade/modkit/install(obj/item/gun/energy/recharge/kinetic_accelerator/KA, mob/user, transfer_to_loc = TRUE)
+	/// Override so we limit the number of cooldown modkits to our value.
+	var/mk_count = 0
+	for (var/obj/item/borg/upgrade/modkit/modkit_aux in KA.modkits)
+		if (modkit_aux.type == type)
+			mk_count++
+	if (mk_count >= max_same)
+		to_chat(user, span_notice("You cannot install more than [max_same] of [name] at the same time!"))
+		return FALSE
+	. = ..()
+
 /obj/item/borg/upgrade/modkit/damage/modify_projectile(obj/projectile/kinetic/kinetic_projectile)
 	kinetic_projectile.damage += modifier*kinetic_projectile.mod_mult

--- a/modular_nova/modules/mining_pka/code/projectiles.dm
+++ b/modular_nova/modules/mining_pka/code/projectiles.dm
@@ -48,7 +48,6 @@
 /obj/projectile/kinetic/shotgun
 	name = "split kinetic force"
 	damage = 20
-	mod_mult = 0.5
 
 /obj/projectile/kinetic/glock
 	name = "light kinetic force"

--- a/modular_nova/modules/morewizardstuffs/spells/bloodcrawl_potion.dm
+++ b/modular_nova/modules/morewizardstuffs/spells/bloodcrawl_potion.dm
@@ -11,7 +11,7 @@
 	user.log_message("learned the spell bloodcrawl (Mining) ([new_spell])", LOG_ATTACK, color="orange")
 	qdel(src)
 
-datum/action/cooldown/spell/jaunt/bloodcrawl
+/datum/action/cooldown/spell/jaunt/bloodcrawl
 	/// A list of allowed areas that the spell can be used in
 	var/list/allowed_areas = list(
 		/area,

--- a/modular_nova/modules/morewizardstuffs/spells/bloodcrawl_potion.dm
+++ b/modular_nova/modules/morewizardstuffs/spells/bloodcrawl_potion.dm
@@ -28,7 +28,7 @@ datum/action/cooldown/spell/jaunt/bloodcrawl
 		return FALSE
 	. = ..()
 
-datum/action/cooldown/spell/jaunt/bloodcrawl/mining
+/datum/action/cooldown/spell/jaunt/bloodcrawl/mining
 	/// Instant was a bit too much.
 	enter_blood_time = 2 SECONDS
 	failure_message = "This ability can only be used on planetary areas untainted by civilization!"

--- a/modular_nova/modules/morewizardstuffs/spells/bloodcrawl_potion.dm
+++ b/modular_nova/modules/morewizardstuffs/spells/bloodcrawl_potion.dm
@@ -6,7 +6,30 @@
 
 /obj/item/bloodcrawl_bottle/attack_self(mob/user)
 	to_chat(user, span_notice("You drink the contents of [src]."))
-	var/datum/action/cooldown/spell/jaunt/bloodcrawl/new_spell =  new(user)
+	var/datum/action/cooldown/spell/jaunt/bloodcrawl/mining/new_spell =  new(user)
 	new_spell.Grant(user)
-	user.log_message("learned the spell bloodcrawl ([new_spell])", LOG_ATTACK, color="orange")
+	user.log_message("learned the spell bloodcrawl (Limited) ([new_spell])", LOG_ATTACK, color="orange")
 	qdel(src)
+
+datum/action/cooldown/spell/jaunt/bloodcrawl
+	/// A list of allowed areas that the spell can be used in
+	var/list/allowed_areas = list(
+		/area,
+	)
+
+/datum/action/cooldown/spell/jaunt/bloodcrawl/can_cast_spell(feedback = TRUE)
+	if (!is_type_in_list(get_area(owner), allowed_areas))
+		if(feedback)
+			owner.balloon_alert(owner, "This spell cannot be used in this area!")
+		return FALSE
+	. = ..()
+
+datum/action/cooldown/spell/jaunt/bloodcrawl/mining
+	allowed_areas = list(
+			/area/forestplanet,
+			/area/icemoon,
+			/area/lavaland,
+			/area/ocean/generated,
+			/area/ruin,
+			/area/mine,
+	)

--- a/modular_nova/modules/morewizardstuffs/spells/bloodcrawl_potion.dm
+++ b/modular_nova/modules/morewizardstuffs/spells/bloodcrawl_potion.dm
@@ -29,6 +29,7 @@
 	. = ..()
 
 /datum/action/cooldown/spell/jaunt/bloodcrawl/mining
+	name = "Necropolis Blood Crawl"
 	/// Instant was a bit too much.
 	enter_blood_time = 2 SECONDS
 	failure_message = "This ability can only be used on planetary areas untainted by civilization!"

--- a/modular_nova/modules/morewizardstuffs/spells/bloodcrawl_potion.dm
+++ b/modular_nova/modules/morewizardstuffs/spells/bloodcrawl_potion.dm
@@ -16,11 +16,13 @@ datum/action/cooldown/spell/jaunt/bloodcrawl
 	var/list/allowed_areas = list(
 		/area,
 	)
+	/// A list of disallowed areas that the spell can't be used in
+	var/list/disallowed_areas = list()
 	/// Custom message we say to the user when they try to cast in the wrong area
 	var/failure_message = "This spell cannot be used in this area!"
 
 /datum/action/cooldown/spell/jaunt/bloodcrawl/can_cast_spell(feedback = TRUE)
-	if (!is_type_in_list(get_area(owner), allowed_areas))
+	if (!is_type_in_list(get_area(owner), allowed_areas) || is_type_in_list(get_area(owner), disallowed_areas))
 		if(feedback)
 			owner.balloon_alert(owner, failure_message)
 		return FALSE
@@ -29,7 +31,7 @@ datum/action/cooldown/spell/jaunt/bloodcrawl
 datum/action/cooldown/spell/jaunt/bloodcrawl/mining
 	/// Instant was a bit too much.
 	enter_blood_time = 2 SECONDS
-	failure_message = "This ability can only be used on planetary areas untainted by technology!"
+	failure_message = "This ability can only be used on planetary areas untainted by civilization!"
 	/// special snowflake jaunt type to eject on mining areas.
 	jaunt_type = /obj/effect/dummy/phased_mob/blood/mining
 	/// Mining areas we got.
@@ -40,11 +42,17 @@ datum/action/cooldown/spell/jaunt/bloodcrawl/mining
 			/area/ocean/generated,
 			/area/ruin,
 	)
+	disallowed_areas = list(
+			/area/ruin/interdyne_planetary_base,
+			/area/ruin/unpowered/ash_walkers,
+			/area/ruin/unpowered/primitive_catgirl_den,
+	)
 
 /obj/effect/dummy/phased_mob/blood
 	var/list/allowed_areas = list(
 		/area,
 	)
+	var/list/disallowed_areas = list()
 
 /obj/effect/dummy/phased_mob/blood/mining/
 	allowed_areas = list(
@@ -54,11 +62,16 @@ datum/action/cooldown/spell/jaunt/bloodcrawl/mining
 			/area/ocean/generated,
 			/area/ruin,
 	)
+	disallowed_areas = list(
+			/area/ruin/interdyne_planetary_base,
+			/area/ruin/unpowered/ash_walkers,
+			/area/ruin/unpowered/primitive_catgirl_den,
+	)
 
 /obj/effect/dummy/phased_mob/blood/relaymove(mob/living/user, direction)
 	var/turf/oldloc = loc
 	. = ..()
 	if(loc != oldloc)
-		if (!is_type_in_list(get_area(user), allowed_areas))
+		if (!is_type_in_list(get_area(user), allowed_areas) || is_type_in_list(get_area(user), disallowed_areas))
 			user.balloon_alert(user, "You are forcibly ejected!")
 			eject_jaunter(TRUE)


### PR DESCRIPTION
## About The Pull Request
Adds the SEVA suit to the list of things you cannot use in the neck.

Make mining crushers not able to use the destabilizers on areas that arent related to mining. 

Makes the Bubblegum Blood Potion grant a Mining variant of the Blood Jaunt.

Expanded base blood jaunt to allow for a white and black list of areas where it can be used. It cannot be used and will expel the user when not in a whitelisted area and when in a blacklisted area.

Mining Blood Jaunt can only be used in planetary areas, with interdyne and tribal areas excluded.

Mining Blood Jaunt has an activation time of 2 seconds, from instant.

Shotgun damage modkit nerf was reverted.

Shotgun was made heavy weight to be used in two hands rather than one, to prevent the PB cheese with two hands.

Code support to limit modkits of the same type was added.

Cooldown modkits were limited to 4 per weapon max, as its the max intended for upgraded pka's in tg code.

## How This Contributes To The Nova Sector Roleplay Experience
SEVA: It was being abused to put the seva in the neck and use an armor underneath to be inmune to the storm. bugs abuse is bad.

Following two were Headmin request:

- Mining crusher: It was being used to annihilate event related fauna instead of the intended mining fauna, it has becoming too common for miners to use overpowered gear to solo dismantle entire station threats.

- Blood Jaunt: A spell with 0 cooldown that lets you jaunt anywhere, that is, turning invisible, inmortal, untargetable, all seeing, faster than a ghost, practically a camera less, body less super AI unfettered by the laws of the living, to hear and see anything in the station at any time, traveling with all the gear you have that is not in your hands. I am surprised we are even letting it remain in the game with such level of abuse.

Requests by players:

- Shotgun nerf to damage kit was removed. Shotgun was made two handed instead.

- Cooldown PKA modkits were limited to a max of 4. Abuse was reported by using more than this amount.

<details>

![image](https://github.com/user-attachments/assets/5c6a9d15-42b7-46fb-944e-50df5ea125bd)

</details>


## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
Seva: It just works.

Crusher:
station:
![image](https://github.com/user-attachments/assets/6f0b42d3-9d97-4412-82eb-05c05bd512de)
Mining buildings:
![image](https://github.com/user-attachments/assets/f4964b65-9ed8-4213-99ea-fe452783e2be)
Mines:
![image](https://github.com/user-attachments/assets/e3c5f23e-e349-41af-a00a-f91185fdd509)
Bitrunning:
![image](https://github.com/user-attachments/assets/f6b5bfb4-d3b1-4ce3-a775-754a38d72f23)


Blood Crawl:

Snow Inside:
![image](https://github.com/user-attachments/assets/167140ed-0f7f-414d-b284-27b8a9c01578)
Snow Outside:
![image](https://github.com/user-attachments/assets/63e65609-445d-42a5-be20-becd14a94f54)
Snow Interdyne:
![image](https://github.com/user-attachments/assets/042f908c-34a2-49cc-bac6-00f0dfd9b37c)
Snow Heartkin:
![image](https://github.com/user-attachments/assets/4bcece60-ad8e-4f96-880d-0286d989aa83)


Lava Station: (Ignore the old text)
![image](https://github.com/user-attachments/assets/1512ef01-5632-414c-a55c-424b892d5483)
Lava Mining:
![image](https://github.com/user-attachments/assets/e5150990-1b54-4e33-be28-6b6ce89846bf)
Lava Shuttle: (Ignore the old text)
![image](https://github.com/user-attachments/assets/8532fa26-000c-4c6c-b3b5-23db9abca280)
Lava Mines:
![image](https://github.com/user-attachments/assets/06867c96-b696-43e7-bbc3-db6fdfb5d4e6)
Lava Interdyne:
![image](https://github.com/user-attachments/assets/f52ffea3-78dc-4f34-a957-a520f4a25a7f)
Lava Ashwalkers:
![image](https://github.com/user-attachments/assets/6514eac0-e23e-48eb-aefb-ba6e061a2c5f)

PKA's

Cooldown limit:

![image](https://github.com/user-attachments/assets/69f0aa9a-4f4f-4339-9b2e-c614965aa2c5)

![image](https://github.com/user-attachments/assets/44a51c9f-5941-4f8c-bdf1-e8e7d9497bf5)

![image](https://github.com/user-attachments/assets/373b9138-12c9-41ac-9898-d55fa05e42ef)

Shotgun two handed:

![image](https://github.com/user-attachments/assets/06447a05-5c59-4efc-b525-07c28f5568e4)

![image](https://github.com/user-attachments/assets/3ca314b3-7496-4b17-8691-ec866862492a)



</details>

## Changelog
:cl:
refactor: Added code to Blood Jaunt so it can use allowed and disallowed areas to it, disallowing its casting and jaunting off when not in the whitelisted areas or in the blacklisted ones. 
balance: Bubblegums Blood Jaunt reward was changed to a Mining subvariant. It has a 2 seconds cast time, and cannot be used in non planetary civilized areas. This means it can only be used in planets and ruins, but not in interdyne or tribal camps.
balance: Proto Kinetic Crushers destabilizers were deemed unsafe to use near humans! They will no longer be allowed to be fired in non mining approved areas, that it is, planetary areas, ruins and mining areas. 
fix: SEVA outfit cannot be used in the neck again, as this allowed people to be inmune to ash storms and use a different armor underneath.
balance: Shotgun Damage modkits un-nerfed, they now apply 10 damage extra to each pellet. Shotgun needs to be used with both hands, but not wielded.
balance: Cooldown PKA Modkits were limited to 4, to prevent cooldown cheese.
/:cl:
