### PR TITLE
Fix clock-out lockboxes, refactor out uneeded hard references

### DIFF
--- a/modular_nova/modules/plexagon_selfserve/code/plexagon_selfserve.dm
+++ b/modular_nova/modules/plexagon_selfserve/code/plexagon_selfserve.dm
@@ -15,10 +15,6 @@
 	size = 0
 	tgui_id = "NtosSelfServe"
 	program_icon = "id-card"
-	/// The ID card used to authenticate.
-	var/obj/item/card/id/authenticated_card
-	/// The name of the registered user, related to `authenticated_card`.
-	var/authenticated_user
 	///What trim is applied to inserted IDs?
 	var/target_trim = /datum/id_trim/job/assistant
 
@@ -33,82 +29,65 @@
 
 	computer.crew_manifest_update = TRUE
 	register_signals()
-	if(computer.computer_id_slot)
-		authenticate(id_card = computer.computer_id_slot)
 
 	return TRUE
 
 /datum/computer_file/program/crew_self_serve/kill_program(mob/user)
 	UnregisterSignal(computer, list(COMSIG_MODULAR_COMPUTER_INSERTED_ID, COMSIG_MODULAR_COMPUTER_REMOVED_ID))
+	computer.crew_manifest_update = FALSE
 	return ..()
 
 /datum/computer_file/program/crew_self_serve/proc/register_signals()
 	RegisterSignals(computer, list(COMSIG_MODULAR_COMPUTER_INSERTED_ID, COMSIG_MODULAR_COMPUTER_REMOVED_ID), PROC_REF(id_changed))
 
-/datum/computer_file/program/crew_self_serve/proc/id_changed(source, obj/item/card/id/id_card, mob/user)
+/datum/computer_file/program/crew_self_serve/proc/id_changed()
 	SIGNAL_HANDLER
-	authenticate(id_card = computer.computer_id_slot)
-
-/**
- * Authenticates the program based on the specific ID card.
- *
- * Arguments:
- * * auth_card - The ID card to attempt to authenticate under.
- */
-/datum/computer_file/program/crew_self_serve/proc/authenticate(source, obj/item/card/id/id_card)
-	if(!id_card)
-		authenticated_card = null
-		authenticated_user = null
-	else
-		authenticated_card = id_card
-		authenticated_user = "[authenticated_card.name]"
-
 	computer.update_static_data_for_all_viewers()
 
 /// Clocks out the currently inserted ID Card
-/datum/computer_file/program/crew_self_serve/proc/clock_out()
-	if(!authenticated_card)
+/datum/computer_file/program/crew_self_serve/proc/clock_out(obj/item/card/id/id_card)
+	if(!id_card)
 		return FALSE
 
-	var/important = is_job_important()
+	var/important = is_job_important(id_card)
 	if(important)
 		if(tgui_alert(usr, "You are a member of security and/or command, make sure that you ahelp before punching out! If you decide to punch back in later, you will need to go to the Head of Personnel or Head of Security. Do you wish to continue?", "[src]", list("No", "Yes")) != "Yes")
 			return FALSE
 
-	log_econ("[authenticated_card.registered_name] clocked out from role [authenticated_card.get_trim_assignment()]")
-	var/datum/component/off_duty_timer/timer_component = authenticated_card.AddComponent(/datum/component/off_duty_timer, TIMECLOCK_COOLDOWN)
+	log_econ("[id_card.registered_name] clocked out from role [id_card.get_trim_assignment()]")
+	var/datum/component/off_duty_timer/timer_component = id_card.AddComponent(/datum/component/off_duty_timer, TIMECLOCK_COOLDOWN)
 	if(important)
 		timer_component.hop_locked = TRUE
-		log_econ("[authenticated_card.registered_name] job slot [authenticated_card.get_trim_assignment()] has been locked from clocking back in")
-		message_admins("[ADMIN_LOOKUPFLW(usr)] clocked out from [span_comradio("restricted role")]: [authenticated_card.get_trim_assignment()].")
+		log_econ("[id_card.registered_name] job slot [id_card.get_trim_assignment()] has been locked from clocking back in")
+		message_admins("[ADMIN_LOOKUPFLW(usr)] clocked out from [span_comradio("restricted role")]: [id_card.get_trim_assignment()].")
 	else
-		message_admins("[ADMIN_LOOKUPFLW(usr)] clocked out from role: [authenticated_card.get_trim_assignment()].")
+		message_admins("[ADMIN_LOOKUPFLW(usr)] clocked out from role: [id_card.get_trim_assignment()].")
 
-	var/current_assignment = authenticated_card.assignment
-	var/datum/id_trim/job/current_trim = authenticated_card.trim
+	var/current_assignment = id_card.assignment
+	var/datum/id_trim/job/current_trim = id_card.trim
 	var/datum/job/clocked_out_job = current_trim.job
 	SSjob.FreeRole(clocked_out_job.title)
 
 	var/obj/machinery/announcement_system/system = pick(GLOB.announcement_systems)
-	system.broadcast("[authenticated_card.registered_name], [current_assignment] has gone off-duty.", list())
+	system.broadcast("[id_card.registered_name], [current_assignment] has gone off-duty.", list())
 	computer.update_static_data_for_all_viewers()
 
-	SSid_access.apply_trim_to_card(authenticated_card, target_trim, TRUE)
-	authenticated_card.assignment = "Off-Duty " + current_assignment
-	authenticated_card.update_label()
+	SSid_access.apply_trim_to_card(id_card, target_trim, TRUE)
+	id_card.assignment = "Off-Duty " + current_assignment
+	id_card.update_label()
 
-	GLOB.manifest.modify(authenticated_card.registered_name, authenticated_card.assignment, authenticated_card.get_trim_assignment())
+	GLOB.manifest.modify(id_card.registered_name, id_card.assignment, id_card.get_trim_assignment())
 	return TRUE
 
 /// Clocks the currently inserted ID Card back in
-/datum/computer_file/program/crew_self_serve/proc/clock_in()
-	if(!authenticated_card)
+/datum/computer_file/program/crew_self_serve/proc/clock_in(obj/item/card/id/id_card)
+	if(!id_card)
 		return FALSE
 
-	if(id_cooldown_check())
+	if(id_cooldown_check(id_card))
 		return FALSE
 
-	var/datum/component/off_duty_timer/id_component = authenticated_card.GetComponent(/datum/component/off_duty_timer)
+	var/datum/component/off_duty_timer/id_component = id_card.GetComponent(/datum/component/off_duty_timer)
 	if(!id_component)
 		return FALSE
 
@@ -118,28 +97,28 @@
 		return FALSE
 
 
-	SSid_access.apply_trim_to_card(authenticated_card, id_component.stored_trim.type, TRUE)
-	authenticated_card.assignment = id_component.stored_assignment
+	SSid_access.apply_trim_to_card(id_card, id_component.stored_trim.type, TRUE)
+	id_card.assignment = id_component.stored_assignment
 
-	log_econ("[authenticated_card.registered_name] clocked in to role [authenticated_card.get_trim_assignment()]")
-	message_admins("[ADMIN_LOOKUPFLW(usr)] clocked in to role: [authenticated_card.get_trim_assignment()].")
+	log_econ("[id_card.registered_name] clocked in to role [id_card.get_trim_assignment()]")
+	message_admins("[ADMIN_LOOKUPFLW(usr)] clocked in to role: [id_card.get_trim_assignment()].")
 
 	var/obj/machinery/announcement_system/system = pick(GLOB.announcement_systems)
-	system.broadcast("[authenticated_card.registered_name] has returned to assignment [authenticated_card.assignment].", list())
-	GLOB.manifest.modify(authenticated_card.registered_name, authenticated_card.assignment, authenticated_card.get_trim_assignment())
+	system.broadcast("[id_card.registered_name] has returned to assignment [id_card.assignment].", list())
+	GLOB.manifest.modify(id_card.registered_name, id_card.assignment, id_card.get_trim_assignment())
 
 	qdel(id_component)
-	authenticated_card.update_label()
+	id_card.update_label()
 	computer.update_static_data_for_all_viewers()
 
 	return TRUE
 
 /// Is the job of the inserted ID being worked by a job that in an important department? If so, this proc will return TRUE.
-/datum/computer_file/program/crew_self_serve/proc/is_job_important()
-	if(!authenticated_card)
+/datum/computer_file/program/crew_self_serve/proc/is_job_important(obj/item/card/id/id_card)
+	if(!id_card)
 		return FALSE
 
-	var/datum/id_trim/job/current_trim = authenticated_card.trim
+	var/datum/id_trim/job/current_trim = id_card.trim
 	var/datum/job/clocked_in_job = current_trim.job
 	if((/datum/job_department/command in clocked_in_job.departments_list) || (/datum/job_department/security in clocked_in_job.departments_list))
 		return TRUE
@@ -147,11 +126,11 @@
 	return FALSE
 
 /// Is the inserted ID on cooldown? return -1 if invalid ID, 0 if ID is not on cooldown, and remaining time until cooldown ends otherwise.
-/datum/computer_file/program/crew_self_serve/proc/id_cooldown_check()
-	if(!authenticated_card)
+/datum/computer_file/program/crew_self_serve/proc/id_cooldown_check(obj/item/card/id/id_card)
+	if(!id_card)
 		return PUNCH_ID_INVALID
 
-	var/datum/component/off_duty_timer/id_component = authenticated_card.GetComponent(/datum/component/off_duty_timer)
+	var/datum/component/off_duty_timer/id_component = id_card.GetComponent(/datum/component/off_duty_timer)
 	if(!id_component)
 		return PUNCH_ID_INVALID
 
@@ -161,8 +140,8 @@
 	return max(TIMECLOCK_COOLDOWN - (world.time - id_component.init_time), 0)
 
 /// Returns the remaining time left for the ID, as a minutes:seconds string.
-/datum/computer_file/program/crew_self_serve/proc/id_cooldown_minutes_seconds()
-	var/remaining_cooldown_time = id_cooldown_check()
+/datum/computer_file/program/crew_self_serve/proc/id_cooldown_minutes_seconds(obj/item/card/id/id_card)
+	var/remaining_cooldown_time = id_cooldown_check(id_card)
 	if (remaining_cooldown_time == PUNCH_ID_INVALID)
 		return "--:--"
 
@@ -176,11 +155,11 @@
 	return addtext(cooldown_remaining_minutes, ":", cooldown_remaining_seconds)
 
 /// Is the inserted ID locked from clocking in? returns TRUE if the ID is locked
-/datum/computer_file/program/crew_self_serve/proc/id_locked_check()
-	if(!authenticated_card)
+/datum/computer_file/program/crew_self_serve/proc/id_locked_check(obj/item/card/id/id_card)
+	if(!id_card)
 		return FALSE
 
-	var/datum/component/off_duty_timer/id_component = authenticated_card.GetComponent(/datum/component/off_duty_timer)
+	var/datum/component/off_duty_timer/id_component = id_card.GetComponent(/datum/component/off_duty_timer)
 	if(!id_component)
 		return FALSE
 
@@ -190,33 +169,26 @@
 	return FALSE
 
 /// Is the inserted ID off-duty? Returns true if the ID is off-duty
-/datum/computer_file/program/crew_self_serve/proc/off_duty_check()
-	if(!authenticated_card)
+/datum/computer_file/program/crew_self_serve/proc/off_duty_check(obj/item/card/id/auth_card)
+	if(!auth_card)
 		return FALSE
 
-	var/datum/component/off_duty_timer/id_component = authenticated_card.GetComponent(/datum/component/off_duty_timer)
+	var/datum/component/off_duty_timer/id_component = auth_card.GetComponent(/datum/component/off_duty_timer)
 	if(!id_component)
 		return FALSE
 
 	return TRUE
 
-/datum/computer_file/program/crew_self_serve/kill_program(mob/user)
-	computer.crew_manifest_update = FALSE
-	if(!isnull(authenticated_card))
-		authenticated_card = null
-
-	return ..()
-
 /// Places any items inside of the `eligible_items` list to a lockbox, to be opened by the player when they clock back in.
-/datum/computer_file/program/crew_self_serve/proc/secure_items(mob/living/carbon/human/human_user, list/eligible_items)
-	var/obj/item/storage/lockbox/timeclock/shame_box = new /obj/item/storage/lockbox/timeclock(get_turf(authenticated_card), authenticated_card)
-	if(isnull(shame_box) || !istype(shame_box))
-		stack_trace("Failed to create lockbox for [authenticated_card.registered_name] trim clock-out.")
+/datum/computer_file/program/crew_self_serve/proc/secure_items(mob/living/carbon/human/human_user, obj/item/card/id/id_card, list/eligible_items)
+	var/obj/item/storage/lockbox/timeclock/shame_box = new /obj/item/storage/lockbox/timeclock(get_turf(id_card), id_card)
+	if(QDELETED(shame_box))
+		stack_trace("Failed to create lockbox for [id_card.registered_name] trim clock-out.")
 		return FALSE
 
 	var/list/held_contents = human_user.get_contents()
 	if(!held_contents)
-		CRASH("Lockbox secure items: no items found on [authenticated_card.registered_name]. that's probably incorrect!")
+		CRASH("Lockbox secure items: no items found on [id_card.registered_name]. that's probably incorrect!")
 
 	var/list/shamebox_items = list()
 	for(var/obj/item/found_item in held_contents)
@@ -244,16 +216,17 @@
 
 /datum/computer_file/program/crew_self_serve/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
+	var/obj/item/card/id/inserted_auth_card = computer.computer_id_slot
 	switch(action)
 		if("PRG_change_status")
-			if(!authenticated_card)
+			if(!inserted_auth_card)
 				return
 
-			if(off_duty_check())
-				if(!authenticated_card)
+			if(off_duty_check(inserted_auth_card))
+				if(!inserted_auth_card)
 					return
 
-				if(!clock_in())
+				if(!clock_in(inserted_auth_card))
 					return
 
 				var/datum/mind/user_mind = usr.mind
@@ -264,12 +237,12 @@
 				playsound(computer, 'sound/machines/ping.ogg', 50, FALSE)
 
 			else
-				if(!clock_out())
+				if(!clock_out(inserted_auth_card))
 					return
 
 				var/mob/living/carbon/human/human_user = usr
 				if(human_user)
-					secure_items(human_user, eligible_items = SELF_SERVE_RETURN_ITEMS)
+					secure_items(human_user, inserted_auth_card, eligible_items = SELF_SERVE_RETURN_ITEMS)
 
 				var/datum/mind/user_mind = usr.mind
 				if(user_mind)
@@ -278,7 +251,6 @@
 				computer.update_static_data_for_all_viewers()
 				playsound(computer, 'sound/machines/ping.ogg', 50, FALSE)
 				computer.RemoveID(human_user, silent = TRUE)
-				authenticate(id_card = computer.computer_id_slot)
 
 			return TRUE
 
@@ -286,28 +258,29 @@
 			var/mob/living/carbon/human/human_user = usr
 			if(human_user)
 				computer.RemoveID(human_user, silent = TRUE)
-				authenticate(id_card = computer.computer_id_slot)
 
 			return TRUE
 
 /datum/computer_file/program/crew_self_serve/ui_data(mob/user)
 	var/list/data = list()
-	data["authCard"] = authenticated_card ? authenticated_card.name : "-----"
-	data["authCardHOPLocked"] = id_locked_check()
-	data["authCardTimeLocked"] = id_cooldown_check() > 0
-	data["authCardTimeRemaining"] = id_cooldown_minutes_seconds()
+	var/obj/item/card/id/inserted_auth_card = computer.computer_id_slot
+	data["authCard"] = inserted_auth_card ? inserted_auth_card.name : "-----"
+	data["authCardHOPLocked"] = id_locked_check(inserted_auth_card)
+	data["authCardTimeLocked"] = id_cooldown_check(inserted_auth_card) > 0
+	data["authCardTimeRemaining"] = id_cooldown_minutes_seconds(inserted_auth_card)
 
 	return data
 
 /datum/computer_file/program/crew_self_serve/ui_static_data(mob/user)
 	var/list/data = list()
-	if(authenticated_card)
-		data["authIDName"] = authenticated_card.registered_name ? authenticated_card.registered_name : "-----"
-		data["authIDRank"] = authenticated_card.assignment ? authenticated_card.assignment : "Unassigned"
-		data["authCardHOPLocked"] = id_locked_check()
-		data["trimClockedOut"] = off_duty_check()
-		if(authenticated_card.trim)
-			var/datum/id_trim/card_trim = authenticated_card.trim
+	var/obj/item/card/id/inserted_auth_card = computer.computer_id_slot
+	if(inserted_auth_card)
+		data["authIDName"] = inserted_auth_card.registered_name ? inserted_auth_card.registered_name : "-----"
+		data["authIDRank"] = inserted_auth_card.assignment ? inserted_auth_card.assignment : "Unassigned"
+		data["authCardHOPLocked"] = id_locked_check(inserted_auth_card)
+		data["trimClockedOut"] = off_duty_check(inserted_auth_card)
+		if(inserted_auth_card.trim)
+			var/datum/id_trim/card_trim = inserted_auth_card.trim
 			data["trimAssignment"] = card_trim.assignment ? card_trim.assignment : ""
 		else
 			data["trimAssignment"] = ""

--- a/modular_nova/modules/plexagon_selfserve/code/plexagon_selfserve.dm
+++ b/modular_nova/modules/plexagon_selfserve/code/plexagon_selfserve.dm
@@ -188,7 +188,7 @@
 
 	var/list/held_contents = human_user.get_contents()
 	if(!held_contents)
-		CRASH("Lockbox secure items: no items found on [id_card.registered_name]. that's probably incorrect!")
+		CRASH("Lockbox secure items: no items found on [id_card.registered_name]. That's probably incorrect!")
 
 	var/list/shamebox_items = list()
 	for(var/obj/item/found_item in held_contents)

--- a/modular_nova/modules/plexagon_selfserve/code/plexagon_selfserve.dm
+++ b/modular_nova/modules/plexagon_selfserve/code/plexagon_selfserve.dm
@@ -46,7 +46,7 @@
 
 /// Clocks out the currently inserted ID Card
 /datum/computer_file/program/crew_self_serve/proc/clock_out(obj/item/card/id/id_card)
-	if(!id_card)
+	if(!istype(id_card))
 		return FALSE
 
 	var/important = is_job_important(id_card)
@@ -81,7 +81,7 @@
 
 /// Clocks the currently inserted ID Card back in
 /datum/computer_file/program/crew_self_serve/proc/clock_in(obj/item/card/id/id_card)
-	if(!id_card)
+	if(!istype(id_card))
 		return FALSE
 
 	if(id_cooldown_check(id_card))
@@ -115,7 +115,7 @@
 
 /// Is the job of the inserted ID being worked by a job that in an important department? If so, this proc will return TRUE.
 /datum/computer_file/program/crew_self_serve/proc/is_job_important(obj/item/card/id/id_card)
-	if(!id_card)
+	if(!istype(id_card))
 		return FALSE
 
 	var/datum/id_trim/job/current_trim = id_card.trim
@@ -127,7 +127,7 @@
 
 /// Is the inserted ID on cooldown? return -1 if invalid ID, 0 if ID is not on cooldown, and remaining time until cooldown ends otherwise.
 /datum/computer_file/program/crew_self_serve/proc/id_cooldown_check(obj/item/card/id/id_card)
-	if(!id_card)
+	if(!istype(id_card))
 		return PUNCH_ID_INVALID
 
 	var/datum/component/off_duty_timer/id_component = id_card.GetComponent(/datum/component/off_duty_timer)
@@ -156,7 +156,7 @@
 
 /// Is the inserted ID locked from clocking in? returns TRUE if the ID is locked
 /datum/computer_file/program/crew_self_serve/proc/id_locked_check(obj/item/card/id/id_card)
-	if(!id_card)
+	if(!istype(id_card))
 		return FALSE
 
 	var/datum/component/off_duty_timer/id_component = id_card.GetComponent(/datum/component/off_duty_timer)
@@ -170,7 +170,7 @@
 
 /// Is the inserted ID off-duty? Returns true if the ID is off-duty
 /datum/computer_file/program/crew_self_serve/proc/off_duty_check(obj/item/card/id/auth_card)
-	if(!auth_card)
+	if(!istype(auth_card))
 		return FALSE
 
 	var/datum/component/off_duty_timer/id_component = auth_card.GetComponent(/datum/component/off_duty_timer)

--- a/modular_nova/modules/plexagon_selfserve/code/shamebox.dm
+++ b/modular_nova/modules/plexagon_selfserve/code/shamebox.dm
@@ -77,3 +77,6 @@
 	usr.visible_message(span_notice("[usr] activates the lockbox mechanism, releasing its contents before vanishing in a puff of bluespace smoke!"))
 	associated_card = null
 	qdel(src)
+
+/obj/item/storage/lockbox/timeclock/toggle_locked(mob/living/user)
+	return

--- a/modular_nova/modules/plexagon_selfserve/code/shamebox.dm
+++ b/modular_nova/modules/plexagon_selfserve/code/shamebox.dm
@@ -9,23 +9,21 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	req_access = list(ACCESS_ALL_PERSONAL_LOCKERS)
 	/// The ID card associated with the box
-	var/obj/item/card/id/associated_card
+	var/datum/weakref/associated_card
 	/// A display formatted list of the locked contents
 	var/locked_contents = null
-	item_flags = ABSTRACT | DROPDEL
 
 /obj/item/storage/lockbox/timeclock/Initialize(mapload, obj/item/card/id/crew_id)
 	. = ..()
-	if(!isnull(loc))
-		return INITIALIZE_HINT_QDEL // These should never be spawned in realspace
+	if(!istype(crew_id) || QDELETED(crew_id))
+		return INITIALIZE_HINT_QDEL
 	atom_storage.allow_big_nesting = TRUE
 	atom_storage.max_slots = 99
 	atom_storage.max_specific_storage = WEIGHT_CLASS_GIGANTIC
 	atom_storage.max_total_storage = 99
-	if(!isnull(crew_id) || !istype(crew_id))
-		associated_card = crew_id
-	if(associated_card?.registered_name)
-		name = "[initial(name)] - [associated_card.registered_name]"
+	associated_card = WEAKREF(crew_id)
+	if(crew_id.registered_name)
+		name = "[initial(name)] - [crew_id.registered_name]"
 
 /obj/item/storage/lockbox/timeclock/examine(mob/user)
 	. = ..()
@@ -56,7 +54,12 @@
 	if(check_access_list(access_card.GetAccess()))
 		release_contents()
 		return TRUE
-	if(access_card != associated_card)
+
+	var/obj/item/card/id/allowed_card = associated_card?.resolve()
+	if(isnull(allowed_card))
+		associated_card = null
+		return FALSE
+	if(access_card != allowed_card)
 		return FALSE
 
 	var/datum/id_trim/job/current_trim = access_card.trim


### PR DESCRIPTION

## About The Pull Request
Fixes that clockout lockboxes were deleting themselves on creation (which also caused some terrible hard deletes) because we couldn't decide if they're abstract or not. Also refactors related code to use weakrefs or arguments instead of storing hard refs to ID cards.
## How This Contributes To The Nova Sector Roleplay Experience
fix
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  

https://github.com/user-attachments/assets/e4fa73cf-2a6c-497a-8123-326d2fd3ac7e


</details>

## Changelog
:cl:
fix: Clocking out via PDA app now properly spawns lockboxes with restricted items
/:cl:
