### PR TITLE
Healable Ethereal Crystal Consequences

### DIFF
--- a/code/modules/surgery/organs/internal/heart/heart_ethereal.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_ethereal.dm
@@ -233,9 +233,9 @@
 	regenerating.apply_status_effect(/datum/status_effect/vulnerable_to_damage) // NOVA EDIT ADDITION - This lasts for five minutes, the full duration of the cooldown.
 
 	if(prob(10)) //10% chance for a severe trauma
-		regenerating.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_ABSOLUTE)
+		regenerating.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_SURGERY)
 	else
-		regenerating.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_ABSOLUTE)
+		regenerating.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_SURGERY)
 
 	// revive calls fully heal -> deletes the crystal.
 	// this qdeleted check is just for sanity.


### PR DESCRIPTION
## About The Pull Request

This PR alters exactly two lines related to the code that applies brain traumas to an Ethereal after they naturally heal from a regenerative crystal stasis. Before this PR, the resulting wound would be _permanent for the round_. This includes anything done in xenobio, any weird meta-edge case surgeries, anything. Nothing will fix it. 

This PR alters the wounds inflicted to require brain surgery specifically to recover from. That's it.

## How This Contributes To The Nova Sector Roleplay Experience

Brain traumas inherently affect the rp in a given round because dialogue is altered. Sometimes in a way you don't entirely wish to have to deal with in the first place. But there SHOULD be a consequence for the regenerative crystal core. This simple change makes it so that you now have very good reason to see your local surgeon instead of suffer in silence.

That and Ethereals are kind of a 'gotcha' for medbay players that don't magically know the thing labeled "resurrection crystal" is something you super want to break to avoid a permanent brain disability. It just feels bad on both ends when it instead could be a good call to action for medbay.

## Proof of Testing

<details>
Regenerated ethereal rolls undesirable brain trauma, can be fixed by surgery
<img width="976" height="1266" alt="problem" src="https://github.com/user-attachments/assets/a18b8870-b148-4632-9d79-6e8ec18a1052" />

Brain surgery solves brain problems. Hooray.
<img width="2586" height="1610" alt="fixed" src="https://github.com/user-attachments/assets/fd90a818-1f82-4e25-b7f7-86d6369439b8" /> 
</details>

## Changelog

:cl:
balance: Ethereal Resurrection Crystal now inflicts traumas that can be healed with brain surgery.
/:cl:

