### PR TITLE
Changes the organ manipulation menu from a tgui list to a radial menu

### DIFF
--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -226,9 +226,22 @@
 			for(var/obj/item/organ/organ in organs)
 				organ.on_find(user)
 				organs -= organ
-				organs[organ.name] = organ
+//				organs[organ.name] = organ // NOVA EDIT OLD
+//				organs[organ] = image(icon = organ.icon, icon_state = organ.icon_state) // NOVA EDIT NEW
+				organs[organ] = organ // NOVA EDIT NEW
 
-			var/chosen_organ = tgui_input_list(user, "Remove which organ?", "Surgery", sort_list(organs))
+//			var/chosen_organ = tgui_input_list(user, "Remove which organ?", "Surgery", sort_list(organs)) NOVA EDIT OLD
+			// NOVA EDIT NEW START
+			var/obj/item/organ/chosen_organ = show_radial_menu(
+				user,
+				target,
+				organs,
+				radius = 30,
+				require_near = TRUE,
+				tooltips = TRUE,
+				autopick_single_option = FALSE,
+			)
+			// NOVA EDIT NEW END
 			if(isnull(chosen_organ))
 				return SURGERY_STEP_FAIL
 			target_organ = chosen_organ

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -227,7 +227,6 @@
 				organ.on_find(user)
 				organs -= organ
 //				organs[organ.name] = organ // NOVA EDIT OLD
-//				organs[organ] = image(icon = organ.icon, icon_state = organ.icon_state) // NOVA EDIT NEW
 				organs[organ] = organ // NOVA EDIT NEW
 
 //			var/chosen_organ = tgui_input_list(user, "Remove which organ?", "Surgery", sort_list(organs)) NOVA EDIT OLD


### PR DESCRIPTION

## About The Pull Request

What it says on the tin, replaces the tgui list with a radial menu that shows the surgeon the icons of the organs

## How This Contributes To The Nova Sector Roleplay Experience

Gameplay reason -- Its just faster and easier to see what organ you want to pull out instead of looking for it in the list

Roleplay reason -- Makes it so you can comment on how someone's organs look before pulling them out adding a new layer of roleplay between a surgeon and their patient, an example: "Wow, your organs look absolutelly disqusting, ya know you shouldn't smoke this much. Now lets get that heart going and since your lungs look so bad lets maybe replace them aswell."

## Proof of Testing

<details>
<summary>Before</summary>
  
<img width="1143" height="860" alt="image" src="https://github.com/user-attachments/assets/4c5aaec9-72e2-47be-b279-8852aeaf692b" />

</details>
<details>
<summary>After</summary>
  
<img width="1144" height="857" alt="image" src="https://github.com/user-attachments/assets/a50b17a9-0a84-42de-bd48-1d0187af0aca" />

</details>

## Changelog

:cl:
qol: changed the organ manipulation surgery from a tgui list to a radial menu
/:cl:
