### PR TITLE
Fix the corpo regs objective/wiki url for manuals

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -198,10 +198,10 @@ IPINTEL_REJECT_BAD
 # FORUMURL http://tgstation13.org/phpBB/index.php
 
 ## Wiki address
-# WIKIURL http://tgstation13.org/wiki
+# WIKIURL https://wiki.novasector13.com/wiki
 
 ## Rules address
-# RULESURL http://tgstation13.org/wiki/Rules
+# RULESURL https://wiki.novasector13.com/Rules
 
 ## Github address
 # GITHUBURL https://www.github.com/tgstation/tgstation

--- a/modular_nova/master_files/code/game/objects/items/wiki_manuals.dm
+++ b/modular_nova/master_files/code/game/objects/items/wiki_manuals.dm
@@ -3,3 +3,6 @@
 	desc = "A set of Nanotrasen regulations for keeping law, order, and procedure followed within their space stations."
 	starting_title = "Corporate Regulations"
 	page_link = "Corporate_Regulations"
+
+/datum/objective_item/steal/traitor/space_law
+	name = "a book on corporate regulations"


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/5617

The URL in the config was not friendly to the formatting the code requires in order to render the print friendly version of the HTML.

## How This Contributes To The Nova Sector Roleplay Experience

Wikis should work

## Proof of Testing

<details>
<summary>Working once more</summary>
  
![image](https://github.com/user-attachments/assets/86732f8f-2e64-49fe-b7bb-14351f38736c)

</details>

## Changelog

:cl:
fix: fixes wiki manuals not loading properly
/:cl: