### PR TITLE
Removes wetstacks from the refitted wetsuit

### DIFF
--- a/modular_nova/modules/modular_items/code/wetsuit.dm
+++ b/modular_nova/modules/modular_items/code/wetsuit.dm
@@ -7,6 +7,10 @@
 	worn_icon = 'modular_nova/modules/modular_items/icons/akulasuit.dmi'
 	female_sprite_flags = FEMALE_UNIFORM_FULL
 
+/obj/item/clothing/under/akula_wetsuit/refit/Initialize(mapload)
+	. = ..()
+	qdel(GetComponent(/datum/component/wetsuit))
+
 /obj/item/clothing/under/akula_wetsuit/refit/examine(mob/user)
 	. = ..()
 	. += span_notice("You can <b>examine closer</b> to learn a little more about this item.")


### PR DESCRIPTION

## About The Pull Request
Removes the component that adds wetstacks from the refitted wetsuit
## How This Contributes To The Nova Sector Roleplay Experience
There is a specific item in the loadout selection that does the exact same thing for any suit, this component doesn't need to be on the refitted wetsuit.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: The refitted wetsuit no longer gives wetstacks, use the stardress hydro-vaporizer suit accessory if you want wetstacks.
/:cl:
