### PR TITLE
Converts the webbing accessories into belts

### DIFF
--- a/modular_nova/modules/clothing_improvements/code/webbings.dm
+++ b/modular_nova/modules/clothing_improvements/code/webbings.dm
@@ -1,32 +1,22 @@
-/obj/item/clothing/accessory/webbing
+/obj/item/storage/belt/webbing
 	name = "webbing"
 	desc = "A sturdy mess of synthetic belts and buckles, ready to share your burden."
 	icon = 'modular_nova/modules/clothing_improvements/icons/clothing.dmi'
 	worn_icon = 'modular_nova/modules/clothing_improvements/icons/clothing_worn.dmi'
 	icon_state = "webbing"
-	attachment_slot = NONE
+	inhand_icon_state = "utility"
+	worn_icon_state = null //Makes it default to whatever icon_state is set to, because they're identical
+	storage_type = /datum/storage/webbing_belt
 
-/datum/storage/pockets/webbing
-	do_rustle = TRUE
-	max_slots = 3
+/datum/storage/webbing_belt
+	max_slots = 5
 	max_specific_storage = WEIGHT_CLASS_SMALL
 
-/obj/item/clothing/accessory/webbing/Initialize(mapload)
+/obj/item/storage/belt/webbing/Initialize(mapload)
 	. = ..()
-	create_storage(storage_type = /datum/storage/pockets/webbing)
+	create_storage(storage_type = /datum/storage/webbing_belt)
 
-/obj/item/clothing/accessory/webbing/can_attach_accessory(obj/item/clothing/under/attach_to, mob/living/user)
-	. = ..()
-	if(!.)
-		return
-
-	if(!isnull(attach_to.atom_storage))
-		if(user)
-			attach_to.balloon_alert(user, "not compatible!")
-		return FALSE
-	return TRUE
-
-/obj/item/clothing/accessory/webbing/vest
+/obj/item/storage/belt/webbing/vest
 	name = "webbing vest"
 	desc = "A robust vest with lots of pockets to hold whatever you need, ready to share your burdens."
 	icon_state = "vest_brown"
@@ -36,7 +26,7 @@
 		"Medical White" = "vest_white",
 	)
 
-/obj/item/clothing/accessory/webbing/pouch
+/obj/item/storage/belt/webbing/pouch
 	name = "drop pouches"
 	gender = PLURAL
 	desc = "A robust pair of drop pouches with good capacity, ready to share your burdens."
@@ -47,7 +37,7 @@
 		"White" = "thigh_white",
 	)
 
-/obj/item/clothing/accessory/webbing/pilot
+/obj/item/storage/belt/webbing/pilot
 	name = "storage rigging"
 	icon_state = "pilot_webbing1"
 	unique_reskin = list(

--- a/modular_nova/modules/company_imports/code/armament_datums/kahraman_industries.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/kahraman_industries.dm
@@ -114,4 +114,4 @@
 	item_type = /obj/item/storage/belt/utility/frontier_colonist
 
 /datum/armament_entry/company_import/kahraman/storage_equipment/vest
-	item_type = /obj/item/clothing/accessory/webbing/colonial
+	item_type = /obj/item/storage/belt/webbing/colonial

--- a/modular_nova/modules/food_replicator/code/clothing.dm
+++ b/modular_nova/modules/food_replicator/code/clothing.dm
@@ -63,7 +63,7 @@
 
 	return ..()
 
-/obj/item/clothing/accessory/webbing/colonial
+/obj/item/storage/belt/webbing/colonial
 	name = "slim colonial webbing vest"
 	desc = "A versatile individual carrying equipment, cherished by colonists and hoarders alike. Compact enough to be worn underneath bulky clothing."
 	icon = 'modular_nova/modules/food_replicator/icons/clothing.dmi'

--- a/modular_nova/modules/food_replicator/code/replicator_designs/replicator_clothing.dm
+++ b/modular_nova/modules/food_replicator/code/replicator_designs/replicator_clothing.dm
@@ -36,7 +36,7 @@
 	id = "slavic_webbing"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass = 200)
-	build_path = /obj/item/clothing/accessory/webbing/colonial
+	build_path = /obj/item/storage/belt/webbing/colonial
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_NRI_CLOTHING,

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_accessory.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_accessory.dm
@@ -279,30 +279,3 @@
 /datum/loadout_item/accessory/medal/ribbon7
 	name = "Ribbon (Two-Tone)"
 	item_path = /obj/item/clothing/accessory/nova/ribbon/ribbon_twotone
-
-/*
-* Webbings
-*/
-
-/datum/loadout_item/accessory/webbing
-	name = "Webbing - Basic"
-	item_path = /obj/item/clothing/accessory/webbing
-
-/datum/loadout_item/accessory/colonial_webbing
-	name = "Webbing - Colonial"
-	item_path = /obj/item/clothing/accessory/webbing/colonial
-
-/datum/loadout_item/accessory/webbing_vest
-	name = "Webbing - Vest"
-	item_path = /obj/item/clothing/accessory/webbing/vest
-	can_be_reskinned = TRUE
-
-/datum/loadout_item/accessory/webbing_pouch
-	name = "Webbing - Drop Pouches"
-	item_path = /obj/item/clothing/accessory/webbing/pouch
-	can_be_reskinned = TRUE
-
-/datum/loadout_item/accessory/webbing_pilot
-	name = "Webbing - Rigging"
-	item_path = /obj/item/clothing/accessory/webbing/pilot
-	can_be_reskinned = TRUE

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_belts.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_belts.dm
@@ -24,6 +24,10 @@
 *	ITEMS BELOW HERE
 */
 
+/datum/loadout_item/belts/candle_box
+	name = "Candle Box"
+	item_path = /obj/item/storage/fancy/candle_box
+
 /datum/loadout_item/belts/fanny_pack_black
 	name = "Fannypack (Black)"
 	item_path = /obj/item/storage/belt/fannypack/black
@@ -68,17 +72,13 @@
 	name = "Fannypack (Yellow)"
 	item_path = /obj/item/storage/belt/fannypack/yellow
 
-/datum/loadout_item/belts/thigh_satchel
-	name = "Thigh Satchel"
-	item_path = /obj/item/storage/belt/thigh_satchel
-
 /datum/loadout_item/belts/lantern
 	name = "Lantern"
 	item_path = /obj/item/flashlight/lantern
 
-/datum/loadout_item/belts/candle_box
-	name = "Candle Box"
-	item_path = /obj/item/storage/fancy/candle_box
+/datum/loadout_item/belts/thigh_satchel
+	name = "Thigh Satchel"
+	item_path = /obj/item/storage/belt/thigh_satchel
 
 // HOLSTERS
 
@@ -119,3 +119,25 @@
 	name = "Chest Rig - Frontier"
 	item_path = /obj/item/storage/belt/utility/frontier_colonist
 
+/datum/loadout_item/belts/webbing
+	name = "Webbing - Basic"
+	item_path = /obj/item/storage/belt/webbing
+
+/datum/loadout_item/belts/webbing_colonial
+	name = "Webbing - Colonial"
+	item_path = /obj/item/storage/belt/webbing/colonial
+
+/datum/loadout_item/belts/webbing_pouch
+	name = "Webbing - Drop Pouches"
+	item_path = /obj/item/storage/belt/webbing/pouch
+	can_be_reskinned = TRUE
+
+/datum/loadout_item/belts/webbing_pilot
+	name = "Webbing - Rigging"
+	item_path = /obj/item/storage/belt/webbing/pilot
+	can_be_reskinned = TRUE
+
+/datum/loadout_item/belts/webbing_vest
+	name = "Webbing - Vest"
+	item_path = /obj/item/storage/belt/webbing/vest
+	can_be_reskinned = TRUE


### PR DESCRIPTION
## About The Pull Request
The title's really about it. All the webbing accessories, are now webbing belts.
They can no longer be attached to Uniforms.
To bump them up a bit, they now hold 5 items instead of just 3.
Otherwise, no other changes. They even still require a uniform to be worn, because that's just how belts work.

All the alternative sprites from #5707 are still perfectly intact. This is only a repath.

_Also alphabetized the belt loadout entries because I somehow forgot when sorting_

## How This Contributes To The Nova Sector Roleplay Experience
**One: storage is too abundant**
We have all these items giving so many slots that it's genuinely become a problem, people carrying way more than they're intended to mechanically. I've even heard _several_ users of these exact items agree it's a bit much.
The precedent of more publicly available 'accessory storage' is just leaning even further into storage-creep and needs to be nipped in the bud.
~~Pocket Protectors are not relevant here. They only hold pens.~~

**Two: uniforms are not intended for storage interactions.** 
The 'storage slots' of uniforms are the 2 pocket slots and the belt slot. Once we start using accessories, it crops up a few gameplay issues beyond just more-storage:
- Medbay has no way to quickly check these for allergy tags, epipens, ID, or really anything relevant (dropping **everything** on the floor and making a mess - sometimes removing lifesaving equipment like airtanks, needing to fumble to redress them and reattach everything. It's not **fun** to interact with.)
- Security has a horrid time searching a resisting crewmember for contraband or paper-permits, as it requires stripping somebody entirely (with the exact same flaws medbay combats)
- Even Miners rescuing fellow Miners can't check these for potentially life-saving tools (again, same issues)
- And it even affects the user themselves, making it notably harder to take off (clickdrag is evil)

The Colonial Webbing alone was already a concern, but with the (really nice) alt-sprites, now people are even more incentivized to take the storage-accessory that shouldn't be an accessory. This is the best of both worlds: the items stay, but they aren't super-extra-free-storage that make you a hassle for anybody handling your corpse.

## Proof of Testing
<details><summary>They have been moved to the Belt loadout tab</summary>

<img width="1047" height="725" alt="image" src="https://github.com/user-attachments/assets/2d72f293-f878-47dd-ad10-df59173fe2df" />

</details>

<details><summary>Proof of them working equipped</summary>

<img width="677" height="173" alt="image" src="https://github.com/user-attachments/assets/8b9f1b0d-6450-419d-8602-4114c5c51b61" />

</details>

## Changelog
:cl:
balance: all 'accessory' webbings are now 'belt' webbings
/:cl:
