### PR TITLE
ups the lings chem regen (again) (modular)

### DIFF
--- a/modular_nova/master_files/code/modules/antagonists/changeling/changeling.dm
+++ b/modular_nova/master_files/code/modules/antagonists/changeling/changeling.dm
@@ -1,6 +1,6 @@
 /datum/antagonist/changeling
 	dna_max = 8 // changed from 6
-	chem_recharge_rate = 0.5
+	/// chem_recharge_rate = 0.5 (disabled override, can reenable when needed)
 	/// The time that the horror form died.
 	var/true_form_death
 	/// Any quirks that we don't want to be mimicked when transforming


### PR DESCRIPTION

## About The Pull Request
ups lings chem regen to tg (maybe), just disabled the override

## How This Contributes To The Nova Sector Roleplay Experience

https://github.com/NovaSector/NovaSector/pull/5765

## Proof of Testing

commented out same deal

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: put lings chem regen back to 1 (was 0.5)
/:cl:
