### PR TITLE
Fix: Hemophage & Slimepeople Organ Flags

### DIFF
--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_organs.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_organs.dm
@@ -11,7 +11,7 @@
 	name = "liver" // Name change is handled by /datum/component/organ_corruption/corrupt_organ()
 	desc = GENERIC_CORRUPTED_ORGAN_DESC
 	icon = 'modular_nova/modules/organs/icons/hemophage_organs.dmi'
-	organ_flags = ORGAN_EDIBLE | ORGAN_TUMOR_CORRUPTED
+	organ_flags = ORGAN_ORGANIC | ORGAN_EDIBLE | ORGAN_TUMOR_CORRUPTED
 
 
 /obj/item/organ/liver/hemophage/Initialize(mapload)
@@ -71,7 +71,7 @@
 	name = "stomach" // Name change is handled by /datum/component/organ_corruption/corrupt_organ()
 	desc = GENERIC_CORRUPTED_ORGAN_DESC
 	icon = 'modular_nova/modules/organs/icons/hemophage_organs.dmi'
-	organ_flags = ORGAN_EDIBLE | ORGAN_TUMOR_CORRUPTED
+	organ_flags = ORGAN_ORGANIC | ORGAN_EDIBLE | ORGAN_TUMOR_CORRUPTED
 
 
 /obj/item/organ/stomach/hemophage/Initialize(mapload)
@@ -93,7 +93,7 @@
 	name = "tongue" // Name change is handled by /datum/component/organ_corruption/corrupt_organ()
 	desc = GENERIC_CORRUPTED_ORGAN_DESC
 	icon = 'modular_nova/modules/organs/icons/hemophage_organs.dmi'
-	organ_flags = ORGAN_EDIBLE | ORGAN_TUMOR_CORRUPTED
+	organ_flags = ORGAN_ORGANIC | ORGAN_EDIBLE | ORGAN_TUMOR_CORRUPTED
 	liked_foodtypes = BLOODY
 	disliked_foodtypes = NONE
 

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_species.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_species.dm
@@ -22,7 +22,6 @@
 	mutantliver = /obj/item/organ/liver/hemophage
 	mutantstomach = /obj/item/organ/stomach/hemophage
 	mutanttongue = /obj/item/organ/tongue/hemophage
-	mutantlungs = null
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	examine_limb_id = SPECIES_HUMAN
 	skinned_type = /obj/item/stack/sheet/animalhide/human

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_tumor.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_tumor.dm
@@ -22,6 +22,7 @@
 	base_icon_state = "tumor"
 	desc = "This pulsating organ nearly resembles a normal heart, but it's been twisted beyond any human appearance, having turned to the color of coal. The way it barely fits where the original organ was sends shivers down your spine... <i>The fact that it's what keeps them alive makes it all the more terrifying.</i>"
 	actions_types = list(/datum/action/cooldown/hemophage/toggle_dormant_state)
+	organ_flags = ORGAN_ORGANIC | ORGAN_UNREMOVABLE | ORGAN_TUMOR_CORRUPTED
 	/// Are we currently dormant? Defaults to PULSATING_TUMOR_ACTIVE (so FALSE).
 	var/is_dormant = PULSATING_TUMOR_ACTIVE
 	/// What is the current rate (per second) at which the tumor is consuming blood?

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -97,30 +97,30 @@
 /obj/item/organ/eyes/jelly
 	name = "photosensitive eyespots"
 	zone = BODY_ZONE_CHEST
-	organ_flags = ORGAN_UNREMOVABLE
+	organ_flags = ORGAN_ORGANIC | ORGAN_UNREMOVABLE
 
 /obj/item/organ/eyes/roundstartslime
 	name = "photosensitive eyespots"
 	zone = BODY_ZONE_CHEST
-	organ_flags = ORGAN_UNREMOVABLE
+	organ_flags = ORGAN_ORGANIC | ORGAN_UNREMOVABLE
 
 /obj/item/organ/ears/jelly
 	name = "core audiosomes"
 	zone = BODY_ZONE_CHEST
-	organ_flags = ORGAN_UNREMOVABLE
+	organ_flags = ORGAN_ORGANIC | ORGAN_UNREMOVABLE
 
 /obj/item/organ/tongue/jelly
 	zone = BODY_ZONE_CHEST
-	organ_flags = ORGAN_UNREMOVABLE
+	organ_flags = ORGAN_ORGANIC | ORGAN_UNREMOVABLE
 
 /obj/item/organ/lungs/slime
 	zone = BODY_ZONE_CHEST
-	organ_flags = ORGAN_UNREMOVABLE
+	organ_flags = ORGAN_ORGANIC | ORGAN_UNREMOVABLE
 
 /obj/item/organ/liver/slime
 	name = "endoplasmic reticulum"
 	zone = BODY_ZONE_CHEST
-	organ_flags = ORGAN_UNREMOVABLE
+	organ_flags = ORGAN_ORGANIC | ORGAN_UNREMOVABLE
 
 // CHEMICAL HANDLING
 // Here's where slimes heal off plasma and where they hate drinking water.
@@ -162,7 +162,7 @@
 /obj/item/organ/stomach/slime
 	name = "golgi apparatus"
 	zone = BODY_ZONE_CHEST
-	organ_flags = ORGAN_UNREMOVABLE
+	organ_flags = ORGAN_ORGANIC | ORGAN_UNREMOVABLE
 
 /obj/item/organ/brain/slime
 	name = "core"


### PR DESCRIPTION
## About The Pull Request

This PR fixes a bug that caused organ-repairing surgeries to stop working for Hemophage and Jelly/Slimeperson species.

The bug was caused by changes in #4503 that caused more surgeries to require organ flag `ORGAN_ORGANIC`, and combined with the fact that Hemophage and Jelly organs lacked that organ flag.

The PR also adds `ORGAN_UNREMOVABLE` to `/obj/item/organ/heart/hemophage` (the tumor) based on staff suggestions.

And finally, the PR includes a tiny change that allows Hemophage species to spawn with default lungs.

## How This Contributes To The Nova Sector Roleplay Experience

The PR will allow organ repair surgeries to work once again on Hemophages and Jelly/Slimeperson species!

Hemophages will majorly benefit from the PR because their vital "tumor" organ will no longer be removable in surgery, and because they will now spawn with atrophied lungs instead of none at all.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![Screenshot 2025-06-28 025050](https://github.com/user-attachments/assets/3a7bc230-98fd-48d9-9183-6832e1031554)
![image](https://github.com/user-attachments/assets/1803937b-3372-40ab-a1d3-0d56f6d445df)

</details>

## Changelog

:cl:
qol: Changed the Hemophage species Tumor heart organ to be unremovable via surgery.
qol: Allowed Hemophage species to spawn with lungs.
fix: Fixed surgeries for Hemophage and Slimeperson species organs.
/:cl:
