### PR TITLE
Fix a headset I missed in Abductor Mothership

### DIFF
--- a/_maps/virtual_domains/abductor_mothership.dmm
+++ b/_maps/virtual_domains/abductor_mothership.dmm
@@ -2663,13 +2663,6 @@
 /mob/living/basic/trooper/russian/ranged,
 /turf/open/floor/plating/abductor2,
 /area/virtual_domain)
-"Vx" = (
-/obj/structure/closet/abductor,
-/obj/item/radio/headset/abductor,
-/obj/item/clothing/under/abductor,
-/obj/item/pillow,
-/turf/open/floor/plating/abductor2,
-/area/virtual_domain)
 "Vy" = (
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 8;
@@ -6212,7 +6205,7 @@ pI
 XL
 XL
 pI
-Vx
+zB
 AU
 pI
 pI


### PR DESCRIPTION

## About The Pull Request

title says all. it was hidden under a pillow and i guess i just didn't notice it during my checking; reminder to self to check the compiled file when doing removals like this
## How This Contributes To The Nova Sector Roleplay Experience

i am making the on a limb assumption bitrunners should not have allcomms
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: Removed the last remaining Abductor Headset from Abductor Mothership. No more allcomms for bitrunners.
/:cl:
