### PR TITLE
[QOL] Improves Shelf and Rack Interactions + Crafting Menu Additions

### DIFF
--- a/modular_nova/master_files/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/modular_nova/master_files/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -29,6 +29,8 @@ GLOBAL_LIST_INIT(nova_metal_recipes, list(
 	new/datum/stack_recipe("elevated floor tile", /obj/item/stack/tile/iron/elevated, 1, 4, 20, category = CAT_TILES),
 	new/datum/stack_recipe("wrestling turnbuckle", /obj/structure/wrestling_corner, 3, time = 2.5 SECONDS, crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ONE_PER_TURF | CRAFT_ON_SOLID_GROUND, category = CAT_STRUCTURE),
 	new/datum/stack_recipe("metal barricade", /obj/structure/deployable_barricade/metal, 2, time = 1 SECONDS, crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ON_SOLID_GROUND | CRAFT_CHECK_DIRECTION, category = CAT_STRUCTURE),
+	new/datum/stack_recipe("gun rack", /obj/structure/rack/gunrack, 1, time = 2 SECONDS, crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ONE_PER_TURF | CRAFT_ON_SOLID_GROUND, category = CAT_STRUCTURE),
+	new/datum/stack_recipe("gun locker", /obj/structure/guncase, 5, time = 2 SECONDS, crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ONE_PER_TURF | CRAFT_ON_SOLID_GROUND, category = CAT_STRUCTURE),
 	new/datum/stack_recipe("metal shelf", /obj/structure/rack/shelf, 1, time = 2 SECONDS, crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ONE_PER_TURF | CRAFT_ON_SOLID_GROUND, category = CAT_STRUCTURE),
 	new/datum/stack_recipe("anvil", /obj/structure/reagent_anvil, 10, time = 2 SECONDS, crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ONE_PER_TURF | CRAFT_ON_SOLID_GROUND, category = CAT_TOOLS),
 	new/datum/stack_recipe("forge", /obj/structure/reagent_forge, 10, time = 2 SECONDS, crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ONE_PER_TURF | CRAFT_ON_SOLID_GROUND, category = CAT_TOOLS),

--- a/modular_nova/modules/aesthetics/rack/code/rack.dm
+++ b/modular_nova/modules/aesthetics/rack/code/rack.dm
@@ -6,3 +6,50 @@
 	desc = "A shelf, for storing things on. Conveinent!"
 	icon = 'modular_nova/modules/aesthetics/rack/icons/rack.dmi'
 	icon_state = "shelf"
+
+/obj/structure/rack/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+    . = ..()
+    if(.)
+        return .
+
+    if(isnull(held_item))
+        return NONE
+
+    // Add tooltips if the item is not a wrench (wrenches handled by parent)
+    if(held_item.tool_behaviour != TOOL_WRENCH)
+        context[SCREENTIP_CONTEXT_LMB] = "Precise placement"
+        context[SCREENTIP_CONTEXT_RMB] = "Center item"
+        . = CONTEXTUAL_SCREENTIP_SET
+
+    return . || NONE
+
+
+/obj/structure/rack/base_item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+    . = ..()
+    if(.)
+        return .
+
+    if((tool.item_flags & ABSTRACT) || (user.combat_mode && !(tool.item_flags & NOBLUDGEON)))
+        return NONE
+
+    // Right-click to center item unless it's a wrench (similar to table code which uses the same code)
+    if(LAZYACCESS(modifiers, RIGHT_CLICK))
+        if(tool.tool_behaviour == TOOL_WRENCH)
+            return NONE
+
+        if(user.transfer_item_to_turf(tool, get_turf(src), silent = FALSE))
+            return ITEM_INTERACT_SUCCESS
+
+        return ITEM_INTERACT_BLOCKING
+
+    // Left-click to do pixel-perfect placement
+    var/x_offset = 0
+    var/y_offset = 0
+    if(LAZYACCESS(modifiers, ICON_X) && LAZYACCESS(modifiers, ICON_Y))
+        x_offset = clamp(text2num(LAZYACCESS(modifiers, ICON_X)) - 16, -(ICON_SIZE_X * 0.5), ICON_SIZE_X * 0.5)
+        y_offset = clamp(text2num(LAZYACCESS(modifiers, ICON_Y)) - 16, -(ICON_SIZE_Y * 0.5), ICON_SIZE_Y * 0.5)
+
+    if(user.transfer_item_to_turf(tool, get_turf(src), x_offset, y_offset, silent = FALSE))
+        return ITEM_INTERACT_SUCCESS
+
+    return ITEM_INTERACT_BLOCKING


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Shelves and racks before forced items to be centered when clicked on or placed in any interaction. This PR allows players to be able to place items with more precision so that items actually look like they're on a shelf.

## How This Contributes To The Nova Sector Roleplay Experience

It felt really odd that shelves despite having a sprite for each row were basically unused. This PR seeks to fix this issue and allow for more personalization within shelfs (Roboticists and Medical players can rejoice, I've seen your setups). 

You can still center the items if you wanted to with right click (more below). Added tooltips to avoid confusion. I also double checked to make sure tool interaction would still work as intended (wrenching to deconstruct iron shelves, crowbar for wooden ones).

Also, gun lockers and gun racks can be crafted with iron now. 1 iron for the gun rack, 5 for the gun closet. I did this mostly for Security and Black Market Dealers.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
<img width="310" height="200" alt="image" src="https://github.com/user-attachments/assets/946aedd6-1a5a-49e6-bea3-bc9077ea8161" />
<img width="388" height="93" alt="image" src="https://github.com/user-attachments/assets/1a63c426-5279-40d9-a099-a40b2fb0c3be" />


A little more messy (from a vertical perspective) but still, point was for personalization and this achieves it.
<img width="84" height="285" alt="image" src="https://github.com/user-attachments/assets/b94ca334-8a9d-410e-a3ec-9530ac37d3fb" />

Examples of centered items
<img width="256" height="110" alt="image" src="https://github.com/user-attachments/assets/7e74ce30-78fa-4d74-9e8d-4bde27fd64d6" />

Deconstruction does not interrupt the new behavior, it functions as is (shows when you're just holding a wrench/crowbar).
<img width="221" height="80" alt="image" src="https://github.com/user-attachments/assets/812136e2-fd24-4836-a44a-c528e3cd192a" />


The gun rack and gun locker (with the radial menu of the locker functioning)
<img width="261" height="231" alt="image" src="https://github.com/user-attachments/assets/c1df3707-eb9f-4180-88fd-6846cc4d90e9" />

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:BasilTamaya
add: The gun rack + gun locker can now be crafted with iron.
qol: Shelves and racks now function differently; left click to place an item precisely, right click to place into the center (default behaviour). Tooltips have been added to avoid confusion.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
