### PR TITLE
Pest Control - pestkiller buff against spiders, effigy checks earpro, webslinger snares nerfed

### DIFF
--- a/modular_nova/master_files/code/modules/reagents/chemistry/reagents.dm
+++ b/modular_nova/master_files/code/modules/reagents/chemistry/reagents.dm
@@ -10,4 +10,4 @@
 	. = ..()
 	if(istype(exposed_obj, /obj/structure/spider))
 		var/obj/structure/spider/webs_or_something = exposed_obj
-		webs_or_something.take_damage(rand(15, 35), BURN, 0) // melts spider stuff pretty fast. pest control, y'know?
+		webs_or_something?.take_damage(rand(1, 3), BURN, 0) // slowly but surely damages web structures

--- a/modular_nova/modules/spider/spider_abilities/spider_abilities.dm
+++ b/modular_nova/modules/spider/spider_abilities/spider_abilities.dm
@@ -32,20 +32,21 @@
 	. = ..()
 	if(!iscarbon(target) || blocked >= 100)
 		return
-	var/obj/item/restraints/legcuffs/bola/webslinger_snare/restraint = new(get_turf(target))
-	restraint.ensnare(target)
+	var/obj/item/restraints/legcuffs/beartrap/webslinger_snare/restraint = new(get_turf(target))
+	restraint.spring_trap(target, ignore_movetypes = TRUE)
 
-/obj/item/restraints/legcuffs/bola/webslinger_snare
+/obj/item/restraints/legcuffs/beartrap/webslinger_snare
 	name = "sticky restraints"
 	desc = "Used by mega-arachnids to immobilize their prey."
 	icon = 'modular_nova/modules/spider/icons/spider.dmi'
 	flags_1 = NONE
 	item_flags = DROPDEL
 	icon_state = "spideregg"
+	armed = TRUE
+	trap_damage = 10
 	breakouttime = 10 SECONDS
-	knockdown = 2 SECONDS
 
-/obj/item/restraints/legcuffs/bola/webslinger_snare/Initialize(mapload)
+/obj/item/restraints/legcuffs/beartrap/webslinger_snare/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/swabable, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
 


### PR DESCRIPTION
## About The Pull Request
Pestkiller now damages spider structures (webs, effigies, etc.) upon exposure (incl. as foam, as smoke, sprayed). Not a lot of it, though.
Webslinger snares do less damage (20 -> 10) and take 10 seconds instead of 30 to resist out of.
Living spider effigies now check for ear protection. If your ears are sufficiently protected, you don't get brain damage.

## How This Contributes To The Nova Sector Roleplay Experience
More tools for dealing with spider infestations and the ensuing cleanup of one spidillion webs.

## Proof of Testing

<img width="450" height="222" alt="image" src="https://github.com/user-attachments/assets/b2dcd2c8-5795-4236-b609-f1ebda668074" />


## Changelog

:cl:
balance: Pestkiller now damages spider structures (e.g. webs, effigies, eggs) upon exposure (e.g. spraying, smoke, foam).
balance: Webslinger snares now do less damage and are easier to resist out of (it still takes 10 seconds though, which is non-negligible).
balance: Spider effigies (the ones that look like Eris sprites) now check for ear protection when trying to inflict brain damage. Bowmans are sufficient to block the trauma infliction, at time of writing.
/:cl:
