### PR TITLE
dryingrack unpowered fix

### DIFF
--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -549,7 +549,6 @@
 	visible_contents = FALSE
 	base_build_path = /obj/machinery/smartfridge/drying/rack
 	use_power = NO_POWER_USE
-	idle_power_usage = 0
 
 /obj/machinery/smartfridge/drying/rack/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

makes wooden drying rack actually work without power - there was some weird interaction between `use_power = NO_POWER_USE` and `idle_power_usage = 0` - it didn't like that it was flagged as using no power but also had a value inputted for idle power use, even if it's zero
## How This Contributes To The Nova Sector Roleplay Experience

fixes https://github.com/NovaSector/NovaSector/issues/5747
## Proof of Testing

https://discord.com/channels/1171566433923239977/1172988592658841680/1393628267411542118

## Changelog
:cl:
fix: wooden dryingrack no longer requires power
/:cl:
