### PR TITLE
[NOGBP]Disables on-going visual of transfer vote to match the map vote

### DIFF
--- a/modular_nova/modules/autotransfer/code/transfer_vote.dm
+++ b/modular_nova/modules/autotransfer/code/transfer_vote.dm
@@ -3,6 +3,7 @@
 
 /datum/vote/transfer_vote
 	name = "Transfer"
+	display_statistics = FALSE
 	default_choices = list(
 		CHOICE_TRANSFER,
 		CHOICE_CONTINUE,


### PR DESCRIPTION

## About The Pull Request

Given we hide mapvotes this is for the same reasoning.

## How This Contributes To The Nova Sector Roleplay Experience

The meme of 4 people swapping votes at 2 seconds as a troll isn't very fun

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  

![image](https://github.com/user-attachments/assets/bc9f156a-acda-4a36-a5f7-7e4acb5d0ac8)


</details>

## Changelog
:cl:
code: Map Transfer vote will hide pending results, similar to the Map vote
/:cl:
