### PR TITLE
Removes mob_name from ghostroles spawners

### DIFF
--- a/modular_nova/modules/encounters/code/nri_raiders.dm
+++ b/modular_nova/modules/encounters/code/nri_raiders.dm
@@ -218,7 +218,6 @@ GLOBAL_VAR(first_officer)
 /obj/effect/mob_spawn/ghost_role/human/nri_raider/officer
 	name = "NRI Officer sleeper"
 	prompt_name = "a NRI Field Officer"
-	mob_name = "Novaya Rossiyskaya Imperiya police patrol's field officer"
 	outfit = /datum/outfit/pirate/nri/officer
 	flavour_text = "The station has refused to pay the fine for breaking Imperial regulations, as a consequence you are here to perform a prolonged inspection."
 	important_text = "Allowed races are humans, Akulas, IPCs. Roleplay accordingly. There is an important document in your pocket I'd advise you to read and keep safe."

--- a/modular_nova/modules/mapping/code/mob_spawns.dm
+++ b/modular_nova/modules/mapping/code/mob_spawns.dm
@@ -14,7 +14,6 @@
 	name = "Black Market Trader"
 	prompt_name = "a blackmarket dealer"
 	desc = "A humming cryo pod. The machine is attempting to wake up its occupant."
-	mob_name = "a black market dealer"
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
 	mob_species = /datum/species/human
@@ -246,7 +245,6 @@
 
 /obj/effect/mob_spawn/ghost_role/human/hotel_staff/manager
 	name = "staff manager sleeper"
-	mob_name = "hotel staff manager"
 	outfit = /datum/outfit/hotelstaff/manager
 	you_are_text = "You are the manager of a top-of-the-line space hotel!"
 	flavour_text = "You are the manager of a top-of-the-line space hotel! Make sure the guests are looked after, the hotel is advertised, and your employees aren't slacking off!"
@@ -486,7 +484,6 @@
 	name = "freighter cryo crew pod"
 	prompt_name = "a lost cargo tech"
 	desc = "A humming cryo pod. There's a freight hauler inside."
-	mob_name = "Freighter Crew"
 	outfit = /datum/outfit/freighter_crew
 	spawner_job_path = /datum/job/freighter_crew
 	icon = 'icons/obj/machines/sleeper.dmi'
@@ -520,7 +517,6 @@
 	name = "freighter cryo excavator pod"
 	prompt_name = "a lost miner"
 	desc = "A humming cryo pod. There's an excavation worker inside."
-	mob_name = "Freighter Excavator"
 	outfit = /datum/outfit/freighter_excavator
 	spawner_job_path = /datum/job/freighter_crew
 	icon = 'icons/obj/machines/sleeper.dmi'
@@ -562,7 +558,6 @@
 	name = "freighter cryo boss pod"
 	prompt_name = "a lost Quartermaster"
 	desc = "A humming cryo pod. You see someone who looks In Charge inside."
-	mob_name = "Freighter Chief"
 	outfit = /datum/outfit/freighter_boss
 	spawner_job_path = /datum/job/freighter_crew
 	icon = 'icons/obj/machines/sleeper.dmi'


### PR DESCRIPTION
## About The Pull Request
'mob_name' should be used as defaul name for a mob, mostly for dead bodies and not for ghost spawners. This should preven us getting 'a black market dealer' and 'Freighter Crew' characters, when they decide to select a random one.

<img width="475" height="254" alt="изображение" src="https://github.com/user-attachments/assets/b54a70f2-8d47-495f-ab16-76799b90df72" />
## How This Contributes To The Nova Sector Roleplay Experience
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: Random characters created from Cargodise Lost spawners should now have proper random names and not 'Freighter Crew'
fix: Same holds true for BMD. No longer will you have 'a black market dealer' as random char name
/:cl:
