### PR TITLE
Fixes a midround sometimes spawning w/o suit deployed

### DIFF
--- a/modular_nova/modules/contractor/code/datums/midround/antag_datum.dm
+++ b/modular_nova/modules/contractor/code/datums/midround/antag_datum.dm
@@ -18,11 +18,8 @@
 	if(!ishuman(owner.current))
 		return
 	var/mob/living/carbon/human/person = owner.current
-	var/datum/outfit/outfit_to_apply = new contractor_outfit
-	if(person.jumpsuit_style == PREF_SKIRT)
-		outfit_to_apply.uniform = /obj/item/clothing/under/syndicate/nova/tactical/skirt
-	person.equipOutfit(outfit_to_apply)
 	SSquirks.AssignQuirks(person, person.client)
+	person.equipOutfit(/datum/outfit/contractor)
 	return TRUE
 
 /datum/antagonist/contractor/on_gain()

--- a/modular_nova/modules/contractor/code/datums/midround/outfit.dm
+++ b/modular_nova/modules/contractor/code/datums/midround/outfit.dm
@@ -28,6 +28,10 @@
 
 	id_trim = /datum/id_trim/chameleon/contractor
 
+/datum/outfit/contractor/pre_equip(mob/living/carbon/human/user)
+	if(user.jumpsuit_style == PREF_SKIRT)
+		uniform = /obj/item/clothing/under/syndicate/nova/tactical/skirt
+
 /datum/outfit/contractor/post_equip(mob/living/carbon/human/user, visualsOnly)
 	. = ..()
 	if(visualsOnly)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Optimizes the code a little and puts quirk loading before the contractor outfit worn.

## How This Contributes To The Nova Sector Roleplay Experience

Bugs are bad.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
I tested it but forgot to make a pic.
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Quirks which give clothing (essential for life) no longer cause midround contractor to spawn with their suit undeployed in space
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
