### PR TITLE
Adds an option to open a TG upstream issue from the bug report verb

### DIFF
--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -68,12 +68,12 @@
 	var/has_testmerge_data = (length(testmerge_data) != 0)
 
 	// NOVA EDIT ADDITION START
-	var/issue_source_message = "Are you reporting a TG issue, or a Nova issue?"
-	issue_source_message += "<br>If you are unsure whether the problem comes from TG or not, choose 'Nova Issue'."
-	var/issue_source = tg_alert(src, issue_source_message, "Report Issue", "Nova Issue", "TG Issue")
+	var/issue_source_message = "Are you reporting a TG issue, or a Nova issue?\
+		<br>If you are unsure whether the problem comes from upstream or not, choose 'Nova Issue'."
+	var/issue_source = tg_alert(src, issue_source_message, "Report Issue", "Nova Issue", "TG Upstream Issue")
 	if(isnull(issue_source))
 		return
-	if(issue_source == "TG Issue")
+	if(issue_source == "TG Upstream Issue")
 		githuburl = "https://www.github.com/tgstation/tgstation"
 	// NOVA EDIT ADDITION END
 	var/message = "This will open the Github issue reporter in your browser. Are you sure?"
@@ -93,11 +93,11 @@
 	concatable += ("&reporting-version=" + client_version)
 
 	// the way it works is that we use the ID's that are baked into the template YML and replace them with values that we can collect in game.
-	if(GLOB.round_id)
+	if(GLOB.round_id && issue_source != "TG Upstream Issue") // NOVA EDIT CHANGE - ORIGINAL: if(GLOB.round_id)
 		concatable += ("&round-id=" + GLOB.round_id)
 
 	// Insert testmerges
-	if(has_testmerge_data && issue_source != "TG Issue") // NOVA EDIT CHANGE - ORIGINAL: if(has_testmerge_data)
+	if(has_testmerge_data && issue_source != "TG Upstream Issue") // NOVA EDIT CHANGE - ORIGINAL: if(has_testmerge_data)
 		var/list/all_tms = list()
 		for(var/entry in testmerge_data)
 			var/datum/tgs_revision_information/test_merge/tm = entry


### PR DESCRIPTION
## About The Pull Request

Tin, adds a prompt where you can directly report an issue to TG if you know it's a TG issue. It does warn to pick Nova if unsure.

We don't want people to be reporting bugs on TG if they're just from us generally, but at the same time given the large portion of bug reports being TG ones I think this is a useful feature to have.

## How This Contributes To The Nova Sector Roleplay Experience

Some QoL for bug reporters.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_h8mLZSz8lB](https://github.com/user-attachments/assets/fde94888-3964-4dd4-b835-26e4070c8077)

</details>

## Changelog

:cl:
qol: you can now report a bug directly to tg through the in game bug report. please only do this if you're sure it's an upstream bug!
/:cl: