### PR TITLE
Fixes razorwire and shell launcher sprites looking as if augs are installed in the other hand

### DIFF
--- a/modular_nova/modules/implants/code/augments_arms.dm
+++ b/modular_nova/modules/implants/code/augments_arms.dm
@@ -309,8 +309,8 @@
 		even from a few steps away. However, results against anything more durable will heavily vary."
 	icon = 'modular_nova/modules/implants/icons/implants.dmi'
 	icon_state = "razorwire_weapon"
-	righthand_file = 'modular_nova/modules/implants/icons/inhands/lefthand.dmi'
-	lefthand_file = 'modular_nova/modules/implants/icons/inhands/righthand.dmi'
+	righthand_file = 'modular_nova/modules/implants/icons/inhands/righthand.dmi'
+	lefthand_file = 'modular_nova/modules/implants/icons/inhands/lefthand.dmi'
 	inhand_icon_state = "razorwire"
 	w_class = WEIGHT_CLASS_BULKY
 	sharpness = SHARP_EDGED
@@ -369,8 +369,8 @@
 		shells famously seen in the 'Kiboko' launcher."
 	icon = 'modular_nova/modules/implants/icons/implants.dmi'
 	icon_state = "shell_cannon_weapon"
-	righthand_file = 'modular_nova/modules/implants/icons/inhands/lefthand.dmi'
-	lefthand_file = 'modular_nova/modules/implants/icons/inhands/righthand.dmi'
+	righthand_file = 'modular_nova/modules/implants/icons/inhands/righthand.dmi'
+	lefthand_file = 'modular_nova/modules/implants/icons/inhands/lefthand.dmi'
 	inhand_icon_state = "shell_cannon"
 	worn_icon = 'icons/mob/clothing/belt.dmi'
 	worn_icon_state = "gun"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
The inhand sprites were fine but were displayed incorrectly because of a small typo. A shell launcher aug, if installed into the right arm, would be shown as if its on the left arm and vice versa, same for razorwire spool. I fixed that.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
A minor purely visual fix. Maybe a roboticist will notice it after a year or so.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
Not sure if they are needed at all considering how simplistic the fix is, but here it is
<details>
<summary>Screenshots/Videos</summary>
<img width="247" height="257" alt="image" src="https://github.com/user-attachments/assets/c154cf30-d00f-413c-a140-b8fbc94b810f" />
<img width="346" height="323" alt="imageee" src="https://github.com/user-attachments/assets/b2702aec-4dc2-4ed1-9406-323d45f8c749" />

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Razorwire and Shell launcher cyberimps are no longer displayed as if they are on the opposite hand
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
