### PR TITLE
Removes the opfor action button

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -36,7 +36,6 @@
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 	GLOB.human_list += src
-	SSopposing_force.give_opfor_button(src) //NOVA EDIT - OPFOR SYSTEM
 	ADD_TRAIT(src, TRAIT_CAN_MOUNT_HUMANS, INNATE_TRAIT)
 	ADD_TRAIT(src, TRAIT_CAN_MOUNT_CYBORGS, INNATE_TRAIT)
 

--- a/modular_nova/modules/opposing_force/code/opposing_force_datum.dm
+++ b/modular_nova/modules/opposing_force/code/opposing_force_datum.dm
@@ -1002,21 +1002,6 @@
 	fdel(to_write_file)
 
 
-/datum/action/opfor
-	name = "Open Opposing Force Panel"
-	button_icon_state = "round_end"
-
-/datum/action/opfor/Trigger(trigger_flags)
-	. = ..()
-	if(!.)
-		return
-	owner.opposing_force()
-
-/datum/action/opfor/IsAvailable(feedback = FALSE)
-	if(!target)
-		return FALSE
-	return ..()
-
 /obj/effect/statclick/opfor_specific
 	var/datum/opposing_force/opfor
 

--- a/modular_nova/modules/opposing_force/code/opposing_force_subsystem.dm
+++ b/modular_nova/modules/opposing_force/code/opposing_force_subsystem.dm
@@ -195,9 +195,3 @@ SUBSYSTEM_DEF(opposing_force)
 		returned_html += " - [opposing_force.build_html_panel_entry()]"
 
 	return returned_html.Join("<br>")
-
-/// Gives a mind the opfor action button, which calls the opfor verb when pressed
-/datum/controller/subsystem/opposing_force/proc/give_opfor_button(mob/living/carbon/human/player)
-	var/datum/action/opfor/info_button
-	info_button = new(src)
-	info_button.Grant(player)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the action button that gets added to every mob.

## How This Contributes To The Nova Sector Roleplay Experience
Less action bloat. Press escape if you want to opfor, (or use the verb input bar)

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  Its just a removal
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed the OPFOR action button, press escape to OPFOR!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
