### PR TITLE
[Port] Subtle improvements, pun intended

### DIFF
--- a/modular_nova/modules/verbs/code/subtle.dm
+++ b/modular_nova/modules/verbs/code/subtle.dm
@@ -111,7 +111,7 @@
 		in_view.Remove(user)
 
 		for(var/mob/mob in in_view) // Filters out the AI eye and clientless mobs.
-			if(istype(mob, /mob/eye/camera/ai))
+			if(!istype(mob, /mob/eye/camera/ai))
 				continue
 			if(mob.client)
 				continue


### PR DESCRIPTION

## About The Pull Request
Ports https://github.com/Bubberstation/Bubberstation/pull/2901 and https://github.com/Bubberstation/Bubberstation/pull/2883, credit to StrangeWeirdKitten.

Basically filters non clients from the subtler list _AND_ lets you use subtler farther than just one tiile, while removing the need for Telekinesis to do so. You can now use subtler on anyone in sight, as long as they are a client.

## How This Contributes To The Nova Sector Roleplay Experience
This allows people to have more uses for subtler, keeps the options for such uses on their relevant channels, and encourage people to keep the ERP stuff to ERP channels and other conversation channels to their original purpose. 

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="700" height="499" alt="image" src="https://github.com/user-attachments/assets/326b852b-7558-408d-97d1-d063af0ff12d" />


</details>

Tested it locally, Bubber  live tested it, we should still do a TM before a Merge.

## Changelog
:cl:
qol: Subtler was upgraded to filter out non client entities of it, and its possible range for 1v1 emotes to be on the visibility range. Port from StrangeWeirdKitten and their work on Bubberstation.
/:cl:
