### PR TITLE
Blueshield "Praetorian" Modsuit Adjustment

### DIFF
--- a/modular_nova/master_files/code/modules/mod/mod_types.dm
+++ b/modular_nova/master_files/code/modules/mod/mod_types.dm
@@ -204,9 +204,8 @@
 	icon = 'modular_nova/master_files/icons/obj/clothing/modsuit/mod_clothing.dmi'
 	icon_state = "praetorian-control"
 	theme = /datum/mod_theme/blueshield
-	applied_cell = /obj/item/stock_parts/power_store/cell/high
 	applied_modules = list(
-		/obj/item/mod/module/storage,
+		/obj/item/mod/module/storage/large_capacity,
 		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/flashlight,
 		/obj/item/mod/module/projectile_dampener,


### PR DESCRIPTION
## About The Pull Request

This PR simply changes 2 lines of code, making it so the blueshield recieves the default powercell assigned by its parent type `/obj/item/mod/control/pre_equipped` (The powercell in specifics is `/obj/item/stock_parts/power_store/cell/super` known in-game as the "super-capacity power cell" and grants the blueshield a greater amount of storage in their modsuit.

## How This Contributes To The Nova Sector Roleplay Experience

Compared to many modsuits the powercell in the blueshield's mod is the worst one out of them all, this change to default cells will put them in the same ballpark as everyone else in regards of modsuit power. As for the storage module it would put it on par with many modsuits within command, matching its zone of expertise, granted the blueshield is not a command department head, they are still apart of the command team, same as the NTC.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
<img width="764" height="597" alt="image" src="https://github.com/user-attachments/assets/feb395d8-fe05-454d-95d7-d85b18a8a482" />

</details>

## Changelog

:cl:
balance: Gave the blueshield modsuit the default modsuit powercell instead of a downgrade
balance: replaced the blueshield modsuit's standard mod storage with an expanded one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
