### PR TITLE
Blacklists Masquerade quirk from non-hemophage species.

### DIFF
--- a/modular_nova/modules/quirk_masquerade/masquerade.dm
+++ b/modular_nova/modules/quirk_masquerade/masquerade.dm
@@ -8,3 +8,10 @@
 	mob_trait = TRAIT_MASQUERADE_FOOD
 	icon = FA_ICON_MASKS_THEATER
 	quirk_flags = QUIRK_HUMAN_ONLY
+
+/datum/quirk/masquerade_food/is_species_appropriate(datum/species/mob_species)
+	var/datum/species_traits = GLOB.species_prototypes[mob_species].inherent_traits
+	if(TRAIT_DRINKS_BLOOD in species_traits)
+		return TRUE
+	else
+		return FALSE


### PR DESCRIPTION
## About The Pull Request

Creator was unable to blacklist it, so we did. https://github.com/IrisSS13/IrisStation/pull/525

## How This Contributes To The Nova Sector Roleplay Experience

The quirk is useless on non-hemophage. 

## Proof of Testing
Compiled. Tested on Iris too. 

![Screenshot 2025-07-02 215934](https://github.com/user-attachments/assets/aa7f558a-bc0c-428c-ac86-2106a6ddaaf4)




## Changelog

:cl: KnighTheThrasher 
fix: Blacklisted Masquerade quirk from non-hemophages
/:cl:

