### PR TITLE
Restores original behavior of drifting contractor event rolling and candidacy

### DIFF
--- a/modular_nova/modules/contractor/code/datums/midround/ruleset.dm
+++ b/modular_nova/modules/contractor/code/datums/midround/ruleset.dm
@@ -5,7 +5,6 @@
 	preview_antag_datum = /datum/antagonist/contractor
 	weight = 6
 	min_pop = 25
-	min_antag_cap = 2
 	minimum_required_age = 14
 	midround_type = HEAVY_MIDROUND
 


### PR DESCRIPTION
## About The Pull Request

Prior to the dynamic refactor, drifting contractor only required 1 candidate to spawn. This got upped to 2 during the dynamic refactor mirror and it has been struggling to find candidacy.
Drifting contractor has a 1 in 3 odds to spawn 2, if candidacy provides, and perhaps this gimmick confused a dev causing this edit. (It means there's been a 1 in 3 odds the event could roll _3_ contractors if candidacy was available.)

## How This Contributes To The Nova Sector Roleplay Experience

Its mostly just fixing what I assume is an oversight, it also just makes the event fail less which is nice.

## Proof of Testing


## Changelog
:cl:
fix: Drifting contractor event no longer requires 2 candidates to succeed spawning
/:cl:

