### PR TITLE
Latejoin borg's station alert listener now properly tied to station Z

### DIFF
--- a/modular_nova/master_files/code/modules/mob/living/sillicon/robot.dm
+++ b/modular_nova/master_files/code/modules/mob/living/sillicon/robot.dm
@@ -38,6 +38,20 @@
 			movable_parent.particles.position = list(6, 12, 0)
 			movable_parent.particles.drift = generator("vector", list(0, 0.4), list(0.8, -0.2))
 
+/datum/station_alert/New(holder, list/alarm_types, list/listener_z_level, list/listener_areas, title, camera_view)
+	. = ..()
+	RegisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED, PROC_REF(change_listener_level))
+
+/datum/station_alert/Destroy()
+	. = ..()
+	UnregisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED)
+
+/datum/station_alert/proc/change_listener_level(datum/source, mob/living/new_crewmember, rank)
+	SIGNAL_HANDLER
+
+	if(new_crewmember != holder)
+		return
+	listener.allowed_z_levels = SSmapping.levels_by_trait(ZTRAIT_STATION)
 
 /mob/living/silicon/robot/proc/toggle_smoke()
 	set name = "Toggle smoke"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Latejoin borgs created at lobby area first before getting teleported to their spawn point as a part of `AttemptLateSpawn` proc. That causes their alarm handler to be tied to z = 1. So we just change it as soon as other code finishes with character creation.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
<img width="980" height="517" alt="image" src="https://github.com/user-attachments/assets/fd5e58fc-d3f5-44cb-aa04-fe37d85528ce" />

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: borg alert monitor is fixed (probably? finally?)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
