### PR TITLE
Makes slimes check for BZ before moving when being spat out of a xenobiology console

### DIFF
--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -187,6 +187,7 @@ Due to keyboard shortcuts, the second one is not necessarily the remote eye's lo
 		stored_slime.visible_message(span_notice("[stored_slime] is spat out!"))
 		stored_slimes -= stored_slime
 		REMOVE_TRAIT(stored_slime, TRAIT_STASIS, XENOBIO_CONSOLE_TRAIT)
+		stored_slime.handle_slime_stasis(0) // NOVA EDIT ADDITION
 	xeno_hud.on_update_hud(LAZYLEN(stored_slimes), monkeys, max_slimes)
 
 ///Places every slime not controlled by a player into the internal storage, respecting its limits


### PR DESCRIPTION
## About The Pull Request

Makes slimes trigger `handle_slime_stasis` when being spat out by a xenobiology console

## How This Contributes To The Nova Sector Roleplay Experience

Slimes as-is can move in their containment area filled with BZ very briefly before their life tick and mess up your organization. There is no counter.
This makes it so you can actually organize your slimes properly without your grey slimes swapping places with your orange ones for the 5th time this shift

## Proof of Testing

Bit useless here since its literally 1 line of code and there's just the absence of it.

<details>
<summary>Video how they no longer move in stasis (yes its a youtube video because its 1.6 MB over github)</summary>

https://youtu.be/PahJbcYs0Fs

</details>

## Changelog

:cl:
fix: Slimes will no longer have a chance to move when being put in BZ enviroments via the xenobiology console
/:cl:
