### PR TITLE
Fixes the breathing quirks not providing a gas mask

### DIFF
--- a/modular_nova/master_files/code/datums/quirks/neutral_quirks/breather/breather_quirk.dm
+++ b/modular_nova/master_files/code/datums/quirks/neutral_quirks/breather/breather_quirk.dm
@@ -5,6 +5,8 @@
 	var/alert_text = "Be sure to equip your breathing apparatus, or you may end up choking!"
 	///the type of gas the dogtag accessory will be showing
 	var/breath_type = "oxygen"
+	///the mask that will be supplied once, can be none
+	var/obj/item/clothing/mask/breathing_mask = /obj/item/clothing/mask/gas/glass
 	///the tank of gas that will be supplied once
 	var/obj/item/breathing_tank = /obj/item/tank/internals/emergency_oxygen/engi
 	///this stores the old lungs so we can grant them on removal of the quirk
@@ -26,6 +28,8 @@
 	var/obj/item/clothing/accessory/breathing/target_tag = new(get_turf(quirk_holder))
 	target_tag.breath_type = breath_type
 
+	if(breathing_mask)
+		give_item_to_holder(breathing_mask, list(LOCATION_MASK, LOCATION_LPOCKET, LOCATION_RPOCKET, LOCATION_BACKPACK, LOCATION_HANDS))
 	give_item_to_holder(target_tag, list(LOCATION_LPOCKET, LOCATION_RPOCKET, LOCATION_BACKPACK, LOCATION_HANDS))
 	give_item_to_holder(breathing_tank,
 		list(

--- a/modular_nova/master_files/code/datums/quirks/neutral_quirks/breather/water_breather.dm
+++ b/modular_nova/master_files/code/datums/quirks/neutral_quirks/breather/water_breather.dm
@@ -7,6 +7,7 @@
 	gain_text = span_notice("You suddenly have a hard time breathing through thin air.")
 	lose_text = span_danger("You suddenly feel like you aren't bound to breathing through liquid anymore.")
 	value = 0
+	breathing_mask = NONE
 	breathing_tank = /obj/item/clothing/accessory/vaporizer
 	breath_type = "water"
 	// bonus trait


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The refactored version of the breathing quirks didn't provide a gas mask to breathe through. This was an oversight.

## How This Contributes To The Nova Sector Roleplay Experience
Equipping the mask from the emergency box every shift sucks, and if you don't have such a box like some antags you're kinda boned.

## Changelog

:cl:
fix: Nitrogen breather quirk and plasma breather quirk provide a gas mask now
/:cl:
