### PR TITLE
[QOL] Burn wound name changes

### DIFF
--- a/modular_nova/modules/medical/code/wounds/burns.dm
+++ b/modular_nova/modules/medical/code/wounds/burns.dm
@@ -1,0 +1,8 @@
+// modular overrides to the names of burn wounds so that we stop confusing people by calling the first-tier burns "second-degree"
+// catastrophic (T3) burns are unchanged as the name was basically fine already
+
+/datum/wound/burn/flesh/moderate
+	name = "Superficial Burns"
+
+/datum/wound/burn/flesh/severe
+	name = "Deep Burns"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8393,6 +8393,7 @@
 #include "modular_nova\modules\medical\code\cargo\packs.dm"
 #include "modular_nova\modules\medical\code\wounds\_wounds.dm"
 #include "modular_nova\modules\medical\code\wounds\bleed.dm"
+#include "modular_nova\modules\medical\code\wounds\burns.dm"
 #include "modular_nova\modules\medical\code\wounds\medical.dm"
 #include "modular_nova\modules\medical\code\wounds\medicine_reagents.dm"
 #include "modular_nova\modules\medical\code\wounds\muscle.dm"


### PR DESCRIPTION
## About The Pull Request
This modularly renames the T1 and T2 burn wounds from "Second-Degree Burns" and "Third-Degree Burns" to "Superficial Burns" and "Deep Burns."

## How This Contributes To The Nova Sector Roleplay Experience

This has been a point of confusion for new or intermittent Medical players for a while: the T1 burns are "second-degree" and the T2 burns are "third-degree." This means a lot of people are genuinely misinformed on which burn wounds are what, a lot of folks reasonably assuming that the third-degree burns are a T3 (critical) burn wound, because, you know, third-degree, tier-three, it just makes sense.
This is really just a small QOL change that makes it easier to tell at first blush which burns are what. And QOL changes are good, I think!

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
<img width="512" height="348" alt="image" src="https://github.com/user-attachments/assets/a6294a57-1f59-46d7-b9f6-7cb5478884dc" />

</details>

## Changelog
:cl:
qol: T1 and T2 burns are now called "Superficial Burns" and "Deep Burns" respectively, so people stop getting confused by third-degree burns being the second tier of burn wounds.
/:cl:
