### PR TITLE
rounds the BR38 magazines and degradation numbers to nice, round, even numbers

### DIFF
--- a/modular_nova/master_files/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/modular_nova/master_files/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -1,3 +1,3 @@
 /obj/item/ammo_box/magazine/m38
 	w_class = WEIGHT_CLASS_SMALL
-	max_ammo = 28
+	max_ammo = 30 // seriously why buff this from 15 to 28. why not just a round number. be fr

--- a/modular_nova/master_files/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/modular_nova/master_files/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1,4 +1,4 @@
 /obj/item/gun/ballistic/automatic/battle_rifle
-	max_shots_before_degradation = 18
-	shots_before_degradation = 18
+	max_shots_before_degradation = 30 // one clean mag before maintenance becomes an issue
+	shots_before_degradation = 30
 	degradation_probability = 5


### PR DESCRIPTION
## About The Pull Request
br38 mags now hold 30 bullets, up from 28, because 28 is a stupid number why is it not a clean multiple of 6
br38 now only starts degrading after one full mag of dumping in someone's general direction (30 shots)

## How This Contributes To The Nova Sector Roleplay Experience
maybe one day the br38 won't be overlooked, right chat
![potential_rifle](https://github.com/user-attachments/assets/efde719e-4f25-4845-8bd0-8abbb9af47c6)

## Changelog

:cl:
balance: Further developments to the BR-38 program allowed the designers to expand the magazines to 30 rounds (up from 28) and harden the rail system to at least prevent degradation for one magazine's worth of fire (30 rounds). Maintenance, however, remains an issue.
/:cl:
