### PR TITLE
Fixes runtime when DNRing as a non-human

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -412,7 +412,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		current_mob.med_hud_set_status()
 		current_mob.log_message("had their player ([key_name(src)]) do-not-resuscitate / DNR", LOG_GAME, color = COLOR_GREEN, log_globally = FALSE)
 		//NOVA EDIT ADDITION START - DNR TRAIT (Fixes ghost-DNR'ing not actually DNR'ing)
-		if(!current_mob.has_quirk(/datum/quirk/dnr))
+		if(ishuman(current_mob) && !current_mob.has_quirk(/datum/quirk/dnr))
 			current_mob.add_quirk(/datum/quirk/dnr)
 		var/datum/job/job_to_free = SSjob.get_job(current_mob.mind.assigned_role.title)
 		if(job_to_free)


### PR DESCRIPTION
## About The Pull Request
Oops

Adds an ishuman() check. That's it.

## How This Contributes To The Nova Sector Roleplay Experience
Runtimes bad
Fixes https://github.com/NovaSector/NovaSector/issues/5885

## Proof of Testing
<img width="1111" height="317" alt="image" src="https://github.com/user-attachments/assets/124c403e-6a63-42bb-9b1a-711d144a3cb5" />


## Changelog
No player facing changes