### PR TITLE
[DEV SUGGEST]Cargo Apparatus

### DIFF
--- a/modular_nova/master_files/code/modules/research/techweb/all_nodes.dm
+++ b/modular_nova/master_files/code/modules/research/techweb/all_nodes.dm
@@ -327,6 +327,7 @@
 		"borg_upgrade_clamp",
 		"borg_upgrade_brush",
 		"borg_upgrade_shrink",
+		"borg_upgrade_cargo_apparatus"
 	)
 	return ..()
 

--- a/modular_nova/modules/borgs/code/mechafabricator_designs.dm
+++ b/modular_nova/modules/borgs/code/mechafabricator_designs.dm
@@ -181,3 +181,14 @@
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG + RND_SUBCATEGORY_MECHFAB_CYBORG_CHASSIS,
 	)
+
+/datum/design/borg_upgrade_cargo_apparatus
+	name = "Cargo Apparatus"
+	id = "borg_upgrade_cargo_apparatus"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/cargo_papermanipulator
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT*2.5)
+	construction_time = 4 SECONDS
+	category = list(
+		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_CARGO
+	)

--- a/modular_nova/modules/borgs/code/robot_upgrade.dm
+++ b/modular_nova/modules/borgs/code/robot_upgrade.dm
@@ -464,3 +464,44 @@
 		borg.model.remove_module(tickler)
 	for(var/obj/item/clothing/sextoy/fleshlight/fleshlight in borg.model.modules)
 		borg.model.remove_module(fleshlight)
+
+/obj/item/borg/upgrade/cargo_papermanipulator
+	name = "Cargo Cyborg Paper Manipulator"
+	desc = "An upgrade to the service model cyborg, to help handle foods and paper."
+	icon_state = "module_miner"
+	require_model = TRUE
+	model_type = list(/obj/item/robot_model/cargo)
+	model_flags = BORG_MODEL_CARGO
+
+	items_to_add = list(/obj/item/borg/apparatus/cargo_papermanipulator)
+
+/obj/item/borg/apparatus/cargo_papermanipulator
+	name = "Cargo apparatus"
+	desc = "A not so special apparatus designed for the most tedious of tasks, holding paper..."
+	icon_state = "borg_service_apparatus"
+	storable = list(
+		/obj/item/paper,
+	)
+
+/obj/item/borg/apparatus/cargo_papermanipulator/Initialize(mapload)
+	update_appearance()
+	return ..()
+
+/obj/item/borg/apparatus/cargo_papermanipulator/update_overlays()
+	. = ..()
+	var/mutable_appearance/arm = mutable_appearance(icon, "borg_hardware_apparatus_arm1")
+	if(stored)
+		stored.pixel_w = -3
+		stored.pixel_z = 0
+		var/mutable_appearance/stored_copy = new /mutable_appearance(stored)
+		stored_copy.layer = FLOAT_LAYER
+		stored_copy.plane = FLOAT_PLANE
+		. += stored_copy
+	. += arm
+
+/obj/item/borg/apparatus/cargo_papermanipulator/examine()
+	. = ..()
+	if(stored)
+		. += "The apparatus currently has [stored] secured."
+	. += span_notice("<i>Alt-click</i> will drop the currently secured item.")
+


### PR DESCRIPTION
## About The Pull Request

Adds the cargo apparatus as requested in https://discord.com/channels/1171566433923239977/1400559510862434455

## How This Contributes To The Nova Sector Roleplay Experience

This allows borgs to ACTUALLY HOLD PAPERS PROPERLY. without losing their shit with a clipboard.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
<img width="614" height="148" alt="image" src="https://github.com/user-attachments/assets/aef72162-70f4-4a83-a2ee-c0f0f7d4558b" />

<img width="461" height="169" alt="image" src="https://github.com/user-attachments/assets/7a2d203a-9a0a-4145-9768-f1c0dc59bbbb" />

<img width="803" height="681" alt="image" src="https://github.com/user-attachments/assets/88e6c191-2235-4138-b452-4cddc515e733" />

<img width="812" height="629" alt="image" src="https://github.com/user-attachments/assets/15fd48cc-89af-45eb-8ee0-e9ad5cf8bc07" />

</details>

## Changelog


:cl:
add: [DEV SUGGEST] Added the Cargo Apparatus, an object manipulator that only picks up paper.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
