### PR TITLE
Buffs contractors by letting them create space

### DIFF
--- a/modular_nova/modules/contractor/code/items/modsuit/modsuit.dm
+++ b/modular_nova/modules/contractor/code/items/modsuit/modsuit.dm
@@ -12,7 +12,6 @@
 		/obj/item/mod/module/shock_absorber,
 		/obj/item/mod/module/quick_cuff,
 		/obj/item/mod/module/flashlight,
-		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/storage/syndicate,
 		/obj/item/mod/module/tether,
 	)
@@ -30,7 +29,6 @@
 		/obj/item/mod/module/shock_absorber,
 		/obj/item/mod/module/quick_cuff,
 		/obj/item/mod/module/jetpack,
-		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/storage/syndicate,
 		/obj/item/mod/module/flamethrower,
 	)

--- a/modular_nova/modules/contractor/code/items/modsuit/modsuit.dm
+++ b/modular_nova/modules/contractor/code/items/modsuit/modsuit.dm
@@ -32,11 +32,13 @@
 		/obj/item/mod/module/jetpack,
 		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/storage/syndicate,
+		/obj/item/mod/module/flamethrower,
 	)
 	default_pins = list(
 		/obj/item/mod/module/armor_booster/contractor,
 		/obj/item/mod/module/jetpack,
 		/obj/item/mod/module/baton_holster/preloaded,
+		/obj/item/mod/module/flamethrower,
 	)
 
 /obj/item/mod/control/pre_equipped/contractor/upgraded/adminbus


### PR DESCRIPTION
## About The Pull Request
Gives the Syndicate contractor a MOD module that allows them to create space.

## How This Contributes To The Nova Sector Roleplay Experience
What this antag really needs is to be able to create some space for themselves.

## Proof of Testing

https://github.com/user-attachments/assets/66dece99-5e8a-4c49-a385-e07d5240ce12

## Changelog

:cl:
balance: Syndicate Contractors can now create space for themselves, be careful when approaching one.
balance: The Syndicate Contractor MODsuit has lost the magnetic harness module, they didn't need this anyway
/:cl: