### PR TITLE
[Feature] Stasis Beds report people, block surgeries when on, allow blood filtering

### DIFF
--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -97,6 +97,15 @@
 	var/fail_prob = 0//100 - fail_prob = success_prob
 	var/advance = FALSE
 
+	// NOVA EDIT ADDITION START - Makes it so you cannot operate on people in turned on Stasis Beds, unless we are doing a blood filter surgery
+	if(target.buckled)
+		var/obj/machinery/stasis/stasis_bed = target.buckled
+		if(istype(stasis_bed) && stasis_bed.stasis_enabled && !istype(surgery, /datum/surgery/blood_filter))
+			to_chat(user, span_warning("[target] cannot be operated in the [target.buckled], as the machine interferes with the surgery!"))
+			surgery.step_in_progress = FALSE
+			return FALSE
+	// NOVA EDIT ADDITION END -
+
 	if(!chem_check(target))
 		user.balloon_alert(user, "missing [LOWER_TEXT(get_chem_list())]!")
 		to_chat(user, span_warning("[target] is missing the [LOWER_TEXT(get_chem_list())] required to perform this surgery step!"))

--- a/modular_nova/master_files/code/game/machinery/stasis.dm
+++ b/modular_nova/master_files/code/game/machinery/stasis.dm
@@ -1,0 +1,34 @@
+/obj/machinery/stasis
+	name = "lifeform stasis unit MK-II"
+	/// Controls wherever the stasis bed gives an announcement when someone is buckled to it or not.
+	var/announce = FALSE
+
+/obj/machinery/stasis/Initialize(mapload)
+	. = ..()
+	var/obj/item/circuitboard/machine/stasis/board = circuit
+	if (board.fresh)
+		if (is_station_level(z))
+			announce = TRUE
+			board.announce = TRUE
+		board.fresh = FALSE
+	else
+		announce = board.announce
+
+/obj/machinery/stasis/post_buckle_mob(mob/living/L)
+	. = ..()
+	if (announce)
+		var/obj/machinery/announcement_system/system = pick(GLOB.announcement_systems)
+		if (system)
+			system.broadcast("Critical Patient [L.name] set in stasis at [get_area(src)]!", list(RADIO_CHANNEL_MEDICAL))
+
+/obj/item/circuitboard/machine/stasis
+	/// Controls wherever the stasis bed gives an announcement when someone is buckled to it or not.
+	var/announce = FALSE
+	/// Flag that tells wherever this is a freshly created board, in which case it will go with the z level logic, or if it was modified and thus needs to read the new logic.
+	var/fresh = TRUE
+
+/obj/item/circuitboard/machine/stasis/multitool_act(mob/living/user)
+	. = ..()
+	announce = !announce
+	fresh = FALSE
+	to_chat(user, span_notice("Medbay announcement set to [announce ? "Enabled" : "Disabled"]."))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6892,6 +6892,7 @@
 #include "modular_nova\master_files\code\game\machinery\deployable.dm"
 #include "modular_nova\master_files\code\game\machinery\hologram.dm"
 #include "modular_nova\master_files\code\game\machinery\limbgrower.dm"
+#include "modular_nova\master_files\code\game\machinery\stasis.dm"
 #include "modular_nova\master_files\code\game\machinery\status_display.dm"
 #include "modular_nova\master_files\code\game\machinery\suit_storage.dm"
 #include "modular_nova\master_files\code\game\machinery\syndiepad.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This was born from here https://discord.com/channels/1171566433923239977/1403055644554170399

Going to cheat and explain from the requester Point of View:

Stasis beds are infallible. You can do practically anything on them, (And literally everything on them if you have a modsuit with the surgical processor!) very fucking slowly. That's supposed to be the downside, it's slow

The problem? Medical is already slow

Every shift a chemist makes chems that go unused, a scientist researches surgeries that go unused, and a patient is wondering why this Tend Wounds (Basic) is only ticking once every 10 seconds.

Stasis beds are a catch all solution. You got a bleed? No you don't, get on Stasis. You got Allergies? No you don't, stasis. You're an un-penned corpse rotting away? Syke, Stasis.

We have a lot of mechanics that go wildly unused a lot of the time because we're one step away from just having Autodocs. Doctors might feel bored because we hand them a solved puzzle and expect them to be satisfied with it.

/////

And for the requester of the messaging feature:

Because the ideal use case for stasis is to stop someone dying long enough for medical to be able to tend to them. I'd argue even for an automatic radiocall for a critical patient in a pod?

This encourages first aid on the field more, plus chemistry prepwork at the fridge/handing out the hoard of medkits that medical will never realistically all use that's rotting in the back of med storage

////

Additionally, mid development it was noted by other contributors that blood filtering (and its robotic variant) should be left excempt of this, as it could cause troubles to gameplay otherwise.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Well, all these medical mains suggested it as an improvement, this is kind of a mixed bag of a QoL and nerf that guides people to the ideal mechanics we want to promote, and from my out of medical view, I think its better for people to be operated on the surgery rooms instead of directly on the stasis bed. 

Plus you know, I think if we announce in the radio we got a bounty, its the more reason to announce in medbay we got someone in stasis bed waiting for being attended.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
<img width="513" height="110" alt="image" src="https://github.com/user-attachments/assets/e549fdd8-d4fe-45c6-b6fa-e7a4cda499b8" />

<img width="500" height="345" alt="image" src="https://github.com/user-attachments/assets/7031fd4a-e067-49d8-b356-4c625846db10" />

<img width="508" height="295" alt="image" src="https://github.com/user-attachments/assets/ebeddf0c-d37c-4e7e-9cec-aec501a85497" />

<img width="514" height="193" alt="image" src="https://github.com/user-attachments/assets/8fcb552f-ac39-4842-b0ac-59ae5bd9f686" />


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Stasis Beds now report in the medical channel if someone is buckled to them. This can be changed with a multitool on their boards, come on by default if the bed is created on an NT space, or off if its not the case.
balance: Stasis Beds no longer let you do surgeries (Except for Blood filter / Hydraulics Purge) while its on. (You can turn it off with alt click)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
