### PR TITLE
Fixes borgs splashing reagents in beakers when cryoing

### DIFF
--- a/modular_nova/modules/cryosleep/code/cryopod.dm
+++ b/modular_nova/modules/cryosleep/code/cryopod.dm
@@ -414,6 +414,14 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 		else
 			mob_occupant.transferItemToLoc(item_content, drop_location(), force = TRUE, silent = TRUE)
 
+	// Borgs will splash the ground with their beaker reagents on qdel, let's make sure this does not happen
+	if(iscyborg(occupant))
+		var/mob/living/silicon/robot/cyborg_occupant = occupant
+		var/obj/item/borg/apparatus/beaker/borg_beaker = (locate() in cyborg_occupant.model.modules) || (locate() in cyborg_occupant.held_items)
+		if(borg_beaker && borg_beaker.stored)
+			var/obj/item/reagent_containers/reagent_container = borg_beaker.stored
+			reagent_container.reagents?.clear_reagents()
+
 	GLOB.joined_player_list -= occupant_ckey
 
 	handle_objectives()


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/5609

## How This Contributes To The Nova Sector Roleplay Experience

Tones down the space-OSHA violations a smidge.

![image](https://github.com/user-attachments/assets/b137e095-e5d7-451f-890c-c94e10d2e42e)

## Proof of Testing

<details>
<summary>No more radioactive sludge</summary>

![dreamseeker_t0pgxfR4E0](https://github.com/user-attachments/assets/8046eddb-beca-4b18-a86c-a688613934f9)

</details>

## Changelog

:cl:
fix: borgs will no longer leave the entire contents of their beaker module on the floor when cryoing
/:cl:
