### PR TITLE
Adds stoat to the list of pets selectable with pet owner

### DIFF
--- a/modular_nova/modules/pet_owner/pet_owner.dm
+++ b/modular_nova/modules/pet_owner/pet_owner.dm
@@ -102,6 +102,7 @@ GLOBAL_LIST_INIT(possible_player_pet, list(
 	"Sloth" = /mob/living/basic/sloth,
 	"Snake" = /mob/living/basic/snake,
 	"Spider" = /mob/living/basic/spider/maintenance,
+	"Stoat" = /mob/living/basic/stoat,
 	"Tegu" = /mob/living/basic/lizard/tegu,
 	"Turtle" = /mob/living/basic/turtle,
 )) //some of these are too big to be put back into the pet carrier once taken out, so I put a warning on the carrier.


### PR DESCRIPTION
## About The Pull Request

Adds stoat as a selectable pet for the pet owner quirk.

## How This Contributes To The Nova Sector Roleplay Experience

There're stoats on station. You can take them home. They're free. I have 153 stoats living in my space garage.

People have fallen in love with the little guys since they've come on station, and I've seen a few crewmates tame the little fellows. This will allow for persistent stoat pets.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/9cadc199-b316-4edd-a99e-79fbac3d6aa3)
![image](https://github.com/user-attachments/assets/3f94e204-4b7d-4e95-a217-75b2fb968d02)
![image](https://github.com/user-attachments/assets/a4ba5f93-15b4-4c1d-8681-b2d867fe55d1)
![image](https://github.com/user-attachments/assets/7f501df9-3157-4e34-a4a1-77a6886937a3)

</details>

## Changelog
:cl:
add: Following NanoTrasen's recent introduction of stoats on station as a viable pest control solution, Central Command has found it fit to relax their customs policy to allow crewmates to bring stoats (rather obtained on station or through the intergalactic pet trade) through customs as part of their progressive Bring-Your-Pet-To-Work initiative.
/:cl:
