### PR TITLE
Add the WT-550 To Armory Orders and Black Market

### DIFF
--- a/modular_nova/modules/modular_wt/orders.dm
+++ b/modular_nova/modules/modular_wt/orders.dm
@@ -1,0 +1,50 @@
+/datum/supply_pack/security/armory/wt550/sec
+	name = "Surplus WT-550 Crate"
+	desc = "An entire crate of outdated service rifles, offered by your wonderful benefactors, Nanotrasen. \
+	Employees are reminded that rumors of face-melting are just that, and these weapons are entirely safe, if not \
+	entirely up to modern standards; all the same, Nanotrasen is not responsible for issues arising from their deployment. \
+	Ammo sold separately."
+	hidden = FALSE
+	cost = CARGO_CRATE_VALUE * 8
+	access = ACCESS_ARMORY
+	access_view = ACCESS_ARMORY
+	contains = list(
+		/obj/item/gun/ballistic/automatic/wt550 = 3,
+	)
+	crate_name = "Surplus Autorifles Crate"
+	crate_type = /obj/structure/closet/crate/secure/weapon
+
+/datum/supply_pack/security/armory/wt550ammo_sec
+	name = "Surplus WT-550 Ammo Crate"
+	desc = "A crate of WT-550 ammunition, intended to supply surplus rifles, or be taken as a novelty."
+	hidden = FALSE
+	cost = CARGO_CRATE_VALUE * 6
+	access = ACCESS_ARMORY
+	access_view = ACCESS_ARMORY
+	contains = list(
+		/obj/item/ammo_box/magazine/wt550m9 = 3,
+		/obj/item/ammo_box/magazine/wt550m9/rub = 3,
+	)
+	crate_name = "Surplus Ammunition Crate"
+	crate_type = /obj/structure/closet/crate/secure/weapon
+
+/datum/market_item/weapon/wt550
+	name = "WT-550 Autorifle"
+	desc = "*!&@#FANCY SEEING YOU HERE, AGENT! YOU KNOW THE OFFER - AN AUTORIFLE, FOR YOUR USE AND ENJOYMENT!#@*$"
+	item = /obj/item/gun/ballistic/automatic/wt550
+
+	price_min = CARGO_CRATE_VALUE * 0.75
+	price_max = CARGO_CRATE_VALUE * 3
+	stock_max = 3
+	availability_prob = 60 // There are multiple routes to obtaining these
+
+/datum/market_item/weapon/wt550/ammo
+	name = "WT-550 Autorifle Ammunition"
+	desc = "'Enumerate with your WT-550: Projectile Thrown Weapon. Container has 6 REAL WT-550 Magazine Ammunitions and hours of fun!'"
+	item = /obj/item/storage/toolbox/ammobox/wt550
+
+	price_min = CARGO_CRATE_VALUE * 2 // the ammo in this is a lot harder to get than the guns themselves
+	price_max = CARGO_CRATE_VALUE * 5
+	stock_max = 4 // the contents of these boxes are fundamentally random; carry a few in case one spawns with all rubbers or something
+	stock_min = 2
+	availability_prob = 90 // These are largely available exclusively here

--- a/modular_nova/modules/modular_wt/wt550.dm
+++ b/modular_nova/modules/modular_wt/wt550.dm
@@ -1,0 +1,30 @@
+/obj/item/ammo_box/magazine/wt550m9/rub
+	name = "\improper WT-550 magazine (4.6x30mm rubber)"
+	desc = "A top-loading 4.6x30mm magazine, specifically to carry less than lethal ammo."
+	ammo_band_color = "#2596be"
+	ammo_type = /obj/item/ammo_casing/c46x30mm/rubber
+
+/obj/item/ammo_casing/c46x30mm/rubber
+	name = "4.6x30mm rubber bullet casing"
+	desc = "A 4.6x30mm rubber bullet casing. It is less lethal. Were you expecting some great insight?"
+	projectile_type = /obj/projectile/bullet/c46x30mm/rubber
+
+/obj/projectile/bullet/c46x30mm/rubber
+	name = "4.6x30mm rubber bullet"
+	damage = 5
+	stamina = 20
+	wound_bonus = -10
+	ricochets_max = 2
+	ricochet_incidence_leeway = 0
+	ricochet_chance = 70
+	ricochet_decay_damage = 0.7
+	sharpness = NONE
+
+/obj/item/storage/toolbox/ammobox/wt550
+	name = "ammo box (wt-550)"
+	desc = "If the label's accurate, this contains 'Standerd Capacity Ammo Full Size Ammo Capacity Magazine Shoot Gun For Wt-550 Gun Rifle Security BEST PRICE'."
+
+/obj/item/storage/toolbox/ammobox/wt550/PopulateContents()
+	for(var/i in 1 to 6)
+		var/glib = pick(/obj/item/ammo_box/magazine/wt550m9, /obj/item/ammo_box/magazine/wt550m9/rub, /obj/item/ammo_box/magazine/wt550m9/wtic, /obj/item/ammo_box/magazine/wt550m9/wtap)
+		new glib(src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8639,6 +8639,8 @@
 #include "modular_nova\modules\modular_weapons\code\overrides\energy.dm"
 #include "modular_nova\modules\modular_weapons\code\overrides\mystery_box_additions.dm"
 #include "modular_nova\modules\modular_weapons\code\overrides\suppressor_size_change_override.dm"
+#include "modular_nova\modules\modular_wt\orders.dm"
+#include "modular_nova\modules\modular_wt\wt550.dm"
 #include "modular_nova\modules\mold\code\_mold_defines.dm"
 #include "modular_nova\modules\mold\code\mold.dm"
 #include "modular_nova\modules\mold\code\mold_controller.dm"


### PR DESCRIPTION
## About The Pull Request
Adds a WT-550 surplus crate and ammo crate to the armory tab of cargo imports, as well as making the weapon and its ammunition available through the black market. Also adds less-lethal ammo for the WT-550.

## How This Contributes To The Nova Sector Roleplay Experience
This would not only allow a popular but underutilized weapon to see more light, but also vary the methods of obtaining weapons for characters who either do not want to or cannot go through cargo. This also allows security to not only better stock their armory for more situations but also actually obtain what was apparently a rather well-liked weapon.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
<img width="542" height="150" alt="wt550blackmarket" src="https://github.com/user-attachments/assets/6d1f97e7-bcf4-4c64-8b4f-711da2526911" />
<img width="571" height="160" alt="wt550s order" src="https://github.com/user-attachments/assets/7babbd66-1a96-4a22-937a-44639dd2333e" />
<img width="150" height="220" alt="guns junk" src="https://github.com/user-attachments/assets/a2d3cd9a-a6e5-4cb0-8b3a-d1a8f71cf22d" />
<img width="83" height="79" alt="azra and his blicky" src="https://github.com/user-attachments/assets/370b11ff-d534-4951-a6c3-47ce37b8bb17" />
<img width="502" height="82" alt="image_2025-07-10_202822538" src="https://github.com/user-attachments/assets/afd070f0-f83d-4de5-9d2c-49c3e01b9257" />
<img width="497" height="83" alt="random spawns" src="https://github.com/user-attachments/assets/b3a68533-e0ce-4792-86be-a70811e687c4" />

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Now that the rumors have (mostly) died down, the WT-550 is available in bulk for budget-constrained security departments to stock their armories with. 
add: The Black Market now has its grubby little bluespace transceivers on the WT-550 and its variant ammo types.
add: The premiere weapon interns at Nanotrasen have haphazardly created a Rubber round for the WT-550, available through security orders.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
