### PR TITLE
[NO GBP] haywire bullets make an EMP visual effect on impact

### DIFF
--- a/modular_nova/modules/modular_weapons/code/modular_projectiles/projectiles.dm
+++ b/modular_nova/modules/modular_weapons/code/modular_projectiles/projectiles.dm
@@ -11,6 +11,7 @@
 /obj/projectile/bullet/c38/haywire/on_hit(atom/target, blocked, pierce_hit)
 	. = ..()
 	empulse(target, 0, emp_radius)
+	new /obj/effect/temp_visual/emp/pulse(get_turf(target))
 
 // .357
 
@@ -25,6 +26,7 @@
 /obj/projectile/bullet/c357/haywire/on_hit(atom/target, blocked, pierce_hit)
 	. = ..()
 	empulse(target, emp_radius, emp_radius)
+	new /obj/effect/temp_visual/emp/pulse(get_turf(target))
 
 // .45
 


### PR DESCRIPTION
## About The Pull Request
title

## How This Contributes To The Nova Sector Roleplay Experience
should probably realize when you're getting tagged with EMP bullets that are sending your batteries to the shadow realm

## Changelog

:cl:
add: Haywire bullets create electromagnetic pulse visual effects for the sake of visual clarity.
/:cl:
