### PR TITLE
Gas miner beacon now show canisters as selectable options (only visually)

### DIFF
--- a/modular_nova/modules/modular_items/code/summon_beacon.dm
+++ b/modular_nova/modules/modular_items/code/summon_beacon.dm
@@ -14,7 +14,8 @@
 		/area,
 	)
 
-	/// A list of possible atoms available to spawn
+	/// A list of possible atoms available to spawn. Cen be either regular list or associative list.
+	/// Atoms in keys of assotiative list will be used as variants shown to user, values - actual items to spawn.
 	var/list/selectable_atoms = list(
 		/obj/item/summon_beacon,
 	)
@@ -61,15 +62,21 @@
 
 	selected_atom = show_radial_menu(user, src, radial_build, radius = 40, tooltips = TRUE)
 
+	if(selectable_atoms[selected_atom])
+		selected_atom = selectable_atoms[selected_atom]
+
 /obj/item/summon_beacon/proc/get_available_options()
 	var/list/options = list()
 	for(var/iterating_choice in selectable_atoms)
-		var/obj/our_object = iterating_choice
+		var/obj/icon_object = iterating_choice
+		var/choice_icon = icon_object.greyscale_config ? SSgreyscale.GetColoredIconByType(icon_object.greyscale_config, icon_object.greyscale_colors) : initial(icon_object.icon)
 		var/datum/radial_menu_choice/option = new
-		option.image = image(icon = initial(our_object.icon), icon_state = initial(our_object.icon_state))
-		option.info = span_boldnotice("[initial(our_object.desc)]")
+		var/obj/our_object = selectable_atoms[iterating_choice]
+		option.image = image(icon = choice_icon, icon_state = initial(icon_object.icon_state))
+		option.name = our_object ? initial(our_object.name) : initial(icon_object.name)
+		option.info = span_boldnotice("[selectable_atoms[iterating_choice] ? initial(our_object.desc) : initial(icon_object.desc)]")
 
-		options[our_object] = option
+		options[icon_object] = option
 
 	sort_list(options)
 
@@ -140,11 +147,11 @@
 	)
 
 	selectable_atoms = list(
-		/obj/machinery/atmospherics/miner/carbon_dioxide,
-		/obj/machinery/atmospherics/miner/n2o,
-		/obj/machinery/atmospherics/miner/nitrogen,
-		/obj/machinery/atmospherics/miner/oxygen,
-		/obj/machinery/atmospherics/miner/plasma,
+		/obj/machinery/portable_atmospherics/canister/carbon_dioxide = /obj/machinery/atmospherics/miner/carbon_dioxide,
+		/obj/machinery/portable_atmospherics/canister/nitrous_oxide = /obj/machinery/atmospherics/miner/n2o,
+		/obj/machinery/portable_atmospherics/canister/nitrogen = /obj/machinery/atmospherics/miner/nitrogen,
+		/obj/machinery/portable_atmospherics/canister/oxygen = /obj/machinery/atmospherics/miner/oxygen,
+		/obj/machinery/portable_atmospherics/canister/plasma = /obj/machinery/atmospherics/miner/plasma,
 	)
 
 	area_string = "atmospherics"
@@ -176,7 +183,7 @@
 		/obj/machinery/vending/imported/mothic, // "Nomad Fleet Ration Chit Exchange"
 		/obj/machinery/vending/imported/tiziran, // "Tiziran Imported Delicacies"
 		/obj/machinery/vending/imported/yangyu, // "Fudobenda"
-		/obj/machinery/vending/deforest_medvend, // "DeForest Med-Vend"	
+		/obj/machinery/vending/deforest_medvend, // "DeForest Med-Vend"
 	)
 
 /obj/item/summon_beacon/vendors/equipped(mob/user, slot, initial)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds "item masking" and support for GAGS to summon_beacon, allowing us to add other item's icons as options and also handling in case options turn out to be greyscale.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
hmmm which of the miners should i place, grey circle or grey circle
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  options for gasminers

![image](https://github.com/user-attachments/assets/2fa82cde-9435-4b0b-a1cd-784c9881c0ce)

options for new vendor vendor (still work)
![image](https://github.com/user-attachments/assets/25de9d89-9a9c-43dd-b70d-f5110e8aa962)

they DO both spawn correctly, but I accidentally deleted third screenshot :(
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: gas miner beacon now show canisters of different gases as choice options
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
