### PR TITLE
[Admin] Removes the Admin Debug GPS from the debug box

### DIFF
--- a/code/game/objects/items/storage/boxes/engineering_boxes.dm
+++ b/code/game/objects/items/storage/boxes/engineering_boxes.dm
@@ -40,7 +40,7 @@
 		/obj/item/uplink/debug=1,
 		/obj/item/uplink/nuclear/debug=1,
 		/obj/item/clothing/ears/earmuffs/debug=1,
-		/obj/item/gps/visible_debug=1,
+		// /obj/item/gps/visible_debug=1, //NOVA EDIT REMOVAL
 		)
 	generate_items_inside(items_inside, src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Removes the debug gps from the admin debug bag.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

The debug GPS, while its an useful, yet situational, debug tool, the problem of including it there is that this bag is spawned too often with tools admins use, and since the tiles are numbered and colored when the gps is use (without a switch off), which is problematic as admins often use this kit in a bundle to do subtle changes and this would break inmersion and probably spend more time for admins to fix their effects than what they spawned themselves in to fix.


## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

Before:

<img width="378" height="311" alt="image" src="https://github.com/user-attachments/assets/69929d3b-36fc-48f5-ab9e-5a0f9f2e110e" />

After:

<img width="685" height="546" alt="image" src="https://github.com/user-attachments/assets/ceb2af18-9afb-4668-b724-f636faeacdf6" />
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Removed the Admin GPS from the debug tool box. Its still spawnable if needed, but it should make admin intervention less overtly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
