### PR TITLE
Dusty Paperwork Crate (Because It's Funny)

### DIFF
--- a/modular_nova/modules/cargo/code/packs.dm
+++ b/modular_nova/modules/cargo/code/packs.dm
@@ -789,9 +789,9 @@
 /datum/supply_pack/misc/ancient_paperwork
 	name = "Unfiled Paperwork"
 	desc = "Hey, we've apparently got a backlog of paperwork here. It's pretty bad. \
-	If you guys could help get this processed so we can file this stuff away, \
-	it'll look a lot nicer on our quarterly reports, which means we can justify putting a few extra credits in your budget. \
-	Thanks."
+		If you guys could help get this processed so we can file this stuff away, \
+		it'll look a lot nicer on our quarterly reports, which means we can justify putting a few extra credits in your budget. \
+		Thanks."
 	cost = CARGO_CRATE_VALUE * 6
 	/*
 	one properly stamped paperwork is CARGO_CRATE_VALUE * 3.


### PR DESCRIPTION
## About The Pull Request
Adds an old paperwork crate to Cargo, costing 1200 cr (CARGO_CRATE_VALUE * 6), but with a potential sale value of 3000 cr, for a profit of 1800 cr... at the cost of having to Get Stamps.

<details>
<summary>What's The Deal With Paperwork?</summary>
Original PR is tgstation/tgstation#70863, but tl;dr:

To file this paperwork successfully, you need to examine it closely to get a vague idea of who it needs to get stamped by. Get it correctly stamped, and you can export it! Photocopy it, and you can possibly double-dip on profit... until Central gets mad and tells you to kick rocks (and fines you pretty badly).
</details>

## How This Contributes To The Nova Sector Roleplay Experience
cargo upheaval means people are bouncing this idea around and instead of allowing the citadel-era paperwork to go through i figured this would be significantly more interesting, because to turn a profit you actually have to Interact With People (wow! what a bold idea)

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
yeah give me a sec lmao
</details>

## Changelog

:cl:
add: Central Command, in tandem with the Free Trade Union, has discovered a concerningly large cache of old paperwork that... really, really needs to be filed. For a small deposit, you, too, can dig away at this in return for budget!
/:cl: