### PR TITLE
[Balance] Interaction between slime people and water breathing.

### DIFF
--- a/modular_nova/master_files/code/datums/quirks/neutral_quirks/breather/water_breather.dm
+++ b/modular_nova/master_files/code/datums/quirks/neutral_quirks/breather/water_breather.dm
@@ -34,3 +34,17 @@
 /datum/quirk/item_quirk/breather/water_breather/remove()
 	. = ..()
 	quirk_holder.clear_alert(ALERT_NOT_ENOUGH_WATER)
+
+/datum/quirk/item_quirk/breather/water_breather/add_unique(client/client_source)
+	. = ..()
+	// The button/action may be granted after quirks run, so defer and purge it
+	spawn(0)
+		remove_hydrophobia_action(quirk_holder)
+
+/// Find and remove the slime hydrophobia spell/action if present
+/proc/remove_hydrophobia_action(mob/living/L)
+	if (!L || QDELETED(L) || !islist(L.actions))
+		return
+	for (var/datum/action/cooldown/spell/slime_hydrophobia/A in L.actions)
+		A.Remove(L)   // ungrants from owner
+		qdel(A)       // delete the action datum

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -150,7 +150,7 @@
 			to_chat(organ_owner, span_purple("Your body's thirst for plasma is quenched, your inner and outer membrane using it to regenerate."))
 
 	if(chem.type == /datum/reagent/water)
-		if(HAS_TRAIT(organ_owner, TRAIT_SLIME_HYDROPHOBIA))
+		if (HAS_TRAIT(organ_owner, TRAIT_SLIME_HYDROPHOBIA) || HAS_TRAIT(organ_owner, TRAIT_WATER_BREATHING))
 			return
 
 		organ_owner.blood_volume -= 3 * seconds_per_tick
@@ -353,31 +353,59 @@
 	return TRUE
 
 // HEALING SECTION
-// Handles passive healing and water damage.
+// Handles passive healing and water damage for slimes and water-breathing variants.
 /datum/species/jelly/spec_life(mob/living/carbon/human/slime, seconds_per_tick, times_fired)
 	. = ..()
+
+	// Skip if unconscious
 	if(slime.stat != CONSCIOUS)
 		return
 
 	var/healing = TRUE
 
+	// Get wetness effect if it exists
 	var/datum/status_effect/fire_handler/wet_stacks/wetness = locate() in slime.status_effects
+	var/wetness_amount = 0
+	if(istype(wetness))
+		wetness_amount = wetness.stacks
+
+	// Skip if hydrophobic
 	if(HAS_TRAIT(slime, TRAIT_SLIME_HYDROPHOBIA))
 		return
-	if(istype(wetness) && wetness.stacks > (DAMAGE_WATER_STACKS))
-		slime.blood_volume -= 2 * seconds_per_tick
-		if(SPT_PROB(25, seconds_per_tick))
-			slime.visible_message(span_danger("[slime]'s form begins to lose cohesion, seemingly diluting with the water!"), span_warning("The water starts to dilute your body, dry it off!"))
 
-	if(istype(wetness) && wetness.stacks > (REGEN_WATER_STACKS))
-		healing = FALSE
-		if(SPT_PROB(1, seconds_per_tick))
-			to_chat(slime, span_warning("You can't pull your body together and regenerate with water inside it!"))
-			slime.blood_volume -= 1 * seconds_per_tick
+	// Determine if water-breathing logic should be inverted
+	var/inverted = HAS_TRAIT(slime, TRAIT_WATER_BREATHING)
 
+	// WATER DAMAGE / REGEN
+	if(inverted)
+		// Water-breathing slimes: damaged when dry, heal only when wet
+		if(wetness_amount <= REGEN_WATER_STACKS)
+			slime.blood_volume -= 2 * seconds_per_tick
+			healing = FALSE
+			if(SPT_PROB(25, seconds_per_tick))
+				slime.visible_message(
+					span_danger("[slime]'s form begins to lose cohesion, seemingly drying out!"),
+					span_warning("Your body loses cohesion as it dries, only immersion can restore it!")
+				)
+		else
+			healing = TRUE
+	else
+		// Normal slimes: damaged when too wet, cannot heal if too wet
+		if(wetness_amount > DAMAGE_WATER_STACKS)
+			slime.blood_volume -= 2 * seconds_per_tick
+			if(SPT_PROB(25, seconds_per_tick))
+				slime.visible_message(
+					span_danger("[slime]'s form begins to lose cohesion, seemingly diluting with the water!"),
+					span_warning("The water starts to dilute your body, dry it off!")
+				)
+		if(wetness_amount > REGEN_WATER_STACKS)
+			healing = FALSE
+			if(SPT_PROB(1, seconds_per_tick))
+				to_chat(slime, span_warning("You can't pull your body together and regenerate with water inside it!"))
+				slime.blood_volume -= 1 * seconds_per_tick
+
+	// PASSIVE HEALING
 	if(slime.blood_volume >= BLOOD_VOLUME_NORMAL && healing)
-		if(HAS_TRAIT(slime, TRAIT_SLIME_HYDROPHOBIA))
-			return
 		if(slime.stat != CONSCIOUS)
 			return
 		slime.heal_overall_damage(brute = 1.5 * seconds_per_tick, burn = 1.5 * seconds_per_tick, required_bodytype = BODYTYPE_ORGANIC)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
-Inverses the regen algorithm for slime people with the water breathing quirk. (You regen when wet and slowly loose blood when dry, until you become a nugget and then die)
-Disable the damage from ingesting water for slime people with the water breathing quirk.
-Removes the Hydrophobia toggle for slime people with the water breathing quirk.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Currently, water breathing quirk, when taken on a slime person, only allows them to breathe underwater while the water slowly kills them, unless they toggle hydrophobia. Forcing them to be super slow and deactivating their regen (by turning on hydrophobia), or die from either the fact that they are wet, or the fact that they aren't wet.
We already have a lore example of water adapted slimes with the slime fishes, so I figured why not do this.
Allows players to be water based slimes, trading off their water weakness to an EMP weakness. As the main way to stay wet, the Stardress hydro-vaporizer is destroyed when EMP'ed.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

https://github.com/user-attachments/assets/54d3d761-c8a9-4391-9925-71fe0c468079


https://github.com/user-attachments/assets/15269a1c-9a85-4cfb-bfda-d387e26f93c2


https://github.com/user-attachments/assets/6f8e5111-d96b-49b3-8000-2b8d385530e6

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Inverses the regen algorithm for slime people with the water breathing quirk.
add: Disable the damage from ingesting water for slime people with the water breathing quirk.
add : Removes the Hydrophobia toggle for slime people with the water breathing quirk.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
