### PR TITLE
Fix for automatic addition and removal of labels(?)

### DIFF
--- a/tools/pull_request_hooks/autoLabel.js
+++ b/tools/pull_request_hooks/autoLabel.js
@@ -69,7 +69,7 @@ function check_title_for_labels(title) {
 }
 
 function check_diff_line_for_element(diff, element) {
-  const tag_re = new RegExp(`^diff --git a/${element}/`);
+  const tag_re = new RegExp(`diff --git a/${element}/`); // NOVA EDIT CHANGE - original: const tag_re = new RegExp(`^diff --git a/${element}/`);
   return tag_re.test(diff);
 }
 


### PR DESCRIPTION
## About The Pull Request

The necessary labels related to file modifications were not added to the pull request. 
That's what I discovered using my silly tests:

<details>
<summary>Silly test</summary>
  
Here's what I got:
<img width="290" height="161" alt="image" src="https://github.com/user-attachments/assets/f8a35db7-6322-4130-a90c-7ac825e2ba32" />

with the following code:
<img width="466" height="227" alt="image" src="https://github.com/user-attachments/assets/863292b9-edd7-48c0-887e-a95ffa1ad9eb" />

</details>

The /Label and GBP/ workflow checked diff with the following regular expression: `^diff --git a/${element}/`. The `^` symbol means the beginning of a line... This was probably the reason why, if it worked at all, it only added one label 
(And it also [removed labels](https://github.com/NovaSector/NovaSector/pull/5486), even if they were added manually)
I have no idea why it works fine on TG, while it doesn't work for us
## How This Contributes To The Nova Sector Roleplay Experience

Another bit of help for maintainers
(I am almost one of you! :3)
## Proof of Testing
I don't know how to show it, but now the workflow in my repository has started adding labels

<details>
<summary>Screenshots/Videos</summary>

<img width="587" height="77" alt="image" src="https://github.com/user-attachments/assets/9c84f1cf-b340-4c71-80bf-032c44f45423" />
  
<img width="781" height="70" alt="image" src="https://github.com/user-attachments/assets/f72116fb-1210-47de-89c8-ac61a6728163" />

</details>

## Changelog
Not required?
