### PR TITLE
Fixes GAGS

### DIFF
--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_clothing/ballgag.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_clothing/ballgag.dm
@@ -5,7 +5,7 @@
 	worn_icon_muzzled = 'modular_nova/modules/modular_items/lewd_items/icons/mob/lewd_clothing/lewd_masks_muzzled.dmi'
 	greyscale_colors = "#383840#dc7ef4"
 	icon = 'icons/map_icons/clothing/mask.dmi'
-	icon_state = "/obj/item/clothing/mask/ballgag"
+	icon_state = "/obj/item/clothing/mask/muzzle/ballgag"
 	post_init_icon_state = "ballgag"
 	greyscale_config = /datum/greyscale_config/ball_gag
 	greyscale_config_worn = /datum/greyscale_config/ball_gag/worn
@@ -19,7 +19,7 @@
 	desc = "Prevents the wearer from speaking, as well as making breathing harder."
 	worn_icon_state = "ballgag"
 	icon = 'icons/map_icons/clothing/mask.dmi'
-	icon_state = "/obj/item/clothing/mask/ballgag/choking"
+	icon_state = "/obj/item/clothing/mask/muzzle/ballgag/choking"
 	post_init_icon_state = "chokegag_small"
 	greyscale_config = /datum/greyscale_config/ball_gag/choke_gag
 	unique_reskin = list(


### PR DESCRIPTION
## About The Pull Request

Which gags might you be referring to, vinylspiders?

My response to that:

'yes'.

## How This Contributes To The Nova Sector Roleplay Experience

![hGGmcr2zjH](https://github.com/user-attachments/assets/8fb91787-298d-46d3-ba41-fcebea61e167)

Fixes this, which is the result of a recent repath that did not update the icon_state.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/09e57797-e351-4f60-a2ae-9d410b8f72dd)

</details>

## Changelog

:cl:
fix: fixes ball gags' GAGS preview in the loadout menu showing up as an error
/:cl: