### PR TITLE
Fixes SerenityStation surface_luna run Active Turfs

### DIFF
--- a/_maps/RandomRuins/JungleRuins/surface_luna.dmm
+++ b/_maps/RandomRuins/JungleRuins/surface_luna.dmm
@@ -91,7 +91,7 @@
 /turf/open/misc/asteroid/forest,
 /area/ruin/unpowered/luna)
 "y" = (
-/turf/open/water,
+/turf/open/water/forest_atmos,
 /area/ruin/unpowered/luna)
 "z" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner,

--- a/modular_nova/modules/serenitystation/code/turfs.dm
+++ b/modular_nova/modules/serenitystation/code/turfs.dm
@@ -126,6 +126,10 @@
 	desc = "Sturdy exterior hull plating that separates you from the outside world."
 	initial_gas_mix = FOREST_DEFAULT_ATMOS
 
+/turf/open/water/forest_atmos
+	initial_gas_mix = FOREST_DEFAULT_ATMOS
+	baseturfs = /turf/open/water/forest_atmos
+
 /turf/open/lava/plasma/forest
 	initial_gas_mix = FOREST_DEFAULT_ATMOS
 	baseturfs = /turf/open/lava/plasma/forest


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This horrid, evil water is the right atmos type now.
<img width="495" height="516" alt="image" src="https://github.com/user-attachments/assets/9701919e-3a33-40df-92a7-835dc41e04c1" />

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Bugfix. Active Turfs connected directly to planet atmos are the worst active turf.s
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
I... can't actually do this. This map won't run well enough on my local right now.
But it's a repath of one tile to the same tile with the same initial_gas_mix as all the surrounding tiles so like. That's the bug fixed.
<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed some active turfs on SerenityStation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
