### PR TITLE
Adds hard-tier spacevine event, removes all old spacevine nerfs

### DIFF
--- a/code/__DEFINES/spacevines.dm
+++ b/code/__DEFINES/spacevines.dm
@@ -27,10 +27,10 @@
 #define SEVERITY_MAJOR 10
 
 /// Kudzu mutativeness is based on a scale factor * potency
-#define MUTATIVENESS_SCALE_FACTOR 0.1 // NOVA EDIT CHANGE - Original: 0.2
+#define MUTATIVENESS_SCALE_FACTOR 0.2
 
 /// Kudzu maximum mutation severity is a linear function of potency
-#define MAX_SEVERITY_LINEAR_COEFF 0.1 // NOVA EDIT CHANGE - Original: 0.15
+#define MAX_SEVERITY_LINEAR_COEFF 0.15
 #define MAX_SEVERITY_CONSTANT_TERM 10
 
 /// Additional maximum mutation severity given to kudzu spawned by a random event

--- a/code/modules/events/space_vines/vine_mutations.dm
+++ b/code/modules/events/space_vines/vine_mutations.dm
@@ -290,7 +290,7 @@
 
 	if(prob(THORN_MUTATION_CUT_PROB) && istype(crosser) && !isvineimmune(crosser))
 		var/mob/living/victim = crosser
-		victim.adjustBruteLoss(5) // NOVA EDIT CHANGE - Original: 15
+		victim.adjustBruteLoss(15)
 		to_chat(victim, span_danger("You cut yourself on the thorny vines."))
 
 /datum/spacevine_mutation/thorns/on_hit(obj/structure/spacevine/holder, mob/living/hitter, obj/item/item, expected_damage)
@@ -305,7 +305,7 @@
 
 	if(prob(THORN_MUTATION_CUT_PROB) && istype(hitter) && !isvineimmune(hitter))
 		var/mob/living/victim = hitter
-		victim.adjustBruteLoss(5) // NOVA EDIT CHANGE - Original: 15
+		victim.adjustBruteLoss(15)
 		to_chat(victim, span_danger("You cut yourself on the thorny vines."))
 
 	return expected_damage

--- a/code/modules/events/space_vines/vine_structure.dm
+++ b/code/modules/events/space_vines/vine_structure.dm
@@ -164,7 +164,7 @@
 	if(!istype(stepturf))
 		return
 
-	if(is_space_or_openspace(stepturf) || !stepturf.Enter(src))
+	if(!stepturf.Enter(src)) // NOVA EDIT lets spacevines into space, old code: if(is_space_or_openspace(stepturf) || !stepturf.Enter(src))
 		return
 	if(ischasm(stepturf) && !HAS_TRAIT(stepturf, TRAIT_CHASM_STOPPED))
 		return

--- a/modular_nova/modules/ices_events/code/ICES_event_config.dm
+++ b/modular_nova/modules/ices_events/code/ICES_event_config.dm
@@ -525,6 +525,10 @@
 	max_occurrences = 2
 	weight = MED_EVENT_FREQ
 
+/datum/round_event_control/spacevine/difficult
+	max_occurrences = 1
+	weight = LOW_EVENT_FREQ
+
 /**
  * Spiders
  *

--- a/modular_nova/modules/space_vines/venus.dm
+++ b/modular_nova/modules/space_vines/venus.dm
@@ -1,5 +1,0 @@
-/mob/living/basic/venus_human_trap/start_pulling(atom/movable/movable_target, state, force, supress_message)
-	if(isliving(movable_target))
-		to_chat(src, span_boldwarning("You cannot drag living things!"))
-		return
-	return ..()

--- a/modular_nova/modules/space_vines/vine_event.dm
+++ b/modular_nova/modules/space_vines/vine_event.dm
@@ -1,0 +1,38 @@
+/datum/round_event_control/spacevine/difficult
+	name = "Space Vines (Hard)"
+	typepath = /datum/round_event/spacevine/difficult
+	min_players = 30
+	description = "Kudzu begins to overtake the station. Will spawn man-traps."
+	admin_setup = list(
+		/datum/event_admin_setup/set_location/spacevine,
+	)
+
+/datum/round_event/spacevine/difficult
+
+/datum/round_event/spacevine/difficult/start()
+	var/list/turfs = list()
+	if(override_turf)
+		turfs += override_turf
+	else
+		var/obj/structure/spacevine/vine = new()
+		for(var/area/area in GLOB.areas)
+			if(istype(area, /area/station/hallway) || istype(area, /area/station/maintenance) || (istype(area, /area/station/solars) && !SSmapping.is_planetary()))
+				for(var/turf/open/floor in area.get_turfs_from_all_zlevels())
+					if(!isopenspaceturf(floor) && floor.Enter(vine) && (floor.get_lumcount() > LIGHTING_TILE_IS_DARK))
+						//yea ok we can spawn in maintenance now but there has to be light on the tile
+						turfs += floor
+		qdel(vine)
+
+	if(length(turfs))
+		var/turf/floor = pick(turfs)
+		new /datum/spacevine_controller(
+			floor,
+			list(
+				/datum/spacevine_mutation/flowering,
+				/datum/spacevine_mutation/light,
+				/datum/spacevine_mutation/cold_proof,
+				),
+			MAX_SEVERITY_LINEAR_COEFF,
+			MAX_POSSIBLE_PRODUCTIVITY_VALUE,
+			src,
+			)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9022,7 +9022,7 @@
 #include "modular_nova\modules\soulstone_changes\code\soulstone.dm"
 #include "modular_nova\modules\soulstone_changes\code\components\return_on_death.dm"
 #include "modular_nova\modules\space_vines\scythes.dm"
-#include "modular_nova\modules\space_vines\venus.dm"
+#include "modular_nova\modules\space_vines\vine_event.dm"
 #include "modular_nova\modules\space_vines\vine_mutations.dm"
 #include "modular_nova\modules\space_vines\vine_structure.dm"
 #include "modular_nova\modules\specialist_armor\code\cargo_packs.dm"


### PR DESCRIPTION
## About The Pull Request
Reverts old nerfs of spacevine. Adds a second spacevine event that won't mutate but will spawn man-eaters.

## How This Contributes To The Nova Sector Roleplay Experience
This antag was nerfed into a big juicy nothing-burger, a long time ago.
The server has changed since then. Lets start from the beginning and go from there.

## Proof of Testing
<img width="1344" height="959" alt="image" src="https://github.com/user-attachments/assets/ba5aa66a-1dca-49c9-a053-bdf09e4768fb" />

## Changelog
:cl:
balance: Spacevine's thorns mutation does 15 brute on touch instead of 5
balance: Spacevine's mutativeness factor and coefficient have gone up
balance: Spacevine can now into space
balance: Man-eaters can now pull living beings again
add: Difficult spacevines event, always spawns man-eaters and can appear in more places than just hallways
/:cl:
