### PR TITLE
Some BRM Balancing i meant to do when i first balanced them a year ago

### DIFF
--- a/code/__DEFINES/mining.dm
+++ b/code/__DEFINES/mining.dm
@@ -68,9 +68,9 @@
 #define ORE_WALL_FAR 1
 
 /// The number of points a miner gets for discovering a vent, multiplied by BOULDER_SIZE when completing a wave defense minus the discovery bonus.
-#define MINER_POINT_MULTIPLIER 100
+#define MINER_POINT_MULTIPLIER 150 // NOVA EDIT: ORIGINAL #define MINER_POINT_MULTIPLIER 100
 /// The multiplier that gets applied for automatically generated mining points.
-#define MINING_POINT_MACHINE_MULTIPLIER 0.8
+#define MINING_POINT_MACHINE_MULTIPLIER 0.5 // NOVA EDIT: ORIGINAL #define MINING_POINT_MACHINE_MULTIPLIER 0.8 - To scale point generation for a longer round
 
 //String defines to use with CaveGenerator presets for what ore breakdown to use.
 #define OREGEN_PRESET_LAVALAND "lavaland"

--- a/code/__DEFINES/mining.dm
+++ b/code/__DEFINES/mining.dm
@@ -70,7 +70,7 @@
 /// The number of points a miner gets for discovering a vent, multiplied by BOULDER_SIZE when completing a wave defense minus the discovery bonus.
 #define MINER_POINT_MULTIPLIER 150 // NOVA EDIT: ORIGINAL #define MINER_POINT_MULTIPLIER 100
 /// The multiplier that gets applied for automatically generated mining points.
-#define MINING_POINT_MACHINE_MULTIPLIER 0.5 // NOVA EDIT: ORIGINAL #define MINING_POINT_MACHINE_MULTIPLIER 0.8 - To scale point generation for a longer round
+#define MINING_POINT_MACHINE_MULTIPLIER 0.6 // NOVA EDIT: ORIGINAL #define MINING_POINT_MACHINE_MULTIPLIER 0.8 - To scale point generation for a longer round
 
 //String defines to use with CaveGenerator presets for what ore breakdown to use.
 #define OREGEN_PRESET_LAVALAND "lavaland"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Been meaning to do this for over a year but this just slightly lowers their point generation.

The alternative option is to slow down their boulder production, but i feel that'd be a bit overly impactful for the moment at least. the Vent system is designed for quicker shifts than what we standardize as, and while i wish this was a dynamic adjustment based on default roundtime - that's up to TG to handle that maths.

points_held = round(points_held + (quantity * possible_mat.points_per_unit * MINING_POINT_MACHINE_MULTIPLIER)) 

**Old**
100 = round ( 100 + (23 * 15 * 0.8)
376 points

**New**
100 = round ( 100 + (23 * 15 * 0.6)
307 points

_These are not actual values but rather a representation of the math, each boulder has their own value assigned as well as quantity_

|276−207|[(276+207)2]×100
|69|[4832]×100
69241.5×100
0.285714×100
=28.5714%difference

if BYOND math was perfect i'd have it at .55 but it wont math past .5 annoyingly due to how the decimal comes into play, but this is a ~30% decrease in points across the round. This math is the baseline of an unupgraded BRM.

## How This Contributes To The Nova Sector Roleplay Experience

we cant really kid ourselves with how many mining points a few vents can pump out in a long shift, dropping it from 0.8 to 0.5 on the multiplier is what my calculator says is the balance that'd work out.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
Glass and Iron doin work
![image](https://github.com/user-attachments/assets/785a4844-cea6-498a-b980-be693ca41c43)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: slightly lowers the points per boulder of the BRM
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
