### PR TITLE
Gas miners can now be placed in custom areas + some logging when doing so

### DIFF
--- a/modular_nova/modules/modular_items/code/summon_beacon.dm
+++ b/modular_nova/modules/modular_items/code/summon_beacon.dm
@@ -89,7 +89,7 @@
 		return FALSE
 	if(!target_area)
 		return FALSE
-	if(!(is_type_in_list(target_area, allowed_areas) || (target_area.GetComponent(/datum/component/custom_area) && allow_custom_areas)))
+	if(!(is_type_in_list(target_area, allowed_areas) || (allow_custom_areas && target_area.GetComponent(/datum/component/custom_area))))
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request
Adds ability for gas miners to be placed in custom created areas
## How This Contributes To The Nova Sector Roleplay Experience
Atmosians and ghost roles will be able to enjoy building their custom gas setups outside of designated areas. Because miners can still be used to grief atmos even with current limitations, theres no point in forbidding it. But to at least see if someone had a malicious intent, theres now additional logging added for when people call a miner (someone should have added it long time ago, actually).
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/150565ef-d74e-45ad-b4b9-32aca15ceb03)

![image](https://github.com/user-attachments/assets/ef7fa244-c616-4e19-b936-9a505e5fb8b2)

</details>

## Changelog
:cl:
add: Gas miners can now be called in custom areas
/:cl:
