### PR TITLE
Adds baseturfs to the maintsroom

### DIFF
--- a/_maps/RandomZLevels/maintsroom.dmm
+++ b/_maps/RandomZLevels/maintsroom.dmm
@@ -9943,6 +9943,10 @@
 	},
 /turf/open/floor/carpet,
 /area/awaymission/caves/maintsroom)
+"Mr" = (
+/obj/effect/baseturf_helper/beach,
+/turf/closed/indestructible/reinforced,
+/area/awaymission/caves/maintsroom)
 "Ms" = (
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
@@ -38237,7 +38241,7 @@ jf
 jf
 "}
 (115,1,1) = {"
-jf
+Mr
 jf
 jf
 jf


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bug fix of the maintsrooms, makes space-ing it impossible

## How This Contributes To The Nova Sector Roleplay Experience

The maintsroom shouldn't space

## Proof of Testing

tested it on local, it works, no more space-ing from bombs or otherwise.

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

Adds one baseturf helper.

:cl:
fix: Added one baseturf helper to the maintsroom gateway.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
