### PR TITLE
You can once again select between organic and cybernetic lungs in augs+

### DIFF
--- a/modular_nova/modules/customization/modules/client/augment/organs.dm
+++ b/modular_nova/modules/customization/modules/client/augment/organs.dm
@@ -27,6 +27,15 @@
 	name = "Hydraulic pump engine"
 	path =/obj/item/organ/heart/synth
 
+//LUNGS
+/datum/augment_item/organ/lungs
+	slot = AUGMENT_SLOT_LUNGS
+	allowed_biotypes = MOB_ORGANIC | MOB_ROBOTIC
+
+/datum/augment_item/organ/lungs/normal
+	name = "Organic lungs"
+	path = /obj/item/organ/lungs
+
 /datum/augment_item/organ/lungs/cybernetic
 	name = "Cybernetic lungs"
 	path = /obj/item/organ/lungs/cybernetic


### PR DESCRIPTION

## About The Pull Request
Restores some code that was accidentally removed by https://github.com/NovaSector/NovaSector/pull/5578

before 

<img width="325" height="70" alt="image" src="https://github.com/user-attachments/assets/1a4ee082-f12b-424a-b1ac-054ad70fa5e3" />

after

<img width="348" height="140" alt="image" src="https://github.com/user-attachments/assets/e302cf36-1c45-43fa-9cd2-b8fd13c95638" />
## How This Contributes To The Nova Sector Roleplay Experience
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: cyber lungs can be selected once again
/:cl:
