### PR TITLE
Adds an admin fax for 'Interdyne Pharmaceuticals'

### DIFF
--- a/modular_nova/master_files/code/modules/paperwork/fax.dm
+++ b/modular_nova/master_files/code/modules/paperwork/fax.dm
@@ -1,4 +1,8 @@
-//DS-2 override for Syndicate centcom fax
+// Overrides Fax special networks to be relevant to each team
 /obj/machinery/fax/Initialize(mapload)
-	special_networks["syndicate"]["fax_name"] = "Syndicate Sectorial Command"
+	special_networks = list(
+		nanotrasen = list(fax_name = "NT HR Department", fax_id = "central_command", color = "teal", emag_needed = FALSE),
+		tarkon = list(fax_name = "Syndicate Sectorial Command", fax_id = "tarkon", color = "red", emag_needed = TRUE),
+		interdyne = list(fax_name = "Interdyne Legal Department", fax_id = "interdyne", color = "green", emag_needed = TRUE),
+	)
 	return ..()


### PR DESCRIPTION
## About The Pull Request

Adds a fax that is specific to interdyne pharmaceuticals so they can message admins functionally.

## How This Contributes To The Nova Sector Roleplay Experience

This will allow for more opportune roleplay for interdyne to be able to communicate with external leadership, it may not be a perfect system but it can work for what it is. Since DS-2 and NT have one it would make the most amount of sense for Interdyne to have one too.

## Proof of Testing

![image](https://github.com/user-attachments/assets/3d44aecc-f44f-4073-a07f-e25793e1fdca)
![image](https://github.com/user-attachments/assets/b0485936-0a3c-4f81-b1df-083bc790f771)
![image](https://github.com/user-attachments/assets/277f5e09-e905-4e8f-b94b-ae82c6e94379)

## Changelog

:cl:
qol: after many galactic cycles and shifts interdyne now has a fax address number for interdyne headquarters to communicate with upper levels of staff instead of remaining isolated.
/:cl:
