### PR TITLE
Fix missing escape menu buttons

### DIFF
--- a/modular_nova/modules/escape_menu/code/escape_menu_nova.dm
+++ b/modular_nova/modules/escape_menu/code/escape_menu_nova.dm
@@ -6,7 +6,7 @@
 			/* hud_owner = */ null,
 			/* hud_owner = */ src,
 			/* button_text = */ "OPFOR",
-			/* offset = */ list(-276, -260),
+			/* offset = */ list(-276, 30),
 			/* font_size = */ 24,
 			/* on_click_callback = */ CALLBACK(src, PROC_REF(home_opfor)),
 		)
@@ -18,7 +18,7 @@
 			/* hud_owner = */ null,
 			/* hud_owner = */ src,
 			/* button_text = */ "Ghost",
-			/* offset = */ list(-311, -260),
+			/* offset = */ list(-311, 30),
 			/* font_size = */ 24,
 			/* on_click_callback = */ CALLBACK(src, PROC_REF(home_ghost)),
 		)
@@ -30,7 +30,7 @@
 			/* hud_owner = */ null,
 			/* hud_owner = */ src,
 			/* button_text = */ "Respawn",
-			/* offset = */ list(-346, -260),
+			/* offset = */ list(-346, 30),
 			/* font_size = */ 24,
 			/* on_click_callback = */ CALLBACK(src, PROC_REF(home_respawn)),
 		)


### PR DESCRIPTION

## About The Pull Request
Updates our menu buttons as per https://github.com/tgstation/tgstation/pull/92670
## How This Contributes To The Nova Sector Roleplay Experience
click button, button good
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="788" height="615" alt="image" src="https://github.com/user-attachments/assets/730d0b12-59fe-4cc9-8024-6a8b501ef2eb" />

</details>

## Changelog
:cl:
fix: Fix missing opfor/ghost/respawn buttons on the escape menu.
/:cl:
