### PR TITLE
some assorted milsim fixes

### DIFF
--- a/_maps/safehouses/ancientmilsim_nova.dmm
+++ b/_maps/safehouses/ancientmilsim_nova.dmm
@@ -31,7 +31,7 @@
 /obj/item/clothing/gloves/frontier_colonist,
 /obj/item/radio/headset/headset_faction/bowman,
 /obj/item/storage/pouch/ammo,
-/obj/item/storage/belt/security/webbing/blue,
+/obj/item/storage/belt/security/webbing/peacekeeper,
 /obj/item/clothing/glasses/night,
 /turf/open/floor/iron,
 /area/virtual_domain/safehouse)
@@ -159,7 +159,7 @@
 /obj/item/clothing/gloves/frontier_colonist,
 /obj/item/radio/headset/headset_faction/bowman,
 /obj/item/storage/pouch/ammo,
-/obj/item/storage/belt/security/webbing/blue,
+/obj/item/storage/belt/security/webbing/peacekeeper,
 /obj/item/clothing/glasses/night,
 /turf/open/floor/iron,
 /area/virtual_domain/safehouse)
@@ -248,7 +248,7 @@
 /obj/item/clothing/gloves/frontier_colonist,
 /obj/item/radio/headset/headset_faction/bowman,
 /obj/item/storage/pouch/ammo,
-/obj/item/storage/belt/security/webbing/blue,
+/obj/item/storage/belt/security/webbing/peacekeeper,
 /obj/item/clothing/glasses/night,
 /turf/open/floor/iron,
 /area/virtual_domain/safehouse)

--- a/modular_nova/modules/bitrunning/code/virtual_domains/ancient_milsim/mobs.dm
+++ b/modular_nova/modules/bitrunning/code/virtual_domains/ancient_milsim/mobs.dm
@@ -9,7 +9,8 @@
 	attack_sound = 'sound/items/weapons/blade1.ogg'
 	attack_vis_effect = ATTACK_EFFECT_SLASH
 	faction = list(ROLE_SYNDICATE)
-	loot = list(/obj/effect/mob_spawn/corpse/human/cin_soldier)
+	loot = list()
+	corpse = /obj/effect/mob_spawn/corpse/human/cin_soldier
 	mob_spawner = /obj/effect/mob_spawn/corpse/human/cin_soldier
 
 /datum/ai_controller/basic_controller/trooper/calls_reinforcements/ancient_milsim
@@ -37,7 +38,7 @@
 /mob/living/basic/trooper/cin_soldier/melee
 	r_hand = /obj/item/melee/energy/sword/saber/purple
 	l_hand = /obj/item/shield/energy
-	loot = list(/obj/effect/mob_spawn/corpse/human/cin_soldier, /obj/effect/spawner/random/ancient_milsim/melee)
+	loot = list(/obj/effect/spawner/random/ancient_milsim/melee)
 	var/projectile_deflect_chance = 20
 
 /mob/living/basic/trooper/cin_soldier/melee/bullet_act(obj/projectile/projectile)
@@ -51,7 +52,7 @@
 	melee_damage_upper = 10
 	ai_controller = /datum/ai_controller/basic_controller/trooper/calls_reinforcements/ancient_milsim/ranged
 	r_hand = /obj/item/gun/ballistic/automatic/miecz
-	loot = list(/obj/effect/mob_spawn/corpse/human/cin_soldier, /obj/effect/spawner/random/ancient_milsim/ranged)
+	loot = list(/obj/effect/spawner/random/ancient_milsim/ranged)
 	/// Type of bullet we use
 	var/casingtype = /obj/item/ammo_casing/c27_54cesarzowa
 	/// Sound to play when firing weapon


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#5126 changed the milsim webbings to a subtype that does not exist (belt/security/webbing/blue) instead of the peacekeeper webbings they were previously. This caused to not spawn properly; this has been fixed, and the milsimmers have their webbings again.

#90037 (upstream) gave basic troopers a corpse value that could display damage dealt to them on death. CIN mobs are old, and had their corpses placed in their loot table. This meant they both dropped their corpses as loot, and inherited the basic trooper mob's corpse drop, which resulted in dropping their own corpse and a generic, unrelated human.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
buncha shit broken in milsim now it aint

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

<img width="465" height="404" alt="proof of webbig" src="https://github.com/user-attachments/assets/38ee4c0c-66cd-4770-bebc-ed83ca1387c9" />  

<img width="311" height="298" alt="only one corpse!!" src="https://github.com/user-attachments/assets/e9a2640b-8813-4285-8d7e-345b603322a5" />

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The virtual CIN no longer undergo mitosis upon death.
fix: Ancient Military Simulator no longer attempts to spawn a webbing type which does not exist, and spawns the bitrunner's webbing properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
