### PR TITLE
shocking shocker. (maintsroom fix)

### DIFF
--- a/_maps/RandomZLevels/maintsroom.dmm
+++ b/_maps/RandomZLevels/maintsroom.dmm
@@ -554,9 +554,9 @@
 /turf/open/floor/plating/rust,
 /area/awaymission/caves/maintsroom)
 "cp" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden/crude,
 /obj/structure/barricade/wooden,
+/obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/awaymission/caves/maintsroom)
 "cq" = (
@@ -2389,12 +2389,6 @@
 /obj/structure/flora/bush/jungle/a/style_random,
 /turf/open/misc/grass/jungle,
 /area/awaymission/caves/maintsroom)
-"iU" = (
-/obj/structure/barricade/wooden/crude,
-/obj/structure/barricade/wooden,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/awaymission/caves/maintsroom)
 "iV" = (
 /obj/structure/alien/weeds,
 /mob/living/carbon/human/species/monkey,
@@ -2528,11 +2522,6 @@
 	pixel_y = 7
 	},
 /turf/open/floor/iron,
-/area/awaymission/caves/maintsroom)
-"jx" = (
-/obj/structure/broken_flooring/pile/directional/east,
-/obj/structure/trap/stun,
-/turf/open/floor/plating,
 /area/awaymission/caves/maintsroom)
 "jy" = (
 /obj/structure/chair/plastic,
@@ -3313,7 +3302,6 @@
 	name = "The Gobetting Barmaid"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/awaymission/caves/maintsroom)
 "mt" = (
@@ -4099,7 +4087,6 @@
 /turf/open/floor/white,
 /area/awaymission/caves/maintsroom)
 "pm" = (
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
@@ -6213,11 +6200,6 @@
 /obj/machinery/newscaster/directional/east,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
-/area/awaymission/caves/maintsroom)
-"yb" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/cable,
-/turf/open/floor/plating,
 /area/awaymission/caves/maintsroom)
 "yd" = (
 /obj/structure/constructshell,
@@ -11436,13 +11418,6 @@
 	},
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
-/area/awaymission/caves/maintsroom)
-"Se" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/trap/stun,
-/obj/structure/alien/weeds,
-/obj/structure/cable,
-/turf/open/floor/iron,
 /area/awaymission/caves/maintsroom)
 "Sf" = (
 /obj/structure/closet/crate/engineering/electrical,
@@ -32778,7 +32753,7 @@ NQ
 GS
 GS
 GS
-iU
+cp
 GS
 NQ
 NQ
@@ -32986,9 +32961,9 @@ GS
 NQ
 NQ
 NQ
-eO
+aK
 WU
-yb
+NE
 kz
 UK
 NQ
@@ -32998,7 +32973,7 @@ gE
 CK
 GS
 GS
-iU
+cp
 GS
 Ox
 TJ
@@ -34074,7 +34049,7 @@ oh
 Ih
 Ih
 hC
-Se
+OG
 zF
 GS
 nX
@@ -34732,7 +34707,7 @@ sQ
 sh
 fW
 ym
-jx
+JZ
 iF
 iA
 GS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

removes 2 shock traps, makes some windows tinted, removes a pipe which leads to nothing.

## How This Contributes To The Nova Sector Roleplay Experience

some people spawn in as the beno only to die to the shock trap, this sucks for these people to spawn in as something rare only to then almost immediately die.

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: a few shocktraps from the maintsroom
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
