### PR TITLE
Adds nuke-op uplink weapons to traitor uplink

### DIFF
--- a/modular_nova/modules/traitor-uplinks/code/categories/dangerous.dm
+++ b/modular_nova/modules/traitor-uplinks/code/categories/dangerous.dm
@@ -35,6 +35,26 @@
 	purchasable_from = ~UPLINK_SPY //spy get their own tg version
 	uplink_item_flags = SYNDIE_ILLEGAL_TECH | SYNDIE_TRIPS_CONTRABAND
 
+/datum/uplink_item/dangerous/katana
+	name = "Katana"
+	desc = "A really sharp Katana. Did I mention it's sharp?"
+	item = /obj/item/katana
+	cost = 11
+	purchasable_from = UPLINK_TRAITORS
+
+// TG Overrides - Allows nukie weapons on normal op uplinks
+/datum/uplink_item/weapon_kits/low_cost
+	purchasable_from = (UPLINK_TRAITORS | UPLINK_SERIOUS_OPS)
+
+/datum/uplink_item/weapon_kits/medium_cost
+	purchasable_from = (UPLINK_TRAITORS | UPLINK_SERIOUS_OPS)
+
+/datum/uplink_item/weapon_kits/high_cost
+	purchasable_from = (UPLINK_TRAITORS | UPLINK_SERIOUS_OPS)
+
+/datum/uplink_item/ammo_nuclear
+	purchasable_from = (UPLINK_TRAITORS | UPLINK_SERIOUS_OPS)
+
 // TG Overrides - Raises cost of this by 2x
 /datum/uplink_item/role_restricted/his_grace
 	cost = 40 // forces you to murderbone, so we're taking two antags out for one if they try it

--- a/modular_nova/modules/traitor-uplinks/code/uplink_items.dm
+++ b/modular_nova/modules/traitor-uplinks/code/uplink_items.dm
@@ -1,0 +1,13 @@
+// removes syndicate weapon pins for weapons that may have them in the traitor uplink (nukeop weapons that we made available for tots)
+/datum/uplink_item/spawn_item(spawn_path, mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)
+	var/atom/movable/created = ..()
+	if(!created)
+		return
+	if(!(uplink_handler.uplink_flag & UPLINK_TRAITORS))
+		return
+
+	if(isgun(created))
+		replace_pin(created)
+	else if(istype(created, /obj/item/storage/toolbox/guncase))
+		for(var/obj/item/gun/gun in created)
+			replace_pin(gun)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9228,6 +9228,7 @@
 #include "modular_nova\modules\title_screen\code\title_screen_html.dm"
 #include "modular_nova\modules\title_screen\code\title_screen_pref_middleware.dm"
 #include "modular_nova\modules\title_screen\code\title_screen_subsystem.dm"
+#include "modular_nova\modules\traitor-uplinks\code\uplink_items.dm"
 #include "modular_nova\modules\traitor-uplinks\code\categories\ammunition.dm"
 #include "modular_nova\modules\traitor-uplinks\code\categories\bundles.dm"
 #include "modular_nova\modules\traitor-uplinks\code\categories\contractor.dm"


### PR DESCRIPTION
## About The Pull Request
Adds the nuke-op weapons to the regular tot uplink, adds an overwrite that removes the syndicate implant checking pins if this happens.

One day nova'll get its own uplink, I'm sure. But until then, there's this.

## How This Contributes To The Nova Sector Roleplay Experience

Yea so basically these weapons are necessary to match the crew's firepower.
If you roll the wrong objective (any involving command) you have to match might that's not going to be fazed by a guepe or sindano.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
![img-HDz1g_(x)](https://github.com/user-attachments/assets/e03cf904-967e-4b95-a983-2a202cd94de4)

https://github.com/user-attachments/assets/8c74008f-f8d0-4132-a665-05ecabe64280

</details>

## Changelog
:cl:
balance: Regular traitor uplink now allows purchase of weaponry from the nuke-op uplink.
balance: Including the katana.
/:cl:
