### PR TITLE
Prevents mobs from being unbuckled from the arrival shuttle mid flight

### DIFF
--- a/code/modules/shuttle/mobile_port/shuttle_move_callbacks.dm
+++ b/code/modules/shuttle/mobile_port/shuttle_move_callbacks.dm
@@ -339,8 +339,9 @@ All ShuttleMove procs go here
 		//if we're on the arrival shuttle, unbuckle so that new player's don't get stuck in there
 		// NOVA EDIT ADDITION START - Ensures that the unbuckling only happens when its leaving hyperspace not entering
 		if (!istype(oldT, /turf/open/space/transit) || istype(buckled, /obj/vehicle/ridden/wheelchair))
+			return
 		// NOVA EDIT ADDITION END
-			buckled.user_unbuckle_mob(src, src)
+		buckled.user_unbuckle_mob(src, src)
 		return
 	if(knockdown > 0)
 		if(buckled)


### PR DESCRIPTION
## About The Pull Request

I was alerted to an issue where people where getting unbuckled on the arrival shuttle and thus falling flat on their face as the shuttle arrives on station. I figured out the issue came from https://github.com/tgstation/tgstation/pull/91708

The issue we where having is because of how our arrivals shuttle works compared to TG, on TG you just spawn on the shuttle. So this code is 100% fine for them, but for us we spawn on the interlink then go onto the shuttle to go to the station.

This code gets called whenever the shuttle changes state (AKA, changing z-levels)

So it got called twice, once when the shuttle left the interlink, and again when it arrives on station (if you re-buckled yourself mid flight)

I simply made the code check if the previous turf the shuttle was on was hyperspace, if it was then it will unbuckle, if it wasn't, you stay buckled.

## How This Contributes To The Nova Sector Roleplay Experience

Seat-belts are meant to keep you from falling onto your face when things come to an abrupt stop, not unbuckle themselves mid flight.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/223e7966-422e-45f8-ae47-7e9578efeb0d

</details>

## Changelog

:cl:
fix: You no longer get unbuckled from the arrival shuttle mid-flight, Remember to buckle your seat-belts.
/:cl:

