### PR TITLE
Ghost role console reporting

### DIFF
--- a/modular_nova/modules/cargo/code/expressconsole.dm
+++ b/modular_nova/modules/cargo/code/expressconsole.dm
@@ -28,12 +28,19 @@
 
 	pod_type = /obj/structure/closet/supplypod/bluespacepod
 
+/obj/machinery/computer/cargo/express/interdyne/on_construction(mob/user)
+	. = ..()
+	packin_up()
+
+	/// Should report the player that built the console to the admins, in case anything fucky happens.
+	message_admins("[ADMIN_LOOKUPFLW(usr)] Has built a ghost role imports console ([src.name]) at [AREACOORD(src)].")
+
 /obj/machinery/computer/cargo/express/interdyne/emag_act(mob/user, obj/item/card/emag/emag_card)
 	if(user)
 		to_chat(user, span_notice("You try to change the routing protocols, but the machine displays a runtime error and reboots!"))
 	return FALSE //never let this console be emagged
 
-/obj/machinery/computer/cargo/express/interdyne/packin_up(forced = FALSE) //we're the dauntless, add the company imports stuff to our express console
+/obj/machinery/computer/cargo/express/interdyne/packin_up(forced = FALSE) //we're the ghost role, add the company imports stuff to our express console
 	. = ..()
 
 	if(meme_pack_data["Company Imports"])


### PR DESCRIPTION
## About The Pull Request

This PR simply provides quality of life, and maintains the PR lightly for admins. Now when the ghost role consoles are built, they will report which console it is and where it was built and by who. This aims to help admins prevent potential future scenarios in which individuals get these console boards and abuse them without being the proper ghost role.

## How This Contributes To The Nova Sector Roleplay Experience

This does not provide active experiences for players, only admins

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
<img width="1189" height="256" alt="image" src="https://github.com/user-attachments/assets/dfde8531-cace-444f-a427-1b21fd718265" />

</details>

## Changelog

:cl:
admin: Ghost role cargo consoles now report when they are built to administrators.
/:cl: