### PR TITLE
Reverts a guncase change with unintended consequences.

### DIFF
--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/gun_cases.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/gun_cases.dm
@@ -23,11 +23,6 @@
 	max_total_storage = 14 // Technically means you could fit multiple large guns in here but it's a case you cant backpack anyways so what it do
 	max_slots = 6 // We store some extra items in these so lets make a little extra room
 
-/datum/storage/toolbox/guncase/nova/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
-	. = ..()
-	//No small-cases-in-large-cases shenanigans
-	set_holdable(cant_hold_list = /obj/item/storage/toolbox/guncase)
-
 /obj/item/storage/toolbox/guncase/nova/update_icon()
 	. = ..()
 	if(opened)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I'll be 100. Forgot these were a backpack option. Kind of breaks the entire backpack option if it can't store these, makes them a much less usable choice.

~~The fact we have a Toolbox subtype as a backpack is a separate issue that's left me miffed but oh well c'est la vie.~~
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Players with these as backpacks shouldn't be at a disadvantage for cosmetic choices.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

Also gonna be 100 here. My nova branch is really mad about this ddos so I can't test this locally.
However - I tested it prior to adding these 3 lines during the original PR. I know removing them will break nothing and function as intended.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: you can once again stick small guncases in large guncase backpacks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
