### PR TITLE
standardizes conversion kit instructions and times, fixes a conversion bug

### DIFF
--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/conversion_kits.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/conversion_kits.dm
@@ -25,12 +25,16 @@
 		/obj/item/crafting_conversion_kit/riot_sol_super = 1
 	)
 	steps = list(
-		"Empty the M64's magazine",
-		"Empty the M64's chamber"
+		"Empty the magazine",
+		"Empty the chamber"
 	)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
 	time = 15 SECONDS
 	category = CAT_WEAPON_RANGED
+
+/datum/crafting_recipe/riot_sol_to_riot_super/New()
+	..()
+	blacklist |= typesof(/obj/item/gun/ballistic/shotgun/riot/sol/super) // let's not try to super-ize our already super shotgun i think
 
 /datum/crafting_recipe/riot_sol_to_riot_sol_super/check_requirements(mob/user, list/collected_requirements)
 	var/obj/item/gun/ballistic/shotgun/riot/sol/the_piece = collected_requirements[/obj/item/gun/ballistic/shotgun/riot/sol][1]

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/conversion_kits.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/conversion_kits.dm
@@ -16,7 +16,7 @@
 	. = ..()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_ARCHON)
 
-/datum/crafting_recipe/riot_sol_to_riot_sol_super
+/datum/crafting_recipe/riot_sol_super
 	name = "M64 to KOLBEN/NACHTREIHER Shotgun Conversion"
 	desc = "Bring order to chaos."
 	result = /obj/item/gun/ballistic/shotgun/riot/sol/super/empty
@@ -32,11 +32,11 @@
 	time = 15 SECONDS
 	category = CAT_WEAPON_RANGED
 
-/datum/crafting_recipe/riot_sol_to_riot_super/New()
+/datum/crafting_recipe/riot_sol_super/New()
 	..()
 	blacklist |= typesof(/obj/item/gun/ballistic/shotgun/riot/sol/super) // let's not try to super-ize our already super shotgun i think
 
-/datum/crafting_recipe/riot_sol_to_riot_sol_super/check_requirements(mob/user, list/collected_requirements)
+/datum/crafting_recipe/riot_sol_super/check_requirements(mob/user, list/collected_requirements)
 	var/obj/item/gun/ballistic/shotgun/riot/sol/the_piece = collected_requirements[/obj/item/gun/ballistic/shotgun/riot/sol][1]
 	if(the_piece.get_ammo())
 		return FALSE

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/conversion_kits.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/conversion_kits.dm
@@ -75,6 +75,10 @@
 	time = 15 SECONDS
 	category = CAT_WEAPON_RANGED
 
+/datum/crafting_recipe/c38_super/New()
+	..()
+	blacklist |= typesof(/obj/item/gun/ballistic/revolver/c38/super) // let's not try to super-ize our already super revolver i think
+
 /datum/crafting_recipe/c38_super/check_requirements(mob/user, list/collected_requirements)
 	var/obj/item/gun/ballistic/revolver/c38/the_piece = collected_requirements[/obj/item/gun/ballistic/revolver/c38][1]
 	if(the_piece.get_ammo())

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/conversion_kits.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/conversion_kits.dm
@@ -27,8 +27,8 @@
 		/obj/item/crafting_conversion_kit/reclaimer_reverse = 1
 	)
 	steps = list(
-		"Remove the rC-20's magazine",
-		"Clear the rC-20's chamber"
+		"Remove the magazine",
+		"Clear the chamber"
 	)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
 	time = 15 SECONDS
@@ -69,7 +69,7 @@
 		/obj/item/crafting_conversion_kit/c38_super = 1
 	)
 	steps = list(
-		"Clear your revolver's cylinder",
+		"Clear the cylinder",
 	)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
 	time = 15 SECONDS

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/scarborough_arms/conversion_kits.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/scarborough_arms/conversion_kits.dm
@@ -28,8 +28,8 @@
 		/obj/item/crafting_conversion_kit/reclaimer_c20r = 1
 	)
 	steps = list(
-		"Remove the NT20's magazine",
-		"Clear the NT20's chamber"
+		"Remove the magazine",
+		"Clear the chamber"
 	)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
 	time = 15 SECONDS

--- a/modular_nova/modules/modular_weapons/code/conversion_kits.dm
+++ b/modular_nova/modules/modular_weapons/code/conversion_kits.dm
@@ -38,11 +38,11 @@
 		/obj/item/crafting_conversion_kit/mosin_pro = 1
 	)
 	steps = list(
-		"Empty the rifle",
+		"Empty the magazine",
 		"Leave the bolt open"
 	)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
-	time = 30 SECONDS
+	time = 15 SECONDS
 	category = CAT_WEAPON_RANGED
 
 /datum/crafting_recipe/mosin_pro/New()


### PR DESCRIPTION
## About The Pull Request
Conversion kits now have slightly less verbose instructions in regards to making sure a gun is empty before converting it.
Nachtreiher shotgun and Laevateinn revolver recipes no longer look for already-converted Nachtreihers and Laevateinns.
Standardizes the Rengo kit to the same 15 seconds as every other conversion kit.

## How This Contributes To The Nova Sector Roleplay Experience
consistency is probably good actually.

## Changelog

:cl:
fix: Nachtreiher and Laevateinn recipes no longer look for already-converted guns.
spellcheck: Made some of the weapon conversion kit instructions in recipes less verbose.
/:cl: