### PR TITLE
[github] make stale workflow work for issues again (issue managers (me) rejoice)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,8 +22,10 @@ jobs:
           days-before-stale: 14
           days-before-close: 14
           stale-pr-label: "Stale"
-          days-before-issue-stale: -1
+          days-before-issue-stale: 0
+          days-before-issue-close: 7
           stale-issue-label: "Cleanup Flagged"
+          only-label: "Cleanup Flagged"
           remove-issue-stale-when-updated: false
           exempt-pr-labels: "RED LABEL,Good First PR"
           operations-per-run: 300


### PR DESCRIPTION

## About The Pull Request

changes `days-before-issue-stale:` to `0` so that the issue part of stale workflow actually runs
adds `days-before-issue-close:` set to `7` - if an issue is flagged as stale (cleanup flagged) then it closes after 7 days
adds `only-labels: "Cleanup Flagged"` the bot only affects issues with the cleanup-flag label, so that it doesn't start auto-adding the cleanup flag label to every issue every day - since they don't have the cleanup flagged label - so only issues that are manually flagged count as stale and get autoclosed
## How This Contributes To The Nova Sector Roleplay Experience

it doesnt, but it makes our life a little bit easier (the other workflows are still broken i dont know yaml so im not touching them)
## Proof of Testing

i do not have a way to test this
## Changelog
