### PR TITLE
Assorted Voidraptor map cleanup

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -209,11 +209,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/effect/turf_decal/trimline/dark_red/filled/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
@@ -439,8 +439,11 @@
 	dir = 8
 	},
 /obj/structure/sign/flag/terragov/directional/north,
-/turf/open/floor/iron/airless{
-	icon_state = "dark_large"
+/obj/effect/turf_decal/tile/neutral/anticorner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_corner/airless{
+	dir = 8
 	},
 /area/space/nearstation)
 "agC" = (
@@ -1300,7 +1303,8 @@
 	pixel_x = 32
 	},
 /obj/machinery/light/cold/directional/east,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "asQ" = (
 /obj/structure/easel,
@@ -1530,6 +1534,12 @@
 /area/station/service/chapel)
 "awh" = (
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
 /turf/open/floor/carpet/cyan,
 /area/station/commons/dorms)
 "awj" = (
@@ -1596,7 +1606,8 @@
 "axd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "axe" = (
 /obj/structure/chair/office,
@@ -1918,7 +1929,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/structure/cable/layer3,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "aBc" = (
 /obj/structure/cable,
@@ -1994,7 +2006,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/sign/poster/random/directional/north,
+/obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/central)
 "aCq" = (
@@ -2401,6 +2413,7 @@
 "aKT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
 "aKU" = (
@@ -2575,9 +2588,6 @@
 	},
 /area/station/security/brig)
 "aMy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -2670,7 +2680,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "aNj" = (
 /turf/closed/wall/mineral/wood,
@@ -2713,7 +2724,8 @@
 /area/station/command/heads_quarters/hop)
 "aNH" = (
 /obj/structure/cable,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "aNJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2967,7 +2979,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/directional/west{
-	c_tag = "Cargo Bay - Delivery Office Port";
+	c_tag = "Cargo - Delivery Office Port";
 	name = "cargo camera"
 	},
 /obj/structure/window/reinforced/spawner/directional/east{
@@ -4044,7 +4056,13 @@
 /area/station/security/lockers)
 "bfi" = (
 /obj/structure/table/wood,
-/obj/item/documents/syndicate,
+/obj/item/folder/ancient_paperwork{
+	pixel_x = 6
+	},
+/obj/item/folder/ancient_paperwork{
+	pixel_y = -1;
+	pixel_x = -5
+	},
 /turf/open/floor/wood,
 /area/station/maintenance/rus_gambling)
 "bfB" = (
@@ -4153,20 +4171,13 @@
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
 "bie" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 8;
-	name = "killroom vent"
-	},
-/obj/effect/turf_decal/weather/snow,
-/turf/open/floor/iron/dark/telecomms,
+/turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
 "bik" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
-/obj/machinery/camera/directional/south{
-	dir = 5
-	},
+/obj/machinery/camera/directional/south,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "bip" = (
@@ -4225,7 +4236,6 @@
 /turf/open/floor/iron,
 /area/station/service/bar)
 "bjI" = (
-/obj/machinery/camera/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/textured_large,
@@ -4234,13 +4244,15 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "bjS" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /obj/machinery/holopad/secure,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "bka" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4730,6 +4742,9 @@
 	pixel_y = 4
 	},
 /obj/machinery/light/warm/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "bsr" = (
@@ -5308,7 +5323,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "bBk" = (
 /obj/machinery/smartfridge,
@@ -5528,7 +5544,8 @@
 "bES" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad/secure,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "bFv" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
@@ -5554,7 +5571,6 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/rd)
 "bFT" = (
-/obj/machinery/vending/medical,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
@@ -5564,6 +5580,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/cold/directional/west,
+/obj/machinery/photocopier/prebuilt,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
@@ -6608,7 +6625,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat/service)
 "bYe" = (
 /obj/effect/landmark/start/security_officer,
@@ -6751,7 +6769,8 @@
 /area/station/maintenance/department/medical/central)
 "caG" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "caK" = (
 /obj/machinery/camera/directional/west{
@@ -7609,7 +7628,8 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/smes/super/full,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "cog" = (
 /obj/machinery/light/floor,
@@ -7820,7 +7840,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/cyborg,
 /obj/structure/cable,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "cqK" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -8006,12 +8027,10 @@
 	},
 /area/station/science/robotics/lab)
 "cut" = (
-/obj/effect/turf_decal/tile/blue/full,
-/turf/open/floor/iron/airless{
-	icon = 'modular_nova/modules/advanced_shuttles/icons/erokez.dmi';
-	icon_state = "floor1"
-	},
-/area/space/nearstation)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/photocopier/prebuilt,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/port/central)
 "cuA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -8434,9 +8453,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/window/reinforced/spawner/directional/west{
-	pixel_x = -4
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
@@ -9294,11 +9310,11 @@
 	},
 /area/station/hallway/secondary/command)
 "cOf" = (
-/turf/open/floor/iron/airless{
-	icon = 'modular_nova/modules/advanced_shuttles/icons/erokez.dmi';
-	icon_state = "floor1"
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
 	},
-/area/space/nearstation)
+/turf/open/floor/carpet,
+/area/station/commons/dorms)
 "cOi" = (
 /obj/structure/sign/gym/right{
 	pixel_y = 32
@@ -9405,7 +9421,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/camera/directional/east{
-	c_tag = "Research Division - Starboard";
+	c_tag = "Science - Starboard";
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -9420,7 +9436,8 @@
 "cPS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat/service)
 "cPU" = (
 /obj/item/radio/intercom/directional/north{
@@ -9468,11 +9485,6 @@
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "cQn" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Atmospherics - Project Room Fore";
-	dir = 5;
-	name = "atmospherics camera"
-	},
 /obj/effect/turf_decal/bot,
 /obj/structure/table,
 /obj/item/multitool,
@@ -9542,10 +9554,6 @@
 "cRT" = (
 /obj/machinery/computer/exoscanner_control{
 	dir = 1
-	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Cargo Bay - Drone Launch Room";
-	pixel_x = 14
 	},
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/effect/turf_decal/trimline/brown/filled/line,
@@ -9734,7 +9742,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "cVe" = (
 /obj/effect/turf_decal/stripes/line,
@@ -9864,7 +9873,6 @@
 	dir = 6
 	},
 /obj/structure/trash_pile,
-/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/bitrunning/den)
 "cXX" = (
@@ -9976,8 +9984,11 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/iron/airless{
-	icon_state = "dark_large"
+/obj/effect/turf_decal/tile/neutral/anticorner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_corner/airless{
+	dir = 4
 	},
 /area/space/nearstation)
 "cZv" = (
@@ -10044,7 +10055,7 @@
 /area/station/maintenance/aft/greater)
 "dap" = (
 /obj/structure/fireplace,
-/turf/open/floor/carpet/cyan,
+/turf/open/floor/stone,
 /area/station/commons/dorms)
 "dar" = (
 /obj/machinery/disposal/bin,
@@ -10249,7 +10260,7 @@
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/stripes/white/box,
 /obj/effect/turf_decal/bot_red,
-/turf/open/floor/vault,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "dcB" = (
 /obj/structure/disposalpipe/junction/flip{
@@ -10850,14 +10861,15 @@
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "dkU" = (
-/obj/machinery/door/window/left/directional/south{
-	critical_machine = 1;
-	name = "Kill Chamber";
-	req_access = list("xenobiology")
+/obj/machinery/door/airlock/research{
+	name = "Slime Euthanization Chamber";
+	opacity = 0;
+	glass = 1
 	},
-/obj/effect/turf_decal/weather/snow,
+/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/plasticflaps/kitchen,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/iron/dark/telecomms,
+/turf/open/floor/iron,
 /area/station/science/xenobiology)
 "dkX" = (
 /obj/effect/turf_decal/vg_decals/department/hop{
@@ -11229,6 +11241,9 @@
 /obj/effect/spawner/liquids_spawner{
 	reagent_list = list(/datum/reagent/water=600)
 	},
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/misc/asteroid,
 /area/station/medical/medbay/lobby)
 "dri" = (
@@ -11617,7 +11632,7 @@
 /area/station/construction/mining/aux_base)
 "dwg" = (
 /obj/machinery/camera/directional/east{
-	c_tag = "Cargo Bay - Delivery Office Starboard";
+	c_tag = "Cargo - Delivery Office Starboard";
 	name = "cargo camera"
 	},
 /obj/effect/turf_decal/tile/red/half,
@@ -11815,7 +11830,8 @@
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/stripes/white/box,
 /obj/effect/turf_decal/bot_red,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "dzp" = (
 /obj/structure/window/spawner/directional/south,
@@ -12753,6 +12769,10 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
+/obj/machinery/microwave{
+	desc = "Cooks and boils stuff, somehow.";
+	pixel_x = -2
+	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/starboard/greater)
 "dLo" = (
@@ -13060,7 +13080,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "dPm" = (
 /obj/structure/table,
@@ -13561,9 +13582,8 @@
 /area/station/service/library)
 "dWs" = (
 /obj/item/banner/command/mundane,
-/turf/open/floor/iron/airless{
-	icon_state = "dark_large"
-	},
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/textured_large/airless,
 /area/space/nearstation)
 "dWt" = (
 /obj/structure/rack,
@@ -13887,7 +13907,8 @@
 	pixel_x = -32
 	},
 /obj/machinery/light/cold/directional/west,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai)
 "eak" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14000,11 +14021,7 @@
 	department = "Kitchen";
 	name = "Kitchen Requests Console"
 	},
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -2;
-	pixel_y = 5
-	},
+/obj/machinery/microwave,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "ecq" = (
@@ -14313,14 +14330,9 @@
 /turf/open/floor/iron/half,
 /area/station/hallway/primary/central)
 "efz" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/effect/turf_decal/weather/snow,
-/obj/machinery/camera/directional/east{
-	c_tag = "Xenobiology - Euthanasia Chamber";
-	network = list("ss13","rd","xeno")
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/science/xenobiology)
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/department/science/xenobiology)
 "efH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14904,6 +14916,9 @@
 /obj/structure/bed/double,
 /obj/effect/spawner/random/bedsheet/any/double,
 /obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "enJ" = (
@@ -14937,7 +14952,8 @@
 /obj/effect/turf_decal/stripes/white/box,
 /obj/structure/sign/departments/aisat/directional/west,
 /obj/machinery/light/cold/directional/west,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "enW" = (
 /turf/closed/wall/r_wall,
@@ -15383,7 +15399,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/cyborg,
 /obj/structure/cable,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "evR" = (
 /obj/structure/cable,
@@ -15646,7 +15663,8 @@
 "eza" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/bluespace_beacon,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/service)
 "eze" = (
 /obj/structure/cable,
@@ -16425,7 +16443,8 @@
 	pixel_x = 32
 	},
 /obj/machinery/light/cold/directional/east,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai)
 "eJY" = (
 /obj/structure/flora/ocean/coral,
@@ -16682,9 +16701,8 @@
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
 "eNH" = (
-/turf/open/floor/iron/airless{
-	icon = 'modular_nova/modules/advanced_shuttles/icons/evac_shuttle.dmi'
-	},
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large/airless,
 /area/space/nearstation)
 "eNJ" = (
 /obj/machinery/airalarm/directional/north,
@@ -17077,7 +17095,7 @@
 	dir = 1
 	},
 /obj/structure/sign/directions/evac/directional/east{
-	dir = 8;
+	dir = 1;
 	pixel_y = -8
 	},
 /turf/open/floor/iron/smooth_large,
@@ -17424,7 +17442,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "eYK" = (
 /obj/machinery/door/airlock/maintenance{
@@ -17899,7 +17918,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "fhi" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -18175,7 +18195,6 @@
 	critical_machine = 1;
 	name = "Medical Freezer"
 	},
-/obj/structure/fans/tiny,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -18246,9 +18265,6 @@
 "fmM" = (
 /obj/structure/table/reinforced/rglass,
 /obj/machinery/door/firedoor,
-/obj/structure/window/reinforced/spawner/directional/south{
-	pixel_y = -4
-	},
 /obj/item/reagent_containers/cup/bottle/multiver{
 	pixel_x = 6
 	},
@@ -18655,6 +18671,9 @@
 /obj/effect/spawner/random/bedsheet/any/double,
 /obj/machinery/newscaster/directional/east,
 /obj/structure/bed/double/pod,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
 /turf/open/floor/carpet/cyan,
 /area/station/commons/dorms)
 "fst" = (
@@ -19030,7 +19049,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
 "fyP" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -19536,7 +19556,8 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/multitool,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
 "fHl" = (
 /obj/structure/table/wood/fancy,
@@ -19571,7 +19592,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_red/filled/corner{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/telecomms,
@@ -19901,7 +19922,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/layer3,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "fOq" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -20061,6 +20083,13 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/commons/dorms)
+"fQX" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8;
+	name = "killroom vent"
+	},
+/turf/open/floor/circuit/telecomms,
+/area/station/science/xenobiology)
 "fRf" = (
 /turf/open/floor/carpet/blue,
 /area/station/command/bridge)
@@ -20609,6 +20638,7 @@
 /area/station/medical/virology)
 "fZt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "fZv" = (
@@ -21162,7 +21192,8 @@
 "gil" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "git" = (
 /obj/machinery/airalarm/directional/west,
@@ -21950,7 +21981,8 @@
 	name = "AI Core Shutters"
 	},
 /obj/machinery/newscaster/directional/north,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "gsU" = (
 /turf/closed/wall,
@@ -22158,7 +22190,8 @@
 /obj/effect/landmark/start/cyborg,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable/layer3,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "gvt" = (
 /obj/machinery/disposal/bin,
@@ -23691,6 +23724,9 @@
 /obj/effect/turf_decal/trimline/white/mid_joiner{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "gQK" = (
@@ -25053,7 +25089,8 @@
 	dir = 8
 	},
 /obj/effect/landmark/navigate_destination/aiupload,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "hkh" = (
 /obj/structure/cable,
@@ -25555,6 +25592,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 5
 	},
+/obj/structure/sign/departments/exam_room/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "htz" = (
@@ -25616,7 +25654,8 @@
 /obj/structure/transit_tube/station/dispenser/reverse/flipped{
 	dir = 8
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "hut" = (
 /obj/effect/decal/cleanable/dirt,
@@ -26053,7 +26092,8 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/service)
 "hzT" = (
 /obj/effect/turf_decal/trimline/green/line{
@@ -26375,7 +26415,8 @@
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Teleporter"
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/service)
 "hDf" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -26502,10 +26543,8 @@
 /obj/structure/transit_tube/horizontal{
 	dir = 1
 	},
-/turf/open/floor/iron/airless{
-	icon = 'modular_nova/modules/advanced_shuttles/icons/erokez.dmi';
-	icon_state = "floor1"
-	},
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large/airless,
 /area/space/nearstation)
 "hEJ" = (
 /obj/structure/table,
@@ -27217,7 +27256,8 @@
 "hRb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
 "hRe" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
@@ -27571,7 +27611,7 @@
 /area/station/commons/vacant_room/office)
 "hUI" = (
 /obj/effect/turf_decal/tile/blue/diagonal_centre,
-/obj/structure/sign/poster/random/directional/south,
+/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/central)
 "hUR" = (
@@ -27586,6 +27626,9 @@
 /area/station/hallway/primary/fore)
 "hUZ" = (
 /obj/structure/bookcase/random/fiction,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
 "hVk" = (
@@ -27940,7 +27983,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/directional/east{
-	c_tag = "Cargo Bay - Starboard";
+	c_tag = "Cargo - Docking Bay";
 	name = "cargo camera"
 	},
 /obj/effect/turf_decal/bot,
@@ -30031,9 +30074,8 @@
 /area/station/hallway/secondary/entry)
 "iEJ" = (
 /obj/effect/turf_decal/weather/snow,
-/obj/machinery/camera/directional/west{
+/obj/machinery/camera/directional/south{
 	c_tag = "Service - Kitchen Coldroom";
-	dir = 5;
 	name = "service camera"
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
@@ -30609,9 +30651,8 @@
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/medbay/lobby)
 "iNU" = (
-/turf/open/floor/iron/airless{
-	icon_state = "dark_large"
-	},
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/textured_large/airless,
 /area/space/nearstation)
 "iNV" = (
 /turf/closed/wall,
@@ -30714,7 +30755,7 @@
 	req_access = list("ai_upload")
 	},
 /obj/structure/cable,
-/turf/open/floor/vault,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai)
 "iPJ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
@@ -31145,6 +31186,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Cargo - Drone Launch Room"
+	},
 /turf/open/floor/iron/smooth_edge{
 	dir = 8
 	},
@@ -31182,6 +31226,9 @@
 /area/station/commons/dorms/laundry)
 "iWk" = (
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "iWn" = (
@@ -31342,7 +31389,8 @@
 /area/station/engineering/atmos/storage/gas)
 "iXW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "iXY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -31614,7 +31662,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/layer3,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "jbg" = (
 /obj/machinery/mass_driver/chapelgun,
@@ -31827,7 +31876,8 @@
 /obj/effect/turf_decal/stripes/white/box,
 /obj/structure/sign/departments/aisat/directional/east,
 /obj/machinery/light/cold/directional/east,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "jfq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32133,8 +32183,8 @@
 /turf/open/floor/plating,
 /area/station/medical/chemistry)
 "jji" = (
-/obj/structure/sign/poster/contraband/crocin_pool/directional/south,
 /obj/effect/spawner/liquids_spawner,
+/obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/iron/pool,
 /area/station/common/pool)
 "jjw" = (
@@ -32310,7 +32360,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/engineering/tracking_beacon,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "jlN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32529,10 +32580,10 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen/abandoned)
 "jpF" = (
-/obj/effect/turf_decal/trimline/dark_red/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "jpG" = (
@@ -32548,9 +32599,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 6
-	},
-/obj/structure/window/reinforced/spawner/directional/east{
-	pixel_x = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -32673,6 +32721,9 @@
 /area/station/medical/medbay/lobby)
 "jrn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/carpet/cyan,
 /area/station/commons/dorms)
 "jrq" = (
@@ -32869,6 +32920,9 @@
 /obj/effect/spawner/liquids_spawner{
 	reagent_list = list(/datum/reagent/water=600)
 	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/misc/asteroid,
 /area/station/medical/medbay/lobby)
 "jtH" = (
@@ -33036,7 +33090,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "jvr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33320,6 +33375,9 @@
 /obj/machinery/light/warm/directional/west,
 /obj/item/folder,
 /obj/item/razor,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /turf/open/floor/carpet/cyan,
 /area/station/commons/dorms)
 "jzM" = (
@@ -33508,6 +33566,9 @@
 	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "jBY" = (
@@ -33517,7 +33578,8 @@
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/stripes/white/box,
 /obj/effect/turf_decal/bot_red,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "jCo" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -33778,7 +33840,8 @@
 	name = "AI Core Shutters"
 	},
 /obj/machinery/newscaster/directional/north,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "jEG" = (
 /obj/machinery/power/shuttle_engine/propulsion,
@@ -35643,9 +35706,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/firealarm/directional/south,
-/obj/machinery/camera/directional/south{
-	dir = 5
-	},
+/obj/machinery/camera/directional/south,
 /turf/open/floor/iron/smooth_edge{
 	dir = 1
 	},
@@ -36782,7 +36843,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "kxD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37507,7 +37569,6 @@
 	name = "Server Access"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/structure/fans/tiny,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -37646,7 +37707,8 @@
 	id = "AI Core shutters";
 	name = "AI Core Shutters"
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "kHq" = (
 /obj/structure/cable,
@@ -37746,7 +37808,6 @@
 	name = "Coldroom"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/structure/fans/tiny,
 /obj/structure/cable,
 /obj/structure/plasticflaps/kitchen,
 /turf/open/floor/iron/freezer,
@@ -37883,6 +37944,9 @@
 	},
 /obj/effect/turf_decal/trimline/white/mid_joiner,
 /obj/effect/turf_decal/trimline/white/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/end{
 	dir = 1
 	},
 /turf/open/floor/carpet/cyan,
@@ -38343,8 +38407,8 @@
 /area/station/command/heads_quarters/captain/private)
 "kRg" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/surgery_tray/full,
 /obj/machinery/status_display/evac/directional/south,
+/obj/effect/spawner/surgery_tray/full/morgue,
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
@@ -38513,7 +38577,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "kTZ" = (
 /obj/structure/table,
@@ -39096,6 +39161,9 @@
 /area/station/security/checkpoint/medical)
 "lbM" = (
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
 "lbP" = (
@@ -40187,6 +40255,7 @@
 	name = "medical camera";
 	network = list("ss13","medical")
 	},
+/obj/machinery/vending/medical,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "lri" = (
@@ -40916,7 +40985,8 @@
 /area/station/engineering/main)
 "lBW" = (
 /obj/item/kirbyplants/random,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "lCb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -41015,7 +41085,8 @@
 "lDe" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/service)
 "lDm" = (
 /obj/structure/cable,
@@ -43881,7 +43952,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai)
 "mqB" = (
 /obj/effect/turf_decal/siding/wood,
@@ -44281,11 +44353,8 @@
 	},
 /area/station/science/research)
 "mxQ" = (
-/obj/effect/turf_decal/weather/snow,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/telecomms,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
 "mym" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -44329,7 +44398,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "mzb" = (
 /obj/structure/cable,
@@ -46154,7 +46224,7 @@
 /obj/machinery/light_switch/directional/east,
 /obj/item/kirbyplants/monkey,
 /obj/machinery/camera/directional/east{
-	c_tag = "Research Division - Circuits Lab";
+	c_tag = "Science - Circuits Lab";
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -46415,7 +46485,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/camera/directional/south{
 	c_tag = "Atmospherics - Project Room Fore";
-	dir = 5;
 	name = "atmospherics camera"
 	},
 /turf/open/floor/iron/dark/smooth_large,
@@ -46731,9 +46800,6 @@
 /turf/closed/wall/r_wall/rust,
 /area/station/engineering/atmos)
 "nhi" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	pixel_x = 4
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
@@ -47125,6 +47191,9 @@
 "nlu" = (
 /obj/structure/dresser,
 /obj/machinery/newscaster/directional/east,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "nlz" = (
@@ -47140,7 +47209,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/toy/talking/ai,
 /obj/structure/cable/layer3,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "nlO" = (
 /obj/structure/railing{
@@ -47813,7 +47883,8 @@
 	dir = 8
 	},
 /obj/item/toy/talking/ai,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "nvL" = (
 /turf/open/floor/wood/large,
@@ -47950,10 +48021,7 @@
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
 	},
-/turf/open/floor/iron/airless{
-	icon = 'modular_nova/modules/advanced_shuttles/icons/erokez.dmi';
-	icon_state = "floor1"
-	},
+/turf/open/floor/iron/dark/smooth_large/airless,
 /area/space/nearstation)
 "nxn" = (
 /obj/machinery/door/airlock/rd{
@@ -48023,7 +48091,8 @@
 	name = "motion-sensitive ai camera";
 	network = list("aiupload")
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "nyb" = (
 /obj/effect/spawner/random/trash/moisture_trap,
@@ -48598,6 +48667,11 @@
 	},
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/bot_red,
+/obj/machinery/camera/directional/south{
+	c_tag = "Medbay - Pharmacy";
+	name = "medbay camera";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/pharmacy)
 "nIK" = (
@@ -49061,7 +49135,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "nPl" = (
 /obj/effect/landmark/start/captain,
@@ -49173,6 +49248,9 @@
 /obj/structure/bed/double,
 /obj/effect/spawner/random/bedsheet/any/double,
 /obj/machinery/newscaster/directional/east,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
 "nQj" = (
@@ -49248,6 +49326,9 @@
 /area/station/engineering/atmos)
 "nQY" = (
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 1
+	},
 /turf/open/floor/carpet/cyan,
 /area/station/commons/dorms)
 "nRd" = (
@@ -49347,10 +49428,6 @@
 /area/station/science/xenobiology)
 "nRS" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_x = 4;
-	pixel_y = 18
-	},
 /obj/item/reagent_containers/cup/beaker{
 	pixel_x = -8;
 	pixel_y = 12
@@ -49358,6 +49435,10 @@
 /obj/item/reagent_containers/cup/beaker{
 	pixel_x = -8;
 	pixel_y = 4
+	},
+/obj/machinery/reagentgrinder{
+	pixel_x = 6;
+	pixel_y = 6
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
@@ -49636,7 +49717,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "nUN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -51762,7 +51844,7 @@
 /obj/machinery/monkey_recycler,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/bot_red,
-/obj/structure/sign/poster/contraband/arc_slimes/directional/south,
+/obj/structure/sign/xenobio_guide/directional/south,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -52050,7 +52132,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "oEC" = (
@@ -53179,10 +53261,10 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/lab)
 "oVa" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/smooth_edge{
 	dir = 1
 	},
@@ -53219,6 +53301,9 @@
 	pixel_y = 5
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
 "oVv" = (
@@ -53245,7 +53330,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/directional/north{
-	c_tag = "Research Division - Port";
+	c_tag = "Science - Port";
 	dir = 9;
 	name = "science camera";
 	network = list("ss13","rd")
@@ -53811,6 +53896,9 @@
 "pcI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "pcK" = (
@@ -53860,10 +53948,19 @@
 	},
 /area/station/hallway/secondary/command)
 "pdg" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/effect/turf_decal/weather/snow,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/science/xenobiology)
+/obj/item/reagent_containers/cup/bottle/epinephrine,
+/obj/item/reagent_containers/cup/bottle/multiver{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/syringe,
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/left/directional/north{
+	name = "Medbay Front Desk";
+	req_access = list("medical")
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/medbay/lobby)
 "pdh" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -53895,7 +53992,7 @@
 	dir = 5
 	},
 /obj/machinery/processor{
-	pixel_y = 12
+	pixel_y = 6
 	},
 /obj/structure/railing,
 /turf/open/floor/iron/kitchen,
@@ -54659,7 +54756,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "png" = (
 /obj/machinery/computer/holodeck{
@@ -55014,6 +55112,9 @@
 "psR" = (
 /obj/structure/sign/poster/contraband/random/directional/east,
 /obj/structure/table,
+/obj/machinery/camera/directional/east{
+	c_tag = "Cargo - Bitrunning Den"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/bitrunning/den)
 "psS" = (
@@ -55761,8 +55862,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/poster/random/directional/south,
 /obj/machinery/light/directional/south,
+/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/central)
 "pDg" = (
@@ -56978,11 +57079,11 @@
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/rd)
 "pWe" = (
-/obj/structure/sign/poster/random/directional/north,
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/sign/poster/contraband/clown/directional/north,
 /turf/open/floor/iron/large,
 /area/station/hallway/secondary/service)
 "pWf" = (
@@ -58441,7 +58542,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai)
 "qmI" = (
 /obj/machinery/flasher/directional/south{
@@ -59080,6 +59182,9 @@
 /obj/structure/table/wood,
 /obj/item/food/grown/poppy/lily,
 /obj/machinery/light/warm/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
 "qxc" = (
@@ -59635,7 +59740,8 @@
 	name = "Tertiary AI Core Acces Door";
 	req_access = list("ai_upload")
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai)
 "qEL" = (
 /obj/structure/disposalpipe/segment{
@@ -59690,7 +59796,8 @@
 	c_tag = "AI Chamber - Entrance";
 	network = list("aicore")
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "qFH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -59875,7 +59982,8 @@
 "qIb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/item/kirbyplants/random,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "qIf" = (
 /obj/effect/turf_decal/siding/wood,
@@ -61035,6 +61143,9 @@
 	name = "Dormitory Door Lock";
 	normaldoorcontrol = 1;
 	specialfunctions = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
 	},
 /turf/open/floor/carpet/cyan,
 /area/station/commons/dorms)
@@ -63399,9 +63510,7 @@
 /obj/structure/sign/poster/official/periodic_table/directional/north,
 /obj/machinery/light/cold/directional/north,
 /obj/structure/table/reinforced/rglass,
-/obj/machinery/reagentgrinder{
-	pixel_y = 7
-	},
+/obj/machinery/reagentgrinder,
 /obj/item/ph_booklet{
 	pixel_x = -7;
 	pixel_y = -2
@@ -64127,7 +64236,8 @@
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai)
 "rTu" = (
 /obj/structure/sign/departments/evac,
@@ -64304,6 +64414,9 @@
 	},
 /area/station/engineering/atmos)
 "rUQ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
 "rUS" = (
@@ -65120,7 +65233,8 @@
 /area/station/cargo/drone_bay)
 "shM" = (
 /obj/structure/closet/crate/bin,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "shV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -65274,9 +65388,7 @@
 "skL" = (
 /obj/effect/turf_decal/tile/blue/full,
 /obj/structure/sign/flag/nanotrasen/directional/north,
-/turf/open/floor/iron/airless{
-	icon_state = "dark_large"
-	},
+/turf/open/floor/iron/dark/smooth_large/airless,
 /area/space/nearstation)
 "skP" = (
 /obj/structure/closet/crate/hydroponics,
@@ -65933,9 +66045,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 10
 	},
-/obj/structure/window/reinforced/spawner/directional/west{
-	pixel_x = -4
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -66467,7 +66576,6 @@
 /turf/open/floor/iron/smooth,
 /area/station/engineering/atmos)
 "sCX" = (
-/obj/effect/turf_decal/trimline/white/mid_joiner,
 /obj/machinery/incident_display/delam/directional/north,
 /turf/open/floor/iron/smooth_edge,
 /area/station/hallway/secondary/entry)
@@ -66492,6 +66600,9 @@
 "sDB" = (
 /obj/structure/dresser,
 /obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
 "sDI" = (
@@ -66594,6 +66705,11 @@
 /obj/item/stock_parts/power_store/cell/high{
 	pixel_x = 8;
 	pixel_y = -5
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Atmospherics - Project Room Fore";
+	dir = 5;
+	name = "atmospherics camera"
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/atmos)
@@ -67253,7 +67369,8 @@
 	},
 /obj/machinery/light/small/directional/east,
 /obj/machinery/computer/security/telescreen/aiupload/directional/west,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "sLs" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -67441,7 +67558,8 @@
 	req_access = list("ai_upload")
 	},
 /obj/structure/cable,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "sNa" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -67469,6 +67587,9 @@
 	pixel_y = 3
 	},
 /obj/item/storage/briefcase,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "sNq" = (
@@ -68798,7 +68919,8 @@
 	pixel_x = -32
 	},
 /obj/machinery/light/cold/directional/west,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "teQ" = (
 /obj/structure/table/wood,
@@ -69137,7 +69259,8 @@
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Atmospherics"
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
 "tjC" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -69457,7 +69580,8 @@
 /obj/effect/landmark/start/cyborg,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "toY" = (
 /obj/structure/sign/warning/vacuum/external/directional/south,
@@ -69979,9 +70103,7 @@
 /area/station/medical/chemistry)
 "tvm" = (
 /obj/effect/turf_decal/tile/blue/full,
-/turf/open/floor/iron/airless{
-	icon_state = "dark_large"
-	},
+/turf/open/floor/iron/dark/smooth_large/airless,
 /area/space/nearstation)
 "tvo" = (
 /obj/effect/turf_decal/siding/wood{
@@ -70016,7 +70138,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/box,
 /obj/machinery/button/door/directional/west{
 	id = "xenobio1";
@@ -70027,6 +70148,9 @@
 	dir = 9
 	},
 /obj/machinery/light/cold/directional/west,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	name = "Containment Pen Injection Port"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "twa" = (
@@ -70650,7 +70774,6 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "tDI" = (
-/obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
@@ -70658,6 +70781,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 4
 	},
@@ -70904,7 +71028,8 @@
 	dir = 8;
 	name = "Air to Distro"
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
 "tGJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -71584,11 +71709,11 @@
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/fore)
 "tRY" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 1
 	},
 /obj/item/pai_card,
+/obj/structure/closet/cabinet,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "tSb" = (
@@ -72208,8 +72333,7 @@
 "ucu" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/camera/directional/north{
-	c_tag = "Chapel Access";
-	name = "library camera"
+	c_tag = "Chapel Access"
 	},
 /obj/effect/turf_decal/tile/green/diagonal_centre,
 /obj/machinery/status_display/evac/directional/north,
@@ -72823,7 +72947,8 @@
 	id = "AI Core shutters";
 	name = "AI Core Shutters"
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "uln" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
@@ -73330,9 +73455,7 @@
 "urn" = (
 /obj/effect/turf_decal/tile/blue/full,
 /obj/structure/sign/flag/terragov/directional/north,
-/turf/open/floor/iron/airless{
-	icon_state = "dark_large"
-	},
+/turf/open/floor/iron/dark/smooth_large/airless,
 /area/space/nearstation)
 "urM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -73770,7 +73893,8 @@
 	name = "Primary AI Core Acces Door";
 	req_access = list("ai_upload")
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "uwo" = (
 /obj/structure/closet/l3closet/virology,
@@ -74274,7 +74398,8 @@
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/stripes/white/box,
 /obj/effect/turf_decal/bot_red,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "uDd" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/east,
@@ -74537,7 +74662,8 @@
 	uses = 10
 	},
 /obj/structure/cable/layer3,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "uGz" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -75137,7 +75263,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "uPy" = (
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "uPA" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -75222,10 +75349,7 @@
 /obj/structure/transit_tube/horizontal{
 	dir = 1
 	},
-/turf/open/floor/iron/airless{
-	icon = 'modular_nova/modules/advanced_shuttles/icons/erokez.dmi';
-	icon_state = "floor1"
-	},
+/turf/open/floor/iron/dark/smooth_large/airless,
 /area/space/nearstation)
 "uQo" = (
 /obj/effect/turf_decal/trimline/dark_red/arrow_ccw,
@@ -75386,7 +75510,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "uTs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -75870,6 +75995,7 @@
 "vam" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/cyan,
 /area/station/commons/dorms)
 "vaq" = (
@@ -76261,7 +76387,8 @@
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai)
 "vhP" = (
 /turf/open/floor/engine/co2,
@@ -76448,7 +76575,8 @@
 	name = "Starboard Bow Solar Control"
 	},
 /obj/structure/cable,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "vkB" = (
 /obj/structure/rack/shelf,
@@ -76770,7 +76898,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/camera/directional/south{
-	c_tag = "Atmospherics - Project Room Closet";
+	c_tag = "Atmospherics - Aft";
 	name = "atmospherics camera"
 	},
 /obj/item/clothing/head/cone,
@@ -77375,7 +77503,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "vxe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -77785,12 +77914,10 @@
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/security/lockers)
 "vEz" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 4;
-	name = "killroom vent"
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
 	},
-/obj/effect/turf_decal/weather/snow,
-/turf/open/floor/iron/dark/telecomms,
+/turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
 "vEH" = (
 /obj/machinery/vending/tool,
@@ -77903,7 +78030,8 @@
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
 "vFF" = (
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "vFG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -78093,7 +78221,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai)
 "vIC" = (
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
@@ -78704,6 +78833,9 @@
 	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
 "vRf" = (
@@ -78711,21 +78843,17 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/starboard/greater)
 "vRi" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/clothing/suit/jacket{
-	desc = "All the class of a trenchcoat without the security fibers.";
-	icon_state = "detective";
-	name = "trenchcoat"
-	},
 /obj/item/clothing/suit/toggle/lawyer/purple,
-/obj/item/clothing/head/fedora{
-	icon_state = "detective"
-	},
 /obj/item/clothing/under/rank/civilian/lawyer/beige,
 /obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6/directional/west,
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 1
 	},
+/obj/item/clothing/head/fedora/brown,
+/obj/item/clothing/suit/toggle/jacket/trenchcoat{
+	greyscale_colors = "#784F44"
+	},
+/obj/structure/closet/cabinet,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "vRq" = (
@@ -79042,11 +79170,6 @@
 "vVO" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Medbay - Pharmacy";
-	name = "medbay camera";
-	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -80729,11 +80852,11 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/effect/turf_decal/trimline/dark_red/filled/line{
-	dir = 8
-	},
 /obj/machinery/power/terminal{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
@@ -82020,7 +82143,8 @@
 	},
 /area/station/science/xenobiology)
 "wKt" = (
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "wKz" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/south,
@@ -82142,7 +82266,8 @@
 /obj/machinery/atmospherics/components/binary/pump/off{
 	dir = 8
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
 "wLU" = (
 /obj/effect/turf_decal/delivery,
@@ -83123,6 +83248,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/mid_joiner,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
 "xcq" = (
@@ -84261,6 +84389,9 @@
 	pixel_x = -2;
 	pixel_y = 5
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
 /turf/open/floor/carpet/cyan,
 /area/station/commons/dorms)
 "xsW" = (
@@ -84449,20 +84580,12 @@
 /turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/central)
 "xvR" = (
-/obj/item/reagent_containers/cup/bottle/epinephrine,
-/obj/item/reagent_containers/cup/bottle/multiver{
-	pixel_x = 6
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4;
+	name = "killroom vent"
 	},
-/obj/item/reagent_containers/syringe,
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/structure/sign/departments/exam_room/directional/west,
-/obj/machinery/door/window/left/directional/north{
-	name = "Medbay Front Desk";
-	req_access = list("medical")
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/medbay/lobby)
+/turf/open/floor/circuit/telecomms,
+/area/station/science/xenobiology)
 "xwb" = (
 /obj/machinery/light/warm/directional/north,
 /obj/machinery/button/door/directional/north{
@@ -84598,7 +84721,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "xyc" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
@@ -84638,7 +84762,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "xyD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -85362,7 +85487,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai)
 "xKm" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
@@ -85786,7 +85912,8 @@
 	name = "Secondary AI Core Acces Door";
 	req_access = list("ai_upload")
 	},
-/turf/open/floor/vault,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/turret_protected/ai)
 "xRx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -86352,11 +86479,7 @@
 "xYN" = (
 /obj/item/radio/intercom/directional/east,
 /obj/structure/table,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -2;
-	pixel_y = 5
-	},
+/obj/machinery/microwave,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "xZa" = (
@@ -86735,7 +86858,7 @@
 /area/station/security/execution/transfer)
 "yef" = (
 /obj/machinery/camera/directional/north{
-	c_tag = "Art Gallery";
+	c_tag = "Library - Art Gallery";
 	name = "library camera"
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -86945,7 +87068,6 @@
 /turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/central)
 "yhC" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/clothing/suit/jacket/letterman_nanotrasen,
 /obj/item/clothing/suit/toggle/lawyer,
 /obj/item/clothing/under/costume/maid,
@@ -86953,6 +87075,7 @@
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 1
 	},
+/obj/structure/closet/cabinet,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "yhD" = (
@@ -106813,7 +106936,7 @@ ttw
 ttw
 ttw
 ttw
-ttw
+dWX
 dWX
 mIm
 nQt
@@ -107070,11 +107193,11 @@ ttw
 ttw
 ttw
 ttw
-ttw
 dWX
 mIm
-djc
-djc
+mIm
+efz
+woJ
 kVR
 raP
 uiw
@@ -107327,10 +107450,10 @@ ttw
 ttw
 ttw
 ttw
-ttw
 dWX
 bMr
 kVR
+oRY
 oRY
 kVR
 tEK
@@ -107584,12 +107707,12 @@ ttw
 ttw
 ttw
 ttw
-ttw
 dWX
 bMr
 oRY
-vEz
-pdg
+xvR
+bie
+seE
 tvP
 sig
 xNR
@@ -107841,10 +107964,10 @@ ttw
 ttw
 ttw
 ttw
-ttw
 dWX
 ttO
 oRY
+vEz
 mxQ
 dkU
 kxA
@@ -108098,12 +108221,12 @@ ttw
 ttw
 ttw
 ttw
-ttw
 dWX
 bMr
 oRY
+fQX
 bie
-efz
+seE
 uyE
 xyc
 bwJ
@@ -108355,10 +108478,10 @@ gPJ
 ttw
 ttw
 ttw
-ttw
 dWX
 mIm
 kVR
+oRY
 oRY
 kVR
 mom
@@ -108612,11 +108735,11 @@ gPJ
 ttw
 ttw
 ttw
-ttw
 dWX
 mIm
-djc
-djc
+mIm
+efz
+woJ
 kVR
 lXQ
 uiw
@@ -108869,7 +108992,7 @@ gPJ
 ttw
 ttw
 ttw
-ttw
+dWX
 dWX
 bMr
 sAL
@@ -113795,7 +113918,7 @@ wjI
 nqC
 jDw
 rhF
-jtc
+cOf
 sNj
 bsn
 jBX
@@ -116904,7 +117027,7 @@ sKu
 nBH
 nBH
 kaN
-kaN
+cut
 xES
 cnC
 cnC
@@ -117168,7 +117291,7 @@ fwc
 iAk
 bFT
 lrh
-xvR
+puQ
 bmU
 mVV
 mVV
@@ -117425,7 +117548,7 @@ jML
 aDx
 vAX
 fkX
-puQ
+pdg
 fyY
 oob
 qtB
@@ -118103,9 +118226,9 @@ oXW
 tGR
 jqn
 jqn
-cut
-cut
-cut
+tvm
+tvm
+tvm
 nAw
 wLb
 tuF
@@ -118616,9 +118739,9 @@ jqn
 jqn
 mXy
 jqn
-cut
-cut
-cut
+tvm
+tvm
+tvm
 lyY
 doJ
 doJ
@@ -119130,9 +119253,9 @@ xxv
 pcM
 cIK
 ska
-cut
-cut
-cut
+tvm
+tvm
+tvm
 lyY
 okp
 kID
@@ -119644,8 +119767,8 @@ xxv
 ska
 xxv
 nxj
-cut
-cut
+tvm
+tvm
 eNH
 lyY
 qzL
@@ -119900,7 +120023,7 @@ ttw
 xMq
 oBb
 eNH
-cut
+tvm
 xMq
 xMq
 eNH
@@ -120415,8 +120538,8 @@ xMq
 oBb
 eNH
 xMq
-cut
-cut
+tvm
+tvm
 lyY
 wsm
 gIo
@@ -120671,8 +120794,8 @@ ttw
 xMq
 oBb
 eNH
-cut
-cut
+tvm
+tvm
 xMq
 lyY
 wSg
@@ -120929,8 +121052,8 @@ xMq
 oBb
 eNH
 xMq
-cut
-cut
+tvm
+tvm
 lyY
 ckL
 xgQ
@@ -121442,7 +121565,7 @@ ttw
 xMq
 oBb
 eNH
-cut
+tvm
 xMq
 xMq
 eNH
@@ -121700,8 +121823,8 @@ aei
 bZk
 aei
 nxj
-cut
-cut
+tvm
+tvm
 eNH
 lyY
 sXl
@@ -122214,9 +122337,9 @@ aei
 cRr
 rbc
 bZk
-cut
-cut
-cut
+tvm
+tvm
+tvm
 lyY
 wot
 mMZ
@@ -122728,9 +122851,9 @@ usB
 usB
 uHz
 usB
-cut
-cut
-cut
+tvm
+tvm
+tvm
 lyY
 xlE
 xlE
@@ -122985,10 +123108,10 @@ lOc
 tIo
 bKX
 vfM
-cOf
-cOf
-cut
-cOf
+eNH
+eNH
+tvm
+eNH
 sKT
 elm
 lje
@@ -123243,9 +123366,9 @@ usB
 sPi
 usB
 usB
-cut
-cut
-cut
+tvm
+tvm
+tvm
 sKT
 xha
 vGj

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -6834,6 +6834,7 @@
 	},
 /obj/effect/turf_decal/siding/dark_blue,
 /obj/effect/turf_decal/tile/blue/half,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/command/bridge)
 "cbB" = (
@@ -8031,11 +8032,9 @@
 	},
 /area/station/science/robotics/lab)
 "cut" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/turf/open/floor/carpet,
-/area/station/commons/dorms)
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/department/science/xenobiology)
 "cuA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -25374,13 +25373,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
-"hoR" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 4;
-	name = "killroom vent"
-	},
-/turf/open/floor/circuit/telecomms,
-/area/station/science/xenobiology)
 "hpe" = (
 /turf/open/floor/iron/smooth_large,
 /area/station/security/checkpoint/engineering)
@@ -27527,6 +27519,9 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/white/end{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/mid_joiner{
 	dir = 1
 	},
 /turf/open/floor/iron/smooth_edge{
@@ -46147,7 +46142,7 @@
 "mWD" = (
 /obj/machinery/griddle,
 /obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/carpet,
+/turf/open/floor/iron/small,
 /area/station/commons/dorms)
 "mWF" = (
 /obj/machinery/suit_storage_unit/engine,
@@ -48667,6 +48662,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/smooth,
 /area/station/science/ordnance)
+"nIE" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4;
+	name = "killroom vent"
+	},
+/turf/open/floor/circuit/telecomms,
+/area/station/science/xenobiology)
 "nIJ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
@@ -53963,9 +53965,11 @@
 	},
 /area/station/hallway/secondary/command)
 "pdg" = (
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/department/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/circuit/telecomms,
+/area/station/science/xenobiology)
 "pdh" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -77919,12 +77923,11 @@
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/security/lockers)
 "vEz" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 8;
-	name = "killroom vent"
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
 	},
-/turf/open/floor/circuit/telecomms,
-/area/station/science/xenobiology)
+/turf/open/floor/carpet,
+/area/station/commons/dorms)
 "vEH" = (
 /obj/machinery/vending/tool,
 /obj/effect/turf_decal/bot,
@@ -84588,8 +84591,9 @@
 /turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/central)
 "xvR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8;
+	name = "killroom vent"
 	},
 /turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
@@ -107203,7 +107207,7 @@ ttw
 dWX
 mIm
 mIm
-pdg
+cut
 woJ
 kVR
 raP
@@ -107717,7 +107721,7 @@ ttw
 dWX
 bMr
 oRY
-hoR
+nIE
 bie
 seE
 tvP
@@ -107974,7 +107978,7 @@ ttw
 dWX
 ttO
 oRY
-xvR
+pdg
 mxQ
 dkU
 kxA
@@ -108231,7 +108235,7 @@ ttw
 dWX
 bMr
 oRY
-vEz
+xvR
 bie
 seE
 uyE
@@ -108745,7 +108749,7 @@ ttw
 dWX
 mIm
 mIm
-pdg
+cut
 woJ
 kVR
 lXQ
@@ -113925,7 +113929,7 @@ wjI
 nqC
 jDw
 rhF
-cut
+vEz
 sNj
 bsn
 jBX

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -3739,7 +3739,9 @@
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
 /area/station/command/bridge)
 "bbm" = (
 /obj/effect/turf_decal/trimline/dark_red/arrow_ccw,
@@ -5695,7 +5697,9 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/tile/blue/anticorner,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 1
+	},
 /area/station/command/bridge)
 "bIW" = (
 /obj/structure/dresser,
@@ -6830,7 +6834,7 @@
 	},
 /obj/effect/turf_decal/siding/dark_blue,
 /obj/effect/turf_decal/tile/blue/half,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/station/command/bridge)
 "cbB" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -8027,10 +8031,11 @@
 	},
 /area/station/science/robotics/lab)
 "cut" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/photocopier/prebuilt,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/port/central)
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/carpet,
+/area/station/commons/dorms)
 "cuA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -9310,11 +9315,19 @@
 	},
 /area/station/hallway/secondary/command)
 "cOf" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
+/obj/item/reagent_containers/cup/bottle/epinephrine,
+/obj/item/reagent_containers/cup/bottle/multiver{
+	pixel_x = 6
 	},
-/turf/open/floor/carpet,
-/area/station/commons/dorms)
+/obj/item/reagent_containers/syringe,
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/left/directional/north{
+	name = "Medbay Front Desk";
+	req_access = list("medical")
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/medbay/lobby)
 "cOi" = (
 /obj/structure/sign/gym/right{
 	pixel_y = 32
@@ -11237,14 +11250,12 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "dqZ" = (
-/obj/structure/flora/ocean/longseaweed,
-/obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
-	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/misc/asteroid,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/lavendergrass,
+/turf/open/floor/grass,
 /area/station/medical/medbay/lobby)
 "dri" = (
 /obj/structure/table,
@@ -14330,9 +14341,10 @@
 /turf/open/floor/iron/half,
 /area/station/hallway/primary/central)
 "efz" = (
-/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/photocopier/prebuilt,
 /turf/open/floor/iron/smooth,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/maintenance/port/central)
 "efH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16996,7 +17008,7 @@
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark/smooth_corner,
 /area/station/command/bridge)
 "eSD" = (
 /obj/effect/spawner/random/structure/crate,
@@ -20083,13 +20095,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/commons/dorms)
-"fQX" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 8;
-	name = "killroom vent"
-	},
-/turf/open/floor/circuit/telecomms,
-/area/station/science/xenobiology)
 "fRf" = (
 /turf/open/floor/carpet/blue,
 /area/station/command/bridge)
@@ -25369,6 +25374,13 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
+"hoR" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4;
+	name = "killroom vent"
+	},
+/turf/open/floor/circuit/telecomms,
+/area/station/science/xenobiology)
 "hpe" = (
 /turf/open/floor/iron/smooth_large,
 /area/station/security/checkpoint/engineering)
@@ -32916,14 +32928,15 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/construction)
 "jtG" = (
-/obj/structure/flora/ocean/glowweed,
-/obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
-	},
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/misc/asteroid,
+/obj/structure/flora/bush/lavendergrass,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/pointy{
+	pixel_y = -8
+	},
+/turf/open/floor/grass,
 /area/station/medical/medbay/lobby)
 "jtH" = (
 /obj/machinery/door/airlock/maintenance{
@@ -46636,7 +46649,9 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/station/command/bridge)
 "ndE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53948,19 +53963,9 @@
 	},
 /area/station/hallway/secondary/command)
 "pdg" = (
-/obj/item/reagent_containers/cup/bottle/epinephrine,
-/obj/item/reagent_containers/cup/bottle/multiver{
-	pixel_x = 6
-	},
-/obj/item/reagent_containers/syringe,
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/north{
-	name = "Medbay Front Desk";
-	req_access = list("medical")
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/medbay/lobby)
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/department/science/xenobiology)
 "pdh" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -77914,8 +77919,9 @@
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/security/lockers)
 "vEz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8;
+	name = "killroom vent"
 	},
 /turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
@@ -82224,7 +82230,9 @@
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
 /area/station/command/bridge)
 "wLl" = (
 /obj/item/storage/medkit/regular{
@@ -84580,9 +84588,8 @@
 /turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/central)
 "xvR" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 4;
-	name = "killroom vent"
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
 	},
 /turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
@@ -107196,7 +107203,7 @@ ttw
 dWX
 mIm
 mIm
-efz
+pdg
 woJ
 kVR
 raP
@@ -107710,7 +107717,7 @@ ttw
 dWX
 bMr
 oRY
-xvR
+hoR
 bie
 seE
 tvP
@@ -107967,7 +107974,7 @@ ttw
 dWX
 ttO
 oRY
-vEz
+xvR
 mxQ
 dkU
 kxA
@@ -108224,7 +108231,7 @@ ttw
 dWX
 bMr
 oRY
-fQX
+vEz
 bie
 seE
 uyE
@@ -108738,7 +108745,7 @@ ttw
 dWX
 mIm
 mIm
-efz
+pdg
 woJ
 kVR
 lXQ
@@ -113918,7 +113925,7 @@ wjI
 nqC
 jDw
 rhF
-cOf
+cut
 sNj
 bsn
 jBX
@@ -117027,7 +117034,7 @@ sKu
 nBH
 nBH
 kaN
-cut
+efz
 xES
 cnC
 cnC
@@ -117548,7 +117555,7 @@ jML
 aDx
 vAX
 fkX
-pdg
+cOf
 fyY
 oob
 qtB


### PR DESCRIPTION
## About The Pull Request

#5841 but voidraptor

This map respected the contraband poster-mainhall thing a lot more so those aren't really touched. Mostly just cleanup of stray decals and a few clunky rooms/pixelshifted objects. 
**Notably** I've removed lots of the gross unrepairable floors. Visually it's as similar as I could get it, but it's. Rebuildable now. So yay.

<details><summary>Comprehensive Changes</summary>

- Clean a few public-facing contraband Posters 
_(see #5841)_
- Retiles all of the AI Sat with normal tiles instead of irreparable Vault tiles
- Retiles all of AI Upload with normal tiles instead of irreparable Vault tiles
- Retiles the irreparable big space decals around the bridge with normal tiles
- Redoes Xenobio Freezer
_It was really jank. People keep needing to handbuild a holofan. It required I expand the thing a bit but it's got the coldflaps and real door now and lit circuit tiles. So it's much nicer to use. (Also gave Xenobio the slime chart on their wall instead of a poster telling them their job is Murder. Who would put that in a workplace? Wtf?)_
- Gives Medbay a photocopier
_Mm paperwork._
- Removes a few pixelshifted things that were jank
_Kitchen stuff floating off tables, the medbay aquarium that breaks tile-boundaries and generally upsets engineering because its irrepairable, stuff like that_
- Fixes a few cameras
_Few renames, few cameras incorrectly mounted on walls_
- Removes Syndicate Documents from Maints
_These are an antag objective, to steal them from 'any corporation'. We shouldn't just have a freebie on the map._
- Some light improvement in Dorms
_Tiles should look a bit nicer, and the cabinets are a different type; they can't lock, but now they have their intended items. Because for some reason the lockable ones don't take the intended items._
</details>

## How This Contributes To The Nova Sector Roleplay Experience

Mostly fixes and QOL. A station should be repairable.
Fixes https://github.com/NovaSector/NovaSector/issues/3979
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
 Pretty much the same. But now you just place dark fulltiles and paint them neutral or blue.
<img width="927" height="487" alt="image" src="https://github.com/user-attachments/assets/8fc2c63f-56f6-4335-b65b-bd2665b85a5a" />

Same in AI Upload...
<img width="307" height="508" alt="image" src="https://github.com/user-attachments/assets/796bc388-4dee-4c32-8a93-b67b77a719b8" />

And AI Sat
<img width="985" height="708" alt="image" src="https://github.com/user-attachments/assets/47accf40-a6ee-4f5f-9fb4-deded1e6bf01" />


Killchamber has a real door now.
<img width="356" height="375" alt="image" src="https://github.com/user-attachments/assets/1ba18670-9047-48ac-b648-e19c9c64a54a" />


  
</details>

## Changelog
:cl:
map: Voidraptor: Medbay now has a photocopier and had their fishless aquarium replaced, high-traffic posters are now more Corporation-friendly, Xenobio's Slime Euthanization Chamber is now up to standard, fixed a few irreparable tiles/misplaced decals, cameras should be a bit more consistent, and other small fixes.
/:cl:
