### PR TITLE
Nerf the MMRs into something resembling acceptable

### DIFF
--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/rifle.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/rifle.dm
@@ -35,12 +35,12 @@
 	suppressor_y_offset = 1
 
 	burst_size = 1
-	fire_delay = 0.2 SECONDS
+	fire_delay = 0.25 SECONDS
 	actions_types = list()
 
 	spread = 2
-	projectile_wound_bonus = 10
-	projectile_damage_multiplier = 0.75
+	projectile_wound_bonus = 0
+	projectile_damage_multiplier = 0.5
 
 	lore_blurb = "The MMR-2543 is the current standard service rifle for all branches of the Sol Federation Armed Forces.<br><br>\
 		Initially created for use by the Sagittarian Triumvirate’s military, its adoption by SolFed came a few years later. \
@@ -89,7 +89,7 @@
 
 	spawn_magazine_type = /obj/item/ammo_box/magazine/c40sol_rifle
 
-	fire_delay = 1.6 SECONDS
+	fire_delay = 0.85 SECONDS
 	burst_delay = 0.1 SECONDS
 
 	actions_types = list(/datum/action/item_action/toggle_firemode)
@@ -99,8 +99,8 @@
 
 	burst_size = 3
 	spread = 5.5
-	projectile_damage_multiplier = 1
-	projectile_wound_bonus = 3
+	projectile_damage_multiplier = 0.5
+	projectile_wound_bonus = -10
 
 	model_specific_lore = "This variant is the Infantry model, and is the primary rifle \
 		for both the SolFed Hydro Corps and Atmospheric Corps. It features excellent accuracy and durability, \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Severely throttles the damage output of some of the most drastically overperforming weapons on the station.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

The MMRs are two frankly **ludicrous** weapons capable of easily outperforming weapons wielded by assops or even the dreaded pulse rifle, which functions as an ERT unit's diagetic way to smite people at behest of the admins. The 'marksman' rifle output huge bursts of damage that would nearly instantly down you, and only had a TTK above two seconds due to an obscene fire delay strapped to it. The automatic MMR, on the other hand, was through-and-through ridiculous, sporting a TTD of **1.3**. 

These weapons are overcentralizing and completely nullify anything you point them at. We have balance problems with guns, but these weapons personified them entirely; heretics can be mowed down and redsuits frankly stepped on by a weapon that barely costs more than the starting funds.

Replacement statistics are blunt, heavily penalizing their damage output (as they fire a round intended for semi-automatic rifles in fully automatic fire) to bring it more in line with other weapons on the server, with consideration given to their very large magazine capacities and versatility.

I will admit outright: I am not entirely happy with this solution, and I would rather move the MMRs entirely and place a more fitting weapon in their stead, but this solution requires sprites I at the moment do not have. I would _like_ to simply re-use our old sprites for this purpose, or use the sprites from our cousins in Bubber and Splurt, but I have received some pushback to the idea from staff; if I had permission to use them I could get it out quite soon, but without I'm going to have to request sprites from some people.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing


https://github.com/user-attachments/assets/eac63854-9cee-4775-950d-e68789724832


https://github.com/user-attachments/assets/16952a5e-a8ff-4aeb-883b-223cb8b53a55



<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The MMRs have had their statistics heavily throttled to be in line with all other station-sided weapons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
