### PR TITLE
A bunch of Blueshift mapping fixes

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -39599,7 +39599,10 @@
 	linked_elevator_id = "publicElevator"
 	},
 /obj/machinery/light/directional/north,
-/obj/machinery/door/window/elevator/left/directional/west,
+/obj/machinery/door/window/elevator/left/directional/west{
+	transport_linked_id = "publicElevator";
+	elevator_mode = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "hES" = (
@@ -87711,7 +87714,10 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/obj/machinery/door/window/elevator/right/directional/west,
+/obj/machinery/door/window/elevator/right/directional/west{
+	transport_linked_id = "publicElevator";
+	elevator_mode = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "qOZ" = (
@@ -109007,7 +109013,10 @@
 	linked_elevator_id = "publicElevator"
 	},
 /obj/machinery/light/directional/north,
-/obj/machinery/door/window/elevator/right/directional/east,
+/obj/machinery/door/window/elevator/right/directional/east{
+	transport_linked_id = "publicElevator";
+	elevator_mode = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "uQl" = (

--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -104105,6 +104105,7 @@
 "tTX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},

--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -46660,13 +46660,6 @@
 /turf/open/floor/wood,
 /area/station/maintenance/abandon_art_studio)
 "iYN" = (
-/obj/item/clothing/under/rank/security/detective,
-/obj/item/clothing/suit/toggle/jacket/det_trench{
-	icon_state = "curator"
-	},
-/obj/item/clothing/head/fedora/det_hat{
-	icon_state = "curator"
-	},
 /obj/machinery/camera/directional/east{
 	c_tag = "Detective's Study"
 	},
@@ -120601,7 +120594,7 @@
 /area/station/maintenance/department/medical)
 "wYS" = (
 /obj/machinery/computer/records/security,
-/obj/structure/noticeboard/directional/north,
+/obj/structure/detectiveboard/directional/north,
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
 "wYV" = (

--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -4694,12 +4694,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper)
-"aXa" = (
-/mob/living/basic/mouse/gray{
-	health = 0
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "aXb" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -10069,6 +10063,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/warning/electric_shock/directional/north,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/barricade/wooden,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/solars/starboard/fore)
 "bXe" = (
@@ -15421,13 +15416,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/upper)
 "cUS" = (
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
+/obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
 "cUX" = (
@@ -17482,8 +17475,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "dqq" = (
-/obj/structure/cable,
 /obj/structure/grille/broken,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "dqw" = (
@@ -23754,9 +23747,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "eBm" = (
-/obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/spawner/random/structure/steam_vent,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "eBn" = (
@@ -28746,6 +28737,7 @@
 	},
 /obj/structure/sign/warning/electric_shock/directional/north,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/barricade/wooden,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/solars/starboard/fore)
 "fxa" = (
@@ -29030,6 +29022,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/barricade/wooden,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/solars/port/fore)
 "fzZ" = (
@@ -29876,7 +29869,7 @@
 "fKh" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
-/turf/open/floor/plating/airless,
+/turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/starboard/aft)
 "fKm" = (
 /obj/effect/decal/cleanable/dirt{
@@ -30356,9 +30349,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "fOt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "fOB" = (
@@ -36930,6 +36921,9 @@
 /area/station/maintenance/department/security/prison_upper)
 "hcO" = (
 /obj/machinery/camera/autoname/directional/west,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "hcY" = (
@@ -37602,6 +37596,7 @@
 "hjI" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engineering/engine_aft_starboard)
 "hjL" = (
@@ -39599,7 +39594,7 @@
 	linked_elevator_id = "publicElevator"
 	},
 /obj/machinery/light/directional/north,
-/obj/machinery/door/window/elevator/left/directional/west{
+/obj/machinery/door/window/elevator/right/directional/west{
 	transport_linked_id = "publicElevator";
 	elevator_mode = 1
 	},
@@ -46716,13 +46711,6 @@
 	dir = 1
 	},
 /area/station/science/research)
-"iZc" = (
-/obj/structure/cable,
-/mob/living/basic/mouse/gray{
-	health = 0
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
 "iZi" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/corner{
@@ -49743,10 +49731,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "jCJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/maintenance/department/security/lesser)
 "jCK" = (
 /obj/structure/barricade/security,
 /obj/effect/turf_decal/stripes{
@@ -57959,6 +57949,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/qm)
 "lec" = (
@@ -64648,9 +64639,9 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
 	},
-/obj/machinery/door/window/elevator/left/directional/east{
-	elevator_mode = 1;
-	transport_linked_id = "publicElevator"
+/obj/machinery/door/window/elevator/right/directional/east{
+	transport_linked_id = "publicElevator";
+	elevator_mode = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
@@ -65366,6 +65357,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/qm)
 "mCj" = (
@@ -76560,6 +76553,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/barricade/wooden,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/solars/port/fore)
 "oIp" = (
@@ -78399,6 +78393,7 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "paH" = (
+/obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/starboard/aft)
 "paJ" = (
@@ -87273,6 +87268,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "qJF" = (
@@ -87714,7 +87710,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/obj/machinery/door/window/elevator/right/directional/west{
+/obj/machinery/door/window/elevator/left/directional/west{
 	transport_linked_id = "publicElevator";
 	elevator_mode = 1
 	},
@@ -89641,9 +89637,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology/control)
-"rhu" = (
-/turf/open/floor/iron/submarine_perf/airless,
-/area/space/nearstation)
 "rhA" = (
 /obj/structure/table/wood,
 /obj/item/storage/bag/books,
@@ -109013,9 +109006,9 @@
 	linked_elevator_id = "publicElevator"
 	},
 /obj/machinery/light/directional/north,
-/obj/machinery/door/window/elevator/right/directional/east{
-	transport_linked_id = "publicElevator";
-	elevator_mode = 1
+/obj/machinery/door/window/elevator/left/directional/east{
+	elevator_mode = 1;
+	transport_linked_id = "publicElevator"
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
@@ -109341,7 +109334,6 @@
 "uTe" = (
 /obj/structure/window/spawner/directional/north,
 /obj/structure/window/spawner/directional/south,
-/obj/structure/cable,
 /obj/effect/spawner/structure/electrified_grille,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engineering/engine_aft_starboard)
@@ -114862,6 +114854,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/stairs/old,
 /area/station/cargo/office)
 "vUW" = (
@@ -125039,6 +125032,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/lesser)
 "xTk" = (
@@ -150945,8 +150939,8 @@ dNC
 ofE
 qlU
 hcO
-qlU
-nds
+deS
+him
 fQT
 llL
 nah
@@ -155991,7 +155985,7 @@ hGf
 hGf
 hGf
 wQs
-kNY
+jCJ
 odQ
 sxa
 mxi
@@ -156248,7 +156242,7 @@ lqx
 unA
 hGf
 chS
-kNY
+jCJ
 bws
 jYr
 mxi
@@ -156505,7 +156499,7 @@ vqv
 pvj
 hGf
 ssK
-kNY
+jCJ
 vFi
 jhS
 mxi
@@ -156762,7 +156756,7 @@ eQu
 uvf
 hGf
 kXY
-kNY
+jCJ
 www
 www
 trQ
@@ -161763,9 +161757,9 @@ aXj
 mvq
 mvq
 uTe
-aXj
-aXj
-aXj
+kxR
+kxR
+kxR
 jrA
 jrA
 jrA
@@ -226270,12 +226264,12 @@ gLc
 ezW
 gLc
 gLc
-rhu
-rhu
-rhu
-rhu
-rhu
-rhu
+hcy
+hcy
+hcy
+hcy
+hcy
+hcy
 bYD
 esy
 ccH
@@ -226527,12 +226521,12 @@ gLc
 gLc
 fmg
 gLc
-rhu
-rhu
-rhu
-rhu
-rhu
-rhu
+hcy
+hcy
+hcy
+hcy
+hcy
+hcy
 lwQ
 rns
 ccH
@@ -226785,9 +226779,9 @@ gLc
 bYD
 gLc
 gLc
-rhu
-rhu
-rhu
+hcy
+hcy
+hcy
 gLc
 gLc
 gLc
@@ -227043,9 +227037,9 @@ bYD
 gLc
 gLc
 gLc
-rhu
-rhu
-rhu
+hcy
+hcy
+hcy
 gLc
 gLc
 vQA
@@ -227298,12 +227292,12 @@ gLc
 gLc
 bYD
 gLc
-rhu
-rhu
-rhu
-rhu
-rhu
-rhu
+hcy
+hcy
+hcy
+hcy
+hcy
+hcy
 gLc
 vQA
 dBf
@@ -227555,12 +227549,12 @@ gLc
 gLc
 lwQ
 gLc
-rhu
-rhu
-rhu
-rhu
-rhu
-rhu
+hcy
+hcy
+hcy
+hcy
+hcy
+hcy
 gLc
 orn
 kBb
@@ -230856,7 +230850,7 @@ rId
 osg
 sbR
 ukR
-ukR
+qwm
 psl
 qRS
 eDq
@@ -231112,8 +231106,8 @@ jBZ
 dhT
 osg
 psl
+ukR
 sob
-iZc
 psl
 sbR
 sbR
@@ -231370,7 +231364,7 @@ cUY
 pUQ
 psl
 ukR
-ukR
+qwm
 psl
 gRh
 psl
@@ -231884,7 +231878,7 @@ rId
 pUQ
 sbR
 wCN
-ukR
+qwm
 jAS
 vmz
 icJ
@@ -232140,8 +232134,8 @@ jBZ
 dhT
 pUQ
 sbR
-sob
 ukR
+qwm
 sbR
 icJ
 vje
@@ -232397,8 +232391,8 @@ oSf
 cUY
 pUQ
 psl
-sKW
-ukR
+dqq
+sob
 sbR
 vmz
 vAi
@@ -232654,8 +232648,8 @@ pUQ
 pUQ
 pUQ
 psl
-qwm
 ukR
+qwm
 psl
 mLX
 oCw
@@ -232911,8 +232905,8 @@ gAt
 rId
 pUQ
 sbR
-aXa
-jCJ
+ukR
+sob
 psl
 aOI
 buD
@@ -233168,8 +233162,8 @@ jBZ
 dhT
 pUQ
 sbR
-qwm
-dqq
+ukR
+sKW
 jHG
 hck
 jHG
@@ -236256,7 +236250,7 @@ klU
 ojX
 klU
 ojX
-gTL
+paH
 gLc
 paH
 loJ


### PR DESCRIPTION
## About The Pull Request
A myriad of map fixes because it's a great map haunted by a lack of maintinence.

Before this is merged, if anybody knows of any other mapping issues on Blueshift, feel free to comment! Might as well get a few fixes in instead of just one! 
_(Issues that **DON'T** require a full rework. Small things, like the elevator, a missing light, a misplaced decal... Not solars. We all know about the solars.)_

<details><summary>Current list of changes:</summary>

- Fixes the Elevator Doors
- Fixes missing cable into Art Supply Storage
- Fixes missing cables to APC in Lesser Security Maintenance
- Adds APC to Quartermaster's Office
- Fixes a doubled wire in Engi Maints
- Fixes some incomplete pipes in Engi/Tcomms
- Removed Medbay's guaranteed power-cutoff mice trap (the mice room still exists right beside it, and mice can still randomly spawn on these tiles ofc. It just stops the 2 roundstart cutting medbay off immediately. Because that's stupid.
- Barricaded the useless interior Solar Arrays (because they can never actually get sunlight)
- Replaced the external Foam Sprayer on the AI sat with a holopad (the area was too small to be used right, and the dir-windows didn't function right with them
- Replaced the big N by the AI Sat with a different tile (so it's not a pool. for some reason.)
- Added wires under all the solar plating of the only working solar array (otherwise t-rays are REQUIRED, so you know which tiles to pull up. This is not good gameplay.)
- Gives the Detective their new board
- Removes the var-edited detective clothes (we #hate varedits)(also this caused error sprites)
</details>

## How This Contributes To The Nova Sector Roleplay Experience
Map fixes. Just a buttload of map fixes.

Fixes #4713
Fixes #4980

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

Not getting a screenshot of each tiny single-tile change but I did fly around to make sure they all went through right.

Woah.. elevator
  <img width="601" height="306" alt="image" src="https://github.com/user-attachments/assets/a3d7110e-9da2-4ae7-a0b5-6c0fcf8a617a" />
  
 QM APC
<img width="270" height="251" alt="image" src="https://github.com/user-attachments/assets/06dc55e2-8f38-40cd-b16b-a87a468b2ca3" />

AI SAT
<img width="838" height="757" alt="image" src="https://github.com/user-attachments/assets/791644ec-a88d-47f2-95f1-fba4161769bf" />

  
</details>

## Changelog

:cl:
fix: Fixed a few things on Blueshift, such as missing cables, the elevator doors, the Detective's noticeboard, and Medbay's mouse problem. Also barricaded the interior solar panels, because those don't even work.
/:cl:
