### PR TITLE
wt550 damage... buff? normalization? something

### DIFF
--- a/modular_nova/modules/modular_weapons/code/modular_projectiles/rifle_calibers.dm
+++ b/modular_nova/modules/modular_weapons/code/modular_projectiles/rifle_calibers.dm
@@ -28,6 +28,26 @@
 	harmful = FALSE
 	print_cost = 0
 
+/obj/projectile/bullet/c46x30mm
+	// 20*1.35=27
+	// not rounding up to 30 this time. wonder why
+	damage = 27
+	wound_bonus = 0
+	exposed_wound_bonus = 5
+	embed_falloff_tile = -2
+
+/obj/projectile/bullet/c46x30mm/ap
+	// 15*1.35 = 20.25
+	// round up because it's funnier that way
+	damage = 21
+
+/obj/projectile/bullet/incendiary/c46x30mm
+	// 10 * 1.35 = 13.5
+	// round up because it's funnier that way
+	damage = 15
+	fire_stacks = 1
+
+
 /*
 *	.223
 */


### PR DESCRIPTION
## About The Pull Request
unofficial pt2 to the pr where i multiplied all of .38's damage numbers by 1.35 because that's the health pool multiplier on nova

except this time it's for the wt550

## How This Contributes To The Nova Sector Roleplay Experience
potential SMG they could never make me hate you

for slightly less of a joke reason, the WT-550's damage values are based on killing people in a 100-health universe. for better or for worse, nova runs a 135-health universe. iirc the comment for that is/was "so gunfights last a little longer". but i think it's probably fine if the WT gets to punch a little harder to account for that.

## Changelog

:cl:
balance: After some slight reflection, Nanotrasen remembered that their 4.6x30mm ammunition was using an older, less-powerful propellant design, and has fixed this oversight, leading to increased ballistic performance (read: WT-550s now do a smidge more damage).
/:cl: