### PR TITLE
[Fix] Prevents a exploit and loss of items with goody cases.

### DIFF
--- a/modular_nova/modules/cargo/code/goodies.dm
+++ b/modular_nova/modules/cargo/code/goodies.dm
@@ -4,7 +4,7 @@
 	atom_storage.max_total_storage = WEIGHT_CLASS_BULKY*35 //Assuming full case+manifest
 	atom_storage.max_slots = 35 //This is to avoid some instances of lost in shipment. In theory before hitting the limit you get a crate.
 	atom_storage.set_holdable(list(
-				/obj/item/paper,
+		/obj/item/paper,
 	))
 
 /*


### PR DESCRIPTION

## About The Pull Request
Made max_specific_storage tiny on the goody case, so when the compare begins no storage inside it is able to be used unless they are also tiny.

Made the slots and total storage of the goody case way over the need of its order cap, so that items that actually bring multiple items inside have less of a chance of overflowing and making items be lost in the ether/floor of the shuttle.

## How This Contributes To The Nova Sector Roleplay Experience
Prevents an exploit of being used to have nearly roundstart a virtually bluespace bag, which can be id locked.

Helps reduce the amount of incidents and cases where ordering items from cargo would result in some overflowing and being lost, due to certain orders having multiple items and being shipped through the goody case thanks to the storage changes.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/b608275c-af05-4e74-895d-fc1cd29cbb9d)


</details>

## Changelog
:cl:
fix: Fixed a cargo exploit with goody cases, no longer they will be used as cheap bluespace bags knock offs.
fix: Ideally reduces the amount of instances where items are lost when ordering things that have multiple cargo items.
/:cl:
