### PR TITLE
Fix Cesarzowa-firing PvE sources doing twice their intended damage

### DIFF
--- a/modular_nova/modules/bitrunning/code/virtual_domains/ancient_milsim/mobs.dm
+++ b/modular_nova/modules/bitrunning/code/virtual_domains/ancient_milsim/mobs.dm
@@ -53,13 +53,23 @@
 	r_hand = /obj/item/gun/ballistic/automatic/miecz
 	loot = list(/obj/effect/mob_spawn/corpse/human/cin_soldier, /obj/effect/spawner/random/ancient_milsim/ranged)
 	/// Type of bullet we use
-	var/casingtype = /obj/item/ammo_casing/c27_54cesarzowa
+	var/casingtype = /obj/item/ammo_casing/c27_54cesarzowa/ancient // We buffed this round, so these guys got unintentionally buffed too.
 	/// Sound to play when firing weapon
 	var/projectilesound = 'modular_nova/modules/modular_weapons/sounds/smg_light.ogg'
 	/// number of burst shots
 	var/burst_shots = 2
 	/// Time between taking shots
 	var/ranged_cooldown = 0.45 SECONDS
+
+/obj/item/ammo_casing/c27_54cesarzowa/ancient
+	projectile_type = /obj/projectile/bullet/c27_54cesarzowa/ancient
+
+/obj/projectile/bullet/c27_54cesarzowa/ancient
+	name = ".27-54 Cesarzowa piercing bullet casing"
+	damage = 18 // original was 15 but we ran this the longest and it worked fine
+	armour_penetration = 30
+	wound_bonus = -30
+	exposed_wound_bonus = -10
 
 /mob/living/basic/trooper/cin_soldier/ranged/Initialize(mapload)
 	. = ..()

--- a/modular_nova/modules/magfed_turret/code/turrets/ruins.dm
+++ b/modular_nova/modules/magfed_turret/code/turrets/ruins.dm
@@ -150,6 +150,7 @@
 	turret_frame = /obj/item/turret_assembly/twin_fang
 	quick_retract = TRUE
 	turret_damage_multiplier = 0.5
+	var/turret_wound_bonus = -30
 	shot_delay = 0.1 SECONDS
 	burst_fire = TRUE
 	burst_delay = 1.5 SECONDS

--- a/modular_nova/modules/magfed_turret/code/turrets/ruins.dm
+++ b/modular_nova/modules/magfed_turret/code/turrets/ruins.dm
@@ -149,6 +149,7 @@
 	fragile = TRUE
 	turret_frame = /obj/item/turret_assembly/twin_fang
 	quick_retract = TRUE
+	turret_damage_multiplier = 0.5
 	shot_delay = 0.1 SECONDS
 	burst_fire = TRUE
 	burst_delay = 1.5 SECONDS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Similarly to #4850, fixes knock-on errors of the Restocking PRs that weren't considered when they were made.

Fixes some PVE sources that were caught in the crossfire of Restocking's fundamental rework of the Miecz to have their (roughly) intended damage output. The Miecz was originally one of our lowest damage per bullet weapons with a massive wound penalty, and was an SMG. Its extremely low damage output per shot made it an easy choice for some sources to use as a light caliber to fire at players in high number during PVE without overly punishing them or melting them as automatics often do.

Restocking completely changed the Miecz into the exact opposite of what it once was - it is now a wound-heavy, slow-firing LMG, and its projectile not only has a wound **bonus,** but has had its damage **doubled.** No consideration was made for the enemies balanced around firing its caliber. This is most blatant in any location that uses the twin-fang turret, which does far more damage and is far more likely to cripple than traditionally able, and Ancient Milsim, in which what were previously submachinegun guys now fire impossibly fast bursts of highcal that make them virtually impossible to engage in melee and kill you far faster than any other enemy type within the domain. This often leads to extremely obnoxious to tend wounds which do nothing but waste the time of players (given mobs can't capitalize on them.)

This has been addressed as non-intrusively as possible; a fake caliber has been made for the Milsim NPCs to restore them to their still difficult but far less ridiculous intended lethality from before restocking. Turrets have simply been given a damage and wound malus; technically, they will underperform against bare targets, however the other option was to replace their caliber entirely, which would make them unable to be reloaded as they were before.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
The balance of several already existing enemy types and areas were thrown violently out of wack, making specific portions of them far more punishing and lethal to players than intended. This is especially problematic in bitrunning, as it makes attempting to melee the enemies firing this round basically random chance as to whether or not they will more or less instantly evaporate you; it also punishes less robust or patient runners extremely heavily compared to everything else we run.

Further, enemies which deal heavy wounds massively slow down progress in any area they're in, as wounds take time to heal and blood to restore; if you're unlucky, they can even lead to frankly unfair deaths due to attrition blood loss stacking rapidly. It is very likely that the Miecz was in part chosen originally for its tendency to deal few or no wounds, and thus act as a raw damage dealer.

There's also, of course, the consideration that a (relatively) tight timing window in between extremely punishing bursts is basically a lock on anyone with high ping in an engine like Byond. Perhaps there is a place for such brutal PVE combat, but it is not in an area not designed for it, where the main draw is its PVP latter half.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
<img width="279" height="21" alt="image" src="https://github.com/user-attachments/assets/7645fd83-2d3e-403f-9543-ba4de7c3e7c1" />

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Cezarowa firing NPCs and structures no longer vastly overperform compared to their intended numbers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
