### PR TITLE
Give the QM a Silver Baton

### DIFF
--- a/modular_nova/modules/jobs/modular_quartermaster.dm
+++ b/modular_nova/modules/jobs/modular_quartermaster.dm
@@ -1,0 +1,4 @@
+/datum/outfit/job/quartermaster
+	backpack_contents = list(
+		/obj/item/melee/baton/telescopic/silver = 1,
+	)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8181,6 +8181,7 @@
 #include "modular_nova\modules\interaction_menu\code\interaction_datum.dm"
 #include "modular_nova\modules\interdyne_pharma\mod.dm"
 #include "modular_nova\modules\job_estimation\job_estimation.dm"
+#include "modular_nova\modules\jobs\modular_quartermaster.dm"
 #include "modular_nova\modules\jungle\code\flora.dm"
 #include "modular_nova\modules\kahraman_equipment\code\gps_beacon.dm"
 #include "modular_nova\modules\kahraman_equipment\code\looping_sounds.dm"


### PR DESCRIPTION
## About The Pull Request
Gives the Quartermaster a silver baton, consistent with every other member of command on the station, instead of a piddly bronze one.

## How This Contributes To The Nova Sector Roleplay Experience
The Quartermaster's bronze baton is an upstream holdover from their being a less important member of command which does not reflect their status on Nova. At best, this is mildly annoying; at worst, this could confuse a migrating player as to our command structure.

Leave the ineffective batons to the black market and bridge assistants; all other members of command get a silver baton, so does the QM. (We also had to do this with weapon permits.)

Addendum: People have raised balance complaints to me. This is reasonable, even if I think people overestimate the viability of batons; after testing, I have found literally no source of stun resistance that does not prevent the silver baton's stun. I'm probably missing some edge case, but everything that comes to mind works on both.

This PR is extremely simple, but it's been months since my last. Tell me and apologies if I forgot something!

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/75df29ea-8584-4b87-8ba6-db97f8ec65de)

</details>

## Changelog
:cl:
balance: After intense and continuous complaining from the Union, the Quartermaster is now issued Nanotrasen's second-finest Silver Telescopic Baton, the same as every other member of their valued command staff.
/:cl:
