### PR TITLE
cockroaches now die to pestspray without exploding

### DIFF
--- a/modular_nova/modules/fauna_reagent/fauna_reagent.dm
+++ b/modular_nova/modules/fauna_reagent/fauna_reagent.dm
@@ -69,3 +69,6 @@
 		if(istype(reagents_within, /datum/reagent/medicine))
 			adjust_health(-1)
 			reagents?.remove_reagent(reagents_within.type, 0.5)
+
+/mob/living/basic/cockroach
+	reagent_health = FALSE // required for the bugspray interaction


### PR DESCRIPTION
## About The Pull Request
see title. disables the reagent health system (which i think doesn't add anything meaningful) for cockroaches so they can properly die to pest spray and become scoopable/leave behind a roach corpse

## How This Contributes To The Nova Sector Roleplay Experience
makes upstream content (roach mutation line) available

## Changelog

:cl:
fix: Roaches now die properly to bugspray (having a few seconds of life before flipping over dramatically and not exploding into paste).
/:cl:
