### PR TITLE
[SEMI-MODULAR] Updates hardened armor to work as described

### DIFF
--- a/code/__DEFINES/~nova_defines/signals.dm
+++ b/code/__DEFINES/~nova_defines/signals.dm
@@ -100,3 +100,6 @@
 
 ///from base of atom/fire_act(): (exposed_temperature, exposed_volume)
 #define COMSIG_ATOM_PRE_FIRE_ACT "atom_fire_act"
+
+///from base of atom/projectile_hit(): (hitting_projectile, def_zone, piercing_hit, blocked)
+#define COMSIG_ATOM_PROJECTILE_HIT "atom_projectile_hit"

--- a/code/game/atom/atom_act.dm
+++ b/code/game/atom/atom_act.dm
@@ -85,6 +85,7 @@
  */
 
 /atom/proc/projectile_hit(obj/projectile/hitting_projectile, def_zone, piercing_hit = FALSE, blocked = null)
+	SEND_SIGNAL(src, COMSIG_ATOM_PROJECTILE_HIT, hitting_projectile, def_zone, piercing_hit, blocked) // NOVA ADDITION EDIT
 	if (isnull(blocked))
 		blocked = check_projectile_armor(def_zone, hitting_projectile)
 	return bullet_act(hitting_projectile, def_zone, piercing_hit, blocked)

--- a/code/genesis_call.dme
+++ b/code/genesis_call.dme
@@ -50,3 +50,12 @@
  */
 /world/proc/_()
 	var/static/_ = world.Genesis()
+// BEGIN_INTERNALS
+// END_INTERNALS
+// BEGIN_FILE_DIR
+#define FILE_DIR .
+// END_FILE_DIR
+// BEGIN_PREFERENCES
+// END_PREFERENCES
+// BEGIN_INCLUDE
+// END_INCLUDE

--- a/modular_nova/modules/specialist_armor/code/hardened.dm
+++ b/modular_nova/modules/specialist_armor/code/hardened.dm
@@ -28,9 +28,9 @@
 
 /obj/item/clothing/suit/armor/sf_hardened/equipped(mob/living/carbon/human/wearer, slot)
 	. = ..()
-	if(!(istype(user) && (slot & ITEM_SLOT_OCLOTHING)))
+	if(!(istype(wearer) && (slot & ITEM_SLOT_OCLOTHING)))
 		return
-	RegisterSignal(wearer, COMSIG_ATOM_PRE_BULLET_ACT, PROC_REF(reduce_ap)
+	RegisterSignal(wearer, COMSIG_ATOM_PRE_BULLET_ACT, PROC_REF(reduce_ap))
 
 /obj/item/clothing/suit/armor/sf_hardened/dropped(mob/living/carbon/human/wearer)
 	. = ..()
@@ -93,9 +93,9 @@
 
 /obj/item/clothing/head/helmet/toggleable/sf_hardened/equipped(mob/living/carbon/human/wearer, slot)
 	. = ..()
-	if(!(istype(user) && (slot & ITEM_SLOT_HEAD)))
+	if(!(istype(wearer) && (slot & ITEM_SLOT_HEAD)))
 		return
-	RegisterSignal(wearer, COMSIG_ATOM_PRE_BULLET_ACT, PROC_REF(reduce_ap)
+	RegisterSignal(wearer, COMSIG_ATOM_PRE_BULLET_ACT, PROC_REF(reduce_ap))
 
 /obj/item/clothing/head/helmet/toggleable/sf_hardened/dropped(mob/living/carbon/human/wearer)
 	. = ..()
@@ -107,10 +107,7 @@
 	SIGNAL_HANDLER
 
 	// dynamic pen-reduction coverage with respect to visor state
-	if(piercing_hit ||
-	(up && !(def_zone in list(BODY_ZONE_HEAD))) ||
-	!(def_zone in list(BODY_ZONE_HEAD, BODY_ZONE_PRECISE_EYES, BODY_ZONE_PRECISE_MOUTH))
-	)
+	if( piercing_hit || (up && !(def_zone in list(BODY_ZONE_HEAD))) || !(def_zone in list(BODY_ZONE_HEAD, BODY_ZONE_PRECISE_EYES, BODY_ZONE_PRECISE_MOUTH)) )
 		return
 
 	incoming_projectile.armour_penetration = 0

--- a/modular_nova/modules/specialist_armor/code/hardened.dm
+++ b/modular_nova/modules/specialist_armor/code/hardened.dm
@@ -1,4 +1,7 @@
-// Hardened vests negate any and all projectile armor penetration, in exchange for having mid af bullet armor
+// Hardened armor negates any and all projectile armor penetration, in exchange for a mediocre armor profile
+
+// vests
+
 /datum/armor/armor_sf_hardened
 	melee = ARMOR_LEVEL_WEAK
 	bullet = ARMOR_LEVEL_MID
@@ -23,12 +26,28 @@
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 	resistance_flags = FIRE_PROOF
 
-/obj/item/clothing/suit/armor/sf_hardened/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, final_block_chance, damage, attack_type, damage_type)
-	if(istype(hitby, /obj/projectile))
-		var/obj/projectile/incoming_projectile = hitby
-		incoming_projectile.armour_penetration = 0
-		playsound(src, SFX_RICOCHET, BLOCK_SOUND_VOLUME, vary = TRUE)
-	return ..()
+/obj/item/clothing/suit/armor/sf_hardened/equipped(mob/living/carbon/human/wearer, slot)
+	. = ..()
+	if(!(istype(user) && (slot & ITEM_SLOT_OCLOTHING)
+		return
+	RegisterSignal(wearer, COMSIG_ATOM_PRE_BULLET_ACT, PROC_REF(reduce_ap)
+
+/obj/item/clothing/suit/armor/sf_hardened/dropped(mob/living/carbon/human/wearer)
+	. = ..()
+	if(!(src == wearer.wear_suit))
+		return
+	UnregisterSignal(wearer, COMSIG_ATOM_PRE_BULLET_ACT)
+
+/obj/item/clothing/suit/armor/sf_hardened/proc/reduce_ap(obj/projectile/incoming_projectile, def_zone, piercing_hit, blocked)
+	SIGNAL_HANDLER
+
+	if(piercing_hit || (def_zone != BODY_ZONE_CHEST))
+		return
+
+	incoming_projectile.armour_penetration = 0
+	playsound(src, SFX_RICOCHET, BLOCK_SOUND_VOLUME, vary = TRUE)
+
+	return COMPONENT_BULLET_ACTED
 
 /obj/item/clothing/suit/armor/sf_hardened/examine_more(mob/user)
 	. = ..()
@@ -44,12 +63,14 @@
 
 	return .
 
-/obj/item/clothing/suit/armor/sf_hardened/emt
+/obj/item/clothing/suit/armor/sf_hardened/emt // google "perfidy"
 	name = "'Archangel' hardened armor vest"
 	desc = "A large white breastplate with a lone red stripe, and a semi-flexible mail of dense panels that cover the torso. \
 		While not so incredible at directly stopping bullets, the vest is uniquely suited to cause bullets \
 		to lose much of their armor penetrating energy before any damage can be done."
 	icon_state = "hardened_emt"
+
+// helmets
 
 /obj/item/clothing/head/helmet/toggleable/sf_hardened
 	name = "'Muur' enclosed helmet"
@@ -70,12 +91,32 @@
 	supports_variations_flags = CLOTHING_SNOUTED_VARIATION_NO_NEW_ICON
 	resistance_flags = FIRE_PROOF
 
-/obj/item/clothing/head/helmet/toggleable/sf_hardened/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, final_block_chance, damage, attack_type, damage_type)
-	if(istype(hitby, /obj/projectile))
-		var/obj/projectile/incoming_projectile = hitby
-		incoming_projectile.armour_penetration = 0
-		playsound(src, SFX_RICOCHET, BLOCK_SOUND_VOLUME, vary = TRUE)
-	return ..()
+/obj/item/clothing/head/helmet/toggleable/sf_hardened/equipped(mob/living/carbon/human/wearer, slot)
+	. = ..()
+	if(!(istype(user) && (slot & ITEM_SLOT_HEAD)
+		return
+	RegisterSignal(wearer, COMSIG_ATOM_PRE_BULLET_ACT, PROC_REF(reduce_ap)
+
+/obj/item/clothing/head/helmet/toggleable/sf_hardened/dropped(mob/living/carbon/human/wearer)
+	. = ..()
+	if(!(src == wearer.head))
+		return
+	UnregisterSignal(wearer, COMSIG_ATOM_PRE_BULLET_ACT)
+
+/obj/item/clothing/head/helmet/toggleable/sf_hardened/proc/reduce_ap(obj/projectile/incoming_projectile, def_zone, piercing_hit, blocked)
+	SIGNAL_HANDLER
+
+	// dynamic pen-reduction coverage with respect to visor state
+	if(piercing_hit ||
+	(up && !(def_zone in list(BODY_ZONE_HEAD))) ||
+	!(def_zone in list(BODY_ZONE_HEAD, BODY_ZONE_PRECISE_EYES, BODY_ZONE_PRECISE_MOUTH))
+	)
+		return
+
+	incoming_projectile.armour_penetration = 0
+	playsound(src, SFX_RICOCHET, BLOCK_SOUND_VOLUME, vary = TRUE)
+
+	return COMPONENT_BULLET_ACTED
 
 /obj/item/clothing/head/helmet/toggleable/sf_hardened/examine_more(mob/user)
 	. = ..()

--- a/modular_nova/modules/specialist_armor/code/hardened.dm
+++ b/modular_nova/modules/specialist_armor/code/hardened.dm
@@ -30,24 +30,22 @@
 	. = ..()
 	if(!(istype(wearer) && (slot & ITEM_SLOT_OCLOTHING)))
 		return
-	RegisterSignal(wearer, COMSIG_ATOM_PRE_BULLET_ACT, PROC_REF(reduce_ap))
+	RegisterSignal(wearer, COMSIG_ATOM_PROJECTILE_HIT, PROC_REF(hit_by_projectile))
 
 /obj/item/clothing/suit/armor/sf_hardened/dropped(mob/living/carbon/human/wearer)
 	. = ..()
 	if(!(src == wearer.wear_suit))
 		return
-	UnregisterSignal(wearer, COMSIG_ATOM_PRE_BULLET_ACT)
+	UnregisterSignal(wearer, COMSIG_ATOM_PROJECTILE_HIT)
 
-/obj/item/clothing/suit/armor/sf_hardened/proc/reduce_ap(obj/projectile/incoming_projectile, def_zone, piercing_hit, blocked)
+/obj/item/clothing/suit/armor/sf_hardened/proc/hit_by_projectile(mob/living/source, obj/projectile/incoming_projectile, def_zone)
 	SIGNAL_HANDLER
 
-	if(piercing_hit || (def_zone != BODY_ZONE_CHEST))
+	if(def_zone != BODY_ZONE_CHEST)
 		return
 
 	incoming_projectile.armour_penetration = 0
 	playsound(src, SFX_RICOCHET, BLOCK_SOUND_VOLUME, vary = TRUE)
-
-	return COMPONENT_BULLET_ACTED
 
 /obj/item/clothing/suit/armor/sf_hardened/examine_more(mob/user)
 	. = ..()
@@ -83,6 +81,7 @@
 	armor_type = /datum/armor/armor_sf_hardened
 	toggle_message = "You extend the visor on"
 	alt_toggle_message = "You retract the visor on"
+	actions_types = list(/datum/action/item_action/toggle)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	visor_flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
@@ -95,25 +94,23 @@
 	. = ..()
 	if(!(istype(wearer) && (slot & ITEM_SLOT_HEAD)))
 		return
-	RegisterSignal(wearer, COMSIG_ATOM_PRE_BULLET_ACT, PROC_REF(reduce_ap))
+	RegisterSignal(wearer, COMSIG_ATOM_PROJECTILE_HIT, PROC_REF(hit_by_projectile))
 
 /obj/item/clothing/head/helmet/toggleable/sf_hardened/dropped(mob/living/carbon/human/wearer)
 	. = ..()
 	if(!(src == wearer.head))
 		return
-	UnregisterSignal(wearer, COMSIG_ATOM_PRE_BULLET_ACT)
+	UnregisterSignal(wearer, COMSIG_ATOM_PROJECTILE_HIT)
 
-/obj/item/clothing/head/helmet/toggleable/sf_hardened/proc/reduce_ap(obj/projectile/incoming_projectile, def_zone, piercing_hit, blocked)
+/obj/item/clothing/head/helmet/toggleable/sf_hardened/proc/hit_by_projectile(mob/living/source, obj/projectile/incoming_projectile, def_zone)
 	SIGNAL_HANDLER
 
 	// dynamic pen-reduction coverage with respect to visor state
-	if( piercing_hit || (up && !(def_zone in list(BODY_ZONE_HEAD))) || !(def_zone in list(BODY_ZONE_HEAD, BODY_ZONE_PRECISE_EYES, BODY_ZONE_PRECISE_MOUTH)) )
+	if((up && (def_zone != BODY_ZONE_HEAD)) || !(def_zone in list(BODY_ZONE_HEAD, BODY_ZONE_PRECISE_EYES, BODY_ZONE_PRECISE_MOUTH)) )
 		return
 
 	incoming_projectile.armour_penetration = 0
 	playsound(src, SFX_RICOCHET, BLOCK_SOUND_VOLUME, vary = TRUE)
-
-	return COMPONENT_BULLET_ACTED
 
 /obj/item/clothing/head/helmet/toggleable/sf_hardened/examine_more(mob/user)
 	. = ..()

--- a/modular_nova/modules/specialist_armor/code/hardened.dm
+++ b/modular_nova/modules/specialist_armor/code/hardened.dm
@@ -23,12 +23,12 @@
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 	resistance_flags = FIRE_PROOF
 
-/obj/item/clothing/suit/armor/sf_hardened/bullet_act(obj/projectile/hitting_projectile, def_zone, piercing_hit)
-
-    hitting_projectile.armour_penetration = 0
-    playsound(src, SFX_RICOCHET, BLOCK_SOUND_VOLUME, vary = TRUE)
-
-    return ..()
+/obj/item/clothing/suit/armor/sf_hardened/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, final_block_chance, damage, attack_type, damage_type)
+	if(istype(hitby, /obj/projectile))
+		var/obj/projectile/incoming_projectile = hitby
+		incoming_projectile.armour_penetration = 0
+		playsound(src, SFX_RICOCHET, BLOCK_SOUND_VOLUME, vary = TRUE)
+	return ..()
 
 /obj/item/clothing/suit/armor/sf_hardened/examine_more(mob/user)
 	. = ..()
@@ -70,12 +70,12 @@
 	supports_variations_flags = CLOTHING_SNOUTED_VARIATION_NO_NEW_ICON
 	resistance_flags = FIRE_PROOF
 
-/obj/item/clothing/head/helmet/toggleable/sf_hardened/bullet_act(obj/projectile/hitting_projectile, def_zone, piercing_hit)
-
-    hitting_projectile.armour_penetration = 0
-    playsound(src, SFX_RICOCHET, BLOCK_SOUND_VOLUME, vary = TRUE)
-
-    return ..()
+/obj/item/clothing/head/helmet/toggleable/sf_hardened/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, final_block_chance, damage, attack_type, damage_type)
+	if(istype(hitby, /obj/projectile))
+		var/obj/projectile/incoming_projectile = hitby
+		incoming_projectile.armour_penetration = 0
+		playsound(src, SFX_RICOCHET, BLOCK_SOUND_VOLUME, vary = TRUE)
+	return ..()
 
 /obj/item/clothing/head/helmet/toggleable/sf_hardened/examine_more(mob/user)
 	. = ..()

--- a/modular_nova/modules/specialist_armor/code/hardened.dm
+++ b/modular_nova/modules/specialist_armor/code/hardened.dm
@@ -28,7 +28,7 @@
 
 /obj/item/clothing/suit/armor/sf_hardened/equipped(mob/living/carbon/human/wearer, slot)
 	. = ..()
-	if(!(istype(user) && (slot & ITEM_SLOT_OCLOTHING)
+	if(!(istype(user) && (slot & ITEM_SLOT_OCLOTHING)))
 		return
 	RegisterSignal(wearer, COMSIG_ATOM_PRE_BULLET_ACT, PROC_REF(reduce_ap)
 
@@ -93,7 +93,7 @@
 
 /obj/item/clothing/head/helmet/toggleable/sf_hardened/equipped(mob/living/carbon/human/wearer, slot)
 	. = ..()
-	if(!(istype(user) && (slot & ITEM_SLOT_HEAD)
+	if(!(istype(user) && (slot & ITEM_SLOT_HEAD)))
 		return
 	RegisterSignal(wearer, COMSIG_ATOM_PRE_BULLET_ACT, PROC_REF(reduce_ap)
 

--- a/modular_nova/modules/specialist_armor/code/hardened.dm
+++ b/modular_nova/modules/specialist_armor/code/hardened.dm
@@ -23,13 +23,12 @@
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 	resistance_flags = FIRE_PROOF
 
-/obj/item/clothing/suit/armor/sf_hardened/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, final_block_chance, damage, attack_type, damage_type)
-	. = ..()
+/obj/item/clothing/suit/armor/sf_hardened/bullet_act(obj/projectile/hitting_projectile, def_zone, piercing_hit)
 
-	if(istype(hitby, /obj/projectile))
-		var/obj/projectile/incoming_projectile = hitby
-		incoming_projectile.armour_penetration = 0
-		playsound(owner, SFX_RICOCHET, BLOCK_SOUND_VOLUME, vary = TRUE)
+    hitting_projectile.armour_penetration = 0
+    playsound(src, SFX_RICOCHET, BLOCK_SOUND_VOLUME, vary = TRUE)
+
+    return ..()
 
 /obj/item/clothing/suit/armor/sf_hardened/examine_more(mob/user)
 	. = ..()
@@ -71,13 +70,12 @@
 	supports_variations_flags = CLOTHING_SNOUTED_VARIATION_NO_NEW_ICON
 	resistance_flags = FIRE_PROOF
 
-/obj/item/clothing/head/helmet/toggleable/sf_hardened/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, final_block_chance, damage, attack_type, damage_type)
-	. = ..()
+/obj/item/clothing/head/helmet/toggleable/sf_hardened/bullet_act(obj/projectile/hitting_projectile, def_zone, piercing_hit)
 
-	if(istype(hitby, /obj/projectile))
-		var/obj/projectile/incoming_projectile = hitby
-		incoming_projectile.armour_penetration = 0
-		playsound(src, SFX_RICOCHET, BLOCK_SOUND_VOLUME, vary = TRUE)
+    hitting_projectile.armour_penetration = 0
+    playsound(src, SFX_RICOCHET, BLOCK_SOUND_VOLUME, vary = TRUE)
+
+    return ..()
 
 /obj/item/clothing/head/helmet/toggleable/sf_hardened/examine_more(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #5589; hardened armor used to reduce the armour_penetration of incoming projectiles in the wrong spot in the attack chain. It now works correctly.

## How This Contributes To The Nova Sector Roleplay Experience

Hardened armor is a really cool concept, which no one uses because it's broken. Hopefully it will see more use with this.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

One round of 9mm AP against hardened armor; target otherwise unarmored. Expected damage is 14 if it works, or 23 if it doesn't. See #5589 for calculation details.
  
![image](https://github.com/user-attachments/assets/67ef1728-6030-4fee-9257-f553bdacb6c5)

Works on the helmet, too; same test parameters.

![image](https://github.com/user-attachments/assets/40b870ee-a901-4161-b9a7-4dc47692d9e5)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Sol Defense Imports has uncovered and stopped an embezzlement scheme affecting the quality of its 'Muur' and 'Archangel' hardened armor systems. The product should now more effectively neutralize armor-piercing projectiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
