### PR TITLE
Custom MOD modules icons

### DIFF
--- a/modular_nova/master_files/code/modules/mod/modules/module.dm
+++ b/modular_nova/master_files/code/modules/mod/modules/module.dm
@@ -4,6 +4,7 @@
 	if(!isnull(get_species_overlay_icon()))
 		add_custom_worn_overlay(source, overlays, standing, draw_target, isinhands, icon_file)
 		return
+	. = ..()
 
 /obj/item/mod/module/proc/get_species_overlay_icon()
 	return mod.wearer?.dna?.species.get_custom_mod_module_icon()

--- a/modular_nova/master_files/code/modules/mod/modules/module.dm
+++ b/modular_nova/master_files/code/modules/mod/modules/module.dm
@@ -1,0 +1,50 @@
+
+
+/obj/item/mod/module/add_module_overlay(obj/item/source, list/overlays, mutable_appearance/standing, mutable_appearance/draw_target, isinhands, icon_file)
+	if(!isnull(get_species_overlay_icon()))
+		add_custom_worn_overlay(source, overlays, standing, draw_target, isinhands, icon_file)
+		return
+
+/obj/item/mod/module/proc/get_species_overlay_icon()
+	return mod.wearer?.dna?.species.get_custom_mod_module_icon()
+
+/obj/item/mod/module/proc/add_custom_worn_overlay(obj/item/source, list/overlays, mutable_appearance/standing, mutable_appearance/draw_target, isinhands, icon_file)
+
+	if (isinhands)
+		return
+
+	var/list/added_overlays = generate_custom_worn_overlay(source, standing)
+	if (!added_overlays)
+		return
+
+	if (!mask_worn_overlay)
+		overlays += added_overlays
+		return
+
+	for (var/mutable_appearance/overlay as anything in added_overlays)
+		overlay.add_filter("mod_mask_overlay", 1, alpha_mask_filter(icon = icon(draw_target.icon, draw_target.icon_state)))
+		overlays += overlay
+
+/obj/item/mod/module/proc/generate_custom_worn_overlay(atom/movable/source, mutable_appearance/standing)
+	if(!mask_worn_overlay)
+		if(!has_required_parts(mod.mod_parts, need_active = TRUE))
+			return
+	else
+		var/datum/mod_part/part_datum = mod.get_part_datum(source)
+		if (!part_datum?.sealed)
+			return
+
+	. = list()
+	var/used_overlay = get_current_overlay_state()
+	if (!used_overlay)
+		return
+
+	var/mutable_appearance/module_icon = mutable_appearance(get_species_overlay_icon(), used_overlay, layer = standing.layer + 0.1)
+	if(use_mod_colors)
+		module_icon.color = mod.color
+		if (mod.cached_color_filter)
+			module_icon = filter_appearance_recursive(module_icon, mod.cached_color_filter)
+
+	. += module_icon
+	SEND_SIGNAL(src, COMSIG_MODULE_GENERATE_WORN_OVERLAY, ., standing)
+

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/custom_bodytype.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/custom_bodytype.dm
@@ -136,3 +136,7 @@
 	set_custom_worn_icon_cached(human_icon, human_icon_state, item.greyscale_colors || "x", final_icon)
 
 	return final_icon
+
+/datum/species/proc/get_custom_mod_module_icon()
+	return null
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7261,6 +7261,7 @@
 #include "modular_nova\master_files\code\modules\mod\mod_construction.dm"
 #include "modular_nova\master_files\code\modules\mod\mod_theme.dm"
 #include "modular_nova\master_files\code\modules\mod\mod_types.dm"
+#include "modular_nova\master_files\code\modules\mod\modules\module.dm"
 #include "modular_nova\master_files\code\modules\mod\modules\modules_general.dm"
 #include "modular_nova\master_files\code\modules\mod\modules\modules_science.dm"
 #include "modular_nova\master_files\code\modules\mod\modules\modules_supply.dm"


### PR DESCRIPTION
## About The Pull Request

This PR adds to species datum `get_custom_mod_module_icon()` functions and simple overrides for `add_module_overlay()` to support custom module icon for species.

## How This Contributes To The Nova Sector Roleplay Experience

This PR makes the display of module icons suitable for each species with a custom body type. For example teshari or vox.

## Proof of Testing

<img width="324" height="197" alt="Screenshot_1" src="https://github.com/user-attachments/assets/9378d75e-31b6-4754-8af5-a1916bc53844" />

## Changelog

:cl:
qol: custom MOD module icons
/:cl:

