### PR TITLE
Increases the char limit on the opfor denial reason

### DIFF
--- a/modular_nova/modules/opposing_force/code/opposing_force_datum.dm
+++ b/modular_nova/modules/opposing_force/code/opposing_force_datum.dm
@@ -328,7 +328,7 @@
 		if("deny")
 			if(!check_rights(R_ADMIN))
 				return
-			var/denied_reason = tgui_input_text(usr, "Denial Reason", "Enter a reason for denying this application:", max_length = MAX_NAME_LEN)
+			var/denied_reason = tgui_input_text(usr, "Denial Reason", "Enter a reason for denying this application:", max_length = MAX_MESSAGE_LEN)
 			// Checking to see if the user is spamming the button, async and all.
 			if((status == OPFOR_STATUS_DENIED) || !denied_reason)
 				return


### PR DESCRIPTION
## About The Pull Request

This doesn't end up on the UI itself, it shows in the chat panel. So no reason not to have it be the max message length (2048).

Was 42 formerly which was not enough.

## Changelog

:cl:
qol: opfor denial character limit has been increased to 2048
/:cl: