### PR TITLE
[QOL] Adds the Kinetic Crusher to the Mining Cyborg's Basic Equipment

### DIFF
--- a/modular_nova/modules/borg_buffs/code/robot.dm
+++ b/modular_nova/modules/borg_buffs/code/robot.dm
@@ -179,3 +179,22 @@
 		var/obj/item/wirebrush/brush = new (cyborg.model)
 		cyborg.model.basic_modules += brush
 		cyborg.model.add_module(brush, FALSE, TRUE)
+
+// Kinetic Crusher for Mining Borg
+/obj/item/kinetic_crusher/robot
+	name = "mining cyborg kinetic-crusher"
+	desc = "A tool fixed to a sillicon's actuators that hold a proto-kinetic crusher."
+	acts_as_if_wielded = TRUE
+	force = 20
+
+/obj/item/robot_model/miner/Initialize(mapload)
+	LAZYINITLIST(basic_modules)
+	LAZYADD(basic_modules, /obj/item/kinetic_crusher/robot)
+	return ..()
+
+/obj/item/kinetic_crusher/robot/Initialize(mapload)
+	. = ..()
+	force = force_wielded
+
+/obj/item/kinetic_crusher/robot/update_wielding()
+	return


### PR DESCRIPTION
## About The Pull Request
Tin, requested by many cyborg players. While I'm not a fan that it might incentivize hunting, I think it's fair for players to want to experiment with other tools without having to spawn in round as a static or as a random gen character they don't care about.

Yes, you can retool it if a miner buys you a retool kit. No, I will not be adding the variants, I don't think it needs to expand beyond the basic equipment. Maybe modules in the future, but that's not what this PR is doing right now.
## How This Contributes To The Nova Sector Roleplay Experience

Mining Cyborgs can now use crushers, incentivizing trophy useage, as well as assisting miners for trophies.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="1751" height="245" alt="image" src="https://github.com/user-attachments/assets/eb3225af-12d9-4b53-bc10-37ca89696d66" />
Tested in combat, it works consistently, but will fix any issues as I investigate further.
</details>

## Changelog
:cl:BasilTamaya
add: Nanotrasen's Research and Development now gives our mining silicon assets the use of a kinetic crusher.
/:cl:
