### PR TITLE
Adds the ability to disable blinking in server config

### DIFF
--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -542,6 +542,7 @@
 		addtimer(CALLBACK(src, PROC_REF(animate_eyelids), owner), blink_delay + duration)
 
 /obj/item/organ/eyes/proc/animate_eyelids(mob/living/carbon/human/parent)
+	if(CONFIG_GET(flag/disable_blinking)) return // NOVA EDIT ADDITION - CONFIG BLINKING
 	var/sync_blinking = synchronized_blinking && (parent.get_organ_loss(ORGAN_SLOT_BRAIN) < ASYNC_BLINKING_BRAIN_DAMAGE)
 	// Randomize order for unsynched animations
 	if (sync_blinking || prob(50))

--- a/config/nova/config_nova.txt
+++ b/config/nova/config_nova.txt
@@ -192,3 +192,6 @@ SHOW_JOB_ESTIMATION
 ## while it has an active whitelist. The \n allows the message to be displayed on a separate line,
 ## to make it more readable in the BYOND window.
 MISSING_WHITELIST_MESSAGE "\nThis server requires you to be whitelisted in order to be allowed to play. Apply on our Discord by simply filling the Access Request form from the #application-instructions channel under the 'Landing Zone' category. Here's the invite link: https://discord.gg/novasector"
+
+#If enabled, /human mobs will no longer occasionally blink
+#DISABLE_BLINKING

--- a/modular_nova/master_files/code/controllers/configuration/entries/config_entries.dm
+++ b/modular_nova/master_files/code/controllers/configuration/entries/config_entries.dm
@@ -95,3 +95,19 @@
 /// to make it more readable in the BYOND window.
 /datum/config_entry/string/missing_whitelist_message
 	default = "\nThis server requires you to be whitelisted in order to be allowed to play. Apply on our Discord by simply filling the Access Request form from the #application-instructions channel under the 'Landing Zone' category. Here's the invite link: https://discord.gg/novasector"
+
+/datum/config_entry/flag/disable_blinking
+	default = FALSE
+
+// blinking won't update without re-running the animate
+/datum/config_entry/flag/disable_blinking/vv_edit_var(var_name, var_value)
+	. = ..()
+	if(var_name == NAMEOF(src, config_entry_value))
+		INVOKE_ASYNC(src, PROC_REF(update_blinkers))
+
+
+/datum/config_entry/flag/disable_blinking/proc/update_blinkers()
+	for(var/mob/living/carbon/human/blinker in GLOB.alive_mob_list)
+		var/obj/item/organ/eyes/eyes = blinker.get_organ_slot(ORGAN_SLOT_EYES)
+		eyes?.blink()
+		CHECK_TICK


### PR DESCRIPTION
## About The Pull Request

https://github.com/Bubberstation/Bubberstation/pull/3703

Ported from Bubber. Blinking is a potential source of client lag, so let's see if disabling it actually makes a noticeable difference.

:cl:

config: added server config for disabling blinking
/:cl: