### PR TITLE
[DO NOT MERGE] FIx: Neuroware + NIF

### DIFF
--- a/code/modules/unit_tests/~nova/liver.dm
+++ b/code/modules/unit_tests/~nova/liver.dm
@@ -5,6 +5,10 @@
 /// 2. SYNTHETIC-oriented neuroware can't process in non-synthetics.
 /// 3. ORGANIC-oriented reagents require PROCESS_ORGANIC or a non-synth liver to process.
 /// 4. ORGANIC-oriented drugs can't process in synthetic humanoids.
+///Expectations for Neuroware:
+/// 1. Neuroware reagents require a brain to metabolize.
+/// 1. Neuroware reagents always metabolize in ORGAN_ROBOTIC brains.
+/// 2. Neuroware reagents never metabolize ORGAN_ORGANIC brains without a functional NIF implant.
 
 // Default synthetic humanoid
 /datum/unit_test/liver/synthetic/Run()
@@ -174,5 +178,25 @@
 	TEST_ASSERT(robot_arm.get_damage() < 5, "Human with robotic liver not healed by nanite slurry reagent.")
 
 /datum/unit_test/liver/hybrid_human/Destroy()
+	SSmobs.ignite()
+	return ..()
+
+// Default human with NIF implant
+/datum/unit_test/liver/human_nif/Run()
+	// Pause natural mob life so it can be handled entirely by the test
+	SSmobs.pause()
+
+	// Setup the human with a NIF implant
+	var/mob/living/carbon/human/consistent/lab_rat = EASY_ALLOCATE()
+	var/obj/item/organ/cyberimp/brain/nif/standard/nif_implant = EASY_ALLOCATE()
+	nif_implant.Insert(lab_rat, special = TRUE)
+
+	// Human with NIF should always be affected by neuroware reagents
+	var/datum/reagent/toxin/mutetoxin/synth/neuroware_mute_toxin = /datum/reagent/toxin/mutetoxin/synth
+	lab_rat.reagents.add_reagent(neuroware_mute_toxin, 15)
+	lab_rat.Life(SSMOBS_DT)
+	TEST_ASSERT(lab_rat.has_status_effect(/datum/status_effect/silenced), "Human with NIF implant not affected by neuroware reagents.")
+
+/datum/unit_test/liver/human_nif/Destroy()
 	SSmobs.ignite()
 	return ..()

--- a/modular_nova/modules/liquids/code/reagents/chemistry/holder.dm
+++ b/modular_nova/modules/liquids/code/reagents/chemistry/holder.dm
@@ -22,9 +22,10 @@
 			// SYNTHETIC-oriented neuroware can't affect organic brains, unless they have a nif
 			if(reagent.chemical_flags & REAGENT_NEUROWARE)
 				var/obj/item/organ/brain/owner_brain = human_processor.get_organ_slot(ORGAN_SLOT_BRAIN)
-				var/obj/item/organ/cyberimp/brain/nif/is_nif_user = human_processor.get_organ_by_type(/obj/item/organ/cyberimp/brain/nif)
-				// Neuroware always metabolizes in synthetic brains regardless of liver, but never metabolizes in organic brains
-				if(owner_brain.organ_flags & ORGAN_ROBOTIC || is_nif_user)
+				var/obj/item/organ/cyberimp/brain/nif/nif_implant = human_processor.get_organ_slot(ORGAN_SLOT_BRAIN_NIF)
+				// Neuroware always metabolizes in synthetic brains regardless of liver.
+				// Neuroware only metabolizes in organic brains if they have a functional NIF implant.
+				if((owner_brain.organ_flags & ORGAN_ROBOTIC) || (!isnull(nif_implant) && !nif_implant.broken))
 					return TRUE
 				else
 					return FALSE

--- a/modular_nova/modules/liquids/code/reagents/chemistry/holder.dm
+++ b/modular_nova/modules/liquids/code/reagents/chemistry/holder.dm
@@ -23,8 +23,10 @@
 			if(reagent.chemical_flags & REAGENT_NEUROWARE)
 				var/obj/item/organ/brain/owner_brain = human_processor.get_organ_slot(ORGAN_SLOT_BRAIN)
 				var/obj/item/organ/cyberimp/brain/nif/nif_implant = human_processor.get_organ_slot(ORGAN_SLOT_BRAIN_NIF)
-				// Neuroware always metabolizes in synthetic brains regardless of liver.
-				// Neuroware only metabolizes in organic brains if they have a functional NIF implant.
+				// Neuroware requires a brain to metabolize
+				if(isnull(owner_brain))
+					return FALSE
+				// Neuroware always metabolizes in synthetic brains, and in organic brains with a functional NIF implant.
 				if((owner_brain.organ_flags & ORGAN_ROBOTIC) || (!isnull(nif_implant) && !nif_implant.broken))
 					return TRUE
 				else
@@ -41,7 +43,7 @@
 			// ORGANIC-oriented drugs can't affect synthetic brains
 			if(!(reagent.process_flags & REAGENT_SYNTHETIC) && istype(reagent, /datum/reagent/drug))
 				var/obj/item/organ/brain/owner_brain = human_processor.get_organ_slot(ORGAN_SLOT_BRAIN)
-				if(owner_brain.organ_flags & ORGAN_ROBOTIC)
+				if(!isnull(owner_brain) && (owner_brain.organ_flags & ORGAN_ROBOTIC))
 					return FALSE
 			if(processor_flags & PROCESS_ORGANIC)
 				return TRUE

--- a/modular_nova/modules/neuroware/code/objects/items/_neuroware.dm
+++ b/modular_nova/modules/neuroware/code/objects/items/_neuroware.dm
@@ -122,18 +122,21 @@
 			return TRUE
 	return FALSE
 
-///Installs only if the mob has a synthetic brain, unless they got a nif
+///Installs only if the mob has a synthetic brain, unless they have a NIF implant
 /obj/item/disk/neuroware/proc/try_install(mob/living/carbon/human/target, mob/living/carbon/human/user)
 	if(!ishuman(target))
 		return
 	if(uses == 0)
 		balloon_alert(user, "it's been used up!")
 		return
+
+	// Check for robotic brain type or presence of NIF implant
 	var/obj/item/organ/brain/owner_brain = target.get_organ_slot(ORGAN_SLOT_BRAIN)
-	var/obj/item/organ/cyberimp/brain/nif/is_nif_user = target.get_organ_by_type(/obj/item/organ/cyberimp/brain/nif)
-	if(isnull(owner_brain) || !(owner_brain.organ_flags & ORGAN_ROBOTIC) || !is_nif_user)
+	var/obj/item/organ/cyberimp/brain/nif/nif_implant = target.get_organ_slot(ORGAN_SLOT_BRAIN_NIF)
+	if((!isnull(owner_brain) && !(owner_brain.organ_flags & ORGAN_ROBOTIC)) || (!isnull(nif_implant) && nif_implant.broken))
 		balloon_alert(user, "synthetic brain or NIF required!")
 		return
+
 	if(is_lewd && !(target.client?.prefs.read_preference(/datum/preference/toggle/erp/aphro)))
 		balloon_alert(user, "installation failed!")
 		return


### PR DESCRIPTION
## About The Pull Request

This PR is a draft and isn't ready to merge yet!

Recently PR #5897 added the ability for mobs with NIF implants to metabolize neuroware reagents. This PR adds a new unit test to check for this new reagent interaction, and refines some of the relevant code.

Additionally, I added an extra condition for neuroware in non-synths which requires the NIF to be functional.

## How This Contributes To The Nova Sector Roleplay Experience

Provides more documentation and messages relevant to neuroware chips being compatible with NIF implants. Should help players to better understand how NIF and neuroware work together.

## Proof of Testing

Draft status. Coming soon!

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl:
qol: Organic crew now require a functional NIF implant in order to use neuroware chips.
fix: Fixed a bug that was preventing neuroware from working with NIF implants.
/:cl:
