### PR TITLE
fixes bullet hitsounds

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -376,7 +376,7 @@
 		impact_sound = target.bullet_impact_sound
 	if(impact_sound)
 		hitsound = null // don't play the hitsound
-		playsound(src, GLOB.sfx_datum_by_key[impact_sound], vol_by_damage(), TRUE, -1)
+		playsound(src, impact_sound, vol_by_damage(), TRUE, -1)
 	// NOVA EDIT ADDITION END
 
 	if(damage > 0 && (damage_type == BRUTE || damage_type == BURN) && iswallturf(target_turf) && prob(75))


### PR DESCRIPTION
## About The Pull Request

title. fixes bullet hitsounds

## How This Contributes To The Nova Sector Roleplay Experience

wow! cool soundscape fix! (also stops runtimes. stopping runtimes is pretty huge.)

## Proof of Testing

would you believe me if i say i discovered this while testing the enforcer handgun

## Changelog

:cl:
fix: Bullet hitsounds on surfaces now properly play and don't cause a runtime.
/:cl:
