### PR TITLE
downtunes shotgun slugs' AP

### DIFF
--- a/modular_nova/modules/shotgunrebalance/code/shotgun.dm
+++ b/modular_nova/modules/shotgunrebalance/code/shotgun.dm
@@ -21,6 +21,7 @@
 
 /obj/projectile/bullet/shotgun_slug
 	damage = 50 // based on old stats
+	armour_penetration = 10 // except old stats didn't give these armor pen. but they can keep some as a treat
 
 /obj/item/ammo_casing/shotgun/milspec
 	desc = "A hot-loaded 12 gauge milspec slug shell, used by various paramilitaries and mercenary forces. Probably not legal to use under corporate regulations."
@@ -30,6 +31,7 @@
 
 /obj/projectile/bullet/shotgun_slug/milspec
 	damage = 60 // the fine art of physically removing chunks of flesh from your fellow spaceman
+	armour_penetration = 30 // these can keep the armor pen though. maybe. probably.
 	speed = 1.5
 
 // THE BELOW TWO SLUGS ARE NOTED AS ADMIN ONLY AND HAVE ***EIGHTY*** WOUND BONUS. NOT BARE WOUND BONUS. FLAT WOUND BONUS.


### PR DESCRIPTION
## About The Pull Request

TG gave slugs 30 AP but kicked them down to 25 force. I buffed them in NovaSector/NovaSector#5065 back to 50 damage, based off the old stats, but let them keep the AP. Upon further reflection, not a great plan. Slugs still keep their 50 damage but their AP got downtuned to 10 AP, so they've still got a leg up over a lot of other ammo types regarding raw damage/AP but they're not overperforming.

Milspec slugs keep the 30 AP though. Because they're evil.

## How This Contributes To The Nova Sector Roleplay Experience
Makes slugs slightly less overperforming as a shotgun shell choice in regards to sending people to deadchat. Unless you have milspec ammo, in which case you're still going to be sending people to deadchat anyway.

## Changelog

:cl:
balance: As a cost-cutting measure, new manufacturing specs for shotgun slugs in-sector came with reduced powder loads and adjusted metallurgic techniques, reducing their armor penetration capabilities (10, down from 30). Scarborough Arms's hot-loaded, "mil-spec" shells are unaffected.
/:cl:
