### PR TITLE
Adds a tally of joinable soulcatchers to ghost's hud

### DIFF
--- a/code/__DEFINES/~nova_defines/signals.dm
+++ b/code/__DEFINES/~nova_defines/signals.dm
@@ -92,6 +92,9 @@
 /// Whenever we need to get the soul of the mob inside of the soulcatcher.
 #define COMSIG_SOULCATCHER_SCAN_BODY "soulcatcher_scan_body"
 
+/// When a soulcatcher room's joinability is updated by opening the room, closing the room, allowing ghosts, etc
+#define COMSIG_SOULCATCHER_UPDATE_JOINABILITY "soulcatcher_update_joinability"
+
 /// Whenever a baton successfully executes its nonlethal attack. WARNING HORRIBLE FUCKING CODE THIS IS ASS AAAAAAAAAAAAH
 #define COMSIG_PRE_BATON_FINALIZE_ATTACK "pre_baton_finalize_attack"
 

--- a/modular_nova/modules/modular_implants/code/soulcatcher/soulcatcher_tgui.dm
+++ b/modular_nova/modules/modular_implants/code/soulcatcher/soulcatcher_tgui.dm
@@ -119,6 +119,7 @@
 
 		if("toggle_joinable")
 			ghost_joinable = !ghost_joinable
+			send_joinability_signal()
 			return TRUE
 
 		if("toggle_approval")
@@ -245,6 +246,11 @@
 
 			remove_self()
 			return TRUE
+
+/datum/component/soulcatcher/proc/send_joinability_signal()
+	var/list/all_observers = GLOB.dead_player_list + GLOB.current_observers_list
+	for(var/mob/observer as anything in all_observers)
+		SEND_SIGNAL(observer, COMSIG_SOULCATCHER_UPDATE_JOINABILITY)
 
 /datum/component/soulcatcher_user/New()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Adds an overlay to the ghost hud's soulcatcher element that tallies joinable soulcatchers.

## How This Contributes To The Nova Sector Roleplay Experience

Pulls eyes to an underused gameplay element.

## Proof of Testing

https://github.com/user-attachments/assets/8a65d0c4-0161-4da4-93e1-2cc96d930c99

## Changelog

:cl:
qol: The 'Enter Soulcatcher' button on the ghost hud now has a live tally of joinable soulcatchers
/:cl:

