### PR TITLE
Code maintenance for sauna-oven

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/spacehotel.dmm
@@ -2441,11 +2441,8 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/hotel/power)
 "lr" = (
-/obj/structure/sauna_oven{
-	fuel_amount = -1;
-	water_amount = -1
-	},
 /obj/item/stack/sheet/mineral/wood/fifty,
+/obj/structure/sauna_oven,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel/sauna)
 "lx" = (
@@ -4535,10 +4532,7 @@
 /turf/open/floor/carpet/neon/simple/white/nodots,
 /area/ruin/space/has_grav/hotel/guestroom)
 "xW" = (
-/obj/structure/sauna_oven{
-	fuel_amount = -1;
-	water_amount = -1
-	},
+/obj/structure/sauna_oven,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel/guestroom)
 "xX" = (

--- a/modular_nova/master_files/code/game/objects/effects/effects.dm
+++ b/modular_nova/master_files/code/game/objects/effects/effects.dm
@@ -72,13 +72,6 @@
 	if(carbon_mob.has_status_effect(/datum/status_effect/washing_regen/hot_spring/sauna))
 		carbon_mob.remove_status_effect(/datum/status_effect/washing_regen/hot_spring/sauna)
 
-/obj/effect/abstract/fake_steam/sauna/process(seconds_per_tick)
-	. = ..()
-	for(var/mob/living/carbon/carbon_mob as anything in get_turf(src))
-		if(iscarbon(carbon_mob))
-			carbon_mob.adjust_bodytemperature(10 * seconds_per_tick, min_temp = BODYTEMP_HEATING_MAX, max_temp = BODYTEMP_HEAT_DAMAGE_LIMIT)
-			carbon_mob.set_wet_stacks(stacks = SAUNA_WET_STACKS, remove_fire_stacks = FALSE)
-
 /obj/effect/abstract/fake_steam/sauna/stage_up()
 	. = ..()
 	for(var/mob/living/carbon/carbon_mob as anything in get_turf(src))
@@ -97,11 +90,14 @@
 	return ..()
 
 /datum/status_effect/washing_regen/hot_spring/sauna
+
+/datum/status_effect/washing_regen/hot_spring/sauna/on_apply()
+	. = ..()
 	alert_type = /atom/movable/screen/alert/status_effect/washing_regen/hotspring/sauna
 
 /atom/movable/screen/alert/status_effect/washing_regen/hotspring/sauna
 	name = "Sauna"
-	desc = "A warm sauna is so relaxing..."
+	desc = "A steaming hot sauna is so relaxing..."
 
 #undef MAX_FAKE_STEAM_STAGES
 #undef STAGE_DOWN_TIME

--- a/modular_nova/master_files/code/game/objects/effects/effects.dm
+++ b/modular_nova/master_files/code/game/objects/effects/effects.dm
@@ -1,0 +1,109 @@
+#define MAX_FAKE_STEAM_STAGES 5
+#define STAGE_DOWN_TIME (10 SECONDS)
+#define FAKE_STEAM_TARGET_ALPHA 204
+
+/// Fake steam effect
+/obj/effect/abstract/fake_steam
+	layer = FLY_LAYER
+	icon = 'icons/effects/atmospherics.dmi'
+	icon_state = "water_vapor"
+	blocks_emissive = FALSE
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	var/next_stage_down = 0
+	var/current_stage = 0
+
+/obj/effect/abstract/fake_steam/Initialize(mapload)
+	. = ..()
+	START_PROCESSING(SSobj, src)
+
+/obj/effect/abstract/fake_steam/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	return ..()
+
+/obj/effect/abstract/fake_steam/process()
+	if(next_stage_down > world.time)
+		return
+	stage_down()
+
+/obj/effect/abstract/fake_steam/proc/update_alpha()
+	alpha = FAKE_STEAM_TARGET_ALPHA * (current_stage / MAX_FAKE_STEAM_STAGES)
+
+/obj/effect/abstract/fake_steam/proc/stage_down()
+	if(!current_stage)
+		qdel(src)
+		return
+	current_stage--
+	next_stage_down = world.time + STAGE_DOWN_TIME
+	update_alpha()
+
+/obj/effect/abstract/fake_steam/proc/stage_up(max_stage = MAX_FAKE_STEAM_STAGES)
+	var/target_max_stage = min(MAX_FAKE_STEAM_STAGES, max_stage)
+	current_stage = min(current_stage + 1, target_max_stage)
+	next_stage_down = world.time + STAGE_DOWN_TIME
+	update_alpha()
+
+#define SAUNA_WET_STACKS 1
+
+/obj/effect/abstract/fake_steam/sauna
+
+/obj/effect/abstract/fake_steam/sauna/Initialize(mapload)
+	. = ..()
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
+		COMSIG_ATOM_EXITED = PROC_REF(on_exited),
+	)
+	AddElement(/datum/element/connect_loc, loc_connections)
+
+/obj/effect/abstract/fake_steam/sauna/proc/on_entered(datum/source, atom/movable/entered)
+	SIGNAL_HANDLER
+	if(!iscarbon(entered))
+		return
+	var/mob/living/carbon/carbon_mob = entered
+	if(!carbon_mob.has_status_effect(/datum/status_effect/washing_regen/hot_spring/sauna))
+		carbon_mob.apply_status_effect(/datum/status_effect/washing_regen/hot_spring/sauna)
+
+/obj/effect/abstract/fake_steam/sauna/proc/on_exited(datum/source, atom/movable/exited)
+	SIGNAL_HANDLER
+	if(locate(/obj/effect/abstract/fake_steam/sauna) in get_turf(exited))
+		return
+	if(!iscarbon(exited))
+		return
+	var/mob/living/carbon/carbon_mob = exited
+	if(carbon_mob.has_status_effect(/datum/status_effect/washing_regen/hot_spring/sauna))
+		carbon_mob.remove_status_effect(/datum/status_effect/washing_regen/hot_spring/sauna)
+
+/obj/effect/abstract/fake_steam/sauna/process(seconds_per_tick)
+	. = ..()
+	for(var/mob/living/carbon/carbon_mob as anything in get_turf(src))
+		if(iscarbon(carbon_mob))
+			carbon_mob.adjust_bodytemperature(10 * seconds_per_tick, min_temp = BODYTEMP_HEATING_MAX, max_temp = BODYTEMP_HEAT_DAMAGE_LIMIT)
+			carbon_mob.set_wet_stacks(stacks = SAUNA_WET_STACKS, remove_fire_stacks = FALSE)
+
+/obj/effect/abstract/fake_steam/sauna/stage_up()
+	. = ..()
+	for(var/mob/living/carbon/carbon_mob as anything in get_turf(src))
+		if(!iscarbon(carbon_mob))
+			continue
+		if(!carbon_mob.has_status_effect(/datum/status_effect/washing_regen/hot_spring/sauna))
+			carbon_mob.apply_status_effect(/datum/status_effect/washing_regen/hot_spring/sauna)
+
+/obj/effect/abstract/fake_steam/sauna/stage_down()
+	if(!current_stage)
+		for(var/mob/living/carbon/carbon_mob as anything in get_turf(src))
+			if(!iscarbon(carbon_mob))
+				continue
+			if(carbon_mob.has_status_effect(/datum/status_effect/washing_regen/hot_spring/sauna))
+				carbon_mob.remove_status_effect(/datum/status_effect/washing_regen/hot_spring/sauna)
+	return ..()
+
+/datum/status_effect/washing_regen/hot_spring/sauna
+	alert_type = /atom/movable/screen/alert/status_effect/washing_regen/hotspring/sauna
+
+/atom/movable/screen/alert/status_effect/washing_regen/hotspring/sauna
+	name = "Sauna"
+	desc = "A warm sauna is so relaxing..."
+
+#undef MAX_FAKE_STEAM_STAGES
+#undef STAGE_DOWN_TIME
+#undef FAKE_STEAM_TARGET_ALPHA
+#undef SAUNA_WET_STACKS

--- a/modular_nova/master_files/code/game/objects/structures/sauna_oven.dm
+++ b/modular_nova/master_files/code/game/objects/structures/sauna_oven.dm
@@ -72,7 +72,7 @@
 			return ITEM_INTERACT_BLOCKING
 		if(reagents.total_volume >= SAUNA_REAGENT_MAX)
 			return ITEM_INTERACT_BLOCKING
-		var/datum/reagent/master_reagent = container.reagents.get_master_reagent()
+		var/datum/reagent/master_reagent = reagent_container.reagents.get_master_reagent()
 		if(istype(master_reagent, /datum/reagent/water))
 			reagent_container.reagents.trans_to(src, reagent_container.amount_per_transfer_from_this)
 			user.visible_message(span_notice("[user] pours some \

--- a/modular_nova/master_files/code/game/objects/structures/sauna_oven.dm
+++ b/modular_nova/master_files/code/game/objects/structures/sauna_oven.dm
@@ -114,7 +114,7 @@
 		qdel(interacting_item)
 		playsound(src, 'sound/items/handling/paper_drop.ogg', 75, TRUE)
 		return ITEM_INTERACT_SUCCESS
-	return NONE
+	return ..()
 
 /obj/structure/sauna_oven/process()
 	if(reagents.total_volume)

--- a/modular_nova/master_files/code/game/objects/structures/sauna_oven.dm
+++ b/modular_nova/master_files/code/game/objects/structures/sauna_oven.dm
@@ -114,7 +114,7 @@
 		qdel(interacting_item)
 		playsound(src, 'sound/items/handling/paper_drop.ogg', 75, TRUE)
 		return ITEM_INTERACT_SUCCESS
-	return ..()
+	return NONE
 
 /obj/structure/sauna_oven/process()
 	if(reagents.total_volume)

--- a/modular_nova/master_files/code/game/objects/structures/sauna_oven.dm
+++ b/modular_nova/master_files/code/game/objects/structures/sauna_oven.dm
@@ -72,7 +72,8 @@
 			return ITEM_INTERACT_BLOCKING
 		if(reagents.total_volume >= SAUNA_REAGENT_MAX)
 			return ITEM_INTERACT_BLOCKING
-		if(reagent_container.reagents.has_reagent(/datum/reagent/water))
+		var/datum/reagent/master_reagent = container.reagents.get_master_reagent()
+		if(istype(master_reagent, /datum/reagent/water))
 			reagent_container.reagents.trans_to(src, reagent_container.amount_per_transfer_from_this)
 			user.visible_message(span_notice("[user] pours some \
 			water into [src]."), span_notice("You pour \

--- a/modular_nova/master_files/code/game/objects/structures/sauna_oven.dm
+++ b/modular_nova/master_files/code/game/objects/structures/sauna_oven.dm
@@ -3,8 +3,8 @@
 #define SAUNA_PAPER_FUEL 5
 #define SAUNA_MAXIMUM_FUEL 3000
 #define SAUNA_WATER_PER_WATER_UNIT 5
-/// Max amount of turfs to spread vapour to
-#define SAUNA_SPREAD_CAP 60
+/// Max amount of turfs to be affected by vapor, counts tiles adjacent to vapor
+#define SAUNA_SPREAD_CAP 120
 
 /obj/structure/sauna_oven
 	name = "sauna oven"
@@ -117,12 +117,13 @@
 		update_steam_particles()
 		var/list/turfs_affected = list(get_turf(src))
 		var/list/turfs_to_spread = list(get_turf(src))
-		var/spread_stage = water_amount
 		for(var/i in 1 to water_amount)
 			if(!length(turfs_to_spread))
 				break
 			var/list/new_spread_list = list()
 			for(var/turf/open/turf_to_spread as anything in turfs_to_spread)
+				if(length(turfs_affected) >= SAUNA_SPREAD_CAP)
+					break
 				if(is_space_or_openspace(turf_to_spread))
 					continue
 				var/obj/effect/abstract/fake_steam/fake_steam = locate() in turf_to_spread
@@ -130,16 +131,13 @@
 				if(!fake_steam)
 					at_edge = TRUE
 					fake_steam = new(turf_to_spread)
-				fake_steam.stage_up(spread_stage)
+				fake_steam.stage_up()
 				if(!at_edge)
 					for(var/turf/open/open_turf as anything in turf_to_spread.atmos_adjacent_turfs)
-						if(length(new_spread_list) >= SAUNA_SPREAD_CAP)
-							break
 						if(!(open_turf in turfs_affected))
 							new_spread_list += open_turf
 							turfs_affected += open_turf
 			turfs_to_spread = new_spread_list
-			spread_stage--
 
 	fuel_amount--
 	if(fuel_amount <= 0)

--- a/modular_nova/master_files/code/game/objects/structures/sauna_oven.dm
+++ b/modular_nova/master_files/code/game/objects/structures/sauna_oven.dm
@@ -100,9 +100,30 @@
 	if(water_amount)
 		water_amount--
 		update_steam_particles()
-		var/turf/open/pos = get_turf(src)
-		if(istype(pos) && pos.air.return_pressure() < 2*ONE_ATMOSPHERE)
-			pos.atmos_spawn_air("water_vapor=10;TEMP=[SAUNA_H2O_TEMP]")
+		var/list/turfs_affected = list(get_turf(src))
+		var/list/turfs_to_spread = list(get_turf(src))
+		var/spread_stage = water_amount
+		for(var/i in 1 to water_amount)
+			if(!turfs_to_spread.len)
+				break
+			var/list/new_spread_list = list()
+			for(var/turf/open/turf_to_spread as anything in turfs_to_spread)
+				if(isspaceturf(turf_to_spread))
+					continue
+				var/obj/effect/abstract/fake_steam/fake_steam = locate() in turf_to_spread
+				var/at_edge = FALSE
+				if(!fake_steam)
+					at_edge = TRUE
+					fake_steam = new(turf_to_spread)
+				fake_steam.stage_up(spread_stage)
+				if(!at_edge)
+					for(var/turf/open/open_turf as anything in turf_to_spread.atmos_adjacent_turfs)
+						if(!(open_turf in turfs_affected))
+							new_spread_list += open_turf
+							turfs_affected += open_turf
+			turfs_to_spread = new_spread_list
+			spread_stage--
+
 	fuel_amount--
 	if(fuel_amount <= 0)
 		lit = FALSE

--- a/modular_nova/master_files/code/game/objects/structures/sauna_oven.dm
+++ b/modular_nova/master_files/code/game/objects/structures/sauna_oven.dm
@@ -73,7 +73,7 @@
 		if(reagents.total_volume >= SAUNA_REAGENT_MAX)
 			return ITEM_INTERACT_BLOCKING
 		if(reagent_container.reagents.has_reagent(/datum/reagent/water))
-			reagent_container.reagents.trans_to(src, reagent_container.reagents.total_volume)
+			reagent_container.reagents.trans_to(src, reagent_container.amount_per_transfer_from_this)
 			user.visible_message(span_notice("[user] pours some \
 			water into [src]."), span_notice("You pour \
 			some water to [src]."))

--- a/modular_nova/modules/bongs/code/bong.dm
+++ b/modular_nova/modules/bongs/code/bong.dm
@@ -189,55 +189,6 @@
 	smoke_range = 7
 	moan_chance = 50
 
-#define MAX_FAKE_STEAM_STAGES 5
-#define STAGE_DOWN_TIME (10 SECONDS)
-
-/// Fake steam effect
-/obj/effect/abstract/fake_steam
-	layer = FLY_LAYER
-	icon = 'icons/effects/atmospherics.dmi'
-	icon_state = "water_vapor"
-	blocks_emissive = FALSE
-	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	var/next_stage_down = 0
-	var/current_stage = 0
-
-/obj/effect/abstract/fake_steam/Initialize(mapload)
-	. = ..()
-	START_PROCESSING(SSobj, src)
-
-/obj/effect/abstract/fake_steam/Destroy()
-	STOP_PROCESSING(SSobj, src)
-	return ..()
-
-/obj/effect/abstract/fake_steam/process()
-	if(next_stage_down > world.time)
-		return
-	stage_down()
-
-#define FAKE_STEAM_TARGET_ALPHA 204
-
-/obj/effect/abstract/fake_steam/proc/update_alpha()
-	alpha = FAKE_STEAM_TARGET_ALPHA * (current_stage / MAX_FAKE_STEAM_STAGES)
-
-#undef FAKE_STEAM_TARGET_ALPHA
-
-/obj/effect/abstract/fake_steam/proc/stage_down()
-	if(!current_stage)
-		qdel(src)
-		return
-	current_stage--
-	next_stage_down = world.time + STAGE_DOWN_TIME
-	update_alpha()
-
-/obj/effect/abstract/fake_steam/proc/stage_up(max_stage = MAX_FAKE_STEAM_STAGES)
-	var/target_max_stage = min(MAX_FAKE_STEAM_STAGES, max_stage)
-	current_stage = min(current_stage + 1, target_max_stage)
-	next_stage_down = world.time + STAGE_DOWN_TIME
-	update_alpha()
-
-#undef MAX_FAKE_STEAM_STAGES
-
 /datum/crafting_recipe/bong
 	name = "Bong"
 	result = /obj/item/bong

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6900,6 +6900,7 @@
 #include "modular_nova\master_files\code\game\machinery\doors\firedoor.dm"
 #include "modular_nova\master_files\code\game\objects\items.dm"
 #include "modular_nova\master_files\code\game\objects\objs.dm"
+#include "modular_nova\master_files\code\game\objects\effects\effects.dm"
 #include "modular_nova\master_files\code\game\objects\effects\decals\remains.dm"
 #include "modular_nova\master_files\code\game\objects\effects\decals\cleanable\blood.dm"
 #include "modular_nova\master_files\code\game\objects\effects\decals\cleanable\misc.dm"


### PR DESCRIPTION
## About The Pull Request
Maintains old code, and finally: **Takes the sauna oven out of atmosia's domain.** Its been a long time coming.
Instead of being a gas, the vapour is now a `/obj/effect/abstract/fake_steam` subtype.

## How This Contributes To The Nova Sector Roleplay Experience

Fixes a crime against atmospherics: sauna-ovens in any type of gas setups.

<details>
<summary>Example of crime against atmos.</summary>

<img width="322" height="327" alt="img-iJmVm_(322x327)" src="https://github.com/user-attachments/assets/ef81dbc7-9376-4c2d-ad1e-c0c8054bed48" />

</details>

## Proof of Testing

https://github.com/user-attachments/assets/95aa4c91-a060-4271-af87-af599b7e4cd7

## Changelog

:cl:
add: Saunas now have their own kind of vapor effect
balance: The sauna vapor effect grants a status effect buff similar to hotsprings
qol: Unlike showers and hotsprings, cat-like folk do enjoy saunas
qol: The sauna vapor effect heats you up to 45° C
fix: Saunas are no longer a cheap source for water vapor
fix: Saunas correctly lose their particle effect when turned off
code: Saunas are updated to use the modern interaction chain
/:cl:
