### PR TITLE
makes simplebots faster

### DIFF
--- a/code/genesis_call.dme
+++ b/code/genesis_call.dme
@@ -50,3 +50,12 @@
  */
 /world/proc/_()
 	var/static/_ = world.Genesis()
+// BEGIN_INTERNALS
+// END_INTERNALS
+// BEGIN_FILE_DIR
+#define FILE_DIR .
+// END_FILE_DIR
+// BEGIN_PREFERENCES
+// END_PREFERENCES
+// BEGIN_INCLUDE
+// END_INCLUDE

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -56,7 +56,7 @@
 	///Used by some bots for tracking failures to reach their target.
 	var/frustration = 0
 	///The speed at which the bot moves, or the number of times it moves per process() tick.
-	var/base_speed = 2
+	var/base_speed = 5
 	///The end point of a bot's path, or the target location.
 	var/turf/ai_waypoint
 	///The bot is on a custom set path.

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -56,7 +56,7 @@
 	///Used by some bots for tracking failures to reach their target.
 	var/frustration = 0
 	///The speed at which the bot moves, or the number of times it moves per process() tick.
-	var/base_speed = 5
+	var/base_speed = 5 /// nova edit, original: var/base_speed = 2
 	///The end point of a bot's path, or the target location.
 	var/turf/ai_waypoint
 	///The bot is on a custom set path.


### PR DESCRIPTION

## About The Pull Request
makes simplebots move at a speed of 5, instead of 2, keep in mind this is only pathing speed, their actual movement speed when controlled or chasing is unchanged

## How This Contributes To The Nova Sector Roleplay Experience

apparently people wanted this, so i tossed the beepsky buffs in exchange for this because it accomplishes the same thing

(health buffs were wanted but i could do that in a seperate PR as thatd need me to change all the bots code)

## Proof of Testing

the bot was fast

yes i still forgot

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: bots are faster now, hopefully increasing their efficiency by 250%!
/:cl:
