### PR TITLE
Adds in service guard lockers to Nova's maps.

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -19232,6 +19232,11 @@
 	dir = 1
 	},
 /area/station/security/checkpoint/science/research)
+"dIk" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/closet/secure_closet/security/service,
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/service)
 "dIn" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -125136,9 +125141,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "xUx" = (
-/obj/structure/closet/crate/hydroponics,
 /obj/machinery/light/directional/west,
 /obj/item/radio/intercom/directional/west,
+/obj/structure/closet/secure_closet/security/service,
 /turf/open/floor/iron/checker,
 /area/station/hallway/secondary/service)
 "xUA" = (
@@ -165261,7 +165266,7 @@ pdU
 hAd
 nYM
 qIW
-ooc
+dIk
 hYX
 nlI
 hFC

--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -15816,20 +15816,14 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/obj/item/storage/cans/sixbeer,
-/obj/structure/closet/cabinet{
-	name = "\proper bouncer's cabinet"
-	},
 /obj/machinery/requests_console/auto_name/directional/south,
 /obj/effect/mapping_helpers/requests_console/assistance,
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/west,
-/obj/item/storage/belt/utility,
-/obj/item/clothing/under/misc/bouncer,
-/obj/item/clothing/mask/whistle,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/closet/secure_closet/security/service,
 /turf/open/floor/wood/large,
 /area/station/security/checkpoint/service)
 "eDD" = (

--- a/_maps/map_files/SerenityStation/SerenityStation.dmm
+++ b/_maps/map_files/SerenityStation/SerenityStation.dmm
@@ -36652,9 +36652,8 @@
 /turf/open/floor/grass,
 /area/station/commons/fitness/recreation)
 "kwl" = (
-/obj/structure/table/wood,
-/obj/item/storage/dice,
 /obj/machinery/light/directional/south,
+/obj/structure/closet/secure_closet/security/service,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "kwm" = (
@@ -39090,6 +39089,7 @@
 /obj/structure/table/wood,
 /obj/item/storage/box/rubbershot,
 /obj/item/gun/ballistic/shotgun/doublebarrel,
+/obj/item/storage/dice,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "liH" = (

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -42221,9 +42221,6 @@
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/computer/security/telescreen/bar/directional/south{
-	name = "Service Telescreen"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -52673,7 +52670,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/closet/secure_closet/security/service,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -62278,10 +62274,7 @@
 "qLC" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
-/obj/machinery/recharger{
-	pixel_y = 3
-	},
-/obj/structure/table/reinforced,
+/obj/structure/closet/secure_closet/security/service,
 /turf/open/floor/iron/dark/side{
 	dir = 6
 	},
@@ -72920,6 +72913,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
+/obj/machinery/computer/security/telescreen/bar/directional/south{
+	name = "Service Telescreen"
+	},
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -76272,6 +76268,9 @@
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
 /obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 10
 	},

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -52673,6 +52673,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/security/service,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -4946,6 +4946,8 @@
 /obj/item/hand_labeler{
 	pixel_y = 9
 	},
+/obj/item/storage/photo_album/bar,
+/obj/item/storage/dice,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "bvt" = (
@@ -15207,15 +15209,13 @@
 /turf/open/floor/iron/small,
 /area/station/hallway/secondary/exit/departure_lounge)
 "esi" = (
-/obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/item/storage/photo_album/bar,
-/obj/item/storage/dice,
 /obj/machinery/airalarm/directional/south,
+/obj/structure/closet/secure_closet/security/service,
 /turf/open/floor/wood/tile,
 /area/station/service/bar)
 "esu" = (


### PR DESCRIPTION
## About The Pull Request

This adds in service guard lockers to the modular maps on Nova. Snowglobe gets one in its service post, Ouroboros in the bouncer's office, replacing the bouncer's cabinet, and Void Raptor, Blueshift, and Serenity all get them in the bar backroom/bar storage.

This pull request could be considered a sort of "first phase" in a two phase plan to add in service guard lockers to the maps. The second would be making mapping templates to add them to /tg/'s maps.

## How This Contributes To The Nova Sector Roleplay Experience

As of now, the only way to get a service guard locker on any map is to ahelp/pray to get one spawned in. While this would still be the case for a lot of maps in the rotation, i still think it's beneficial, because there would at least be five maps with service guard lockers, meaning that you wouldn't need to make a roundstart/post-init ahelp to get one spawned in in those cases.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

![Screenshot_310](https://github.com/user-attachments/assets/a301049d-1837-40de-86fb-9444b922fa41)


</details>

## Changelog
:cl:
map: Snowglobe, Ouroboros, Void Raptor, Blueshift, and Serenity all now have service guard lockers.
/:cl:
