### PR TITLE
appropriately labels .45 rubber casings as rubber casings

### DIFF
--- a/modular_nova/modules/modular_weapons/code/modular_projectiles/pistol_calibers.dm
+++ b/modular_nova/modules/modular_weapons/code/modular_projectiles/pistol_calibers.dm
@@ -139,6 +139,7 @@
 	print_cost = 2
 
 /obj/item/ammo_casing/c45/rubber
+	name = ".45 rubber bullet casing"
 	desc = "A .45 rubber bullet casing.\
 		<br><br>\
 		<i>RUBBER: Less than lethal ammo. Deals both stamina damage and regular damage.</i>"


### PR DESCRIPTION
## About The Pull Request
title

## How This Contributes To The Nova Sector Roleplay Experience
ammo bench compatibility + consistency

Closes https://github.com/NovaSector/NovaSector/issues/5680

## Proof of Testing


## Changelog

:cl:
fix: .45 rubber bullet casings are now appropriately labeled as rubber bullet casings.
/:cl: