### PR TITLE
Adds Civ Bounty Pads to ghost roles

### DIFF
--- a/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1.dmm
+++ b/_maps/RandomRuins/IceRuins/nova/icemoon_underground_interdyne_base1.dmm
@@ -2649,6 +2649,8 @@
 	pixel_x = 6;
 	pixel_y = 6
 	},
+/obj/item/circuitboard/computer/bountypad,
+/obj/item/circuitboard/machine/bountypad,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/interdyne_planetary_base/main/vault)
 "hi" = (

--- a/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/nova/lavaland_surface_interdyne_base1.dmm
@@ -5945,6 +5945,8 @@
 /obj/item/circuitboard/machine/powerator/interdyne,
 /obj/item/circuitboard/machine/powerator/interdyne,
 /obj/item/circuitboard/machine/powerator/interdyne,
+/obj/item/circuitboard/computer/bountypad,
+/obj/item/circuitboard/machine/bountypad,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/interdyne_planetary_base/main/vault)
 "Wk" = (

--- a/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
@@ -5198,6 +5198,8 @@
 /obj/item/circuitboard/machine/powerator/syndicate,
 /obj/item/circuitboard/machine/powerator/syndicate,
 /obj/item/circuitboard/machine/powerator/syndicate,
+/obj/item/circuitboard/machine/bountypad,
+/obj/item/circuitboard/computer/bountypad,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/nova/des_two/bridge/vault)
 "xr" = (

--- a/_maps/RandomRuins/SpaceRuins/nova/port_tarkon.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/port_tarkon.dmm
@@ -42,6 +42,8 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
+/obj/item/circuitboard/machine/bountypad,
+/obj/item/circuitboard/computer/bountypad,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/port_tarkon/power1)
 "am" = (


### PR DESCRIPTION
## About The Pull Request

Gives civilian bounty pads as default to ghost roles so they may access relevant bounties to them immediately.

## How This Contributes To The Nova Sector Roleplay Experience

This allows them to have the boards immediately to make bounty cubes for their individual sides.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

Snowdyne
<img width="619" height="298" alt="image" src="https://github.com/user-attachments/assets/8362a0f8-7922-4aa1-8a53-c0fcff09f917" />


Lavadyne
<img width="593" height="492" alt="image" src="https://github.com/user-attachments/assets/440f9674-de9a-48aa-858a-23f3b7a8eae6" />

DS-2
<img width="634" height="412" alt="image" src="https://github.com/user-attachments/assets/d470a489-5d25-4d64-8496-29dd4c8377cd" />

Tarkon
<img width="532" height="348" alt="image" src="https://github.com/user-attachments/assets/533d6c31-00d9-4014-93b5-367fa960ef00" />
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Added Civilian bountypads to ghost roles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
