### PR TITLE
[Balance] Telepathy hints when used and is not anonymous without the mutation.

### DIFF
--- a/modular_nova/modules/telepathy_quirk/code/telepathy_action.dm
+++ b/modular_nova/modules/telepathy_quirk/code/telepathy_action.dm
@@ -83,6 +83,11 @@
 
 /datum/action/cooldown/spell/pointed/telepathy/cast(mob/living/cast_on)
 	. = ..()
+	owner.visible_message(
+		span_warning("[owner]'s attention locks onto [cast_on]."),
+		span_warning("[owner]'s attention locks onto you!"),
+		ignored_mobs = owner
+	)
 	send_thought(owner, cast_on, message)
 
 /datum/action/cooldown/spell/pointed/telepathy/proc/send_thought(mob/living/caster, mob/living/target, message)
@@ -101,9 +106,9 @@
 			var/datum/mutation/telepathy/tele_mut = human_target.dna.get_mutation(/datum/mutation/telepathy)
 
 			if (tele_mut)
-				to_chat(target, span_boldnotice("[caster]'s psychic presence resounds in your mind: \"[span_purple(message)]\""))
+				to_chat(target, span_boldnotice("A psychic presence resounds in your mind: \"[span_purple(message)]\""))
 			else
-				to_chat(target, span_boldnotice("A voice echoes in your head: \"[span_purple(message)]\""))
+				to_chat(target, span_boldnotice("[caster]'s voice echoes in your head: \"[span_purple(message)]\""))
 
 		if(target.client?.prefs.read_preference(/datum/preference/toggle/enable_runechat))
 			target.create_chat_message(target, target.get_selected_language(), message, list("italics")) // it appears over them since they hear it in their head

--- a/modular_nova/modules/telepathy_quirk/code/telepathy_quirk.dm
+++ b/modular_nova/modules/telepathy_quirk/code/telepathy_quirk.dm
@@ -10,25 +10,13 @@
 	var/datum/weakref/tele_action_ref
 
 /datum/quirk/telepathic/add(client/client_source)
-	if (iscarbon(quirk_holder))
-		var/mob/living/carbon/human/human_holder = quirk_holder
-
-		if (!human_holder.dna.activate_mutation(/datum/mutation/telepathy))
-			human_holder.dna.add_mutation(/datum/mutation/telepathy, MUTATION_SOURCE_ACTIVATED)
-	else if (issilicon(quirk_holder))
-		var/mob/living/silicon/robot_holder = quirk_holder
 		var/datum/action/cooldown/spell/pointed/telepathy/tele_action = new
 
-		tele_action.Grant(robot_holder)
+		tele_action.Grant(quirk_holder)
 		tele_action_ref = WEAKREF(tele_action)
 
 /datum/quirk/telepathic/remove()
 	var/datum/action/cooldown/spell/pointed/telepathy/tele_action = tele_action_ref?.resolve()
-	if (isnull(tele_action))
-		tele_action_ref = null
-	if (iscarbon(quirk_holder))
-		var/mob/living/carbon/human/human_holder = quirk_holder
-		human_holder.dna.remove_mutation(/datum/mutation/telepathy, MUTATION_SOURCE_ACTIVATED)
-	else if (issilicon(quirk_holder) && !isnull(tele_action))
+	if (!isnull(tele_action))
 		QDEL_NULL(tele_action)
-		tele_action_ref = null
+	tele_action_ref = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This affects the telepathic Neutral quirk. 

- It makes it so the quirk no longer automatically gives you the telepathic gene, you have to unlock that yourself via genetics. This has the benefit that it alters your messaging and allows you to be anonymous, which is an advantage, it formely was the other way  around, if you had the mutation then you would be visible, if you didnt had the mutation, you had more benefits!

- Every time someone uses the quirk everyone else(in the sight) will see where their attention is sent. This does not add a visual cue besides the warning in the chat, so its still somewhat discrete.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

First, this means having the quirk AND the special genetics power, an advantage. Beforehand you wouldnt know the identity of someone that didn't had the genetic power. This is good since it means there is at least an upgrade and not a downgrade for getting into the mechanics, specially considering this is a neutral quirk.

Second, given that communication is a trigger for CI, this gives a justification for players to know when the other is using telepathy to call for help, and thus initiate combat.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
how it looks to a third party: 
<img width="367" height="38" alt="image" src="https://github.com/user-attachments/assets/2bbeff81-d0d6-45e0-a12a-8cdc27b18456" />

how it looks to the receiver: (message changed after feedback)
<img width="509" height="62" alt="image" src="https://github.com/user-attachments/assets/26ada1e9-1c9f-4f9b-82f9-09c5b7e188dd" />

how it looks to the user:
<img width="566" height="81" alt="image" src="https://github.com/user-attachments/assets/d64a1ddd-35cf-46b8-9322-f2fac15d4367" />


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Telepathy (Quirk) now shows when the user uses the power and on whom, but not the contents of the message.
balance: Telepathy (Quirk) now tells who the person is using it unless they have the telepathy Gene. Telepathy (Quirk) no longer automatically gives the gene.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
