### PR TITLE
[TM-only?] Fixes 0 amount mineral turfs, mineralAmt now independent from a distance to vent

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -304,8 +304,10 @@
 
 	. = ..()
 	var/dynamic_prob = mineralChance
+	var/ore_amount = rand(1,5)
 	if(proximity_based)
 		dynamic_prob = proximity_ore_chance() // We assign the chance of ore spawning based on probability.
+		ore_amount = scale_ore_to_vent()
 	if (prob(dynamic_prob))
 		var/list/spawn_chance_list = mineral_chances_by_type[type]
 		if (isnull(spawn_chance_list))
@@ -322,7 +324,7 @@
 			if(ismineralturf(T))
 				var/turf/closed/mineral/M = T
 				M.turf_type = src.turf_type
-				M.mineralAmt = scale_ore_to_vent()
+				M.mineralAmt = ore_amount
 				GLOB.post_ore_random["[M.mineralAmt]"] += 1
 				src = M
 				M.levelupdate()
@@ -333,7 +335,7 @@
 		else
 			Change_Ore(path, FALSE)
 			Spread_Vein(path)
-			mineralAmt = scale_ore_to_vent()
+			mineralAmt = ore_amount
 			GLOB.post_ore_manual["[mineralAmt]"] += 1
 
 /turf/closed/mineral/random/high_chance


### PR DESCRIPTION

## About The Pull Request
Shortly after ArcMining came to be, we changed every mineral turf to `proximity_based = FALSE` so no matter how far vents are ores still spawn with same frequency (sorta). Turnes out theres another proc that didcates richness of turfs themselves. And this one is running regardles of proximity var. And also has default value of 0 for whatever reason. Thats why we have empty ores. 

https://github.com/NovaSector/NovaSector/blob/d5040093b71c8c8d47c77d340efd60f4f8baa20e/code/game/turfs/closed/minerals.dm#L142-L157

P.S. it is an upstream issue, but i cannot properly test my code becuase i can't compile any codebase for whatever reason.
## How This Contributes To The Nova Sector Roleplay Experience
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: Empty ores should not be spawning from now on.
/:cl:
