### PR TITLE
Deployable barricade balance

### DIFF
--- a/modular_nova/modules/barricades/code/barricade.dm
+++ b/modular_nova/modules/barricades/code/barricade.dm
@@ -266,13 +266,11 @@
 	can_wire = FALSE
 
 /datum/armor/deployable_barricade_guardrail
+	melee = 35
 	bullet = 50
 	laser = 50
-	energy = 50
-	bomb = 15
-	bio = 100
-	fire = 100
-	acid = 10
+	energy = 100
+	bomb = 10
 
 /obj/structure/deployable_barricade/guardrail/update_icon()
 	. = ..()
@@ -357,9 +355,10 @@
 	var/can_upgrade = TRUE
 
 /datum/armor/deployable_barricade_metal
-	bio = 100
+	bio = 80
 	fire = 80
-	acid = 40
+	acid = 60
+	bomb = 40
 
 /obj/structure/deployable_barricade/metal/click_alt(mob/user)
 	if(portable_type)

--- a/modular_nova/modules/barricades/code/barricade.dm
+++ b/modular_nova/modules/barricades/code/barricade.dm
@@ -357,8 +357,8 @@
 /datum/armor/deployable_barricade_metal
 	bio = 80
 	fire = 80
-	acid = 60
-	bomb = 40
+	acid = 40
+	bomb = 20
 
 /obj/structure/deployable_barricade/metal/click_alt(mob/user)
 	if(portable_type)


### PR DESCRIPTION

## About The Pull Request

Some weirdness and assumed oversight here, but i've just tweaked the armor values of the deployables.

Currently, for some reason. 2 iron rod guadrails were better overall than the cucks for armor - what. And had bio and fire 100?
They now match railings as railings cost 2 iron rods as well.

I also added some bomb resists to the barricade armor var, reducing it from bio 100 (??) to 80 and bumping up acid resist.


## How This Contributes To The Nova Sector Roleplay Experience

This just most likely is an oversight that wasn't noticed, didnt make sense for the guardrails to be so strong.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: C.U.C.K.S. and co barriers are slightly better against bombs and acid, guardrails no longer are better than them and are balanced down to match the material resistances.
/:cl:
