### PR TITLE
magbuck/milspec buck no longer weak against armor

### DIFF
--- a/modular_nova/modules/shotgunrebalance/code/shotgun.dm
+++ b/modular_nova/modules/shotgunrebalance/code/shotgun.dm
@@ -113,7 +113,7 @@
 	wound_falloff_tile = -0.25
 	speed = 1.5
 	armour_penetration = 5
-	// weak_against_armour = FALSE // Probably don't uncomment this unless you have a really compelling reason.
+	weak_against_armour = FALSE // lmao
 
 /obj/item/ammo_casing/shotgun/rubbershot
 	name = "rubber shot shell"
@@ -197,6 +197,7 @@
 	damage = 10
 	exposed_wound_bonus = 10
 	armour_penetration = 5
+	weak_against_armour = FALSE
 
 /obj/projectile/bullet/pellet/shotgun_buckshot/magnum/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

title

## How This Contributes To The Nova Sector Roleplay Experience

alright yeah i guess magbuck should have something more going for it huh

## Changelog

:cl:
balance: Improved propellant mixes for magnum blockshot and mil-spec buckshot shells have rolled out, improving performace against armor. Somewhat.
/:cl: