### PR TITLE
[S][TM] Serenity mitigations

### DIFF
--- a/modular_nova/modules/serenitystation/code/forest_cavegen.dm
+++ b/modular_nova/modules/serenitystation/code/forest_cavegen.dm
@@ -1,16 +1,14 @@
 /datum/map_generator/cave_generator/forest
 	weighted_open_turf_types = list(/turf/open/misc/asteroid/forest = 1)
 	weighted_closed_turf_types = list(/turf/closed/mineral/random/forest = 1)
-	flora_spawn_chance = 35
-	initial_closed_chance = 53
-	birth_limit = 5
-	death_limit = 4
+	flora_spawn_chance = 25
 	smoothing_iterations = 10
+
+	mob_spawn_chance = 2
 
 	weighted_mob_spawn_list = list(
 		/mob/living/basic/deer/mining = 50,
 		/mob/living/basic/mining/megadeer = 15,
-		/mob/living/basic/mining/goldgrub = 1,
 	)
 
 	weighted_flora_spawn_list = list(

--- a/modular_nova/modules/serenitystation/code/forest_cavegen.dm
+++ b/modular_nova/modules/serenitystation/code/forest_cavegen.dm
@@ -2,7 +2,7 @@
 	weighted_open_turf_types = list(/turf/open/misc/asteroid/forest = 1)
 	weighted_closed_turf_types = list(/turf/closed/mineral/random/forest = 1)
 	flora_spawn_chance = 25
-	smoothing_iterations = 10
+	smoothing_iterations = 15
 
 	mob_spawn_chance = 2
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
 Test 1 - Altering cavegen to remove the goldgrubs and lowers the deer spawns from around 6-700 mobs to about 150.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Serenity cavegen has been changed to be less spam
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
