### PR TITLE
Stops reagent container alt_click change amount from breaking the restriction for certain containers (like epi-pens)

### DIFF
--- a/modular_nova/master_files/code/modules/reagents/reagent_containers.dm
+++ b/modular_nova/master_files/code/modules/reagents/reagent_containers.dm
@@ -1,4 +1,6 @@
 /obj/item/reagent_containers/click_alt(mob/living/user)
+	if(!has_variable_transfer_amount)
+		return NONE
 	if(length(possible_transfer_amounts) <= 2) // If there's only two choices, just swap between them.
 		change_transfer_amount(user, FORWARD)
 		return CLICK_ACTION_SUCCESS


### PR DESCRIPTION
## About The Pull Request

Tin, we were not respecting the `has_variable_transfer_amount` var here as it was likely written before that was a thing.

## How This Contributes To The Nova Sector Roleplay Experience

Fixes an oversight with some older code.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl:
fix: fixed being able to alt-click to change transfer amounts for reagent containers that are not supposed to have that feature (like epi-pens for example)
/:cl