### PR TITLE
Increases Station_Trait weight for "Human AI"

### DIFF
--- a/modular_nova/modules/station_traits/code/station_traits.dm
+++ b/modular_nova/modules/station_traits/code/station_traits.dm
@@ -26,4 +26,4 @@
 	weight = 0
 
 /datum/station_trait/job/human_ai
-	weight = 3
+	weight = 2

--- a/modular_nova/modules/station_traits/code/station_traits.dm
+++ b/modular_nova/modules/station_traits/code/station_traits.dm
@@ -24,3 +24,6 @@
 
 /datum/station_trait/skub
 	weight = 0
+
+/datum/station_trait/job/human_ai
+	weight = 3


### PR DESCRIPTION

## About The Pull Request

As the title implies, increases the weight of the Human AI job Station trait from 1 weight to 3 weight making it a more likely spawn making things a small bit more interesting, instead of just a kind of once in a blue moon gimmick

## How This Contributes To The Nova Sector Roleplay Experience

I think this would add more interesting RP to nova sector and allow for a more interesting approach to RP with the AI, as some RP cannot be done as the AI core like if characters are unable to be a real AI but instead volunteer as a "human" AI.

## Proof of Testing
![image](https://github.com/user-attachments/assets/0f53f8cf-b006-4e84-96ea-0b84d170b3c0)

![image](https://github.com/user-attachments/assets/c1be7ce8-e694-4b8e-9c31-c7db0d55bfc3)

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl:
code: Central Command has increased the volunteer pool for "Human AI" testing initiatives 
/:cl:
