### PR TITLE
[QoL] Lowered RTS radiation range and increased the time to rad you from 3 to 15 seconds

### DIFF
--- a/modular_nova/modules/colony_fabricator/code/machines/rtg.dm
+++ b/modular_nova/modules/colony_fabricator/code/machines/rtg.dm
@@ -6,14 +6,14 @@
 		application."
 	icon = 'modular_nova/modules/colony_fabricator/icons/machines.dmi'
 	circuit = null
-	power_gen = 14 KILO WATTS // It's pretty expensive.
+	power_gen = 15 KILO WATTS
 	/// What we turn into when we are repacked
 	var/repacked_type = /obj/item/flatpacked_machine/rtg
 
 /obj/machinery/power/rtg/portable/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/repackable, repacked_type, 2 SECONDS)
-	AddElement(/datum/element/radioactive)
+	AddElement(/datum/element/radioactive, 2, RAD_LIGHT_INSULATION, URANIUM_IRRADIATION_CHANCE, URANIUM_RADIATION_MINIMUM_EXPOSURE_TIME * 5)
 	AddElement(/datum/element/manufacturer_examine, COMPANY_FRONTIER)
 	if(!mapload)
 		flick("rtg_deploy", src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Reduces the colonist RTS (Cargo Imports and RCF) range to 2, and its time of exposure to 15 seconds, from range 3 and 15 seconds. I also changed its power from 14 KW to 15KW, for mental health purposes.

original proposal here: https://discord.com/channels/1171566433923239977/1407823020436881510

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Allows the use of dangerous radiation power sources that are really low intensity (like, a lot of our machines generate way much more elevated, with fish generator setups going for 1200x the magnitude, and the lowest SM setup by 150x) at the cost of making a 5x5 a radiation zone, formely a 7x7 zone, which caused no one using the tool. With this is expected to see a more prevalent use without making people bald so easily, as this is supposed to be a shielded bar ofr uranium.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
<img width="696" height="500" alt="image" src="https://github.com/user-attachments/assets/762a4e42-9f79-48f4-b6d5-b3cf2838b058" />


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Makes the Portable RTS radiation range 2 (from 3) so its a 5x5 with the RTS centered generating radiation. It will also only start doing radiation after 15 seconds instead of 3, and it will produce 15kw instead of 14kw. You can get yours from Cargo Imports or the Rapid Colony Fabricator!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
