### PR TITLE
Labeler fix (Part... Probably 5?)

### DIFF
--- a/tools/pull_request_hooks/autoLabel.js
+++ b/tools/pull_request_hooks/autoLabel.js
@@ -140,7 +140,7 @@ async function check_diff_files_for_labels(github, context) {
         }
       }
     } else {
-      console.error(`Failed to fetch diff files: ${diff.status}`);
+      console.error(`Failed to get file list: ${diff.status}`);
     }
   } catch (e) {
     console.error(e);


### PR DESCRIPTION
## About The Pull Request

I am back again! 
@vinylspiders noticed that my previous version had a limit of 300 modified files... So I decided to switch from a full diff check to a check of only modified files (which should raise the limit to 3000 files)
[octokit.rest.pulls.listFiles](https://octokit.github.io/rest.js/v20/#pulls-list-files) should, in theory, handle the task even more efficiently. If it were not for my silly code with two nested loops

Also reverts #5813 as we no longer need it
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="733" height="87" alt="image" src="https://github.com/user-attachments/assets/174fcb53-d349-4911-877f-c7560c71094f" />

</details>

## Changelog
Weh
