### PR TITLE
Fixes bad argument of Marauder's voucher mapping helpers

### DIFF
--- a/_maps/nova/lazy_templates/midround_traitor.dmm
+++ b/_maps/nova/lazy_templates/midround_traitor.dmm
@@ -733,7 +733,7 @@
 /obj/effect/mapping_helpers/atom_injector/element_injector{
 	target_type = /obj/machinery/rnd/production/protolathe;
 	element_type = /datum/element/voucher_redeemer;
-	element_args = list(/obj/item/paper/paperslip/corporate/syndicate/traitor/implant, /datum/voucher_set/traitor/implant, 'sound/machines/lathe/lathe_print.ogg')
+	element_args = list(/obj/item/paper/paperslip/corporate/syndicate/traitor/implant, /datum/voucher_set/traitor/implant, 0, 'sound/machines/lathe/lathe_print.ogg')
 	},
 /turf/open/floor/iron/dark/corner{
 	dir = 4
@@ -1789,7 +1789,7 @@
 /obj/effect/mapping_helpers/atom_injector/element_injector{
 	target_type = /obj/machinery/limbgrower;
 	element_type = /datum/element/voucher_redeemer;
-	element_args = list(/obj/item/paper/paperslip/corporate/syndicate/traitor/implant, /datum/voucher_set/traitor/organ, 'sound/effects/cartoon_sfx/cartoon_splat.ogg')
+	element_args = list(/obj/item/paper/paperslip/corporate/syndicate/traitor/implant, /datum/voucher_set/traitor/organ, 0, 'sound/effects/cartoon_sfx/cartoon_splat.ogg')
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/showroomfloor,
@@ -2674,7 +2674,7 @@
 /obj/effect/mapping_helpers/atom_injector/element_injector{
 	target_type = /obj/machinery/computer;
 	element_type = /datum/element/voucher_redeemer;
-	element_args = list(/obj/item/paper/paperslip/corporate/syndicate/traitor/supplies, /datum/voucher_set/traitor/supplies/surgery, 'sound/machines/card_slide.ogg')
+	element_args = list(/obj/item/paper/paperslip/corporate/syndicate/traitor/supplies, /datum/voucher_set/traitor/supplies/surgery, 0, 'sound/machines/card_slide.ogg')
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/misc/operative_barracks/surgery)
@@ -2897,7 +2897,7 @@
 /obj/effect/mapping_helpers/atom_injector/element_injector{
 	target_type = /obj/machinery/rnd/production/protolathe;
 	element_type = /datum/element/voucher_redeemer;
-	element_args = list(/obj/item/paper/paperslip/corporate/syndicate/traitor/primary, /datum/voucher_set/traitor/primary_weapon, 'sound/machines/lathe/lathe_print.ogg')
+	element_args = list(/obj/item/paper/paperslip/corporate/syndicate/traitor/primary, /datum/voucher_set/traitor/primary_weapon, 0, 'sound/machines/lathe/lathe_print.ogg')
 	},
 /turf/open/floor/iron/smooth,
 /area/misc/operative_barracks/armoury)
@@ -3267,7 +3267,7 @@
 /obj/effect/mapping_helpers/atom_injector/element_injector{
 	target_type = /obj/machinery/ammo_workbench;
 	element_type = /datum/element/voucher_redeemer;
-	element_args = list(/obj/item/paper/paperslip/corporate/syndicate/traitor/supplies, /datum/voucher_set/traitor/supplies/ammo, 'sound/machines/piston/piston_raise.ogg')
+	element_args = list(/obj/item/paper/paperslip/corporate/syndicate/traitor/supplies, /datum/voucher_set/traitor/supplies/ammo, 0, 'sound/machines/piston/piston_raise.ogg')
 	},
 /turf/open/floor/circuit/red/anim,
 /area/misc/operative_barracks/armoury)
@@ -3638,7 +3638,7 @@
 /obj/effect/mapping_helpers/atom_injector/element_injector{
 	target_type = /obj/structure/showcase;
 	element_type = /datum/element/voucher_redeemer;
-	element_args = list(/obj/item/paper/paperslip/corporate/syndicate/traitor, /datum/voucher_set/traitor/voucher_trade, 'sound/machines/card_slide.ogg')
+	element_args = list(/obj/item/paper/paperslip/corporate/syndicate/traitor, /datum/voucher_set/traitor/voucher_trade, 0, 'sound/machines/card_slide.ogg')
 	},
 /obj/structure/showcase/fakeid,
 /turf/open/floor/mineral/plastitanium/red,


### PR DESCRIPTION
## About The Pull Request

There was an issue with the arguments passed to the voucher's mapping helpers.

## How This Contributes To The Nova Sector Roleplay Experience

Bug bad.

## Proof of Testing


:cl:
fix: The mapping helpers that add the voucher element to the marauder base's equipment now function again
/:cl:
