### PR TITLE
Black market trader gets some starting credits

### DIFF
--- a/modular_nova/modules/mapping/code/mob_spawns.dm
+++ b/modular_nova/modules/mapping/code/mob_spawns.dm
@@ -10,6 +10,9 @@
 	. = ..()
 	spawned_human.grant_language(/datum/language/common, source = LANGUAGE_SPAWNER)
 
+#define BM_TRADER_MIN_CASH 3000
+#define BM_TRADER_MAX_CASH 5000
+
 /obj/effect/mob_spawn/ghost_role/human/blackmarket
 	name = "Black Market Trader"
 	prompt_name = "a blackmarket dealer"
@@ -39,6 +42,11 @@
 
 /datum/outfit/black_market/post_equip(mob/living/carbon/human/shady, visualsOnly)
 	handlebank(shady)
+	if(shady.wear_id)
+		var/obj/item/card/id/id_card = shady.wear_id
+		if(id_card.registered_account)
+			var/datum/bank_account/bank_account = id_card.registered_account
+			bank_account.adjust_money((rand(BM_TRADER_MIN_CASH, BM_TRADER_MAX_CASH)))
 
 	. = ..()
 
@@ -69,6 +77,9 @@
 		/obj/item/gun/ballistic/automatic/sol_smg/evil = 20,
 		/obj/item/gun/ballistic/shotgun/bulldog/unrestricted,
 	)
+
+#undef BM_TRADER_MIN_CASH
+#undef BM_TRADER_MAX_CASH
 
 /obj/effect/mob_spawn/ghost_role/human/ds2
 	name = "DS2 personnel"


### PR DESCRIPTION
## About The Pull Request
Gives a random amount between 3k and 5k credits to the black market trader on their spawn.

## How This Contributes To The Nova Sector Roleplay Experience

It was suggested on the discord board, that way the trader can actually buy guns to sell. This is useful so crew who don't buy permits (me) can still buy permit-locked guns.

## Proof of Testing
I forgot to take a picture.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Black market trader now gets some starting funds on their ID
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
