### PR TITLE
[no gbp] sets a flag i forgot for the new ghost traitor

### DIFF
--- a/modular_nova/modules/marauders/marauder.dm
+++ b/modular_nova/modules/marauders/marauder.dm
@@ -4,6 +4,7 @@
 	job_rank = ROLE_MARAUDER
 	roundend_category = "Marauders"
 	preview_outfit = /datum/outfit/marauder_preview
+	show_to_ghosts = TRUE
 	give_uplink = FALSE
 	should_give_codewords = FALSE
 	/// Identifying number of the traitor


### PR DESCRIPTION
## About The Pull Request

Makes marauders visible to ghosts

## How This Contributes To The Nova Sector Roleplay Experience

Ghosts are prompted when this antag spawns/its a ghost antag, it should be visible to ghosts.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Marauder antag now shows up under the traitor category of the ghost orbit menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
