### PR TITLE
Fixes for digi icons

### DIFF
--- a/modular_nova/master_files/code/modules/clothing/clothing_variation_overrides/shoes.dm
+++ b/modular_nova/master_files/code/modules/clothing/clothing_variation_overrides/shoes.dm
@@ -6,6 +6,23 @@
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
 /**
- * NONE(Squash)
- * Clothing that does not have a digitigrade version, and thus will squash legs to fit.
+ * SUBTYPE WITH NEW ICON
+ * Clothing that has a digitigrade version, but its parent was set to something else earlier in this file or elsewhere entirely.
  */
+/obj/item/clothing/shoes/combat
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
+
+/obj/item/clothing/shoes/jackboots
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
+
+/obj/item/clothing/shoes/workboots
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
+
+/obj/item/clothing/shoes/russian
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
+
+/obj/item/clothing/shoes/winterboots
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
+
+/obj/item/clothing/shoes/sneakers
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION

--- a/modular_nova/master_files/code/modules/clothing/clothing_variation_overrides/suit.dm
+++ b/modular_nova/master_files/code/modules/clothing/clothing_variation_overrides/suit.dm
@@ -204,6 +204,9 @@
 /obj/item/clothing/suit/armor/riot
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
 
+/obj/item/clothing/suit/hooded/explorer
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
+
 //Chaplain Suits
 //TG neglected to sort between legged and robed, so we'll have to just manually set each one
 /obj/item/clothing/suit/chaplainsuit/armor/studentuni

--- a/modular_nova/master_files/code/modules/clothing/clothing_variation_overrides/suit.dm
+++ b/modular_nova/master_files/code/modules/clothing/clothing_variation_overrides/suit.dm
@@ -170,6 +170,9 @@
 /obj/item/clothing/suit/hooded/techpriest
 	supports_variations_flags = NONE
 
+/obj/item/clothing/suit/hooded/explorer/syndicate
+	supports_variations_flags = NONE
+
 /**
  * SUBTYPE WITH NEW ICON
  * Clothing that has a digitigrade version, but its parent was set to something else earlier in this file or elsewhere entirely.
@@ -224,3 +227,13 @@
 /obj/item/clothing/suit/chaplainsuit/shrinehand
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION //Prevents a few glaring missing pixels
 //End Chaplain Suits
+
+/**
+ * SUBTYPE WITH MASK ICON
+ * Clothing that needs the leg part of the sprite to be auto-generated using GAGS, but its parent was set to something else earlier.
+ */
+/obj/item/clothing/under/ethereal_tunic
+	supports_variations_flags = CLOTHING_DIGITIGRADE_MASK
+
+/obj/item/clothing/under/trek/q
+	supports_variations_flags = CLOTHING_DIGITIGRADE_MASK

--- a/modular_nova/master_files/code/modules/clothing/clothing_variation_overrides/under.dm
+++ b/modular_nova/master_files/code/modules/clothing/clothing_variation_overrides/under.dm
@@ -241,3 +241,21 @@
 
 /obj/item/clothing/under/rank/civilian/clown/jesteralt
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
+
+/obj/item/clothing/under/syndicate/combat
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
+
+/obj/item/clothing/under/syndicate/sniper
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
+
+/obj/item/clothing/under/syndicate/bloodred
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
+
+/obj/item/clothing/under/syndicate/camo
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
+
+/obj/item/clothing/under/syndicate/soviet
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
+
+/obj/item/clothing/under/syndicate/rus_army
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION

--- a/modular_nova/master_files/code/modules/clothing/clothing_variation_overrides/under.dm
+++ b/modular_nova/master_files/code/modules/clothing/clothing_variation_overrides/under.dm
@@ -229,3 +229,15 @@
 
 /obj/item/clothing/under/rank/medical/scrubs
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
+
+/obj/item/clothing/under/dress/striped
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
+
+/obj/item/clothing/under/dress/skirt/plaid
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
+
+/obj/item/clothing/under/rank/civilian/clown/jester
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
+
+/obj/item/clothing/under/rank/civilian/clown/jesteralt
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION

--- a/modular_nova/master_files/code/modules/clothing/under/jobs/medical.dm
+++ b/modular_nova/master_files/code/modules/clothing/under/jobs/medical.dm
@@ -5,6 +5,10 @@
 	icon = 'modular_nova/master_files/icons/obj/clothing/under/medical.dmi'
 	worn_icon = 'modular_nova/master_files/icons/mob/clothing/under/medical.dmi'
 
+/obj/item/clothing/under/syndicate/scrubs
+	worn_icon_digi = 'modular_nova/master_files/icons/mob/clothing/under/medical_digi.dmi'
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
+
 
 /obj/item/clothing/under/rank/medical/scrubs/nova
 	icon = 'modular_nova/master_files/icons/obj/clothing/under/medical.dmi'

--- a/modular_nova/master_files/code/modules/clothing/under/skirts_dresses.dm
+++ b/modular_nova/master_files/code/modules/clothing/under/skirts_dresses.dm
@@ -40,15 +40,6 @@
 //TG's icons only have a dress.dmi, but that means it's not ABC-sorted to be beside shorts_pants_shirts.dmi. So it's skirts_dresses for us.
 
 /*
- *	TG DIGI VERSION DRESSES
- */
-/obj/item/clothing/under/dress/striped
-	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
-
-/obj/item/clothing/under/dress/skirt/plaid
-	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
-
-/*
  *	Skirts
  */
 

--- a/modular_nova/modules/customization/modules/clothing/shoes/shoes.dm
+++ b/modular_nova/modules/customization/modules/clothing/shoes/shoes.dm
@@ -177,25 +177,6 @@
 	worn_icon = MODULAR_SHOES_WORN_ICON
 	icon_state = "pink_clown_shoes"
 
-//Modular overide to give jackboots laces
-/obj/item/clothing/shoes/jackboots
-	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
-
-/obj/item/clothing/shoes/combat
-	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
-
-/obj/item/clothing/shoes/workboots
-	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
-
-/obj/item/clothing/shoes/russian
-	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
-
-/obj/item/clothing/shoes/winterboots
-	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
-
-/obj/item/clothing/shoes/sneakers
-	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
-
 /obj/item/clothing/shoes/colorable_laceups
 	name = "laceup shoes"
 	desc = "These don't seem to come pre-polished, how saddening."

--- a/modular_nova/modules/customization/modules/clothing/under/misc.dm
+++ b/modular_nova/modules/customization/modules/clothing/under/misc.dm
@@ -1,9 +1,3 @@
-/obj/item/clothing/under/ethereal_tunic
-	supports_variations_flags = CLOTHING_DIGITIGRADE_MASK
-
-/obj/item/clothing/under/trek/q
-	supports_variations_flags = CLOTHING_DIGITIGRADE_MASK
-
 /obj/item/clothing/under/misc/bluetracksuit
 	name = "blue tracksuit"
 	desc = "Found on a dead homeless man squatting in an alleyway, the classic design has been mass produced to bring terror to the galaxy."

--- a/modular_nova/modules/customization/modules/clothing/under/misc.dm
+++ b/modular_nova/modules/customization/modules/clothing/under/misc.dm
@@ -4,12 +4,6 @@
 /obj/item/clothing/under/trek/q
 	supports_variations_flags = CLOTHING_DIGITIGRADE_MASK
 
-/obj/item/clothing/under/rank/civilian/clown/jester
-	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
-
-/obj/item/clothing/under/rank/civilian/clown/jesteralt
-	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
-
 /obj/item/clothing/under/misc/bluetracksuit
 	name = "blue tracksuit"
 	desc = "Found on a dead homeless man squatting in an alleyway, the classic design has been mass produced to bring terror to the galaxy."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Returns the correct flags for the next clothing:
- /obj/item/clothing/under/syndicate/combat
- /obj/item/clothing/under/syndicate/sniper
- /obj/item/clothing/under/syndicate/bloodred
- /obj/item/clothing/under/syndicate/camo
- /obj/item/clothing/under/syndicate/soviet
- /obj/item/clothing/under/syndicate/rus_army
- /obj/item/clothing/suit/hooded/explorer

Also added worn_icon_digi for `/obj/item/clothing/under/syndicate/scrubs`.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Fixes are always a good thing

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

before:
![image](https://github.com/user-attachments/assets/664332d5-5e06-49b6-90b6-18c55973b431)
![image](https://github.com/user-attachments/assets/1f49382a-799b-4d59-a84c-a86799151fa1)
![image](https://github.com/user-attachments/assets/564e9ca4-188e-441f-9367-0eb0fd441278)

after:
![image](https://github.com/user-attachments/assets/4b6363c2-2486-461d-96bc-7d11488c9786)
![image](https://github.com/user-attachments/assets/9e552661-9390-432f-aaf8-99e8ef6eafc1)
![image](https://github.com/user-attachments/assets/92c721d5-e48d-4f58-9015-56907aba8d64)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The explorer suit and some syndicate uniforms now has a proper icons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
