### PR TITLE
Random skrell names no longer have special symbols

### DIFF
--- a/modular_nova/modules/customization/modules/language/skrell.dm
+++ b/modular_nova/modules/customization/modules/language/skrell.dm
@@ -8,7 +8,7 @@
 	additional_syllable_high = 1
 	flags = TONGUELESS_SPEECH
 	key = "K"
-	syllables = list("qr","qrr","xuq","qil","quum","xuqm","vol","xrim","zaoo","qu-uu","qix","qoo","zix","*","!")
+	syllables = list("qr","qrr","xuq","qil","quum","xuqm","vol","xrim","zaoo","qu-uu","qix","qoo","zix")
 	default_priority = 90
 	icon_state = "skrell"
 	icon = 'modular_nova/master_files/icons/misc/language.dmi'


### PR DESCRIPTION

## About The Pull Request
Fixes #5758
Names aren't supposed to have characters like *, and cause the linked issue if such a name is rolled as a traitor's code phrase as it results in an invalid regex.
## How This Contributes To The Nova Sector Roleplay Experience
Fix bug
## Proof of Testing
I don't really know how to test this, as occurrence of the bug is already rare enough that it has only just been reported despite skrell naming not having changed in the last 4 years
## Changelog
:cl:
fix: Fixed an exceptionally rare bug that caused traitors to go deaf
/:cl:
