### PR TITLE
Bandaid Fix for Shuttle Engines

### DIFF
--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -39,9 +39,6 @@
 	. = ..()
 	AddComponent(/datum/component/simple_rotation)
 	register_context()
-	if(!mapload)
-		engine_state = ENGINE_UNWRENCHED
-		anchored = FALSE
 
 /obj/machinery/power/shuttle_engine/on_construction(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
https://github.com/NovaSector/NovaSector/pull/5552 brought us up to date with changes at /tg/, One of these commits, https://github.com/NovaSector/NovaSector/commit/11f6761c1e55cb5fd278c44289f9549bb5654919, attempted to do . . . something.

On the surface, this commit makes it so shuttle engines built in-game do not spawn anchored - or \tries\ to. Instead, it only updates the variable tracking the state of the engine, responsible for propagating the tool-tip you see while examining it, without actually touching the state of the engine that is constructed - which still comes out anchored to the floor.

This is problematic - you will have an engine that says it is unanchored and requires wrenching to secure, while functioning as if secured. That is to say, cannot be freely moved - the expected result. This also ruins custom-made shuttles created in-round.

This fix is a partial reversion of this change, returning to the state previously - that is to say, making constructed shuttle engines built in-game spawn fully welded into place. It does not touch upon the removal of 'cargo burst' engines, nor adjusting shuttle engine crates from now containing standard burst engine circuit-boards instead.

Further, this fix does not attempt to tackle the bug still plaguing shuttles - wherein a shuttle engine which isn't built on the shuttle will not allow the shuttle to move, even when fully secured.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience
Bandaid bug-fix which mitigates some degree of the the larger issues with custom-made shuttles.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3c3dc511-53d3-4fb8-946f-ab3d1b4ca708" />

Engines now spawn fully welded to the floor. The tool-tip agrees to this, and you cannot freely move them around - as expected of being welded in place. 

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/18e395a8-72dd-4871-a31b-56be2774ac9f" />


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Partial reversion of commit which left shuttle engines unusable for custom shuttles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
