### PR TITLE
Adds a new neutral quirk: Custom Tongue

### DIFF
--- a/modular_nova/modules/quirk_customtongue/customtongue.dm
+++ b/modular_nova/modules/quirk_customtongue/customtongue.dm
@@ -60,7 +60,7 @@
 
 	var/client/client_source = quirk_holder.client
 
-	var/new_ask = client_source.prefs.read_preference(/datum/preference/text/custom_tongue/ask)
+	var/new_ask = client_source?.prefs.read_preference(/datum/preference/text/custom_tongue/ask)
 	if (new_ask)
 		quirk_holder.verb_ask = LOWER_TEXT(new_ask)
 

--- a/modular_nova/modules/quirk_customtongue/customtongue.dm
+++ b/modular_nova/modules/quirk_customtongue/customtongue.dm
@@ -1,8 +1,83 @@
 /datum/quirk/custom_tongue
 	name = "Custom Tongue"
-	desc = "Your tongue is not like the others, it has a shape and texture that is unique to you, affecting the way you speak."
+	desc = "Your tongue is not standard. It has a shape and texture that is unique to you, affecting the way you speak."
 	gain_text = span_notice("Your tongue feels normal.")
 	lose_text = span_notice("Your tongue feels... Different.")
-	medical_record_text = "Patient has a nonstandard tongue."
+	medical_record_text = "Patient speaks a little funny."
 	value = 0
 	icon = FA_ICON_FACE_GRIN_TONGUE
+
+// Parent preference for convenience. Everything that runs on this (Such as the serialize code) will apply to the remainder of our preferences.
+/datum/preference/text/custom_tongue
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "custom_tongue"
+	savefile_identifier = PREFERENCE_CHARACTER
+	can_randomize = FALSE
+	maximum_value_length = 64
+
+/datum/preference/text/custom_tongue/serialize(input)
+	return htmlrendertext(input)
+
+/datum/preference/text/custom_tongue/is_accessible(datum/preferences/preferences)
+	if (!..())
+		return FALSE
+
+	return "Custom Tongue" in preferences.all_quirks
+
+/datum/preference/text/custom_tongue/apply_to_human(mob/living/carbon/human/target, value)
+	return
+
+/datum/preference/text/custom_tongue/ask
+	savefile_key = "custom_tongue_ask"
+
+/datum/preference/text/custom_tongue/exclaim
+	savefile_key = "custom_tongue_exclaim"
+
+/datum/preference/text/custom_tongue/whisper
+	savefile_key = "custom_tongue_whisper"
+
+/datum/preference/text/custom_tongue/yell
+	savefile_key = "custom_tongue_yell"
+
+/datum/preference/text/custom_tongue/say
+	savefile_key = "custom_tongue_say"
+
+/datum/quirk_constant_data/custom_tongue
+	associated_typepath = /datum/quirk/custom_tongue
+	customization_options = list(
+		/datum/preference/text/custom_tongue/ask,
+		/datum/preference/text/custom_tongue/exclaim,
+		/datum/preference/text/custom_tongue/whisper,
+		/datum/preference/text/custom_tongue/yell,
+		/datum/preference/text/custom_tongue/say
+	)
+
+/datum/quirk/custom_tongue/add(client/client_source)
+	var/new_ask = client_source?.prefs.read_preference(/datum/preference/text/custom_tongue/ask)
+	if (new_ask)
+		quirk_holder.verb_ask = new_ask
+
+	var/new_exclaim = client_source?.prefs.read_preference(/datum/preference/text/custom_tongue/exclaim)
+	if (new_exclaim)
+		quirk_holder.verb_exclaim = new_exclaim
+
+	var/new_whisper = client_source?.prefs.read_preference(/datum/preference/text/custom_tongue/whisper)
+	if (new_whisper)
+		quirk_holder.verb_whisper = new_whisper
+
+	var/new_yell = client_source?.prefs.read_preference(/datum/preference/text/custom_tongue/yell)
+	if (new_yell)
+		quirk_holder.verb_yell = new_yell
+
+	var/new_say = client_source?.prefs.read_preference(/datum/preference/text/custom_tongue/say)
+	if (new_say)
+		var/obj/item/organ/tongue/tongue = quirk_holder.get_organ_slot(ORGAN_SLOT_TONGUE)
+		tongue.say_mod = new_say
+
+/datum/quirk/custom_tongue/remove(client/client_source)
+	var/obj/item/organ/tongue/tongue = quirk_holder.get_organ_slot(ORGAN_SLOT_TONGUE)
+	quirk_holder.verb_ask = initial(quirk_holder.verb_ask)
+	quirk_holder.verb_exclaim = initial(quirk_holder.verb_exclaim)
+	quirk_holder.verb_whisper = initial(quirk_holder.verb_whisper)
+	quirk_holder.verb_yell = initial(quirk_holder.verb_yell)
+	tongue.say_mod = initial(tongue.say_mod)

--- a/modular_nova/modules/quirk_customtongue/customtongue.dm
+++ b/modular_nova/modules/quirk_customtongue/customtongue.dm
@@ -1,0 +1,8 @@
+/datum/quirk/custom_tongue
+	name = "Custom Tongue"
+	desc = "Your tongue is not like the others, it has a shape and texture that is unique to you, affecting the way you speak."
+	gain_text = span_notice("Your tongue feels normal.")
+	lose_text = span_notice("Your tongue feels... Different.")
+	medical_record_text = "Patient has a nonstandard tongue."
+	value = 0
+	icon = FA_ICON_FACE_GRIN_TONGUE

--- a/modular_nova/modules/quirk_customtongue/customtongue.dm
+++ b/modular_nova/modules/quirk_customtongue/customtongue.dm
@@ -16,6 +16,9 @@
 	maximum_value_length = 64 // We may want to lower this for sanity.
 
 /datum/preference/text/custom_tongue/serialize(input)
+	var/regex/unwanted_characters = regex(@"[^\w]") // Prevent people from inputting slop into my text fields. No, you CAN'T have an eggplant emoji for when you whisper.
+	if(unwanted_characters.Find(input))
+		return null // No fun allowed.
 	return htmlrendertext(input)
 
 /datum/preference/text/custom_tongue/is_accessible(datum/preferences/preferences)

--- a/modular_nova/modules/quirk_customtongue/customtongue.dm
+++ b/modular_nova/modules/quirk_customtongue/customtongue.dm
@@ -55,24 +55,24 @@
 /datum/quirk/custom_tongue/add(client/client_source)
 	var/new_ask = client_source?.prefs.read_preference(/datum/preference/text/custom_tongue/ask)
 	if (new_ask)
-		quirk_holder.verb_ask = new_ask
+		quirk_holder.verb_ask = LOWER_TEXT(new_ask)
 
 	var/new_exclaim = client_source?.prefs.read_preference(/datum/preference/text/custom_tongue/exclaim)
 	if (new_exclaim)
-		quirk_holder.verb_exclaim = new_exclaim
+		quirk_holder.verb_exclaim = LOWER_TEXT(new_exclaim)
 
 	var/new_whisper = client_source?.prefs.read_preference(/datum/preference/text/custom_tongue/whisper)
 	if (new_whisper)
-		quirk_holder.verb_whisper = new_whisper
+		quirk_holder.verb_whisper = LOWER_TEXT(new_whisper)
 
 	var/new_yell = client_source?.prefs.read_preference(/datum/preference/text/custom_tongue/yell)
 	if (new_yell)
-		quirk_holder.verb_yell = new_yell
+		quirk_holder.verb_yell = LOWER_TEXT(new_yell)
 
 	var/new_say = client_source?.prefs.read_preference(/datum/preference/text/custom_tongue/say)
 	if (new_say)
 		var/obj/item/organ/tongue/tongue = quirk_holder.get_organ_slot(ORGAN_SLOT_TONGUE)
-		tongue.say_mod = new_say
+		tongue.say_mod = LOWER_TEXT(new_say)
 
 /datum/quirk/custom_tongue/remove(client/client_source)
 	var/obj/item/organ/tongue/tongue = quirk_holder.get_organ_slot(ORGAN_SLOT_TONGUE)

--- a/modular_nova/modules/quirk_customtongue/customtongue.dm
+++ b/modular_nova/modules/quirk_customtongue/customtongue.dm
@@ -55,8 +55,12 @@
 		/datum/preference/text/custom_tongue/say
 	)
 
-/datum/quirk/custom_tongue/add(client/client_source)
-	var/new_ask = client_source?.prefs.read_preference(/datum/preference/text/custom_tongue/ask)
+/datum/quirk/custom_tongue/proc/tongue_setup() //Signal handler for when we gain a tongue that overwrites this quirks say modifiers.
+	SIGNAL_HANDLER
+
+	var/client/client_source = quirk_holder.client
+
+	var/new_ask = client_source.prefs.read_preference(/datum/preference/text/custom_tongue/ask)
 	if (new_ask)
 		quirk_holder.verb_ask = LOWER_TEXT(new_ask)
 
@@ -76,6 +80,10 @@
 	if (new_say)
 		var/obj/item/organ/tongue/tongue = quirk_holder.get_organ_slot(ORGAN_SLOT_TONGUE)
 		tongue.say_mod = LOWER_TEXT(new_say)
+
+/datum/quirk/custom_tongue/add(client/client_source)
+	RegisterSignal(quirk_holder, COMSIG_CARBON_GAIN_ORGAN, PROC_REF(tongue_setup)) // Compatibility between custom tongue and the animal traits quirks
+	tongue_setup() // Reuse the proc to avoid code duplication
 
 /datum/quirk/custom_tongue/remove(client/client_source)
 	var/obj/item/organ/tongue/tongue = quirk_holder.get_organ_slot(ORGAN_SLOT_TONGUE)

--- a/modular_nova/modules/quirk_customtongue/customtongue.dm
+++ b/modular_nova/modules/quirk_customtongue/customtongue.dm
@@ -13,7 +13,7 @@
 	savefile_key = "custom_tongue"
 	savefile_identifier = PREFERENCE_CHARACTER
 	can_randomize = FALSE
-	maximum_value_length = 64
+	maximum_value_length = 64 // We may want to lower this for sanity.
 
 /datum/preference/text/custom_tongue/serialize(input)
 	return htmlrendertext(input)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8881,6 +8881,7 @@
 #include "modular_nova\modules\protected_roles\code\antag_restricted_jobs.dm"
 #include "modular_nova\modules\QOL\code\datums\components\crafting\recipes\recipes_misc.dm"
 #include "modular_nova\modules\QOL\code\game\objects\items\mop.dm"
+#include "modular_nova\modules\quirk_customtongue\customtongue.dm"
 #include "modular_nova\modules\quirk_heavyset\heavyset.dm"
 #include "modular_nova\modules\quirk_masquerade\masquerade.dm"
 #include "modular_nova\modules\quirk_skilled\skilled.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/custom_tongue.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/custom_tongue.tsx
@@ -1,0 +1,32 @@
+// THIS IS A NOVA SECTOR UI FILE
+import { Feature, FeatureShortTextInput } from '../../base';
+
+export const custom_tongue_ask: Feature<string> = {
+  name: 'Ask?',
+  description: 'Automated Ask say modifier.',
+  component: FeatureShortTextInput,
+};
+
+export const custom_tongue_exclaim: Feature<string> = {
+  name: 'Exclaim!',
+  description: 'Automated Exclaim say modifier.',
+  component: FeatureShortTextInput,
+};
+
+export const custom_tongue_whisper: Feature<string> = {
+  name: 'whisper',
+  description: 'Automated Whisper say modifier.',
+  component: FeatureShortTextInput,
+};
+
+export const custom_tongue_yell: Feature<string> = {
+  name: 'Yell!!',
+  description: 'Automated Yell say modifier.',
+  component: FeatureShortTextInput,
+};
+
+export const custom_tongue_say: Feature<string> = {
+  name: 'Say.',
+  description: 'Automated Say say modifier.',
+  component: FeatureShortTextInput,
+};

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/custom_tongue.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/custom_tongue.tsx
@@ -3,30 +3,30 @@ import { Feature, FeatureShortTextInput } from '../../base';
 
 export const custom_tongue_ask: Feature<string> = {
   name: 'Ask?',
-  description: 'Automated Ask say modifier.',
+  description: 'Automated Ask say modifier. A-Z Only.',
   component: FeatureShortTextInput,
 };
 
 export const custom_tongue_exclaim: Feature<string> = {
   name: 'Exclaim!',
-  description: 'Automated Exclaim say modifier.',
+  description: 'Automated Exclaim say modifier. A-Z Only.',
   component: FeatureShortTextInput,
 };
 
 export const custom_tongue_whisper: Feature<string> = {
   name: 'whisper',
-  description: 'Automated Whisper say modifier.',
+  description: 'Automated Whisper say modifier. A-Z Only.',
   component: FeatureShortTextInput,
 };
 
 export const custom_tongue_yell: Feature<string> = {
   name: 'Yell!!',
-  description: 'Automated Yell say modifier.',
+  description: 'Automated Yell say modifier. A-Z Only.',
   component: FeatureShortTextInput,
 };
 
 export const custom_tongue_say: Feature<string> = {
   name: 'Say.',
-  description: 'Automated Say say modifier.',
+  description: 'Automated Say say modifier. A-Z Only.',
   component: FeatureShortTextInput,
 };


### PR DESCRIPTION
## About The Pull Request

Adds a new quirk which allows you to customize all of your default say verbs. Yes, you can already do this manually, but there are reasons you may want it automated!
Even works with augments+ tongues out of the box!

<img width="435" height="262" alt="image" src="https://github.com/user-attachments/assets/bbbaeb3f-d409-44ac-81aa-0a18e1b983cc" />

## How This Contributes To The Nova Sector Roleplay Experience

Some people speak in specific ways! Maybe you're a weird alien species and you speak funny but don't want to always have to type your say modifier! Maybe you're a mousegirl and want to squeak when you speak! Maybe you're a weirdo who wants to be past tense! Or maybe you just want to feel special! Possibilities are endless.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="256" height="172" alt="image" src="https://github.com/user-attachments/assets/c7e083da-02ec-4bf0-a1f3-d53c7fa6d5f8" />

With an augments+ cybernetic lizard tongue, say modifier set to 'meows'

<img width="216" height="29" alt="image" src="https://github.com/user-attachments/assets/95ef4c8f-94e8-4372-aef5-0fcb09bade59" />


</details>

## Changelog

:cl: Chestlet
add: Added Custom Tongue quirk. 
/:cl:
