### PR TITLE
bugfix: expeditionary crate medkits' bloodbags no longer kill you

### DIFF
--- a/modular_nova/modules/exp_corps/code/expeditionary_trooper.dm
+++ b/modular_nova/modules/exp_corps/code/expeditionary_trooper.dm
@@ -14,7 +14,7 @@
 	new /obj/item/flashlight/glowstick(src)
 	new /obj/item/tank/internals/emergency_oxygen/double(src)
 	new /obj/item/reagent_containers/cup/glass/waterbottle(src)
-	new /obj/item/reagent_containers/blood/universal(src)
+	new /obj/item/reagent_containers/blood/o_minus(src)
 	new /obj/item/reagent_containers/syringe(src)
 	new /obj/item/storage/pill_bottle/multiver(src)
 


### PR DESCRIPTION
## About The Pull Request

changes the reagent_container/blood inside vanguard crate's box/expeditionary_survival from universal to o_minus
## How This Contributes To The Nova Sector Roleplay Experience

fixes https://github.com/NovaSector/NovaSector/issues/5713
## Proof of Testing

its one line
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: expeditionary medkit fix
/:cl:
