### PR TITLE
[Experimental] Laser recharge gimmick

### DIFF
--- a/modular_nova/modules/modular_weapons/code/overrides/energy_crank.dm
+++ b/modular_nova/modules/modular_weapons/code/overrides/energy_crank.dm
@@ -1,0 +1,79 @@
+//This is where we add the crank elements to energy weapons, using a mix of both the musket and hot/cold revolvers as base. You see me using LASER_SHOTS because its a defined function to calculate a fraction of the power cell, in this case, I use it to calculate a 25% recharge.
+
+// Allstar sc1 laser carbine, the allstar sc1 laser auto carbine (/obj/item/gun/energy/laser/carbine) is included since its a child.
+/obj/item/gun/energy/laser/Initialize(mapload)
+	. = ..()
+	AddComponent( \
+		/datum/component/crank_recharge, \
+		charging_cell = get_cell(), \
+		charge_amount = LASER_SHOTS(4, STANDARD_CELL_CHARGE), \
+		cooldown_time = 6 SECONDS, \
+		charge_sound = 'sound/items/weapons/laser_crank.ogg', \
+		charge_sound_cooldown_time = 3 SECONDS, \
+		charge_move = IGNORE_USER_LOC_CHANGE, \
+	)
+
+// Allstar sc2 energy carbine
+/obj/item/gun/energy/e_gun/Initialize(mapload)
+	. = ..()
+	AddComponent( \
+		/datum/component/crank_recharge, \
+		charging_cell = get_cell(), \
+		charge_amount = LASER_SHOTS(4, STANDARD_CELL_CHARGE), \
+		cooldown_time = 6 SECONDS, \
+		charge_sound = 'sound/items/weapons/laser_crank.ogg', \
+		charge_sound_cooldown_time = 3 SECONDS, \
+		charge_move = IGNORE_USER_LOC_CHANGE, \
+	)
+
+// Hellfire laser gun
+/obj/item/gun/energy/laser/hellgun/Initialize(mapload)
+	. = ..()
+	AddComponent( \
+		/datum/component/crank_recharge, \
+		charging_cell = get_cell(), \
+		charge_amount = LASER_SHOTS(4, STANDARD_CELL_CHARGE), \
+		cooldown_time = 6 SECONDS, \
+		charge_sound = 'sound/items/weapons/laser_crank.ogg', \
+		charge_sound_cooldown_time = 3 SECONDS, \
+		charge_move = IGNORE_USER_LOC_CHANGE, \
+	)
+
+// Ion carbine
+/obj/item/gun/energy/ionrifle/carbine/Initialize(mapload)
+	. = ..()
+	AddComponent( \
+		/datum/component/crank_recharge, \
+		charging_cell = get_cell(), \
+		charge_amount = LASER_SHOTS(4, STANDARD_CELL_CHARGE), \
+		cooldown_time = 6 SECONDS, \
+		charge_sound = 'sound/items/weapons/laser_crank.ogg', \
+		charge_sound_cooldown_time = 3 SECONDS, \
+		charge_move = IGNORE_USER_LOC_CHANGE, \
+	)
+
+// X ray laser gun
+/obj/item/gun/energy/xray/Initialize(mapload)
+	. = ..()
+	AddComponent( \
+		/datum/component/crank_recharge, \
+		charging_cell = get_cell(), \
+		charge_amount = LASER_SHOTS(4, STANDARD_CELL_CHARGE), \
+		cooldown_time = 6 SECONDS, \
+		charge_sound = 'sound/items/weapons/laser_crank.ogg', \
+		charge_sound_cooldown_time = 3 SECONDS, \
+		charge_move = IGNORE_USER_LOC_CHANGE, \
+	)
+
+// Tesla cannon
+/obj/item/gun/energy/tesla_cannon/Initialize(mapload)
+	. = ..()
+	AddComponent( \
+		/datum/component/crank_recharge, \
+		charging_cell = get_cell(), \
+		charge_amount = LASER_SHOTS(4, STANDARD_CELL_CHARGE), \
+		cooldown_time = 6 SECONDS, \
+		charge_sound = 'sound/items/weapons/laser_crank.ogg', \
+		charge_sound_cooldown_time = 3 SECONDS, \
+		charge_move = IGNORE_USER_LOC_CHANGE, \
+	)

--- a/modular_nova/modules/modular_weapons/code/overrides/energy_self_charge.dm
+++ b/modular_nova/modules/modular_weapons/code/overrides/energy_self_charge.dm
@@ -1,0 +1,21 @@
+// This is where we put all the overrides for energy recharge. At the moment of this change, TG default charge_delay is 8. With this they recharge 10% per what charge_delay says
+
+// disabler
+/obj/item/gun/energy/disabler
+	selfcharge = TRUE
+	charge_delay = 15
+
+// hybrid taser
+/obj/item/gun/energy/e_gun/advtaser
+	selfcharge = TRUE
+	charge_delay = 15
+
+// disabler smg
+/obj/item/gun/energy/disabler/smg
+	selfcharge = TRUE
+	charge_delay = 15
+
+// miniature energy gun
+/obj/item/gun/energy/e_gun/mini
+	selfcharge = TRUE
+	charge_delay = 15

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8662,6 +8662,8 @@
 #include "modular_nova\modules\modular_weapons\code\overrides\autolathe_designs.dm"
 #include "modular_nova\modules\modular_weapons\code\overrides\ballistic_master.dm"
 #include "modular_nova\modules\modular_weapons\code\overrides\energy.dm"
+#include "modular_nova\modules\modular_weapons\code\overrides\energy_crank.dm"
+#include "modular_nova\modules\modular_weapons\code\overrides\energy_self_charge.dm"
 #include "modular_nova\modules\modular_weapons\code\overrides\mystery_box_additions.dm"
 #include "modular_nova\modules\modular_weapons\code\overrides\suppressor_size_change_override.dm"
 #include "modular_nova\modules\modular_wt\orders.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This experiments with an idea to solve the utility and use case problems with the laser weapons. What this PR does and achieves to do is deal with the logistics problems that laser weapons face that the ballistic weapons dont have. Its not a PR that aims to balance these weapons, but rather test out different mechanics for each and then when a comfortable state is achieved, things can be balanced on these qualities.

This PR is also not touching plasma weapons, since they do have this problem solved by behaving like ballistic weapons recharge wise, in combat at least.

What This PR does is:

This only targets the weapons in the cargo imports, and it childs as colateralls, since its a proof of concept for players to get a feel of it.

- Assign to energy sidearms a self recharge factor identical to the modular energy rifles series, which is 10% of a standard charge every 15 seconds.
- To the others, ie, the carbines and up, they were given a crank feature, what it does is that you use the weapon and it will begin a 6 seconds crank process, in which you can move but cannot switch hands, when it finalizes, you get 25% of a standard charge. this process is 20% less efficient than a t1 charger, with the values of each charger being 20, 12, 10 and 8 seconds, in comparison to the 24 seconds a perfect crank would take.
- SC2, and it derivates, use the self recharge system, mostly because we dont have yet a crank mode with right click, and to make a lesser mess of it all, since the crank mode would interfere with their mode mechanic change.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Well, this aims to give energy weapons a gimmick of their own instead of being reflavored ballistics, they would stand on utility and appeal to a different player base, it would also give roles that generally dont have an access to high logistics to be able to still be relevant, as having a self or crank based charging weapon would allow for antags, cut off officers, emergency personal and assistants with some kind of firepower. 

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

I did tested it locally, it worked of course, but I feel this is the kind of change we announce and make a TM to see how the playerbase feels about it.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Gives small energy arms, and the SC2 derivates, self recharging capabilities, 10% of their charge per 15 seconds. Gives large energy arms a crank based recharge, 6 seconds of cranking for 25% of the charge, compared to a t1 recharger that takes 20 seconds to a full charge.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
