### PR TITLE
[Fix] Removes Riot and Drake armor ability to use non functional

### DIFF
--- a/modular_nova/modules/clothing_improvements/code/functional_toggle.dm
+++ b/modular_nova/modules/clothing_improvements/code/functional_toggle.dm
@@ -111,3 +111,9 @@ Use CTRL + SHIFT + LEFT CLICK to turn them on and off.
 
 /obj/item/clothing/suit/hooded/seva
 	only_functional = TRUE
+
+/obj/item/clothing/suit/armor/riot
+	only_functional = TRUE
+
+/obj/item/clothing/suit/hooded/cloak/drake
+	only_functional = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds the tag to Riot Armor and Drake armor childs so they cannot use the non functional toggle, as some of their effects were still in play.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Exploits are bad, being able to be tackle inmune or storm inmune with either of those and having a different armor affecting was bad.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
<img width="519" height="557" alt="image" src="https://github.com/user-attachments/assets/e13208cd-ace0-4ac5-abed-350ae8e31489" />


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Riot and Drake armor, and its childs (like the knight armor), cannot be used with the ctrl shift click toggle to make them non functional and wear on the neck, as they were applying some of their effects regardless.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
