### PR TITLE
[QOL] What if Surgical/Cruel Toolsets Actually Had A Bonesetter and Bloodfilter Wouldn't That Be Funny

### DIFF
--- a/modular_nova/modules/implants/code/augments_arms.dm
+++ b/modular_nova/modules/implants/code/augments_arms.dm
@@ -359,6 +359,24 @@
 /obj/item/autosurgeon/syndicate/razorwire
 	name = "razorwire autosurgeon"
 	starting_organ = /obj/item/organ/cyberimp/arm/toolkit/razorwire
+// Surgical toolsets (normal + cruel) additions
+
+/obj/item/organ/cyberimp/arm/toolkit/surgery/Initialize(mapload)
+	if (src.type == /obj/item/organ/cyberimp/arm/toolkit/surgery)
+		LAZYINITLIST(items_to_create)
+		items_to_create += list(
+			/obj/item/bonesetter/augment,
+			/obj/item/blood_filter/augment,
+		)
+	return ..()
+
+/obj/item/organ/cyberimp/arm/toolkit/surgery/cruel/Initialize(mapload)
+	LAZYINITLIST(items_to_create)
+	items_to_create += list(
+		/obj/item/bonesetter/cruel/augment,
+		/obj/item/blood_filter/cruel/augment,
+	)
+	return ..()
 
 // Shell launch system, an arm mounted single-shot shotgun/.980 grenade launcher that comes out of your arm
 

--- a/modular_nova/modules/implants/code/augments_arms.dm
+++ b/modular_nova/modules/implants/code/augments_arms.dm
@@ -370,6 +370,12 @@
 		)
 	return ..()
 
+// Block swapping while a blood filter is active
+/obj/item/organ/cyberimp/arm/toolkit/surgery/swap_tools(active_item)
+	if (istype(src.active_item, /obj/item/blood_filter))
+		return
+	return ..()
+
 /obj/item/organ/cyberimp/arm/toolkit/surgery/cruel/Initialize(mapload)
 	LAZYINITLIST(items_to_create)
 	items_to_create += list(

--- a/modular_nova/modules/toolset_buffs/code/tools.dm
+++ b/modular_nova/modules/toolset_buffs/code/tools.dm
@@ -1,0 +1,7 @@
+/obj/item/bonesetter/augment
+
+/obj/item/blood_filter/augment
+
+/obj/item/bonesetter/cruel/augment
+
+/obj/item/blood_filter/cruel/augment

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9249,6 +9249,7 @@
 #include "modular_nova\modules\title_screen\code\title_screen_html.dm"
 #include "modular_nova\modules\title_screen\code\title_screen_pref_middleware.dm"
 #include "modular_nova\modules\title_screen\code\title_screen_subsystem.dm"
+#include "modular_nova\modules\toolset_buffs\code\tools.dm"
 #include "modular_nova\modules\traitor-uplinks\code\categories\ammunition.dm"
 #include "modular_nova\modules\traitor-uplinks\code\categories\bundles.dm"
 #include "modular_nova\modules\traitor-uplinks\code\categories\contractor.dm"


### PR DESCRIPTION

## About The Pull Request
Tin. 
## How This Contributes To The Nova Sector Roleplay Experience
They're literally two tools that are missing entirely from the toolset implant for zero reason for this server.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="325" height="271" alt="image" src="https://github.com/user-attachments/assets/16c2a6f1-dfa9-4049-b449-254feb90547d" />
<img width="294" height="255" alt="image" src="https://github.com/user-attachments/assets/b9040032-e701-4e33-ae19-42de26f0d6dd" />
<img width="379" height="275" alt="image" src="https://github.com/user-attachments/assets/e6870dfb-ee2c-4d1e-ada6-76f0b3a7b588" />
<img width="320" height="251" alt="image" src="https://github.com/user-attachments/assets/8962b270-bd52-41c1-9ef2-aa77c5873f8a" />

</details>

## Changelog
:cl:BasilTamaya
fix: For no reason, blood filters and bonesetters are missing from both toolsets, which have been added here.
/:cl:
