### PR TITLE
[modular] Hides Command Encryption Key crate in cargo consoles

### DIFF
--- a/code/modules/cargo/packs/general.dm
+++ b/code/modules/cargo/packs/general.dm
@@ -66,7 +66,6 @@
 				)
 	crate_type = /obj/structure/closet/crate/wooden
 
-/* Nova edit 
 /datum/supply_pack/misc/commandkeys
 	name = "Command Encryption Key Crate"
 	desc = "A pack of encryption keys that give access to the command radio network. \
@@ -78,7 +77,6 @@
 	contains = list(/obj/item/encryptionkey/headset_com = 3)
 	crate_type = /obj/structure/closet/crate/secure/centcom
 	crate_name = "command encryption key crate"
-*/
 
 /datum/supply_pack/misc/exploration_drone
 	name = "Exploration Drone"

--- a/code/modules/cargo/packs/general.dm
+++ b/code/modules/cargo/packs/general.dm
@@ -66,6 +66,7 @@
 				)
 	crate_type = /obj/structure/closet/crate/wooden
 
+/* Nova edit 
 /datum/supply_pack/misc/commandkeys
 	name = "Command Encryption Key Crate"
 	desc = "A pack of encryption keys that give access to the command radio network. \
@@ -77,6 +78,7 @@
 	contains = list(/obj/item/encryptionkey/headset_com = 3)
 	crate_type = /obj/structure/closet/crate/secure/centcom
 	crate_name = "command encryption key crate"
+*/
 
 /datum/supply_pack/misc/exploration_drone
 	name = "Exploration Drone"

--- a/modular_nova/modules/cargo/code/packs.dm
+++ b/modular_nova/modules/cargo/code/packs.dm
@@ -410,6 +410,9 @@
 	cost = CARGO_CRATE_VALUE * 6 // 1200 credits
 	contains = list(/obj/item/gravity_harness)
 
+/datum/supply_pack/misc/commandkeys
+	hidden = TRUE
+
 /*
 *	FOOD
 */


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hides the Command Encryption Key crate from purchasing.

While this is honestly more because of some oversight on the Tarkon/DS2/Interdyne express cargo console additions, I do believe its a redundant crate considering each head spawns with a headset + an extra in the lockers. With all heads accounted for + NTC, This comes to ~14 total headsets that could be stolen on any given map. Based on the map some of these are very safe.

Following this, Traitors can already get the Syndicate key, which gives them the ability to listen to all channels, For only 2tc. Changelings have no real problems getting sec comms from a merked officer. And cultists... Can teleport to somewhere that'll care. Cargo is a _**Joke**_ and you shouldn't be able to just buy the keys.

## How This Contributes To The Nova Sector Roleplay Experience

Stops comms being """"compromised"""" because tarkon chucklefucks think its funny to pull a seymore weiner joke on command comms. Could it be policy? Maybe. But i dont need to ahelp every round for this

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/1b8612bf-fc9e-4c3b-8845-3a1c3eebd1d3)

![image](https://github.com/user-attachments/assets/b179dacd-d148-47c4-ae36-b608554ffa43)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Hides command encryption crate from being buyable, making command/sec comms harder to obtain.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
