### PR TITLE
[included with upstream merge] tg 92825 early pull - Fixes mobs without guaranteed butcher drops not dropping any crusher trophies

### DIFF
--- a/code/datums/elements/crusher_loot.dm
+++ b/code/datums/elements/crusher_loot.dm
@@ -48,5 +48,8 @@
 /datum/element/crusher_loot/proc/make_path(mob/living/target, path)
 	if(drop_immediately)
 		new path(get_turf(target))
-	else
-		target.guaranteed_butcher_results[path] = 1
+		return
+
+	if (!target.guaranteed_butcher_results)
+		target.guaranteed_butcher_results = list()
+	target.guaranteed_butcher_results[path] = 1


### PR DESCRIPTION
## About The Pull Request

see tgstation#92825

## Changelog

testmerge until upstream merges come through with this fix again
