### PR TITLE
[Modular] Adds a service guard locker to the code.

### DIFF
--- a/modular_nova/modules/goofsec/code/department_guards.dm
+++ b/modular_nova/modules/goofsec/code/department_guards.dm
@@ -925,7 +925,7 @@
 	name = "service guard's garments"
 	desc = "A bag for storing extra clothes and shoes. This one belongs to the service guard."
 
-/obj/item/storage/bag/garment/science_guard/PopulateContents()
+/obj/item/storage/bag/garment/service_guard/PopulateContents()
 	generate_items_inside(list(
 		/obj/item/radio/headset/headset_srv = 2,
 		/obj/item/clothing/shoes/sneakers/black = 2,

--- a/modular_nova/modules/goofsec/code/department_guards.dm
+++ b/modular_nova/modules/goofsec/code/department_guards.dm
@@ -920,3 +920,18 @@
 		/obj/item/clothing/glasses/hud/security = 2,
 		/obj/item/clothing/glasses/hud/gun_permit = 2,
 	), src)
+
+/obj/item/storage/bag/garment/service_guard
+	name = "service guard's garments"
+	desc = "A bag for storing extra clothes and shoes. This one belongs to the service guard."
+
+/obj/item/storage/bag/garment/science_guard/PopulateContents()
+	generate_items_inside(list(
+		/obj/item/radio/headset/headset_srv = 2,
+		/obj/item/clothing/shoes/sneakers/black = 2,
+		/obj/item/clothing/under/rank/security/officer/blueshirt/nova/bouncer = 2,
+		/obj/item/clothing/head/helmet/blueshirt/nova/guard = 2,
+		/obj/item/clothing/head/beret/sec/service = 2,
+		/obj/item/clothing/suit/armor/vest/blueshirt/nova/guard = 2,
+		/obj/item/clothing/glasses/hud/security = 2,
+	), src)

--- a/modular_nova/modules/goofsec/code/lockers.dm
+++ b/modular_nova/modules/goofsec/code/lockers.dm
@@ -46,3 +46,15 @@
 	new /obj/item/restraints/handcuffs/cable/blue(src)
 	new /obj/item/assembly/flash/handheld(src)
 	new /obj/item/storage/bag/garment/orderly(src)
+
+/obj/structure/closet/secure_closet/security/service
+	name = "\proper service guard's locker"
+	req_access = list(ACCESS_BRIG_ENTRANCE, ACCESS_SERVICE)
+	icon_state = "cabinet"
+	icon = 'icons/obj/storage/closet.dmi'
+
+/obj/structure/closet/secure_closet/security/service/PopulateContents()
+	new /obj/item/ammo_box/advanced/pepperballs(src)
+	new /obj/item/restraints/handcuffs/cable/green(src)
+	new /obj/item/assembly/flash/handheld(src)
+	new /obj/item/storage/bag/garment/service_guard(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds a locker, as well as a garment bag, for the service guard to the code, although not to any maps, at least not yet.

It currently uses the cabinet sprite, as i wasn't able to find anything more fitting, although i'm not against making a new sprite for it.

While i wasn't seemingly able to find any previous attempts to add something like this, i do apologize if there was, and it was rejected for whatever reason.

## How This Contributes To The Nova Sector Roleplay Experience

As of now, the service guard is the only departmental guard which doesn't have a locker of their own, which i feel like is a glaring omission.

Even though this pull request doesn't actually add these lockers to the maps, i still feel it's beneficial, because it lays down some groundwork for potentially adding in more service guard outposts in the future, such as through using automap templates on some other area (such as the arrivals security outpost, or potentially the theater), or adding them directly to Nova's maps. (As far as i know, Snowglobe is the only map that currently has a service guard outpost.)

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![Screenshot_298](https://github.com/user-attachments/assets/708d1f76-0faa-4903-bc23-a49efbb096cf)
![Screenshot_299](https://github.com/user-attachments/assets/624fe448-7e14-4ec5-90e6-64f405ff67a5)
![Screenshot_300](https://github.com/user-attachments/assets/19ec61d0-65e6-4a51-bd51-5a08b84599ec)
![Screenshot_301](https://github.com/user-attachments/assets/e09e4634-46b9-4f37-bffd-43bc3490bd1c)
![Screenshot_302](https://github.com/user-attachments/assets/df2d19fa-23a4-45c4-84ed-98ed24e36a19)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

I don't know if i should add a changelog, since there isn't technically anything player-facing in here.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
