### PR TITLE
Sorts the Shoes and Suit Loadout entries, removes 2 outdated/obsolete items, other assorted cleanup.

### DIFF
--- a/modular_nova/modules/customization/modules/clothing/suits/coats.dm
+++ b/modular_nova/modules/customization/modules/clothing/suits/coats.dm
@@ -135,20 +135,6 @@
 	greyscale_colors = "#61618a"
 	flags_1 = IS_PLAYER_COLORABLE_1
 
-/obj/item/clothing/suit/toggle/lawyer/black/better
-	icon = 'modular_nova/master_files/icons/obj/clothing/suits.dmi'
-	worn_icon = 'modular_nova/master_files/icons/mob/clothing/suit.dmi'
-	icon_state = "suitjacket_black"
-	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
-
-/obj/item/clothing/suit/toggle/lawyer/white
-	name = "white suit jacket"
-	desc = "A very versatile part of a suit ensable. Oddly in fashion with mobsters."
-	icon = 'modular_nova/master_files/icons/obj/clothing/suits.dmi'
-	worn_icon = 'modular_nova/master_files/icons/mob/clothing/suit.dmi'
-	icon_state = "suitjacket_white"
-	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
-
 /obj/item/clothing/suit/armor/vest/det_suit/runner
 	name = "joyful coat"
 	desc = "<i>\"You look like a good Joe.\"</i>"

--- a/modular_nova/modules/customization/modules/clothing/suits/hoodies.dm
+++ b/modular_nova/modules/customization/modules/clothing/suits/hoodies.dm
@@ -19,19 +19,15 @@
 	min_cold_protection_temperature = T0C - 20	//Not as good as the base jacket
 
 /obj/item/clothing/suit/toggle/jacket/nova/hoodie/trim
-	icon = 'icons/map_icons/clothing/suit/_suit.dmi'
 	icon_state = "/obj/item/clothing/suit/toggle/jacket/nova/hoodie/trim"
 	post_init_icon_state = "hoodie_trim"
 	greyscale_config = /datum/greyscale_config/hoodie_trim
 	greyscale_config_worn = /datum/greyscale_config/hoodie_trim/worn
 	greyscale_colors = "#ffffff#313131"
-	flags_1 = IS_PLAYER_COLORABLE_1
 
 /obj/item/clothing/suit/toggle/jacket/nova/hoodie/trim/alt
 	icon_state = "/obj/item/clothing/suit/toggle/jacket/nova/hoodie/trim/alt"
 	post_init_icon_state = "hoodie_trim_alt"
-	greyscale_colors = "#ffffff#313131"
-	flags_1 = IS_PLAYER_COLORABLE_1
 
 /*
 *	PRESET GREYSCALES & BRANDED
@@ -40,66 +36,73 @@
 /obj/item/clothing/suit/toggle/jacket/nova/hoodie/grey
 	icon_state = "/obj/item/clothing/suit/toggle/jacket/nova/hoodie/grey"
 	greyscale_colors = "#a8a8a8"
+	flags_1 = NONE
 
 /obj/item/clothing/suit/toggle/jacket/nova/hoodie/black
 	icon_state = "/obj/item/clothing/suit/toggle/jacket/nova/hoodie/black"
 	greyscale_colors = "#313131"
+	flags_1 = NONE
 
 /obj/item/clothing/suit/toggle/jacket/nova/hoodie/red
 	icon_state = "/obj/item/clothing/suit/toggle/jacket/nova/hoodie/red"
 	greyscale_colors = "#D13838"
+	flags_1 = NONE
 
 /obj/item/clothing/suit/toggle/jacket/nova/hoodie/blue
 	icon_state = "/obj/item/clothing/suit/toggle/jacket/nova/hoodie/blue"
 	greyscale_colors = "#034A8D"
+	flags_1 = NONE
 
 /obj/item/clothing/suit/toggle/jacket/nova/hoodie/green
 	icon_state = "/obj/item/clothing/suit/toggle/jacket/nova/hoodie/green"
 	greyscale_colors = "#1DA103"
+	flags_1 = NONE
 
 /obj/item/clothing/suit/toggle/jacket/nova/hoodie/orange
 	icon_state = "/obj/item/clothing/suit/toggle/jacket/nova/hoodie/orange"
 	greyscale_colors = "#F79305"
+	flags_1 = NONE
 
 /obj/item/clothing/suit/toggle/jacket/nova/hoodie/yellow
 	icon_state = "/obj/item/clothing/suit/toggle/jacket/nova/hoodie/yellow"
 	greyscale_colors = "#F0D655"
+	flags_1 = NONE
 
 /obj/item/clothing/suit/toggle/jacket/nova/hoodie/branded
-	name = "NT hoodie"
-	desc = "A warm, blue sweatshirt.  It proudly bears the silver Nanotrasen insignia lettering on the back.  The edges are trimmed with silver."
+	name = "\improper NT hoodie"
+	desc = "A warm, blue sweatshirt. It proudly bears the silver Nanotrasen insignia lettering on the back. The edges are trimmed with silver."
 	icon = 'icons/map_icons/clothing/suit/_suit.dmi'
 	icon_state = "/obj/item/clothing/suit/toggle/jacket/nova/hoodie/branded"
 	post_init_icon_state = "hoodie_NT"
 	greyscale_config = /datum/greyscale_config/hoodie_branded
 	greyscale_config_worn = /datum/greyscale_config/hoodie_branded/worn
-	greyscale_colors = "#02519A#ffffff"	//white to prevent changing the actual color of the icon. I've no clue why it REQUIRES two inputs despite being set otherwise.
+	greyscale_colors = "#02519A#ffffff"
 	flags_1 = NONE
 
 /obj/item/clothing/suit/toggle/jacket/nova/hoodie/branded/nrti
-	name = "New Reykjavik Technical Institute hoodie"
-	desc = "A warm, gray sweatshirt. It bears the letters NRT on the back, in reference to Sif's premiere technical institute."
+	name = "\improper NRTI hoodie"
+	desc = "A warm, gray sweatshirt. It bears the letters NRT on the back, in reference to Sif's premiere New Reykjavik Technical Institute."
 	icon_state = "/obj/item/clothing/suit/toggle/jacket/nova/hoodie/branded/nrti"
 	post_init_icon_state = "hoodie_NRTI"
 	greyscale_colors = "#747474#a83232"
 
 /obj/item/clothing/suit/toggle/jacket/nova/hoodie/branded/mu
-	name = "mojave university hoodie"
-	desc = "A warm, gray sweatshirt.  It bears the letters MU on the front, a lettering to the well-known public college, Mojave University."
+	name = "\improper MU hoodie"
+	desc = "A warm, gray sweatshirt. It bears the letters MU on the front, a lettering to the well-known public college, Mojave University."
 	icon_state = "/obj/item/clothing/suit/toggle/jacket/nova/hoodie/branded/mu"
 	post_init_icon_state = "hoodie_MU"
 	greyscale_colors = "#747474#ffffff"
 
 /obj/item/clothing/suit/toggle/jacket/nova/hoodie/branded/cti
-	name = "CTI hoodie"
-	desc = "A warm, black sweatshirt.  It bears the letters CTI on the back, a lettering to the prestigious university in Tau Ceti, Ceti Technical Institute.  There is a blue supernova embroidered on the front, the emblem of CTI."
+	name = "\improper CTI hoodie"
+	desc = "A warm, black sweatshirt. It bears the letters CTI on the back, a lettering to the prestigious university in Tau Ceti, Ceti Technical Institute.  There is a blue supernova embroidered on the front, the emblem of CTI."
 	icon_state = "/obj/item/clothing/suit/toggle/jacket/nova/hoodie/branded/cti"
 	post_init_icon_state = "hoodie_CTI"
 	greyscale_colors = "#313131#ffffff"
 
 /obj/item/clothing/suit/toggle/jacket/nova/hoodie/branded/smw
-	name = "Space Mountain Wind hoodie"
-	desc = "A warm, black sweatshirt.  It has the logo for the popular softdrink Space Mountain Wind on both the front and the back."
+	name = "\improper Space Mountain Wind hoodie"
+	desc = "A warm, black sweatshirt. It has the logo for the popular softdrink Space Mountain Wind on both the front and the back."
 	icon_state = "/obj/item/clothing/suit/toggle/jacket/nova/hoodie/branded/smw"
 	post_init_icon_state = "hoodie_SMW"
 	greyscale_colors = "#313131#ffffff"

--- a/modular_nova/modules/customization/modules/clothing/suits/misc.dm
+++ b/modular_nova/modules/customization/modules/clothing/suits/misc.dm
@@ -1,5 +1,5 @@
 /obj/item/clothing/suit/wornshirt
-	name = "worn shirt"
+	name = "wrinkled shirt"
 	desc = "A worn out (or perhaps just baggy), curiously comfortable t-shirt."
 	icon = 'modular_nova/master_files/icons/obj/clothing/suits.dmi'
 	worn_icon = 'modular_nova/master_files/icons/mob/clothing/suit.dmi'
@@ -78,13 +78,10 @@
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 	toggle_noun = "button"
 
-/obj/item/clothing/suit/discoblazer
-	icon = 'modular_nova/master_files/icons/obj/clothing/suits.dmi'
-	worn_icon = 'modular_nova/master_files/icons/mob/clothing/suit.dmi'
+/obj/item/clothing/suit/jacket/discoblazer //armorless version of /obj/item/clothing/suit/jacket/det_suit/disco
 	name = "disco ass blazer"
 	desc = "Looks like someone skinned this blazer off some long extinct disco-animal. It has an enigmatic white rectangle on the back and the right sleeve."
 	icon_state = "jamrock_blazer"
-	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
 /obj/item/clothing/suit/kimjacket
 	icon = 'modular_nova/master_files/icons/obj/clothing/suits.dmi'

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_gloves.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_gloves.dm
@@ -98,11 +98,6 @@
 	name = "Gloves - Rainbow"
 	item_path = /obj/item/clothing/gloves/color/rainbow
 
-/datum/loadout_item/gloves/latex
-	name = "Latex Gloves"
-	item_path = /obj/item/clothing/gloves/long_gloves
-	erp_item = TRUE
-
 /datum/loadout_item/gloves/maid
 	name = "Maid Arm Covers"
 	item_path = /obj/item/clothing/gloves/maid
@@ -129,6 +124,15 @@
 /datum/loadout_item/gloves/silverring
 	name = "Ring - Silver"
 	item_path = /obj/item/clothing/gloves/ring/silver
+
+/*
+*	erp_item
+*/
+
+/datum/loadout_item/gloves/latex
+	name = "Latex Gloves"
+	item_path = /obj/item/clothing/gloves/long_gloves
+	erp_item = TRUE
 
 /*
 *	DONATOR

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_heads.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_heads.dm
@@ -758,6 +758,15 @@
 	group = "Job-Locked"
 
 /*
+*	erp_item
+*/
+
+/datum/loadout_item/head/domina_cap
+	name = "Dominant Cap"
+	item_path = /obj/item/clothing/head/domina_cap
+	erp_item = TRUE
+
+/*
 *	DONATOR
 */
 
@@ -783,8 +792,3 @@
 /datum/loadout_item/head/donator/rainbow_bunch/get_item_information()
 	. = ..()
 	.[FA_ICON_DICE] = TOOLTIP_RANDOM_COLOR
-
-/datum/loadout_item/head/domina_cap
-	name = "Dominant Cap"
-	item_path = /obj/item/clothing/head/domina_cap
-	erp_item = TRUE

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_neck.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_neck.dm
@@ -124,7 +124,6 @@
 /datum/loadout_item/neck/spikecollar
 	name = "Collar (Spiked)"
 	item_path = /obj/item/clothing/neck/collar/spike
-	erp_item = TRUE
 
 /*
 *	SCARVES

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_shoes.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_shoes.dm
@@ -1,9 +1,8 @@
+// LOADOUT ITEM DATUMS FOR THE SHOE SLOT
+
 /datum/loadout_category/shoes
 	tab_order = /datum/loadout_category/hands::tab_order + 1
 
-/*
-*	LOADOUT ITEM DATUMS FOR THE SHOE SLOT
-*/
 /datum/loadout_item/shoes
 	abstract_type = /datum/loadout_item/shoes
 
@@ -21,189 +20,267 @@
 		outfit.shoes = item_path
 
 /*
-*	JACKBOOTS
+*	ITEMS BELOW HERE
 */
 
-/datum/loadout_item/shoes/jackboots
-	name = "Jackboots"
-	item_path = /obj/item/clothing/shoes/jackboots
-
-/datum/loadout_item/shoes/jackboots_sec_blue
-	name = "Blue Security Jackboots"
-	item_path = /obj/item/clothing/shoes/jackboots/sec/blue
-	restricted_roles = list(JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_HEAD_OF_SECURITY)
-
-// Thedragmeme's donator reward, they've decided to make them available to everybody.
-/datum/loadout_item/shoes/jackboots/heel
-	name = "High-Heel Jackboots"
-	item_path = /obj/item/clothing/shoes/jackboots/heel
-
-/datum/loadout_item/shoes/kneeboot
-	name = "Knee Boots"
-	item_path = /obj/item/clothing/shoes/jackboots/knee
-
-/datum/loadout_item/shoes/recolorable_jackboots
-	name = "Recolorable Jackboots"
-	item_path = /obj/item/clothing/shoes/jackboots/recolorable
-
-/datum/loadout_item/shoes/colonial_boots
-	name = "Colonial Half-Boots"
-	item_path = /obj/item/clothing/shoes/jackboots/colonial
-
-/datum/loadout_item/shoes/jackboots/frontier
-	name = "Heavy Frontier Boots"
-	item_path = /obj/item/clothing/shoes/jackboots/frontier_colonist
-
-/*
-*	MISC BOOTS
-*/
-
-/datum/loadout_item/shoes/timbs
-	name = "Hiking Boots"
-	item_path = /obj/item/clothing/shoes/jackboots/timbs
-
-/datum/loadout_item/shoes/jungle
-	name = "Jungle Boots"
-	item_path = /obj/item/clothing/shoes/jungleboots
-
-/datum/loadout_item/shoes/winter_boots
-	name = "Winter Boots"
-	item_path = /obj/item/clothing/shoes/winterboots
-
-/datum/loadout_item/shoes/work_boots
-	name = "Work Boots"
-	item_path = /obj/item/clothing/shoes/workboots
-
-/datum/loadout_item/shoes/mining_boots
-	name = "Mining Boots"
-	item_path = /obj/item/clothing/shoes/workboots/mining
-
-/datum/loadout_item/shoes/russian_boots
-	name = "Russian Boots"
-	item_path = /obj/item/clothing/shoes/russian
-
-/datum/loadout_item/shoes/duck_boots
-	name = "Northeastern Duck Boots"
-	item_path = /obj/item/clothing/shoes/jackboots/duckboots
-
-/*
-*	COWBOY
-*/
-
-/datum/loadout_item/shoes/cowboy_recolorable
-	name = "Cowboy Boots (Recolorable)"
-	item_path = /obj/item/clothing/shoes/cowboy/laced/recolorable
-
-/*
-*	SNEAKERS
-*/
-
-/datum/loadout_item/shoes/greyscale_sneakers
-	name = "Colorable Sneakers"
-	item_path = /obj/item/clothing/shoes/sneakers
-
-/datum/loadout_item/shoes/black_sneakers
-	name = "Black Sneakers"
-	item_path = /obj/item/clothing/shoes/sneakers/black
-	can_be_greyscale = DONT_GREYSCALE
-
-/datum/loadout_item/shoes/blue_sneakers
-	name = "Blue Sneakers"
-	item_path = /obj/item/clothing/shoes/sneakers/blue
-	can_be_greyscale = DONT_GREYSCALE
-
-/datum/loadout_item/shoes/brown_sneakers
-	name = "Brown Sneakers"
-	item_path = /obj/item/clothing/shoes/sneakers/brown
-	can_be_greyscale = DONT_GREYSCALE
-
-/datum/loadout_item/shoes/green_sneakers
-	name = "Green Sneakers"
-	item_path = /obj/item/clothing/shoes/sneakers/green
-	can_be_greyscale = DONT_GREYSCALE
-
-/datum/loadout_item/shoes/purple_sneakers
-	name = "Purple Sneakers"
-	item_path = /obj/item/clothing/shoes/sneakers/purple
-	can_be_greyscale = DONT_GREYSCALE
-
-/datum/loadout_item/shoes/orange_sneakers
-	name = "Orange Sneakers"
-	item_path = /obj/item/clothing/shoes/sneakers/orange
-	can_be_greyscale = DONT_GREYSCALE
-
-/datum/loadout_item/shoes/yellow_sneakers
-	name = "Yellow Sneakers"
-	item_path = /obj/item/clothing/shoes/sneakers/yellow
-	can_be_greyscale = DONT_GREYSCALE
-
-/datum/loadout_item/shoes/white_sneakers
-	name = "White Sneakers"
-	item_path = /obj/item/clothing/shoes/sneakers/white
-	can_be_greyscale = DONT_GREYSCALE
-
-/*
-*	LEG WRAPS
-*/
-
-/datum/loadout_item/shoes/gildedcuffs
-	name = "Gilded Leg Wraps"
-	item_path = /obj/item/clothing/shoes/wraps
-
-/datum/loadout_item/shoes/silvercuffs
-	name = "Silver Leg Wraps"
-	item_path = /obj/item/clothing/shoes/wraps/silver
-
-/datum/loadout_item/shoes/redcuffs
-	name = "Red Leg Wraps"
-	item_path = /obj/item/clothing/shoes/wraps/red
-
-/datum/loadout_item/shoes/bluecuffs
-	name = "Blue Leg Wraps"
-	item_path = /obj/item/clothing/shoes/wraps/blue
-
-/datum/loadout_item/shoes/cuffs
-	abstract_type = /datum/loadout_item/shoes/cuffs
-
-/datum/loadout_item/shoes/cuffs/colourable
-	name = "Colourable Leg Wraps"
-	item_path = /obj/item/clothing/shoes/wraps/colourable
-
-/datum/loadout_item/shoes/clothwrap
-	name = "Colourable Cloth Wraps"
-	item_path = /obj/item/clothing/shoes/wraps/cloth
-
-/*
-*	MISC
-*/
-
-/datum/loadout_item/shoes/laceup
-	name = "Laceup Shoes"
-	item_path = /obj/item/clothing/shoes/laceup
-
-/datum/loadout_item/shoes/recolorable_laceups
-	name = "Recolorable Laceups"
-	item_path = /obj/item/clothing/shoes/colorable_laceups
-
-/datum/loadout_item/shoes/recolorable_sandals
-	name = "Recolorble Sandals"
-	item_path = /obj/item/clothing/shoes/colorable_sandals
+/datum/loadout_item/shoes/kim
+	name = "Aerostatic Shoes"
+	item_path = /obj/item/clothing/shoes/kim
 
 /datum/loadout_item/shoes/high_heels
 	name = "High Heels"
 	item_path = /obj/item/clothing/shoes/high_heels
 
 /datum/loadout_item/shoes/black_heels
-	name = "Fancy Heels"
+	name = "High Heels - Fancy"
 	item_path = /obj/item/clothing/shoes/fancy_heels
 
+/datum/loadout_item/shoes/laceup
+	name = "Laceup Shoes"
+
+/datum/loadout_item/shoes/recolorable_laceups
+	name = "Laceup Shoes (Colorable)"
+	item_path = /obj/item/clothing/shoes/colorable_laceups
+
 /datum/loadout_item/shoes/disco
-	name = "Green Lizardskin Shoes"
+	name = "Lizardskin Shoes"
 	item_path = /obj/item/clothing/shoes/discoshoes
 
-/datum/loadout_item/shoes/kim
-	name = "Aerostatic Shoes"
-	item_path = /obj/item/clothing/shoes/kim
+/datum/loadout_item/shoes/sandals
+	name = "Sandals"
+	item_path = /obj/item/clothing/shoes/sandal
+
+/datum/loadout_item/shoes/recolorable_sandals
+	name = "Sandals  (Colorable)"
+	item_path = /obj/item/clothing/shoes/colorable_sandals
+
+/datum/loadout_item/shoes/sandals_black
+	name = "Sandals (Black)"
+	item_path = /obj/item/clothing/shoes/sandal/alt
+
+/datum/loadout_item/shoes/sandals_laced
+	name = "Sandals - Velcro"
+
+/datum/loadout_item/shoes/sandals_laced_black
+	name = "Sandals - Velcro (Black)"
+
+/datum/loadout_item/shoes/sportshoes
+	name = "Sport Shoes"
+	item_path = /obj/item/clothing/shoes/sports
+
+/*
+*	BOOTS
+*/
+
+/datum/loadout_item/shoes/colonial_boots
+	name = "Boots - Colonial Half-Boots"
+	item_path = /obj/item/clothing/shoes/jackboots/colonial
+
+/datum/loadout_item/shoes/cowboy_recolorable
+	name = "Boots - Cowboy (Colorable)"
+	item_path = /obj/item/clothing/shoes/cowboy/laced/recolorable
+
+/datum/loadout_item/shoes/cowboy_black
+	name = "Boots - Cowboy, Laced (Black)"
+
+/datum/loadout_item/shoes/cowboy_brown
+	name = "Boots - Cowboy, Laced (Brown)"
+
+/datum/loadout_item/shoes/cowboy_white
+	name = "Boots - Cowboy, Laced (White)"
+
+/datum/loadout_item/shoes/jackboots/frontier
+	name = "Boots - Heavy Frontier"
+	item_path = /obj/item/clothing/shoes/jackboots/frontier_colonist
+
+/datum/loadout_item/shoes/timbs
+	name = "Boots - Hiking"
+	item_path = /obj/item/clothing/shoes/jackboots/timbs
+
+/datum/loadout_item/shoes/jackboots
+	name = "Boots - Jackboots"
+	item_path = /obj/item/clothing/shoes/jackboots
+
+/datum/loadout_item/shoes/recolorable_jackboots
+	name = "Boots - Jackboots  (Colorable)"
+	item_path = /obj/item/clothing/shoes/jackboots/recolorable
+
+/datum/loadout_item/shoes/jackboots/heel //Donator reward for Thedragmeme, unrestricted at their request
+	name = "Boots - Jackboots, High-Heel"
+	item_path = /obj/item/clothing/shoes/jackboots/heel
+
+/datum/loadout_item/shoes/kneeboot
+	name = "Boots - Jackboots, Knee"
+	item_path = /obj/item/clothing/shoes/jackboots/knee
+
+/datum/loadout_item/shoes/jungle
+	name = "Boots - Jungle"
+	item_path = /obj/item/clothing/shoes/jungleboots
+
+/datum/loadout_item/shoes/mining_boots
+	name = "Boots - Mining"
+	item_path = /obj/item/clothing/shoes/workboots/mining
+
+/datum/loadout_item/shoes/duck_boots
+	name = "Boots - Northeastern Duckboots"
+	item_path = /obj/item/clothing/shoes/jackboots/duckboots
+
+/datum/loadout_item/shoes/russian_boots
+	name = "Boots - Russian"
+	item_path = /obj/item/clothing/shoes/russian
+
+/datum/loadout_item/shoes/winter_boots
+	name = "Boots - Winter"
+	item_path = /obj/item/clothing/shoes/winterboots
+
+/datum/loadout_item/shoes/work_boots
+	name = "Boots - Work"
+	item_path = /obj/item/clothing/shoes/workboots
+
+/*
+*	SNEAKERS
+*/
+
+/datum/loadout_item/shoes/greyscale_sneakers
+	name = "Sneakers  (Colorable)"
+	item_path = /obj/item/clothing/shoes/sneakers
+
+/datum/loadout_item/shoes/black_sneakers
+	name = "Sneakers (Black)"
+	item_path = /obj/item/clothing/shoes/sneakers/black
+	can_be_greyscale = DONT_GREYSCALE
+
+/datum/loadout_item/shoes/blue_sneakers
+	name = "Sneakers (Blue)"
+	item_path = /obj/item/clothing/shoes/sneakers/blue
+	can_be_greyscale = DONT_GREYSCALE
+
+/datum/loadout_item/shoes/brown_sneakers
+	name = "Sneakers (Brown)"
+	item_path = /obj/item/clothing/shoes/sneakers/brown
+	can_be_greyscale = DONT_GREYSCALE
+
+/datum/loadout_item/shoes/green_sneakers
+	name = "Sneakers (Green)"
+	item_path = /obj/item/clothing/shoes/sneakers/green
+	can_be_greyscale = DONT_GREYSCALE
+
+/datum/loadout_item/shoes/orange_sneakers
+	name = "Sneakers (Orange)"
+	item_path = /obj/item/clothing/shoes/sneakers/orange
+	can_be_greyscale = DONT_GREYSCALE
+
+/datum/loadout_item/shoes/purple_sneakers
+	name = "Sneakers (Purple)"
+	item_path = /obj/item/clothing/shoes/sneakers/purple
+	can_be_greyscale = DONT_GREYSCALE
+
+/datum/loadout_item/shoes/white_sneakers
+	name = "Sneakers (White)"
+	item_path = /obj/item/clothing/shoes/sneakers/white
+	can_be_greyscale = DONT_GREYSCALE
+
+/datum/loadout_item/shoes/yellow_sneakers
+	name = "Sneakers (Yellow)"
+	item_path = /obj/item/clothing/shoes/sneakers/yellow
+	can_be_greyscale = DONT_GREYSCALE
+
+/*
+*	LEG WRAPS
+*/
+
+/datum/loadout_item/shoes/wraps_colorable
+	name = "Wraps  (Colorable)"
+	item_path = /obj/item/clothing/shoes/wraps/colourable
+
+/datum/loadout_item/shoes/bluecuffs
+	name = "Wraps (Blue)"
+	item_path = /obj/item/clothing/shoes/wraps/blue
+
+/datum/loadout_item/shoes/gildedcuffs
+	name = "Wraps (Gilded)"
+	item_path = /obj/item/clothing/shoes/wraps
+
+/datum/loadout_item/shoes/redcuffs
+	name = "Wraps (Red)"
+	item_path = /obj/item/clothing/shoes/wraps/red
+
+/datum/loadout_item/shoes/silvercuffs
+	name = "Wraps (Silver)"
+	item_path = /obj/item/clothing/shoes/wraps/silver
+
+/datum/loadout_item/shoes/clothwrap
+	name = "Wraps - Cloth"
+	item_path = /obj/item/clothing/shoes/wraps/cloth
+
+/*
+*	COSTUME
+*/
+
+/datum/loadout_item/shoes/christmas
+	name = "Christmas Boots (Red)"
+	item_path = /obj/item/clothing/shoes/winterboots/christmas
+	group = "Costumes"
+
+/datum/loadout_item/shoes/christmas/green
+	name = "Christmas Boots (Green)"
+	item_path = /obj/item/clothing/shoes/winterboots/christmas/green
+
+/datum/loadout_item/shoes/glow_shoes
+	name = "Glowing Shoes (Colorable)"
+	group = "Costumes"
+
+/datum/loadout_item/shoes/griffin
+	name = "Griffon Boots"
+	item_path = /obj/item/clothing/shoes/griffin
+	group = "Costumes"
+
+/datum/loadout_item/shoes/jingleshoes
+	name = "Jester Shoes"
+	item_path = /obj/item/clothing/shoes/jester_shoes
+	group = "Costumes"
+
+/datum/loadout_item/shoes/rollerskates
+	name = "Roller Skates"
+	item_path = /obj/item/clothing/shoes/wheelys/rollerskates
+	group = "Costumes"
+
+/datum/loadout_item/shoes/wheelys
+	name = "Wheely-Heels"
+	item_path = /obj/item/clothing/shoes/wheelys
+	group = "Costumes"
+
+/*
+*	JOB-RESTRICTED
+*/
+
+/datum/loadout_item/shoes/jackboots_sec_blue
+	name = "Security Jackboots (Blue)"
+	item_path = /obj/item/clothing/shoes/jackboots/sec/blue
+	restricted_roles = list(JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_HEAD_OF_SECURITY)
+	group = "Job-Locked"
+
+/datum/loadout_item/shoes/clown_shoes
+	abstract_type = /datum/loadout_item/shoes/clown_shoes
+	restricted_roles = list(JOB_CLOWN)
+	group = "Job-Locked"
+
+/datum/loadout_item/shoes/clown_shoes/jester
+	name = "Clown's Jester Shoes"
+	item_path = /obj/item/clothing/shoes/clown_shoes/jester
+
+/datum/loadout_item/shoes/clown_shoes/pink
+	name = "Pink Clown Shoes"
+	item_path = /obj/item/clothing/shoes/clown_shoes/pink
+
+/*
+*	erp_item
+*/
+
+/datum/loadout_item/shoes/ballet_heels
+	name = "Ballet Heels"
+	item_path = /obj/item/clothing/shoes/ballet_heels
+	erp_item = TRUE
 
 /datum/loadout_item/shoes/dominaheels
 	name = "Dominant Heels"
@@ -215,69 +292,6 @@
 	item_path = /obj/item/clothing/shoes/latex_socks
 	erp_item = TRUE
 
-/datum/loadout_item/shoes/ballet_heels
-	name = "Ballet Heels"
-	item_path = /obj/item/clothing/shoes/ballet_heels
-	erp_item = TRUE
-
-/datum/loadout_item/shoes/griffin
-	name = "Griffon Boots"
-	item_path = /obj/item/clothing/shoes/griffin
-
-/datum/loadout_item/shoes/sandals
-	name = "Sandals"
-	item_path = /obj/item/clothing/shoes/sandal
-
-/datum/loadout_item/shoes/sportshoes
-	name = "Sport Shoes"
-	item_path = /obj/item/clothing/shoes/sports
-
-/datum/loadout_item/shoes/rollerskates
-	name = "Roller Skates"
-	item_path = /obj/item/clothing/shoes/wheelys/rollerskates
-
-/datum/loadout_item/shoes/wheelys
-	name = "Wheely-Heels"
-	item_path = /obj/item/clothing/shoes/wheelys
-
-/datum/loadout_item/shoes/jingleshoes
-	name = "Jester Shoes"
-	item_path = /obj/item/clothing/shoes/jester_shoes
-
-/datum/loadout_item/shoes/sandals_black
-	name = "Black Sandals"
-	item_path = /obj/item/clothing/shoes/sandal/alt
-
-/*
-*	SEASONAL
-*/
-
-/datum/loadout_item/shoes/christmas
-	name = "Red Christmas Boots"
-	item_path = /obj/item/clothing/shoes/winterboots/christmas
-
-/datum/loadout_item/shoes/christmas/green
-	name = "Green Christmas Boots"
-	item_path = /obj/item/clothing/shoes/winterboots/christmas/green
-
-
-/*
-*	JOB-RESTRICTED
-*/
-
-/datum/loadout_item/shoes/jester
-	name = "Clown's Jester Shoes"
-	item_path = /obj/item/clothing/shoes/clown_shoes/jester
-	restricted_roles = list(JOB_CLOWN)
-
-/datum/loadout_item/shoes/clown_shoes
-	abstract_type = /datum/loadout_item/shoes/clown_shoes
-
-/datum/loadout_item/shoes/clown_shoes/pink
-	name = "Pink Clown Shoes"
-	item_path = /obj/item/clothing/shoes/clown_shoes/pink
-	restricted_roles = list(JOB_CLOWN)
-
 /*
 *	DONATOR
 */
@@ -287,9 +301,9 @@
 	donator_only = TRUE
 
 /datum/loadout_item/shoes/donator/blackjackboots
-	name = "Black Jackboots"
+	name = "Boots - Jackboots (Black)"
 	item_path = /obj/item/clothing/shoes/jackboots/black
 
 /datum/loadout_item/shoes/donator/rainbow
-	name = "Rainbow Converse"
+	name = "Sneakers - Rainbow"
 	item_path = /obj/item/clothing/shoes/sneakers/rainbow

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_suit.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_suit.dm
@@ -1,12 +1,10 @@
+// LOADOUT ITEM DATUMS FOR THE SHOE SLOT
+
 /datum/loadout_category/suit
 	category_name = "Suit"
 	category_ui_icon = FA_ICON_VEST
 	type_to_generate = /datum/loadout_item/suit
 	tab_order = /datum/loadout_category/neck::tab_order + 1
-
-/*
-*	LOADOUT ITEM DATUMS FOR THE (EXO/OUTER)SUIT SLOT
-*/
 
 /datum/loadout_item/suit
 	abstract_type = /datum/loadout_item/suit
@@ -24,6 +22,74 @@
 		outfit.suit = item_path
 
 /*
+*	ITEMS BELOW HERE
+*/
+
+/datum/loadout_item/suit/dagger_mantle
+	name = "'Dagger' Designer Mantle"
+	item_path = /obj/item/clothing/suit/dagger_mantle
+
+/datum/loadout_item/suit/croptop
+	name = "Crop Top Turtleneck"
+	item_path = /obj/item/clothing/suit/jacket/croptop
+
+/datum/loadout_item/suit/czech
+	name = "Czech Coat"
+	item_path = /obj/item/clothing/suit/modernwintercoatthing
+
+/datum/loadout_item/suit/korea
+	name = "Eastern Coat"
+	item_path = /obj/item/clothing/suit/koreacoat
+
+/datum/loadout_item/suit/hawaiian_shirt
+	name = "Hawaiian Shirt"
+	item_path = /obj/item/clothing/suit/costume/hawaiian
+
+/datum/loadout_item/suit/wellwornshirt
+	name = "Oversized Shirt"
+	item_path = /obj/item/clothing/suit/costume/wellworn_shirt
+
+/datum/loadout_item/suit/wellworn_graphicshirt
+	name = "Oversized Shirt (Graphic)"
+	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/graphic
+
+/datum/loadout_item/suit/ianshirt
+	name = "Oversized Shirt (Ian)"
+	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/graphic/ian
+
+/datum/loadout_item/suit/wornoutshirt
+	name = "Oversized Shirt - Worn-out"
+	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/wornout
+
+/datum/loadout_item/suit/wornout_graphicshirt
+	name = "Oversized Shirt - Worn-out (Graphic)"
+	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/wornout/graphic
+
+/datum/loadout_item/suit/wornout_ianshirt
+	name = "Oversized Shirt - Worn-out (Ian)"
+	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/wornout/graphic/ian
+
+/datum/loadout_item/suit/messyshirt
+	name = "Oversized Shirt - Messy"
+	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/messy
+
+/datum/loadout_item/suit/messy_graphicshirt
+	name = "Oversized Shirt - Messy (Graphic)"
+	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/messy/graphic
+
+/datum/loadout_item/suit/messy_ianshirt
+	name = "Oversized Shirt - Messy (Ian)"
+	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/messy/graphic/ian
+
+/datum/loadout_item/suit/wornshirt
+	name = "Oversized Shirt - Wrinkled"
+	item_path = /obj/item/clothing/suit/wornshirt
+
+/datum/loadout_item/suit/suspenders
+	name = "Suspenders (Colorable)"
+	item_path = /obj/item/clothing/suit/toggle/suspenders
+
+/*
 *	WINTER COATS
 */
 
@@ -31,149 +97,237 @@
 	name = "Winter Coat"
 	item_path = /obj/item/clothing/suit/hooded/wintercoat
 
-/datum/loadout_item/suit/winter_coat_greyscale
-	name = "Greyscale Winter Coat"
-	item_path = /obj/item/clothing/suit/hooded/wintercoat/custom
+/datum/loadout_item/suit/gags_wintercoat
+	name = "Winter Coat (Colorable)"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/colourable
 
 /datum/loadout_item/suit/aformal
-	name = "Assistant's Formal Winter Coat"
+	name = "Winter Coat - Assistant's Formal"
 	item_path = /obj/item/clothing/suit/hooded/wintercoat/nova
 
-/datum/loadout_item/suit/runed
-	name = "Runed Winter Coat"
-	item_path = /obj/item/clothing/suit/hooded/wintercoat/nova/narsie
-
 /datum/loadout_item/suit/brass
-	name = "Brass Winter Coat"
+	name = "Winter Coat - Brass"
 	item_path = /obj/item/clothing/suit/hooded/wintercoat/nova/ratvar
 
-/datum/loadout_item/suit/korea
-	name = "Eastern Winter Coat"
-	item_path = /obj/item/clothing/suit/koreacoat
+/datum/loadout_item/suit/winter_coat/christmas
+	name = "Winter Coat - Christmas"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/nova/christmas
 
-/datum/loadout_item/suit/czech
-	name = "Czech Winter Coat"
-	item_path = /obj/item/clothing/suit/modernwintercoatthing
+/datum/loadout_item/suit/winter_coat/christmas/green
+	name = "Winter Coat - Christmas (Green)"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/nova/christmas/green
 
-/datum/loadout_item/suit/mantella
-	name = "Mothic Mantella"
-	item_path = /obj/item/clothing/suit/mothcoat/winter
+/datum/loadout_item/suit/runed
+	name = "Winter Coat - Runed"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/nova/narsie
+
+/datum/loadout_item/suit/winter_coat_greyscale
+	name = "Winter Coat - Tailored (Colorable)"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/custom
+
+//Job Winter Coats (Don't want to alphabetize these mixed with the other wintercoats)
+/datum/loadout_item/suit/coat_atmos
+	name = "Winter Coat - Atmospherics"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/engineering/atmos
+
+/datum/loadout_item/suit/coat_bar
+	name = "Winter Coat - Bartender"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/nova/bartender
+
+/datum/loadout_item/suit/coat_cargo
+	name = "Winter Coat - Cargo"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/cargo
+
+/datum/loadout_item/suit/coat_eng
+	name = "Winter Coat - Engineering"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/engineering
+
+/datum/loadout_item/suit/coat_hydro
+	name = "Winter Coat - Hydroponics"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/hydro
+
+/datum/loadout_item/suit/coat_med
+	name = "Winter Coat - Medical"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/medical
+
+/datum/loadout_item/suit/coat_miner
+	name = "Winter Coat - Mining"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/miner
+
+/datum/loadout_item/suit/coat_paramedic
+	name = "Winter Coat - Paramedic"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/medical/paramedic
+
+/datum/loadout_item/suit/coat_robotics
+	name = "Winter Coat - Robotics"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/science/robotics
+
+/datum/loadout_item/suit/coat_sci
+	name = "Winter Coat - Science"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/science
 
 /*
 *	SUITS / SUIT JACKETS
 */
 
 /datum/loadout_item/suit/recolorable
-	name = "Recolorable Formal Suit Jacket"
+	name = "Suit Jacket  (Colorable)"
 	item_path = /obj/item/clothing/suit/toggle/lawyer/greyscale
 
 /datum/loadout_item/suit/black_suit_jacket
-	name = "Black Formal Suit Jacket"
+	name = "Suit Jacket (Black)"
 	item_path = /obj/item/clothing/suit/toggle/lawyer/black
 
 /datum/loadout_item/suit/blue_suit_jacket
-	name = "Blue Formal Suit Jacket"
+	name = "Suit Jacket (Blue)"
 	item_path = /obj/item/clothing/suit/toggle/lawyer
 
 /datum/loadout_item/suit/purple_suit_jacket
-	name = "Purple Formal Suit Jacket"
+	name = "Suit Jacket (Purple)"
 	item_path = /obj/item/clothing/suit/toggle/lawyer/purple
 
 /datum/loadout_item/suit/suitwhite
-	name = "Texan Suit Jacket"
+	name = "Suit Jacket - Texan"
 	item_path = /obj/item/clothing/suit/texas
 
-/*
-*	SUSPENDERS
-*/
-
-/datum/loadout_item/suit/suspenders
-	name = "Recolorable Suspenders"
-	item_path = /obj/item/clothing/suit/toggle/suspenders
-
-/*
-*	DRESSES
-*/
-
-/datum/loadout_item/suit/white_dress
-	name = "White Dress"
-	item_path = /obj/item/clothing/suit/costume/whitedress
-
-/*
-*	LABCOATS
-*/
-
-/datum/loadout_item/suit/labcoat
-	name = "Labcoat"
-	item_path = /obj/item/clothing/suit/toggle/labcoat
-
-/datum/loadout_item/suit/labcoat_green
-	name = "Green Labcoat"
-	item_path = /obj/item/clothing/suit/toggle/labcoat/mad
-
-/datum/loadout_item/suit/labcoat_medical
-	name = "Medical Labcoat"
-	item_path = /obj/item/clothing/suit/toggle/labcoat/medical
-
-/datum/loadout_item/suit/labcoat_lalunevest
-	name = "Designer Buttoned Coat"
-	item_path = /obj/item/clothing/suit/toggle/labcoat/nova/lalunevest
-
-/datum/loadout_item/suit/fancy_labcoat
-	name = "Recolorable Labcoat"
-	item_path = /obj/item/clothing/suit/toggle/labcoat/nova/fancy
-
-/datum/loadout_item/suit/labcoat_regular
-	name = "Researcher's Labcoat"
-	item_path = /obj/item/clothing/suit/toggle/labcoat/nova/fancy/regular
-
-/datum/loadout_item/suit/labcoat_pharmacist
-	name = "Pharmacist's Labcoat"
-	item_path = /obj/item/clothing/suit/toggle/labcoat/nova/fancy/pharmacist
-
-/datum/loadout_item/suit/labcoat_geneticist
-	name = "Geneticist's Labcoat"
-	item_path = /obj/item/clothing/suit/toggle/labcoat/nova/fancy/geneticist
-
-/datum/loadout_item/suit/labcoat_roboticist
-	name = "Roboticist's Labcoat"
-	item_path = /obj/item/clothing/suit/toggle/labcoat/nova/fancy/roboticist
-
-/datum/loadout_item/suit/labcoat_custom
-	name = "Custom Labcoat"
-	item_path = /obj/item/clothing/suit/toggle/labcoat/nova/custom
-
-/*
-*	PONCHOS
-*/
-
-/datum/loadout_item/suit/poncho
-	name = "Poncho"
-	item_path = /obj/item/clothing/suit/costume/poncho
-
-/datum/loadout_item/suit/poncho_green
-	name = "Green Poncho"
-	item_path = /obj/item/clothing/suit/costume/poncho/green
-
-/datum/loadout_item/suit/poncho_red
-	name = "Red Poncho"
-	item_path = /obj/item/clothing/suit/costume/poncho/red
-
-/datum/loadout_item/suit/dagger_mantle
-	name = "'Dagger' Designer Mantle"
-	item_path = /obj/item/clothing/suit/dagger_mantle
+/datum/loadout_item/suit/dutchjacket
+	name = "Suit Jacket - Western"
+	item_path = /obj/item/clothing/suit/dutchjacketsr
 
 /*
 *	JACKETS
 */
 
+/datum/loadout_item/suit/big_jacket
+	name = "Alpha Atelier Pilot Jacket"
+	item_path = /obj/item/clothing/suit/big_jacket
+
+/datum/loadout_item/suit/blazer_jacket
+	name = "Blazer (Colorable)"
+	item_path = /obj/item/clothing/suit/jacket/blazer
+
+/datum/loadout_item/suit/discojacket
+	name = "Blazer - Disco"
+	item_path = /obj/item/clothing/suit/jacket/discoblazer
+
 /datum/loadout_item/suit/bomber_jacket
 	name = "Bomber Jacket"
 	item_path = /obj/item/clothing/suit/jacket/bomber
 
+/datum/loadout_item/suit/jacketbomber_alt
+	name = "Bomber Jacket w/ Zipper"
+	item_path = /obj/item/clothing/suit/toggle/jacket/nova
+
+/datum/loadout_item/suit/kimjacket
+	name = "Bomber Jacket, Aerostatic"
+	item_path = /obj/item/clothing/suit/kimjacket
+
+/datum/loadout_item/suit/cardigan
+	name = "Cardigan"
+	item_path = /obj/item/clothing/suit/toggle/jacket/nova/cardigan
+
+/datum/loadout_item/suit/sports_jacket
+	name = "Customizable Jacket (Colorable)"
+	item_path = /obj/item/clothing/suit/crop_jacket/long
+
+/datum/loadout_item/suit/shortsleeve_sports_jacket
+	name = "Customizable Jacket (Short-Sleeved, Colorable)"
+	item_path = /obj/item/clothing/suit/crop_jacket/shortsleeve/long
+
+/datum/loadout_item/suit/sleeveless_sports_jacket
+	name = "Customizable Jacket (Sleeveless, Colorable)"
+	item_path = /obj/item/clothing/suit/crop_jacket/sleeveless/long
+
+/datum/loadout_item/suit/crop_jacket
+	name = "Customizable Jacket - Crop Top (Colorable)"
+	item_path = /obj/item/clothing/suit/crop_jacket
+
+/datum/loadout_item/suit/shortsleeve_crop_jacket
+	name = "Customizable Jacket - Crop-Top (Short-Sleeved, Colorable)"
+	item_path = /obj/item/clothing/suit/crop_jacket/shortsleeve
+
+/datum/loadout_item/suit/sleeveless_crop_jacket
+	name = "Customizable Jacket - Crop-Top (Sleeveless, Colorable)"
+	item_path = /obj/item/clothing/suit/crop_jacket/sleeveless
+
+/datum/loadout_item/suit/colourable_leather_jacket
+	name = "Leather Jacket (Colorable)"
+	item_path = /obj/item/clothing/suit/jacket/leather/colourable
+
+/datum/loadout_item/suit/duster
+	name = "Duster (Colorable)"
+	item_path = /obj/item/clothing/suit/duster
+
+/datum/loadout_item/suit/parka
+	name = "Falls Parka"
+	item_path = /obj/item/clothing/suit/fallsparka
+
+/datum/loadout_item/suit/jacket_fancy
+	name = "Fancy Fur Coat  (Colorable)"
+	item_path = /obj/item/clothing/suit/jacket/fancy
+
+/datum/loadout_item/suit/flannel_gags
+	name = "Flannel  (Colorable)"
+	item_path = /obj/item/clothing/suit/toggle/jacket/nova/flannel/gags
+
+/datum/loadout_item/suit/flannel_aqua
+	name = "Flannel (Aqua)"
+	item_path = /obj/item/clothing/suit/toggle/jacket/nova/flannel/aqua
+
+/datum/loadout_item/suit/flannel_black
+	name = "Flannel (Black)"
+	item_path = /obj/item/clothing/suit/toggle/jacket/nova/flannel
+
+/datum/loadout_item/suit/flannel_brown
+	name = "Flannel (Brown)"
+	item_path = /obj/item/clothing/suit/toggle/jacket/nova/flannel/brown
+
+/datum/loadout_item/suit/flannel_red
+	name = "Flannel (Red)"
+	item_path = /obj/item/clothing/suit/toggle/jacket/nova/flannel/red
+
+/datum/loadout_item/suit/frontierjacket
+	abstract_type = /datum/loadout_item/suit/frontierjacket
+
+/datum/loadout_item/suit/frontierjacket/short
+	name = "Frontier Jacket (Short)"
+	item_path = /obj/item/clothing/suit/jacket/frontier_colonist/short
+
+/datum/loadout_item/suit/maxson
+	name = "Furred Coat (Brown)"
+	item_path = /obj/item/clothing/suit/brownbattlecoat
+
+/datum/loadout_item/suit/bossu
+	name = "Furred Coat (Black)"
+	item_path = /obj/item/clothing/suit/blackfurrich
+
+/datum/loadout_item/suit/leather_jacket
+	name = "Leather Jacket"
+	item_path = /obj/item/clothing/suit/jacket/leather
+
+/datum/loadout_item/suit/leather_jacket/hooded
+	name = "Leather Jacket with Hoodie"
+	item_path = /obj/item/clothing/suit/hooded/leather
+
+/datum/loadout_item/suit/leather_jacket/biker
+	name = "Leather Jacket with Zipper"
+	item_path = /obj/item/clothing/suit/jacket/leather/biker
+
+/datum/loadout_item/suit/woolcoat
+	name = "Leather Overcoat"
+	item_path = /obj/item/clothing/suit/woolcoat
+
 /datum/loadout_item/suit/military_jacket
 	name = "Military Jacket"
 	item_path = /obj/item/clothing/suit/jacket/miljacket
+
+/datum/loadout_item/suit/jacket_oversized
+	name = "Oversized Jacket (Colorable)"
+	item_path = /obj/item/clothing/suit/jacket/oversized
+
+/datum/loadout_item/suit/peacoat
+	name = "Peacoat (Colorable)"
+	item_path = /obj/item/clothing/suit/toggle/peacoat
 
 /datum/loadout_item/suit/puffer_jacket
 	name = "Puffer Jacket"
@@ -183,354 +337,85 @@
 	name = "Puffer Vest"
 	item_path = /obj/item/clothing/suit/jacket/puffer/vest
 
-/datum/loadout_item/suit/leather_jacket
-	name = "Leather Jacket"
-	item_path = /obj/item/clothing/suit/jacket/leather
-
-/datum/loadout_item/suit/leather_jacket/biker
-	name = "Biker Jacket"
-	item_path = /obj/item/clothing/suit/jacket/leather/biker
-
-/datum/loadout_item/suit/leather_jacket/hooded
-	name = "Leather Jacket with a Hoodie"
-	item_path = /obj/item/clothing/suit/hooded/leather
-
 /datum/loadout_item/suit/jacket_sweater
-	name = "Recolorable Sweater Jacket"
+	name = "Sweater Jacket (Colorable)"
 	item_path = /obj/item/clothing/suit/toggle/jacket/sweater
 
-/datum/loadout_item/suit/blazer_jacket
-	name = "Recolorable Blazer"
-	item_path = /obj/item/clothing/suit/jacket/blazer
-
-/datum/loadout_item/suit/jacket_trenchcoat
-	name = "Recolorable Trenchcoat"
-	item_path = /obj/item/clothing/suit/toggle/jacket/trenchcoat
-
-/datum/loadout_item/suit/jacket_oversized
-	name = "Recolorable Oversized Jacket"
-	item_path = /obj/item/clothing/suit/jacket/oversized
-
-/datum/loadout_item/suit/jacket_fancy
-	name = "Recolorable Fancy Fur Coat"
-	item_path = /obj/item/clothing/suit/jacket/fancy
-
 /datum/loadout_item/suit/tailored_jacket
-	name = "Recolorable Tailored Jacket"
+	name = "Tailored Jacket (Colorable)"
 	item_path = /obj/item/clothing/suit/tailored_jacket
 
 /datum/loadout_item/suit/tailored_short_jacket
-	name = "Recolorable Tailored Short Jacket"
+	name = "Tailored Jacket, Short (Colorable)"
 	item_path = /obj/item/clothing/suit/tailored_jacket/short
-
-/datum/loadout_item/suit/ethereal_raincoat
-	name = "Ethereal Raincoat"
-	item_path = /obj/item/clothing/suit/hooded/ethereal_raincoat
-
-/datum/loadout_item/suit/mothcoat
-	name = "Mothic Flightsuit"
-	item_path = /obj/item/clothing/suit/mothcoat
-
-/datum/loadout_item/suit/big_jacket
-	name = "Alpha Atelier Pilot Jacket"
-	item_path = /obj/item/clothing/suit/big_jacket
-
-/*
-*	VARSITY JACKET
-*/
-
-/datum/loadout_item/suit/varsity
-	name = "Varsity Jacket"
-	item_path = /obj/item/clothing/suit/varsity
-
-/*
-*	COSTUMES
-*/
-
-/datum/loadout_item/suit/owl
-	name = "Owl Cloak"
-	item_path = /obj/item/clothing/suit/toggle/owlwings
-
-/datum/loadout_item/suit/griffin
-	name = "Griffon Cloak"
-	item_path = /obj/item/clothing/suit/toggle/owlwings/griffinwings
-
-/datum/loadout_item/suit/syndi
-	name = "Black And Red Space Suit Replica"
-	item_path = /obj/item/clothing/suit/syndicatefake
-
-/datum/loadout_item/suit/bee
-	name = "Bee Outfit"
-	item_path = /obj/item/clothing/suit/hooded/bee_costume
-
-/datum/loadout_item/suit/plague_doctor
-	name = "Plague Doctor Suit"
-	item_path = /obj/item/clothing/suit/bio_suit/plaguedoctorsuit
-
-/datum/loadout_item/suit/snowman
-	name = "Snowman Outfit"
-	item_path = /obj/item/clothing/suit/costume/snowman
-
-/datum/loadout_item/suit/chicken
-	name = "Chicken Suit"
-	item_path = /obj/item/clothing/suit/costume/chickensuit
-
-/datum/loadout_item/suit/monkey
-	name = "Monkey Suit"
-	item_path = /obj/item/clothing/suit/costume/monkeysuit
-
-/datum/loadout_item/suit/cardborg
-	name = "Cardborg Suit"
-	item_path = /obj/item/clothing/suit/costume/cardborg
-
-/datum/loadout_item/suit/xenos
-	name = "Xenos Suit"
-	item_path = /obj/item/clothing/suit/costume/xenos
-
-/datum/loadout_item/suit/ian_costume
-	name = "Corgi Costume"
-	item_path = /obj/item/clothing/suit/hooded/ian_costume
-
-/datum/loadout_item/suit/carp_costume
-	name = "Carp Costume"
-	item_path = /obj/item/clothing/suit/hooded/carp_costume
-
-/datum/loadout_item/suit/shark_costume
-	name = "Shark Costume"
-	item_path = /obj/item/clothing/suit/hooded/shark_costume
-
-/datum/loadout_item/suit/shork_costume
-	name = "Shork Costume"
-	item_path = /obj/item/clothing/suit/hooded/shork_costume
-
-/datum/loadout_item/suit/wizard
-	name = "Wizard Robe"
-	item_path = /obj/item/clothing/suit/wizrobe/fake
-
-/datum/loadout_item/suit/witch
-	name = "Witch Robe"
-	item_path = /obj/item/clothing/suit/wizrobe/marisa/fake
-
-/*
-*	SEASONAL
-*/
-
-/datum/loadout_item/suit/winter_coat/christmas
-	name = "Christmas Coat"
-	item_path = /obj/item/clothing/suit/hooded/wintercoat/nova/christmas
-
-/datum/loadout_item/suit/winter_coat/christmas/green
-	name = "Green Christmas Coat"
-	item_path = /obj/item/clothing/suit/hooded/wintercoat/nova/christmas/green
-
-/*
-*	MISC
-*/
-
-/datum/loadout_item/suit/recolorable_apron
-	name = "Recolorable Apron"
-	item_path = /obj/item/clothing/suit/apron/chef/colorable_apron
-
-/datum/loadout_item/suit/recolorable_overalls
-	name = "Recolorable Overalls"
-	item_path = /obj/item/clothing/suit/apron/overalls
-
-/datum/loadout_item/suit/redhood
-	name = "Red cloak"
-	item_path = /obj/item/clothing/suit/hooded/cloak/david
-
-/datum/loadout_item/suit/wellwornshirt
-	name = "Well-worn Shirt"
-	item_path = /obj/item/clothing/suit/costume/wellworn_shirt
-
-/datum/loadout_item/suit/wellworn_graphicshirt
-	name = "Well-worn Graphic Shirt"
-	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/graphic
-
-/datum/loadout_item/suit/ianshirt
-	name = "Well-worn Ian Shirt"
-	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/graphic/ian
-
-/datum/loadout_item/suit/wornoutshirt
-	name = "Worn-out Shirt"
-	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/wornout
-
-/datum/loadout_item/suit/wornout_graphicshirt
-	name = "Worn-out graphic Shirt"
-	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/wornout/graphic
-
-/datum/loadout_item/suit/wornout_ianshirt
-	name = "Worn-out Ian Shirt"
-	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/wornout/graphic/ian
-
-/datum/loadout_item/suit/messyshirt
-	name = "Messy Shirt"
-	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/messy
-
-/datum/loadout_item/suit/messy_graphicshirt
-	name = "Messy Graphic Shirt"
-	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/messy/graphic
-
-/datum/loadout_item/suit/messy_ianshirt
-	name = "Messy Ian Shirt"
-	item_path = /obj/item/clothing/suit/costume/wellworn_shirt/messy/graphic/ian
-
-/datum/loadout_item/suit/wornshirt
-	name = "Worn Shirt"
-	item_path = /obj/item/clothing/suit/wornshirt
-
-/datum/loadout_item/suit/duster
-	name = "Colorable Duster"
-	item_path = /obj/item/clothing/suit/duster
-
-/datum/loadout_item/suit/peacoat
-	name = "Colorable Peacoat"
-	item_path = /obj/item/clothing/suit/toggle/peacoat
 
 /datum/loadout_item/suit/trackjacket
 	name = "Track Jacket"
 	item_path = /obj/item/clothing/suit/toggle/trackjacket
 
-/datum/loadout_item/suit/croptop
-	name = "Crop Top Turtleneck"
-	item_path = /obj/item/clothing/suit/jacket/croptop
+/datum/loadout_item/suit/jacket_trenchcoat
+	name = "Trenchcoat  (Colorable)"
+	item_path = /obj/item/clothing/suit/toggle/jacket/trenchcoat
 
-/datum/loadout_item/suit/white_robe
-	name = "White Robe"
-	item_path = /obj/item/clothing/suit/jacket/white_robe
-
-/*
-*	FLANNELS
-*/
-
-/datum/loadout_item/suit/flannel_gags
-	name = "Flannel Shirt"
-	item_path = /obj/item/clothing/suit/toggle/jacket/nova/flannel/gags
-
-/datum/loadout_item/suit/flannel_black
-	name = "Black Flannel"
-	item_path = /obj/item/clothing/suit/toggle/jacket/nova/flannel
-
-/datum/loadout_item/suit/flannel_red
-	name = "Red Flannel"
-	item_path = /obj/item/clothing/suit/toggle/jacket/nova/flannel/red
-
-/datum/loadout_item/suit/flannel_aqua
-	name = "Aqua Flannel"
-	item_path = /obj/item/clothing/suit/toggle/jacket/nova/flannel/aqua
-
-/datum/loadout_item/suit/flannel_brown
-	name = "Brown Flannel"
-	item_path = /obj/item/clothing/suit/toggle/jacket/nova/flannel/brown
-
-/*
-*	HAWAIIAN
-*/
-
-
-/datum/loadout_item/suit/hawaiian_shirt
-	name = "Hawaiian Shirt"
-	item_path = /obj/item/clothing/suit/costume/hawaiian
-
-/*
-*	MISC
-*/
+/datum/loadout_item/suit/bltrench
+	name = "Trenchcoat (Black)"
+	item_path = /obj/item/clothing/suit/trenchblack
 
 /datum/loadout_item/suit/frenchtrench
-	name = "Blue Trenchcoat"
+	name = "Trenchcoat (Blue)"
 	item_path = /obj/item/clothing/suit/frenchtrench
 
+/datum/loadout_item/suit/brtrench
+	name = "Trenchcoat (Brown)"
+	item_path = /obj/item/clothing/suit/trenchbrown
+
 /datum/loadout_item/suit/frontiertrench
-	name = "Frontier Trenchcoat"
+	name = "Trenchcoat - Frontier"
 	item_path = /obj/item/clothing/suit/jacket/frontier_colonist
 
 /datum/loadout_item/suit/cossak
 	name = "Ukrainian Coat"
 	item_path = /obj/item/clothing/suit/cossack
 
-/datum/loadout_item/suit/parka
-	name = "Falls Parka"
-	item_path = /obj/item/clothing/suit/fallsparka
-
-/datum/loadout_item/suit/gags_wintercoat
-	name = "Recolorable Winter Coat"
-	item_path = /obj/item/clothing/suit/hooded/wintercoat/colourable
-
 /datum/loadout_item/suit/urban
 	name = "Urban Coat"
 	item_path = /obj/item/clothing/suit/urban
 
-/datum/loadout_item/suit/maxson
-	name = "Fancy Brown Coat"
-	item_path = /obj/item/clothing/suit/brownbattlecoat
+/datum/loadout_item/suit/warm_coat
+	name = "Warm Coat (Colorable)"
+	item_path = /obj/item/clothing/suit/warm_coat
 
-/datum/loadout_item/suit/bossu
-	name = "Fancy Black Coat"
-	item_path = /obj/item/clothing/suit/blackfurrich
+/datum/loadout_item/suit/warm_sweater
+	name = "Warm Sweater (Colorable)"
+	item_path = /obj/item/clothing/suit/warm_sweater
 
-/datum/loadout_item/suit/dutchjacket
-	name = "Western Jacket"
-	item_path = /obj/item/clothing/suit/dutchjacketsr
+/datum/loadout_item/suit/heart_sweater
+	name = "Warm Sweater (Colorable, Heart)"
+	item_path = /obj/item/clothing/suit/heart_sweater
 
-/datum/loadout_item/suit/caretaker
-	name = "Caretaker Jacket"
-	item_path = /obj/item/clothing/suit/victoriantailcoatbutler
+/datum/loadout_item/suit/varsity
+	name = "Varsity Jacket"
+	item_path = /obj/item/clothing/suit/varsity
 
-/datum/loadout_item/suit/jacketbomber_alt
-	name = "Bomber Jacket w/ Zipper"
-	item_path = /obj/item/clothing/suit/toggle/jacket/nova
+/datum/loadout_item/suit/offdep_jacket
+	name = "Work Jacket - Off-Department"
+	item_path = /obj/item/clothing/suit/toggle/jacket/nova/assistant
 
-/datum/loadout_item/suit/colourable_leather_jacket
-	name = "Colourable Leather Jacket"
-	item_path = /obj/item/clothing/suit/jacket/leather/colourable
+/datum/loadout_item/suit/engi_jacket
+	name = "Work Jacket - Engineering"
+	item_path = /obj/item/clothing/suit/toggle/jacket/nova/engi
 
-/datum/loadout_item/suit/frontierjacket
-	abstract_type = /datum/loadout_item/suit/frontierjacket
+/datum/loadout_item/suit/sci_jacket
+	name = "Work Jacket - Science"
+	item_path = /obj/item/clothing/suit/toggle/jacket/nova/sci
 
-/datum/loadout_item/suit/frontierjacket/short
-	name = "Frontier Jacket (Short)"
-	item_path = /obj/item/clothing/suit/jacket/frontier_colonist/short
+/datum/loadout_item/suit/med_jacket
+	name = "Work Jacket - Medbay"
+	item_path = /obj/item/clothing/suit/toggle/jacket/nova/med
 
-/datum/loadout_item/suit/frontierjacket/short/medical
-	name = "Frontier Medical Jacket (Short)"
-	item_path = /obj/item/clothing/suit/jacket/frontier_colonist/medical
-
-/datum/loadout_item/suit/woolcoat
-	name = "Leather Overcoat"
-	item_path = /obj/item/clothing/suit/woolcoat
-
-/datum/loadout_item/suit/flakjack
-	name = "Flak Jacket"
-	item_path = /obj/item/clothing/suit/flakjack
-
-/datum/loadout_item/suit/deckard
-	name = "Runner Coat"
-	item_path = /obj/item/clothing/suit/toggle/deckard
-	restricted_roles = list(JOB_DETECTIVE)
-
-/datum/loadout_item/suit/bltrench
-	name = "Black Trenchcoat"
-	item_path = /obj/item/clothing/suit/trenchblack
-
-/datum/loadout_item/suit/brtrench
-	name = "Brown Trenchcoat"
-	item_path = /obj/item/clothing/suit/trenchbrown
-
-/datum/loadout_item/suit/discojacket
-	name = "Disco Ass Blazer"
-	item_path = /obj/item/clothing/suit/discoblazer
-
-/datum/loadout_item/suit/kimjacket
-	name = "Aerostatic Bomber Jacket"
-	item_path = /obj/item/clothing/suit/kimjacket
-
-/datum/loadout_item/suit/cardigan
-	name = "Cardigan"
-	item_path = /obj/item/clothing/suit/toggle/jacket/nova/cardigan
-
-/datum/loadout_item/suit/blastwave_suit
-	name = "Blastwave Trenchcoat"
-	item_path = /obj/item/clothing/suit/blastwave
+/datum/loadout_item/suit/supply_jacket
+	name = "Work Jacket - Supply"
+	item_path = /obj/item/clothing/suit/toggle/jacket/nova/supply
 
 /*
 *	HOODIES
@@ -540,243 +425,456 @@
 	abstract_type = /datum/loadout_item/suit/hoodie
 
 /datum/loadout_item/suit/hoodie/greyscale
-	name = "Greyscale Hoodie"
+	name = "Hoodie  (Colorable)"
 	item_path = /obj/item/clothing/suit/toggle/jacket/nova/hoodie
 
-/datum/loadout_item/suit/hoodie/greyscale_trim
-	name = "Greyscale Trimmed Hoodie"
-	item_path = /obj/item/clothing/suit/toggle/jacket/nova/hoodie/trim
-
 /datum/loadout_item/suit/hoodie/greyscale_trim_alt
-	name = "Greyscale Trimmed Hoodie (Alt)"
+	name = "Hoodie  (Colorable, Pocket Trim)"
 	item_path = /obj/item/clothing/suit/toggle/jacket/nova/hoodie/trim/alt
 
+/datum/loadout_item/suit/hoodie/greyscale_trim
+	name = "Hoodie  (Colorable, Zipper Trim)"
+	item_path = /obj/item/clothing/suit/toggle/jacket/nova/hoodie/trim
+
 /datum/loadout_item/suit/hoodie/black
-	name = "Black Hoodie"
+	name = "Hoodie (Black)"
 	item_path = /obj/item/clothing/suit/toggle/jacket/nova/hoodie/black
 
 /datum/loadout_item/suit/hoodie/red
-	name = "Red Hoodie"
+	name = "Hoodie (Red)"
 	item_path = /obj/item/clothing/suit/toggle/jacket/nova/hoodie/red
 
 /datum/loadout_item/suit/hoodie/blue
-	name = "Blue Hoodie"
+	name = "Hoodie (Blue)"
 	item_path = /obj/item/clothing/suit/toggle/jacket/nova/hoodie/blue
 
 /datum/loadout_item/suit/hoodie/green
-	name = "Green Hoodie"
+	name = "Hoodie (Green)"
 	item_path = /obj/item/clothing/suit/toggle/jacket/nova/hoodie/green
 
 /datum/loadout_item/suit/hoodie/orange
-	name = "Orange Hoodie"
+	name = "Hoodie (Orange)"
 	item_path = /obj/item/clothing/suit/toggle/jacket/nova/hoodie/orange
 
 /datum/loadout_item/suit/hoodie/yellow
-	name = "Yellow Hoodie"
+	name = "Hoodie (Yellow)"
 	item_path = /obj/item/clothing/suit/toggle/jacket/nova/hoodie/yellow
 
 /datum/loadout_item/suit/hoodie/grey
-	name = "Grey Hoodie"
+	name = "Hoodie (Grey)"
 	item_path = /obj/item/clothing/suit/toggle/jacket/nova/hoodie/grey
 
 /datum/loadout_item/suit/hoodie/nt
-	name = "NT Hoodie"
+	name = "Hoodie - NT"
 	item_path = /obj/item/clothing/suit/toggle/jacket/nova/hoodie/branded
 
 /datum/loadout_item/suit/hoodie/smw
-	name = "SMW Hoodie"
+	name = "Hoodie - SMW"
 	item_path = /obj/item/clothing/suit/toggle/jacket/nova/hoodie/branded/smw
 
 /datum/loadout_item/suit/hoodie/nrti
-	name = "NRTI Hoodie"
+	name = "Hoodie - NRTI"
 	item_path = /obj/item/clothing/suit/toggle/jacket/nova/hoodie/branded/nrti
 
 /datum/loadout_item/suit/hoodie/cti
-	name = "CTI Hoodie"
+	name = "Hoodie - CTI"
 	item_path = /obj/item/clothing/suit/toggle/jacket/nova/hoodie/branded/cti
 
 /datum/loadout_item/suit/hoodie/mu
-	name = "Mojave University Hoodie"
+	name = "Hoodie - MU"
 	item_path = /obj/item/clothing/suit/toggle/jacket/nova/hoodie/branded/mu
+
+/*
+*	WORKWEAR
+*/
+
+/datum/loadout_item/suit/recolorable_apron
+	name = "Apron"
+	item_path = /obj/item/clothing/suit/apron/chef/colorable_apron
+	group = "Workwear"
+
+/datum/loadout_item/suit/frontierjacket/short/medical
+	name = "Frontier Jacket - Medical (Short)"
+	item_path = /obj/item/clothing/suit/jacket/frontier_colonist/medical
+	group = "Workwear"
+
+/datum/loadout_item/suit/cargo_gorka_jacket
+	name = "Gorka Jacket - Cargo"
+	item_path = /obj/item/clothing/suit/toggle/cargo_tech
+	group = "Workwear"
+
+/datum/loadout_item/suit/labcoat_highvis
+	name = "High-Vis Jacket"
+	item_path = /obj/item/clothing/suit/toggle/labcoat/nova/highvis
+	group = "Workwear"
+
+/datum/loadout_item/suit/labcoat
+	name = "Labcoat"
+	item_path = /obj/item/clothing/suit/toggle/labcoat
+	group = "Workwear"
+
+/datum/loadout_item/suit/labcoat_custom
+	name = "Labcoat  (Colorable)"
+	item_path = /obj/item/clothing/suit/toggle/labcoat/nova/custom
+	group = "Workwear"
+
+/datum/loadout_item/suit/labcoat_green
+	name = "Labcoat (Green)"
+	item_path = /obj/item/clothing/suit/toggle/labcoat/mad
+	group = "Workwear"
+
+/datum/loadout_item/suit/labcoat_medical
+	name = "Labcoat -  Medical"
+	item_path = /obj/item/clothing/suit/toggle/labcoat/medical
+	group = "Workwear"
+
+/datum/loadout_item/suit/labcoat_lalunevest
+	name = "Labcoat - Designer"
+	item_path = /obj/item/clothing/suit/toggle/labcoat/nova/lalunevest
+	group = "Workwear"
+
+/datum/loadout_item/suit/fancy_labcoat
+	name = "Labcoat - Fancy (Colorable)"
+	item_path = /obj/item/clothing/suit/toggle/labcoat/nova/fancy
+	group = "Workwear"
+
+/datum/loadout_item/suit/labcoat_regular
+	name = "Labcoat - Fancy, Research"
+	item_path = /obj/item/clothing/suit/toggle/labcoat/nova/fancy/regular
+	group = "Workwear"
+
+/datum/loadout_item/suit/labcoat_pharmacist
+	name = "Labcoat - Fancy, Pharmacy"
+	item_path = /obj/item/clothing/suit/toggle/labcoat/nova/fancy/pharmacist
+	group = "Workwear"
+
+/datum/loadout_item/suit/labcoat_geneticist
+	name = "Labcoat - Fancy, Genetics"
+	item_path = /obj/item/clothing/suit/toggle/labcoat/nova/fancy/geneticist
+	group = "Workwear"
+
+/datum/loadout_item/suit/labcoat_roboticist
+	name = "Labcoat - Fancy, Robotics"
+	item_path = /obj/item/clothing/suit/toggle/labcoat/nova/fancy/roboticist
+	group = "Workwear"
+
+/datum/loadout_item/suit/recolorable_overalls
+	name = "Overalls"
+	item_path = /obj/item/clothing/suit/apron/overalls
+	group = "Workwear"
+
+//Religious Clothing (Workwear for Chaplain. Better sorted here than in Costumes)
+/datum/loadout_item/suit/chap_eastmonk
+	name = "Religious - Eastern Monk's Robe"
+	item_path = /obj/item/clothing/suit/chaplainsuit/monkrobeeast
+	group = "Workwear"
+
+/datum/loadout_item/suit/chap_holiday
+	name = "Religious - Holiday Priest Robe"
+	item_path = /obj/item/clothing/suit/chaplainsuit/holidaypriest
+	group = "Workwear"
+
+/datum/loadout_item/suit/chap_brownmonk
+	name = "Religious - Monk's Habit"
+	item_path = /obj/item/clothing/suit/hooded/chaplainsuit/monkhabit
+	group = "Workwear"
+
+/datum/loadout_item/suit/chap_nun
+	name = "Religious - Nun's Robe"
+	item_path = /obj/item/clothing/suit/chaplainsuit/nun
+	group = "Workwear"
+
+/datum/loadout_item/suit/chap_shrinehand
+	name = "Religious - Shrinehand's Robe"
+	item_path = /obj/item/clothing/suit/chaplainsuit/shrinehand
+	group = "Workwear"
+
+/datum/loadout_item/suit/chap_blackmonk
+	name = "Religious - Tunic"
+	item_path = /obj/item/clothing/suit/chaplainsuit/habit
+	group = "Workwear"
+
+/*
+*	COSTUMES
+*/
+
+/datum/loadout_item/suit/syndi
+	name = "Black And Red Space Suit Replica"
+	item_path = /obj/item/clothing/suit/syndicatefake
+	group = "Costumes"
+
+/datum/loadout_item/suit/blastwave_suit
+	name = "Blastwave Trenchcoat"
+	item_path = /obj/item/clothing/suit/blastwave
+	group = "Costumes"
+
+/datum/loadout_item/suit/caretaker
+	name = "Caretaker Jacket"
+	item_path = /obj/item/clothing/suit/victoriantailcoatbutler
+	group = "Costumes"
+
+/datum/loadout_item/suit/deckers
+	name = "Deckers Hoodie"
+	item_path = /obj/item/clothing/suit/costume/deckers
+	group = "Costumes"
+
+/datum/loadout_item/suit/flakjack
+	name = "Flak Jacket"
+	item_path = /obj/item/clothing/suit/flakjack
+	group = "Costumes"
+
+/datum/loadout_item/suit/plague_doctor
+	name = "Plague Doctor Robes"
+	item_path = /obj/item/clothing/suit/bio_suit/plaguedoctorsuit
+	group = "Costumes"
+
+/datum/loadout_item/suit/pg
+	name = "PG Coat"
+	item_path = /obj/item/clothing/suit/costume/pg
+	group = "Costumes"
+
+/datum/loadout_item/suit/poncho
+	name = "Poncho"
+	item_path = /obj/item/clothing/suit/costume/poncho
+	group = "Costumes"
+
+/datum/loadout_item/suit/poncho_green
+	name = "Poncho (Green)"
+	item_path = /obj/item/clothing/suit/costume/poncho/green
+	group = "Costumes"
+
+/datum/loadout_item/suit/poncho_red
+	name = "Poncho (Red)"
+	item_path = /obj/item/clothing/suit/costume/poncho/red
+	group = "Costumes"
+
+/datum/loadout_item/suit/redhood
+	name = "Red Cloak"
+	item_path = /obj/item/clothing/suit/hooded/cloak/david
+	group = "Costumes"
+
+/datum/loadout_item/suit/soviet
+	name = "Soviet Coat"
+	item_path = /obj/item/clothing/suit/costume/soviet
+	group = "Costumes"
+
+/datum/loadout_item/suit/bee
+	name = "Suit - Bee"
+	item_path = /obj/item/clothing/suit/hooded/bee_costume
+	group = "Costumes"
+
+/datum/loadout_item/suit/cardborg
+	name = "Suit - Cardborg"
+	item_path = /obj/item/clothing/suit/costume/cardborg
+	group = "Costumes"
+
+/datum/loadout_item/suit/carp_costume
+	name = "Suit - Carp"
+	item_path = /obj/item/clothing/suit/hooded/carp_costume
+	group = "Costumes"
+
+/datum/loadout_item/suit/chicken
+	name = "Suit - Chicken"
+	item_path = /obj/item/clothing/suit/costume/chickensuit
+	group = "Costumes"
+
+/datum/loadout_item/suit/ian_costume
+	name = "Suit - Corgi"
+	item_path = /obj/item/clothing/suit/hooded/ian_costume
+	group = "Costumes"
+
+/datum/loadout_item/suit/griffin
+	name = "Suit - Griffon"
+	item_path = /obj/item/clothing/suit/toggle/owlwings/griffinwings
+	group = "Costumes"
+
+/datum/loadout_item/suit/monkey
+	name = "Suit - Monkey"
+	item_path = /obj/item/clothing/suit/costume/monkeysuit
+	group = "Costumes"
+
+/datum/loadout_item/suit/owl
+	name = "Suit - Owl"
+	item_path = /obj/item/clothing/suit/toggle/owlwings
+	group = "Costumes"
+
+/datum/loadout_item/suit/shark_costume
+	name = "Suit - Shark"
+	item_path = /obj/item/clothing/suit/hooded/shark_costume
+	group = "Costumes"
+
+/datum/loadout_item/suit/shork_costume
+	name = "Suit - Shork"
+	item_path = /obj/item/clothing/suit/hooded/shork_costume
+	group = "Costumes"
+
+/datum/loadout_item/suit/snowman
+	name = "Suit - Snowman"
+	item_path = /obj/item/clothing/suit/costume/snowman
+	group = "Costumes"
+
+/datum/loadout_item/suit/xenos
+	name = "Suit - Xenos"
+	item_path = /obj/item/clothing/suit/costume/xenos
+	group = "Costumes"
+
+/datum/loadout_item/suit/tmc
+	name = "TMC Coat"
+	item_path = /obj/item/clothing/suit/costume/tmc
+	group = "Costumes"
+
+/datum/loadout_item/suit/white_dress
+	name = "White Dress"
+	item_path = /obj/item/clothing/suit/costume/whitedress
+	group = "Costumes"
+
+/datum/loadout_item/suit/white_robe
+	name = "White Robe"
+	item_path = /obj/item/clothing/suit/jacket/white_robe
+	group = "Costumes"
+
+/datum/loadout_item/suit/witch
+	name = "Witch Robe"
+	item_path = /obj/item/clothing/suit/wizrobe/marisa/fake
+	group = "Costumes"
+
+/datum/loadout_item/suit/wizard
+	name = "Wizard Robe"
+	item_path = /obj/item/clothing/suit/wizrobe/fake
+	group = "Costumes"
+
+/datum/loadout_item/suit/yuri
+	name = "Yuri Coat"
+	item_path = /obj/item/clothing/suit/costume/yuri
+	group = "Costumes"
+
+/*
+*	SPECIES-UNIQUE
+*/
+
+/datum/loadout_item/suit/mothcoat
+	name = "Mothic Flightsuit"
+	item_path = /obj/item/clothing/suit/mothcoat
+	group = "Species-Unique"
+
+/datum/loadout_item/suit/mantella
+	name = "Mothic Mantella"
+	item_path = /obj/item/clothing/suit/mothcoat/winter
+	group = "Species-Unique"
+
+/datum/loadout_item/suit/ethereal_raincoat
+	name = "Ethereal Raincoat"
+	item_path = /obj/item/clothing/suit/hooded/ethereal_raincoat
+	group = "Species-Unique"
 
 /*
 *	JOB-LOCKED
 */
 
-// WINTER COATS
-/datum/loadout_item/suit/coat_med
-	name = "Medical Winter Coat"
-	item_path = /obj/item/clothing/suit/hooded/wintercoat/medical
+//CARGO
+/datum/loadout_item/suit/qm_jacket
+	name = "Quartermaster's Overcoat"
+	item_path = /obj/item/clothing/suit/jacket/quartermaster
+	restricted_roles = list(JOB_QUARTERMASTER)
+	group = "Job-Locked"
 
-/datum/loadout_item/suit/coat_paramedic
-	name = "Paramedic Winter Coat"
-	item_path = /obj/item/clothing/suit/hooded/wintercoat/medical/paramedic
-
-/datum/loadout_item/suit/coat_robotics
-	name = "Robotics Winter Coat"
-	item_path = /obj/item/clothing/suit/hooded/wintercoat/science/robotics
-
-/datum/loadout_item/suit/coat_sci
-	name = "Science Winter Coat"
-	item_path = /obj/item/clothing/suit/hooded/wintercoat/science
-
-/datum/loadout_item/suit/coat_eng
-	name = "Engineering Winter Coat"
-	item_path = /obj/item/clothing/suit/hooded/wintercoat/engineering
-
-/datum/loadout_item/suit/coat_atmos
-	name = "Atmospherics Winter Coat"
-	item_path = /obj/item/clothing/suit/hooded/wintercoat/engineering/atmos
-
-/datum/loadout_item/suit/coat_hydro
-	name = "Hydroponics Winter Coat"
-	item_path = /obj/item/clothing/suit/hooded/wintercoat/hydro
-
-/datum/loadout_item/suit/coat_bar
-	name = "Bartender Winter Coat"
-	item_path = /obj/item/clothing/suit/hooded/wintercoat/nova/bartender
-
-/datum/loadout_item/suit/coat_cargo
-	name = "Cargo Winter Coat"
-	item_path = /obj/item/clothing/suit/hooded/wintercoat/cargo
-
-/datum/loadout_item/suit/coat_miner
-	name = "Mining Winter Coat"
-	item_path = /obj/item/clothing/suit/hooded/wintercoat/miner
-
-// JACKETS
-/datum/loadout_item/suit/navybluejacketofficer
-	name = "Security Officer's Navy Blue Formal Jacket"
-	item_path = /obj/item/clothing/suit/jacket/officer/blue
-	restricted_roles = list(JOB_WARDEN, JOB_DETECTIVE, JOB_SECURITY_OFFICER, JOB_HEAD_OF_SECURITY, JOB_CORRECTIONS_OFFICER)
-
-/datum/loadout_item/suit/navybluejacketwarden
-	name = "Warden's Navy Blue Formal Jacket"
-	item_path = /obj/item/clothing/suit/jacket/warden/blue
-	restricted_roles = list(JOB_WARDEN)
-
+//SEC
 /datum/loadout_item/suit/navybluejackethos
-	name = "Head of Security's Navy Blue Formal Jacket"
+	name = "Head of Security's Formal Jacket (Navy Blue)"
 	item_path = /obj/item/clothing/suit/jacket/hos/blue
 	restricted_roles = list(JOB_HEAD_OF_SECURITY)
+	group = "Job-Locked"
 
-/datum/loadout_item/suit/security_jacket
-	name = "Security Jacket"
-	item_path = /obj/item/clothing/suit/toggle/jacket/nova/sec
-	restricted_roles = list(JOB_WARDEN, JOB_DETECTIVE, JOB_SECURITY_OFFICER, JOB_HEAD_OF_SECURITY) //Not giving this one to COs because it's actually better than the one they spawn with
-
-/datum/loadout_item/suit/brit
-	name = "High Vis Armored Vest"
-	item_path = /obj/item/clothing/suit/armor/vest/brit
-	restricted_roles = list(JOB_HEAD_OF_SECURITY, JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_DETECTIVE, JOB_CORRECTIONS_OFFICER)
+/datum/loadout_item/suit/navybluejacketwarden
+	name = "Warden's Formal Jacket (Navy Blue)"
+	item_path = /obj/item/clothing/suit/jacket/warden/blue
+	restricted_roles = list(JOB_WARDEN)
+	group = "Job-Locked"
 
 /datum/loadout_item/suit/british_jacket
-	name = "Officer Coat"
+	name = "Security British Coat"
 	item_path = /obj/item/clothing/suit/british_officer
 	restricted_roles = list(JOB_WARDEN, JOB_DETECTIVE, JOB_SECURITY_OFFICER, JOB_HEAD_OF_SECURITY, JOB_CORRECTIONS_OFFICER)
+	group = "Job-Locked"
+
+/datum/loadout_item/suit/navybluejacketofficer
+	name = "Security Formal Jacket (Navy Blue)"
+	item_path = /obj/item/clothing/suit/jacket/officer/blue
+	restricted_roles = list(JOB_WARDEN, JOB_DETECTIVE, JOB_SECURITY_OFFICER, JOB_HEAD_OF_SECURITY, JOB_CORRECTIONS_OFFICER)
+	group = "Job-Locked"
+
+/datum/loadout_item/suit/brit
+	name = "Security High Vis Armored Vest"
+	item_path = /obj/item/clothing/suit/armor/vest/brit
+	restricted_roles = list(JOB_HEAD_OF_SECURITY, JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_DETECTIVE, JOB_CORRECTIONS_OFFICER)
+	group = "Job-Locked"
 
 /datum/loadout_item/suit/highvis_jacket
-	name = "High Vis Security Jacket"
+	name = "Security High-Vis Jacket"
 	item_path = /obj/item/clothing/suit/armor/vest/jacket
 	restricted_roles = list(JOB_WARDEN, JOB_DETECTIVE, JOB_SECURITY_OFFICER, JOB_HEAD_OF_SECURITY, JOB_CORRECTIONS_OFFICER)
+	group = "Job-Locked"
+
+/datum/loadout_item/suit/highvis_jacket/badge
+	name = "Security High-Vis Jacket - Badged"
+	item_path = /obj/item/clothing/suit/armor/vest/jacket/badge
+	restricted_roles = list(JOB_WARDEN, JOB_DETECTIVE, JOB_SECURITY_OFFICER, JOB_HEAD_OF_SECURITY, JOB_CORRECTIONS_OFFICER)
+	group = "Job-Locked"
 
 /datum/loadout_item/suit/security_wintercoat
-	name = "Security Winter Coat"
+	name = "Security Winter Jacket"
 	item_path = /obj/item/clothing/suit/hooded/wintercoat/security
 	restricted_roles = list(JOB_WARDEN, JOB_DETECTIVE, JOB_SECURITY_OFFICER, JOB_HEAD_OF_SECURITY, JOB_CORRECTIONS_OFFICER)
+	group = "Job-Locked"
 
 /datum/loadout_item/suit/security_wintercoat_blue
-	name = "Security Winter Jacket (Blue)"
+	name = "Security Winter Coat (Blue)"
 	item_path = /obj/item/clothing/suit/hooded/wintercoat/security/blue
 	restricted_roles = list(JOB_WARDEN, JOB_DETECTIVE, JOB_SECURITY_OFFICER, JOB_HEAD_OF_SECURITY, JOB_CORRECTIONS_OFFICER)
+	group = "Job-Locked"
 
-/datum/loadout_item/suit/detjacketplain
-	name = "Detective's Jacket"
-	item_path = /obj/item/clothing/suit/toggle/jacket/det_trench
-	restricted_roles = list(JOB_DETECTIVE)
+/datum/loadout_item/suit/security_jacket
+	name = "Security Work Jacket"
+	item_path = /obj/item/clothing/suit/toggle/jacket/nova/sec
+	restricted_roles = list(JOB_WARDEN, JOB_DETECTIVE, JOB_SECURITY_OFFICER, JOB_HEAD_OF_SECURITY) //Not giving this one to COs because it's actually better than the one they spawn with
+	group = "Job-Locked"
 
-/datum/loadout_item/suit/detjacket
-	name = "Detective Jacket (Dark)"
-	item_path = /obj/item/clothing/suit/toggle/jacket/det_trench/noir
+//Detective
+/datum/loadout_item/suit/deckard
+	name = "Detective Runner Coat"
+	item_path = /obj/item/clothing/suit/toggle/deckard
 	restricted_roles = list(JOB_DETECTIVE)
-
-/datum/loadout_item/suit/detjackenoir
-	name = "Detective Jacket (Noir)"
-	item_path = /obj/item/clothing/suit/jacket/det_suit/noir
-	restricted_roles = list(JOB_DETECTIVE)
-
-/datum/loadout_item/suit/detjacketbrown
-	name = "Detective's Brown Jacket"
-	item_path = /obj/item/clothing/suit/jacket/det_suit
-	restricted_roles = list(JOB_DETECTIVE)
+	group = "Job-Locked"
 
 /datum/loadout_item/suit/detectivearmorvest
 	name = "Detective's Armor Vest"
 	item_path = /obj/item/clothing/suit/armor/vest/det_suit
 	restricted_roles = list(JOB_DETECTIVE)
+	group = "Job-Locked"
 
-/datum/loadout_item/suit/highvis_jacket/badge
-	name = "Badged High Vis Jacket"
-	item_path = /obj/item/clothing/suit/armor/vest/jacket/badge
-	restricted_roles = list(JOB_WARDEN, JOB_DETECTIVE, JOB_SECURITY_OFFICER, JOB_HEAD_OF_SECURITY, JOB_CORRECTIONS_OFFICER)
+/datum/loadout_item/suit/detjacketbrown
+	name = "Detective's Jacket"
+	item_path = /obj/item/clothing/suit/jacket/det_suit
+	restricted_roles = list(JOB_DETECTIVE)
+	group = "Job-Locked"
 
-/datum/loadout_item/suit/offdep_jacket
-	name = "Off-Department Jacket"
-	item_path = /obj/item/clothing/suit/toggle/jacket/nova/assistant
+/datum/loadout_item/suit/detjackenoir
+	name = "Detective's Jacket (Noir)"
+	item_path = /obj/item/clothing/suit/jacket/det_suit/noir
+	restricted_roles = list(JOB_DETECTIVE)
+	group = "Job-Locked"
 
-/datum/loadout_item/suit/engi_jacket
-	name = "Engineering Jacket"
-	item_path = /obj/item/clothing/suit/toggle/jacket/nova/engi
+/datum/loadout_item/suit/detjacketplain
+	name = "Detective's Trenchcoat"
+	item_path = /obj/item/clothing/suit/toggle/jacket/det_trench
+	restricted_roles = list(JOB_DETECTIVE)
+	group = "Job-Locked"
 
-/datum/loadout_item/suit/sci_jacket
-	name = "Science Jacket"
-	item_path = /obj/item/clothing/suit/toggle/jacket/nova/sci
-
-/datum/loadout_item/suit/med_jacket
-	name = "Medbay Jacket"
-	item_path = /obj/item/clothing/suit/toggle/jacket/nova/med
-
-/datum/loadout_item/suit/supply_jacket
-	name = "Supply Jacket"
-	item_path = /obj/item/clothing/suit/toggle/jacket/nova/supply
-
-/datum/loadout_item/suit/cargo_gorka_jacket
-	name = "Cargo Gorka Jacket"
-	item_path = /obj/item/clothing/suit/toggle/cargo_tech
-
-/datum/loadout_item/suit/qm_jacket
-	name = "Quartermaster's Overcoat"
-	item_path = /obj/item/clothing/suit/jacket/quartermaster
-	restricted_roles = list(JOB_QUARTERMASTER)
-
-// LABCOATS
-/datum/loadout_item/suit/labcoat_highvis
-	name = "High-Vis Labcoat"
-	item_path = /obj/item/clothing/suit/toggle/labcoat/nova/highvis
-
-/*
-*	FAMILIES
-*/
-
-/datum/loadout_item/suit/tmc
-	name = "TMC Coat"
-	item_path = /obj/item/clothing/suit/costume/tmc
-
-/datum/loadout_item/suit/pg
-	name = "PG Coat"
-	item_path = /obj/item/clothing/suit/costume/pg
-
-/datum/loadout_item/suit/deckers
-	name = "Deckers Hoodie"
-	item_path = /obj/item/clothing/suit/costume/deckers
-
-/datum/loadout_item/suit/soviet
-	name = "Soviet Coat"
-	item_path = /obj/item/clothing/suit/costume/soviet
-
-/datum/loadout_item/suit/yuri
-	name = "Yuri Coat"
-	item_path = /obj/item/clothing/suit/costume/yuri
+/datum/loadout_item/suit/detjacket
+	name = "Detective's Trenchcoat (Dark)"
+	item_path = /obj/item/clothing/suit/toggle/jacket/det_trench/noir
+	restricted_roles = list(JOB_DETECTIVE)
+	group = "Job-Locked"
 
 /*
 *	DONATOR
@@ -786,112 +884,45 @@
 	abstract_type = /datum/loadout_item/suit/donator
 	donator_only = TRUE
 
+/datum/loadout_item/suit/donator/blondie
+	name = "Cowboy Vest"
+	item_path = /obj/item/clothing/suit/cowboyvest
+
+/datum/loadout_item/suit/digicoat_glitched //Public donator reward for Razurath.
+	name = "Digicoat - Glitched"
+	item_path = /obj/item/clothing/suit/toggle/digicoat/glitched
+
+/datum/loadout_item/suit/donator/digicoat
+	abstract_type = /datum/loadout_item/suit/donator/digicoat
+
+/datum/loadout_item/suit/donator/digicoat/interdyne
+	name = "Digicoat - Interdyne"
+	item_path = /obj/item/clothing/suit/toggle/digicoat/interdyne
+
+/datum/loadout_item/suit/donator/digicoat/nanotrasen
+	name = "Digicoat - Nanotrasen"
+	item_path = /obj/item/clothing/suit/toggle/digicoat/nanotrasen
+
 /datum/loadout_item/suit/donator/furredjacket
 	name = "Furred Jacket"
 	item_path = /obj/item/clothing/suit/brownfurrich/public
 
 /datum/loadout_item/suit/donator/whitefurredjacket
-	name = "White Furred Jacket"
+	name = "Furred Jacket (White)"
 	item_path = /obj/item/clothing/suit/brownfurrich/white
 
 /datum/loadout_item/suit/donator/creamfurredjacket
-	name = "Cream Furred Jacket"
+	name = "Furred Jacket (Cream)"
 	item_path = /obj/item/clothing/suit/brownfurrich/cream
+
+/datum/loadout_item/suit/donator/chokha //All-donators donator item for BlindPoet
+	name = "Iseurian Chokha"
+	item_path = /obj/item/clothing/suit/chokha
 
 /datum/loadout_item/suit/donator/modern_winter
 	name = "Modern Winter Coat"
 	item_path = /obj/item/clothing/suit/modern_winter
 
-/datum/loadout_item/suit/donator/blondie
-	name = "Cowboy Vest"
-	item_path = /obj/item/clothing/suit/cowboyvest
-
-/datum/loadout_item/suit/donator/digicoat
-	abstract_type = /datum/loadout_item/suit/donator/digicoat
-
-/datum/loadout_item/suit/donator/digicoat/nanotrasen
-	name = "nanotrasen digicoat"
-	item_path = /obj/item/clothing/suit/toggle/digicoat/nanotrasen
-
-/datum/loadout_item/suit/donator/digicoat/interdyne
-	name = "Interdyne Digicoat"
-	item_path = /obj/item/clothing/suit/toggle/digicoat/interdyne
-
 /datum/loadout_item/suit/donator/replica_parade_jacket
 	name = "Replica Parade Jacket"
 	item_path = /obj/item/clothing/suit/replica_parade_jacket
-
-// All-donators donator item for BlindPoet
-/datum/loadout_item/suit/donator/chokha
-	name = "Iseurian Chokha"
-	item_path = /obj/item/clothing/suit/chokha
-
-/datum/loadout_item/suit/digicoat_glitched //Public donator reward for Razurath.
-	name = "Glitched Digicoat"
-	item_path = /obj/item/clothing/suit/toggle/digicoat/glitched
-
-/datum/loadout_item/suit/warm_coat
-	name = "Colourable Warm Coat"
-	item_path = /obj/item/clothing/suit/warm_coat
-
-/datum/loadout_item/suit/warm_sweater
-	name = "Colourable Warm Sweater"
-	item_path = /obj/item/clothing/suit/warm_sweater
-
-/datum/loadout_item/suit/heart_sweater
-	name = "Colourable Heart Sweater"
-	item_path = /obj/item/clothing/suit/heart_sweater
-
-// Fancy crop-top jackets
-
-/datum/loadout_item/suit/crop_jacket
-	name = "Colourable Crop-Top Jacket"
-	item_path = /obj/item/clothing/suit/crop_jacket
-
-/datum/loadout_item/suit/shortsleeve_crop_jacket
-	name = "Colourable Short-Sleeved Crop-Top Jacket"
-	item_path = /obj/item/clothing/suit/crop_jacket/shortsleeve
-
-/datum/loadout_item/suit/sleeveless_crop_jacket
-	name = "Colourable Sleeveless Crop-Top Jacket"
-	item_path = /obj/item/clothing/suit/crop_jacket/sleeveless
-
-/datum/loadout_item/suit/sports_jacket
-	name = "Colourable Sports Jacket"
-	item_path = /obj/item/clothing/suit/crop_jacket/long
-
-/datum/loadout_item/suit/shortsleeve_sports_jacket
-	name = "Colourable Short-Sleeved Sports Jacket"
-	item_path = /obj/item/clothing/suit/crop_jacket/shortsleeve/long
-
-/datum/loadout_item/suit/sleeveless_sports_jacket
-	name = "Colourable Sleeveless Sports Jacket"
-	item_path = /obj/item/clothing/suit/crop_jacket/sleeveless/long
-
-/*
-*	CHAPLAIN
-*/
-
-/datum/loadout_item/suit/chap_nun
-	name = "Nun's Habit"
-	item_path = /obj/item/clothing/suit/chaplainsuit/nun
-
-/datum/loadout_item/suit/chap_holiday
-	name = "Chaplain's Holiday Robe"
-	item_path = /obj/item/clothing/suit/chaplainsuit/holidaypriest
-
-/datum/loadout_item/suit/chap_brownmonk
-	name = "Monk's Brown Habit"
-	item_path = /obj/item/clothing/suit/hooded/chaplainsuit/monkhabit
-
-/datum/loadout_item/suit/chap_eastmonk
-	name = "Eastern Monk's Robe"
-	item_path = /obj/item/clothing/suit/chaplainsuit/monkrobeeast
-
-/datum/loadout_item/suit/chap_shrinehand
-	name = "Shrinehand Robe"
-	item_path = /obj/item/clothing/suit/chaplainsuit/shrinehand
-
-/datum/loadout_item/suit/chap_blackmonk
-	name = "Monk's Black Habit"
-	item_path = /obj/item/clothing/suit/chaplainsuit/habit

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_suit.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_suit.dm
@@ -79,14 +79,6 @@
 	name = "Purple Formal Suit Jacket"
 	item_path = /obj/item/clothing/suit/toggle/lawyer/purple
 
-/datum/loadout_item/suit/white_suit_jacket
-	name = "White Formal Suit Jacket"
-	item_path = /obj/item/clothing/suit/toggle/lawyer/white
-
-/datum/loadout_item/suit/suitblackbetter
-	name = "Light Black Formal Suit Jacket"
-	item_path = /obj/item/clothing/suit/toggle/lawyer/black/better
-
 /datum/loadout_item/suit/suitwhite
 	name = "Texan Suit Jacket"
 	item_path = /obj/item/clothing/suit/texas

--- a/modular_nova/modules/modular_vending/code/clothesmate.dm
+++ b/modular_nova/modules/modular_vending/code/clothesmate.dm
@@ -138,7 +138,6 @@
 				/obj/item/clothing/suit/tailored_jacket/short = 5,
 				/obj/item/clothing/suit/toggle/peacoat = 5,
 				/obj/item/clothing/suit/toggle/trackjacket = 5,
-				/obj/item/clothing/suit/toggle/lawyer/white = 5,
 				/obj/item/clothing/suit/urban = 5,
 				/obj/item/clothing/suit/duster = 5,
 				/obj/item/clothing/suit/fallsparka = 5,


### PR DESCRIPTION
## About The Pull Request

You thought I was done? #5784? 
No I was just too tired to read my own work. I thought this thing was gibberish. Don't code past midnight.

Pt4 of https://github.com/NovaSector/NovaSector/pull/5720
Atomization of https://github.com/NovaSector/NovaSector/pull/5561 because it was hurting me

Exact same PR by the way. Minus the worn shirt removal.

>**A note before anybody asks why something is in a weird order:**
>_The loadout is always alphabetically sorted. I can't change that.
>All I'm doing it making similar items cluster together in that alphabetized list, and grouping together items that should be in a second alphabetized list (like job-locked gear)_

- Similar items are clustered together (such as Recolors or Variants)
_(Where required, double-spaces are used to put items at the top of their list. More relevant with the Toys so I could cheat the Plushies group down to the bottom._
- Color variants of recolorable items, are no longer recolorable. Use the intended Colorable variants!
(so we don't recolor Red items Blue, but still leave the name/desc with Red)
- Adds a few loadout groupings: 'Workwear', 'Job-Locked', 'Costumes', and 'Species-Unique'

Additionally:
- Makes the spiked collar NOT a [REDACTED] item
_It's just a spiked collar bro... This is punk, not [REDACTED]._
- Converts `/obj/item/clothing/suit/discoblazer` to `/obj/item/clothing/suit/jacket/discoblazer`
_TG added this item as a detective jacket; by making this a /jacket/ subtype it gets the icon, the jacket holdables, the jacket temperature protection... you know, consistent with all the other jackets like it. Basically it's the same thing but armorless/generic-holdables instead of detective._
- **Renames** "Worn Shirt" to "Wrinkled Shirt"
_"Worn" is the internal code name for worn item sprites (i.e. `worn_icon`). This is much less confusing._
_~~This thing still needs a resprite but I didn't realize TG removed all the wrinkles. TG has useless variants even. One is a recolored base of a... white base, recolorable shirt. This is visually indistinguishable if you recolor it anything but white. Just. Preset it that color man. Don't make a whole new base.~~_
- Updates some Hoodie stuff
_Fixes the loadout for one of them, adds /improper where relevant, removes duplicate var defines_
<details><summary>Removes `/obj/item/clothing/suit/toggle/lawyer/black/better` ("light black formal suit jacket")</summary>

_This is literally just an outdated sprite. It's from when TG had /lawyer/black as a **pure 1-color black cube**. 
It was better **then** maybe, but now it's outdated and unneeded because the black jacket isn't vantablack. (This doesn't even match buttondowns it'd be worn on top of any more)_

<img width="93" height="77" alt="image" src="https://github.com/user-attachments/assets/4859c18f-66e5-498a-ae3c-34ef88322dd4" />
</details>

<details><summary>Removes `/obj/item/clothing/suit/toggle/lawyer/white` ("white suit jacket")</summary>

_Same as above. Just a 100% outdated item meant to replace a no-longer-existing item; it's no longer needed. 
TG's suit resprite is recolorable, but default is white. So just. Use it without recoloring. That's white bro._

<img width="86" height="74" alt="image" src="https://github.com/user-attachments/assets/22fbff49-d7f4-417f-9d7d-1c56d2f98dd9" />
</details>

<h5>
 If somebody knows actual UI code and would make real-item-name show somewhere in the Loadout that would be really nice btw. Would help people Renaming too.
(Before it comes up, No, showing the wrong name isn't me breaking a standard. TG does this already: look at every single colored cap. I'm just applying that stuff to all our things equally.)</h5>

## How This Contributes To The Nova Sector Roleplay Experience

<details><summary>The satisfaction I felt seeing all the winter coats actually listed next to each other is unbeatable. Look at this. Isn't it SO much better??</summary>
<img width="685" height="596" alt="image" src="https://github.com/user-attachments/assets/d1cbec74-ddc1-401b-aaa3-5c786bc478fa" />
</details>

Being able to see an item and immediately also see **similar** items is SO much nicer.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

Same screenshots sure, but it's the same code too. Literally. Just compare the two PRs. (The only difference is the not-removed item.)
~~I did test it dw. I just didn't screenshot because I was multitasking.~~

<img width="1464" height="779" alt="image" src="https://github.com/user-attachments/assets/564c23be-b63c-491f-8a38-4662553b8d8f" />
<img width="1435" height="781" alt="image" src="https://github.com/user-attachments/assets/d4d18f40-0327-4df0-b167-d1382821f4a6" />
<img width="1491" height="771" alt="image" src="https://github.com/user-attachments/assets/4890e34c-c918-4d18-a378-4e80535ae3c4" />

</details>

## Changelog

:cl:
qol: Sorted the following Loadout groups: Shoes, Suits.
fix: fixed an incorrect loadout entry for one of the recolorable Hoodies
del: Renamed "Worn Shirt" to "Wrinkled Shirt" (in loadout, "Oversized Shirt - Wrinkled")
del: Removed "white suit jacket" and '/obj/item/clothing/suit/toggle/lawyer/black/better', old resprites of the white/black suit jackets which have since been improved drastically. (search: 'Suit Jacket' in loadout)
/:cl: