### PR TITLE
[Balance ] [Temporal] - Disables Sensitive Hearing until a rework is presented.

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -42,7 +42,6 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/oversized, /datum/quirk/settler),
 	list(/datum/quirk/echolocation, /datum/quirk/monochromatic),
 	list(/datum/quirk/echolocation, /datum/quirk/item_quirk/blindness, /datum/quirk/item_quirk/nearsighted, /datum/quirk/item_quirk/deafness),
-	list(/datum/quirk/sensitive_hearing, /datum/quirk/item_quirk/blindness, /datum/quirk/item_quirk/deafness, /datum/quirk/echolocation),
 	list(/datum/quirk/visitor, /datum/quirk/item_quirk/underworld_connections),
 	list(/datum/quirk/adapted_lungs, /datum/quirk/item_quirk/breather/water_breather, /datum/quirk/item_quirk/breather/nitrogen_breather, /datum/quirk/item_quirk/breather/plasma_breather),
 	//NOVA EDIT ADDITION END

--- a/modular_nova/master_files/code/datums/traits/good.dm
+++ b/modular_nova/master_files/code/datums/traits/good.dm
@@ -157,7 +157,7 @@
 		qdel(old_appendix)
 
 	old_appendix = null
-
+/* - Disabled until its reworked.
 /datum/quirk/sensitive_hearing // Teshari hearing but as a quirk
 	name = "Sensitive Hearing"
 	desc = "You can hear even the quietest of sounds, but you're more vulnerable to hearing damage as a result. NOTE: This is a direct downgrade for Teshari!"
@@ -192,3 +192,4 @@
 	//we could have any subtype at this point so just take that one's initial value
 	//as opposed to making a copy at the start of the player's round (what if they transplant it, etc)
 	ears.damage_multiplier = initial(ears.damage_multiplier)
+*/


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Disables the Sensitive Hearing Perk. (Code commented)

## How This Contributes To The Nova Sector Roleplay Experience

As discussed here: https://discord.com/channels/1171566433923239977/1405082792378892339

Sensitive hearing is way more powerful than the robotics whispering implant, it allows you to hear any whisper you can see in the screen, with perfect clarity, it has no customization options, so it cannot be tonned down easily, which would had been a satisfying option, but at the moment of the writting it has been disrupting rounds way too often, with several people activating the hearing mode round start. The downsides of this rarely if ever come to play, and they can be easily dimished, with some jobs like security coming with equipment that all but negate this for most instances of such downsides.

On the indirects effects, people had been whispering way less thanks to this and been taking things like telepathy and hivemind to avoid interacting with whispering, which makes overhearing stuff rarer and rarer, damaging the inmersion of the game.

I encourage a rework of the perk, but as it is, its not something I could quickly, and the thread at the moment of writting this was not organized enough to settle on requirements, save on accepting the quirk was too powerful in its present presentation.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
<img width="920" height="779" alt="image" src="https://github.com/user-attachments/assets/b9e3b82a-099a-45ed-94f2-cfc9a0c64b8d" />

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removes Sensitive Hearing until someone reworks it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
