### PR TITLE
Refactors sensitive hearing quirk

### DIFF
--- a/modular_nova/master_files/code/datums/traits/good.dm
+++ b/modular_nova/master_files/code/datums/traits/good.dm
@@ -173,35 +173,24 @@
 	desc = "You can hear even the quietest of sounds, but you're more vulnerable to hearing damage as a result. NOTE: This is a direct downgrade for Teshari!"
 	icon = FA_ICON_HEADPHONES_SIMPLE
 	value = 6
+	mob_trait = TRAIT_SENSITIVE_HEARING
 	gain_text = span_notice("You could hear a pin drop from 10 feet away.")
 	lose_text = span_danger("Your hearing feels less sensitive.")
 	medical_record_text = "Patient scored very highly in hearing tests."
+	/// Teshari hearing is an action, so here is its holder
+	var/datum/action/cooldown/spell/teshari_hearing/hearing_action
 
-	var/obj/item/organ/ears/old_ears // The mob's original ears, just in case.
-	var/obj/item/organ/ears/sensitive/sensitive_ears = new /obj/item/organ/ears/sensitive // The replacement ears.
-
-/datum/quirk/sensitive_hearing/post_add()
-	var/mob/living/carbon/carbon_quirk_holder = quirk_holder
-	old_ears = carbon_quirk_holder.get_organ_slot(ORGAN_SLOT_EARS)
-
-	if(!isnull(old_ears))
-		old_ears.Remove(carbon_quirk_holder, special = TRUE)
-		old_ears.moveToNullspace()
-		STOP_PROCESSING(SSobj, old_ears)
-
-	sensitive_ears.Insert(carbon_quirk_holder, special = TRUE)
+/datum/quirk/sensitive_hearing/add_unique()
+	var/obj/item/organ/ears/ears = quirk_holder.get_organ_slot(ORGAN_SLOT_EARS)
+	//add action
+	hearing_action = new
+	ears.actions_types += list(hearing_action.type)
+	ears.add_item_action(hearing_action.type)
+	hearing_action.Grant(quirk_holder)
 
 /datum/quirk/sensitive_hearing/remove()
-	var/mob/living/carbon/carbon_quirk_holder = quirk_holder
-	var/obj/item/organ/ears/current_ears = carbon_quirk_holder.get_organ_slot(ORGAN_SLOT_EARS)
-
-	if(isnull(old_ears)) // Make new generic ears if the original ones are missing
-		old_ears = new /obj/item/organ/ears
-
-	// Return the original ears.
-	if(!isnull(current_ears))
-		current_ears.Remove(carbon_quirk_holder, special = TRUE)
-		qdel(current_ears)
-
-	old_ears.Insert(carbon_quirk_holder, special = TRUE)
-	old_ears = null
+	var/obj/item/organ/ears/ears = quirk_holder.get_organ_slot(ORGAN_SLOT_EARS)
+	//remove action
+	ears.actions_types -= list(hearing_action.type)
+	ears.remove_item_action(hearing_action.type)
+	hearing_action.Remove(quirk_holder)

--- a/modular_nova/modules/organs/code/ears.dm
+++ b/modular_nova/modules/organs/code/ears.dm
@@ -1,8 +1,9 @@
-/// Teshari ears, but as a quirk/organ
+/// Teshari ears, hold the teshari
 /obj/item/organ/ears/sensitive
 	name = "sensitive ears"
 	desc = "Highly sensitive ears capable of detecting even the smallest noises."
 	damage_multiplier = 2
+	organ_traits = list(TRAIT_SENSITIVE_HEARING)
 	actions_types = list(/datum/action/cooldown/spell/teshari_hearing)
 
 /obj/item/organ/ears/sensitive/on_mob_remove(mob/living/carbon/ear_owner)
@@ -11,12 +12,7 @@
 	if(ear_owner.has_status_effect(/datum/status_effect/teshari_hearing))
 		ear_owner.remove_status_effect(/datum/status_effect/teshari_hearing)
 
-	ear_owner.remove_traits(list(TRAIT_GOOD_HEARING, TRAIT_SENSITIVE_HEARING), ORGAN_TRAIT)
-
-/obj/item/organ/ears/sensitive/on_mob_insert(mob/living/carbon/ear_owner)
-	. = ..()
-	// TRAIT_SENSITIVE_HEARING is important for the flavor text distinction
-	ADD_TRAIT(ear_owner, TRAIT_SENSITIVE_HEARING, ORGAN_TRAIT)
+	REMOVE_TRAIT(ear_owner, TRAIT_GOOD_HEARING, ORGAN_TRAIT)
 
 /obj/item/organ/ears/teshari
 	name = "teshari ears"
@@ -51,6 +47,9 @@
 /datum/action/cooldown/spell/teshari_hearing/Remove(mob/living/remove_from)
 	REMOVE_TRAIT(remove_from, TRAIT_GOOD_HEARING, ORGAN_TRAIT)
 	remove_from.update_sight()
+	if(remove_from.has_status_effect(/datum/status_effect/teshari_hearing))
+		//we haven't deactivated yet...
+		teshari_hearing_deactivate(remove_from)
 	return ..()
 
 /datum/action/cooldown/spell/teshari_hearing/cast(list/targets, mob/living/carbon/human/user = usr)
@@ -89,7 +88,7 @@
 	var/obj/item/organ/ears/ears = user.get_organ_slot(ORGAN_SLOT_EARS)
 	if(ears)
 		// Sensitive Hearing users take more hearing damage when they're not listening
-		ears.damage_multiplier = HAS_TRAIT(user, TRAIT_SENSITIVE_HEARING) ? 2 : 1.5
+		ears.damage_multiplier = HAS_TRAIT(user, TRAIT_SENSITIVE_HEARING) ? /obj/item/organ/ears/sensitive::damage_multiplier : /obj/item/organ/ears/teshari::damage_multiplier
 
 /datum/status_effect/teshari_hearing
 	id = "teshari_hearing"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Code that needlessly removes organs and replaces them with a snowflake subtype is bad and should be removed.

## How This Contributes To The Nova Sector Roleplay Experience
Got synth ears and the sensitive hearing quirk? They'll stay synth ears now, while still gaining the quirk's buff.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
https://github.com/user-attachments/assets/c5a8cc26-8ed7-4ac0-a2cc-ec5bfcdca5c3


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Refactors sensitive hearing, updating your ears instead of replacing your ears wholesale.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
