### PR TITLE
Moves hair-ties from head to pocket category in loadout

### DIFF
--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_heads.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_heads.dm
@@ -190,18 +190,6 @@
 *	MISC
 */
 
-/datum/loadout_item/head/hair_tie
-	name = "Hair Tie"
-	item_path = /obj/item/clothing/head/hair_tie
-
-/datum/loadout_item/head/hair_tie_scrunchie
-	name = "Scrunchie"
-	item_path = /obj/item/clothing/head/hair_tie/scrunchie
-
-/datum/loadout_item/head/hair_tie_plastic_beads
-	name = "Colorful Hair tie"
-	item_path = /obj/item/clothing/head/hair_tie/plastic_beads
-
 /datum/loadout_item/head/standalone_hood
 	name = "Recolorable Standalone Hood"
 	item_path = /obj/item/clothing/head/standalone_hood

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_pocket.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_pocket.dm
@@ -56,6 +56,18 @@
 *	MISC
 */
 
+/datum/loadout_item/pocket_items/hair_tie
+	name = "Hair Tie"
+	item_path = /obj/item/clothing/head/hair_tie
+
+/datum/loadout_item/pocket_items/hair_tie_scrunchie
+	name = "Scrunchie"
+	item_path = /obj/item/clothing/head/hair_tie/scrunchie
+
+/datum/loadout_item/pocket_items/hair_tie_plastic_beads
+	name = "Plastic Hair Tie"
+	item_path = /obj/item/clothing/head/hair_tie/plastic_beads
+
 /datum/loadout_item/pocket_items/rag
 	name = "Rag"
 	item_path = /obj/item/rag


### PR DESCRIPTION

## About The Pull Request

Tin.

## How This Contributes To The Nova Sector Roleplay Experience

In retrospect this makes more sense. Especially with hair masking now, you may want 2 hairstyles, so you can use 1 with a hat and one without.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/8abf1bbe-7994-4205-8175-8b78f8a68a3b)


</details>

## Changelog
:cl:
qol: Moves hair-ties from head to pocket category in loadout, now you can bring a hair tie and a hat to work
/:cl:
