### PR TITLE
[HOTFIX] Fixes kinaris carpet only coming one at a time in cargo

### DIFF
--- a/modular_nova/modules/cargo/code/goodies.dm
+++ b/modular_nova/modules/cargo/code/goodies.dm
@@ -148,7 +148,7 @@
 
 /datum/supply_pack/goody/carpet/kinaris
 	name = "Kinaris Regal Carpet"
-	contains = list(/obj/item/stack/tile/carpet/kinaris)
+	contains = list(/obj/item/stack/tile/carpet/kinaris/fifty)
 /*
 * NIF STUFF
 */


### PR DESCRIPTION
## About The Pull Request

Not sure how this made it past me, but Its better to hotfix it now than later

## Changelog

:cl:
fix: Thanks to a manifest mistake, the kinaris carpet now comes in packs of '50' we have had many legal concerns on it. We hope this fixes your issues.
/:cl:

