### PR TITLE
fix armadyne digi

### DIFF
--- a/modular_nova/modules/sec_haul/code/misc/vending.dm
+++ b/modular_nova/modules/sec_haul/code/misc/vending.dm
@@ -63,13 +63,6 @@
 				/obj/item/storage/backpack/satchel/sec = 4,
 				/obj/item/storage/backpack/duffelbag/sec = 4,
 				/obj/item/storage/backpack/messenger/sec = 4,
-				/obj/item/clothing/suit/armor/vest/armadyne/armor = 4,
-				/obj/item/clothing/shoes/jackboots/armadyne = 4,
-				/obj/item/clothing/under/rank/security/armadyne = 4,
-				/obj/item/clothing/under/rank/security/armadyne/tactical = 4,
-				/obj/item/clothing/head/beret/sec/armadyne = 4,
-				/obj/item/clothing/suit/armor/vest/armadyne/armor = 4,
-				/obj/item/clothing/gloves/color/black/security/armadyne = 4,
 			),
 		),
 


### PR DESCRIPTION
## About The Pull Request

Fixes the lack of worn_icon_digi for armadyne clothing

## How This Contributes To The Nova Sector Roleplay Experience

More clothes for officers, why not?

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/b914a0fa-f828-4701-95ef-f2a5ee26ea6b)

</details>

## Changelog

:cl: Saukykouko
fix: armadyne clothing now works properly with digi legs
/:cl: