### PR TITLE
makes the holster module unable to hold bulky guns

### DIFF
--- a/code/modules/mod/modules/modules_security.dm
+++ b/code/modules/mod/modules/modules_security.dm
@@ -123,7 +123,7 @@
 		if(!holding)
 			balloon_alert(mod.wearer, "nothing to holster!")
 			return
-		if(!istype(holding) || holding.w_class > WEIGHT_CLASS_BULKY)
+		if(!istype(holding) || holding.w_class >= WEIGHT_CLASS_BULKY) // NOVA EDIT CHANGE - Original: if(!istype(holding) || holding.w_class > WEIGHT_CLASS_BULKY)
 			balloon_alert(mod.wearer, "doesn't fit!")
 			return
 		if(mod.wearer.transferItemToLoc(holding, src, force = FALSE, silent = TRUE))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
holster module now cannot hold guns that are bulky, only normal or smaller

## How This Contributes To The Nova Sector Roleplay Experience

the holster module is probably the most busted modsuit module we have, you can store a massive, normally unstorable gun (except for syndiduffle and bluespace bag but those are obvious), in your modsuit, which not only means its  pretty much fully hidden, but that you can instantly pull out a giant gun and start blasting, that doesnt seem very fair to be able to hide something, that has a weight class specifically meant to be unstoreable (yes i know TG did it for eguns but we have insane ballistics here), bulky weapons are supposed to be visible due to their strength, mod holster negates that, and thats not only unfun, but just annoying not knowing if someone can just shit out an MMR when you thought they were weaponless

## Proof of Testing
oh i forgot, anyways it worked i'll add a screenshot if needed

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: you can no longer put bulky guns into the modsuit holster module, security and antag players rejoice
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
