### PR TITLE
[MODULAR] adds visibility to the ghost imports consoles

### DIFF
--- a/modular_nova/modules/cargo/code/expressconsole.dm
+++ b/modular_nova/modules/cargo/code/expressconsole.dm
@@ -50,9 +50,12 @@
 				for(var/datum/armament_entry/armament_entry as anything in SSarmaments.entries[armament_category][CATEGORY_ENTRY][subcategory])
 					meme_pack_data["Company Imports"]["packs"] += list(list(
 						"name" = "[armament_category]: [armament_entry.name]",
+						"first_item_icon" = armament_entry?.item_type.icon,
+						"first_item_icon_state" = armament_entry?.item_type.icon_state,
 						"cost" = armament_entry.cost,
 						"id" = REF(armament_entry),
 						"description" = armament_entry.description,
+						"desc" = armament_entry.description,
 					))
 
 /obj/machinery/computer/cargo/express/interdyne/ui_act(action, params, datum/tgui/ui)


### PR DESCRIPTION
## About The Pull Request

This PR adds icons and description to the ghost imports consoles so many dont have to guess what the objects are from name alone.

## How This Contributes To The Nova Sector Roleplay Experience

This improves the player's quality of life as they currently cannot see what is in the consoles. Allowing them to purchase what t hey want with more ease.

## Proof of Testing
<img width="1302" height="711" alt="image" src="https://github.com/user-attachments/assets/b7536d13-b14b-47a2-8429-5100cd85679f" />

## Changelog

:cl:
qol: Made the "company imports" tab for the ghost role consoles able to actually see what is being purchased.
qol: Made the "company imports" for the ghost role console have proper descriptions to which order is which so players don't have to guess by name alone.
/:cl:
