### PR TITLE
Vox announcement help fix

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -419,7 +419,7 @@
 		alert_control.ui_interact(src)
 #ifdef AI_VOX
 	if(href_list["say_word"])
-		play_vox_word(href_list["say_word"], null, src, vox_type) //NOVA EDIT CHANGE - ORIGINAL: play_vox_word(href_list["say_word"], null, src)
+		play_vox_word(href_list["say_word"], get_turf(src), src) //NOVA EDIT CHANGE - ORIGINAL: play_vox_word(href_list["say_word"], null, src)
 		vox_word_string += "[href_list["say_word"]] " //NOVA EDIT ADDITION
 		return
 #endif


### PR DESCRIPTION

## About The Pull Request

Fixes missing vox annonces sound in the preview window.

## How This Contributes To The Nova Sector Roleplay Experience

As it turned out this functionality was demanded by one player, and it works on TG.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
https://github.com/user-attachments/assets/5cd28e5f-b519-41b1-95c7-f4065ea2d12b

</details>

## Changelog
:cl:
fix: The vox sounds of the AI's superior annonces are playing again
/:cl:
