### PR TITLE
Fix: Missing Head Surgeries

### DIFF
--- a/modular_nova/master_files/code/modules/surgery/surgery.dm
+++ b/modular_nova/master_files/code/modules/surgery/surgery.dm
@@ -18,7 +18,7 @@
 	if(isnull(target_organ))
 		return FALSE
 	// Ensure organ is where it's needed
-	if(target_organ.zone != location)
+	if(!(target_organ.zone in possible_locs))
 		return FALSE
 	// Ensure organ has the required amount of damage
 	if(!isnull(requires_organ_damage) && target_organ.damage < requires_organ_damage)


### PR DESCRIPTION
## About The Pull Request

This PR fixes head organ surgeries, which had gone missing from the surgery list due to my own oversight.

I made a small developer oversight in #4503 wherein I added an override to `/datum/surgery/can_start()`. In this override I utilized the `location` variable, however during `can_start()` the variable is always hardcoded to `BODY_ZONE_CHEST`, and isn't really usable at the point I was trying to use it. This essentially caused surgeries to always assume they were operating on the chest, and fail to validate the location of their targeted organs.

## How This Contributes To The Nova Sector Roleplay Experience

The PR fixes a bug introduced by PR #4503 by allowing several surgeries to appear in the surgery initiator list again.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/c868bf96-1d26-4025-8d45-fb85ca9a406f)

</details>

## Changelog

:cl: A.C.M.O.
fix: Fixed head organ surgeries, which were not appearing in the surgery list.
/:cl:
