### PR TITLE
Bouncy quirk which gives you the waddle trait

### DIFF
--- a/modular_nova/master_files/code/datums/quirks/neutral_quirks/bouncy.dm
+++ b/modular_nova/master_files/code/datums/quirks/neutral_quirks/bouncy.dm
@@ -1,0 +1,13 @@
+/datum/quirk/bouncy
+	name = "Bouncy!"
+	desc = "You have a waddle in your step!"
+	gain_text = span_notice("You're hopping around!")
+	lose_text = span_notice("You've lost the pep in your step...")
+	medical_record_text = "Patient walks irregularly."
+	value = 0
+	icon = FA_ICON_TURN_UP
+
+/datum/quirk/bouncy/add()
+	. = ..()
+	var/mob/living/carbon/human/user = quirk_holder
+	user.AddElementTrait(TRAIT_WADDLING, QUIRK_TRAIT, /datum/element/waddling)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6819,6 +6819,7 @@
 #include "modular_nova\master_files\code\datums\quirks\negative_quirks\heavy_sleeper.dm"
 #include "modular_nova\master_files\code\datums\quirks\negative_quirks\nerve_staple.dm"
 #include "modular_nova\master_files\code\datums\quirks\negative_quirks\photophobia.dm"
+#include "modular_nova\master_files\code\datums\quirks\neutral_quirks\bouncy.dm"
 #include "modular_nova\master_files\code\datums\quirks\neutral_quirks\equipping.dm"
 #include "modular_nova\master_files\code\datums\quirks\neutral_quirks\food.dm"
 #include "modular_nova\master_files\code\datums\quirks\neutral_quirks\lungs.dm"


### PR DESCRIPTION
## About The Pull Request

Tin.

## How This Contributes To The Nova Sector Roleplay Experience

Its cute on birds, moths, cervitaurs, or any other demihuman that likes to hop.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/f55c8145-2858-47af-9e95-dd72c2c3fb69

</details>

## Changelog

:cl:
add: Adds the bouncy quirk which makes your character waddle regardless of clownshoes
/:cl:
