### PR TITLE
Revert old non-modular removal of antique's burglar alarm

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -101,8 +101,8 @@
 /obj/structure/displaycase/proc/trigger_alarm()
 	if(!alert)
 		return
-	//var/area/alarmed = get_area(src) NOVA EDIT REMOVAL
-	//alarmed.burglaralert(src) NOVA EDIT REMOVAL
+	var/area/alarmed = get_area(src)
+	alarmed.burglaralert(src)
 
 	alarm_manager.send_alarm(ALARM_BURGLAR)
 	addtimer(CALLBACK(alarm_manager, TYPE_PROC_REF(/datum/alarm_handler, clear_alarm), ALARM_BURGLAR), 1 MINUTES)


### PR DESCRIPTION
## About The Pull Request

Restores this antag objective to its original difficulty.

## How This Contributes To The Nova Sector Roleplay Experience

This was a removal from the Skyrat times, who knows why it was in place. I don't see much of a point to making antag objectives easier, getting found out is part of the fun. Getting away with an objective shouldn't be easy because then it doesn't net roleplay.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog


:cl:
balance: Upon stealing the Captain's antique laser gun, the burglar alarm will once again go off
/:cl: