### PR TITLE
[Balance] Powerators Changes. Civilian 

### DIFF
--- a/modular_nova/modules/bluespace_miner/code/bluespace_miner.dm
+++ b/modular_nova/modules/bluespace_miner/code/bluespace_miner.dm
@@ -248,7 +248,7 @@
 	)
 	needs_anchored = TRUE
 
-/datum/supply_pack/misc/bluespace_miner
+/datum/supply_pack/engineering/bluespace_miner
 	name = "Bluespace Miner"
 	desc = "Nanotrasen has revolutionized the procuring of materials with bluespace-- featuring the Bluespace Miner!"
 	cost = CARGO_CRATE_VALUE * 50 // 10,000

--- a/modular_nova/modules/cargo/code/packs.dm
+++ b/modular_nova/modules/cargo/code/packs.dm
@@ -801,3 +801,19 @@
 	contains = list(
 		/obj/item/folder/ancient_paperwork = 5
 	)
+
+/*
+* ACCESS OVERWRITES
+*/
+
+/datum/supply_pack/engineering/portagrav
+	access_view = NONE
+
+/datum/supply_pack/engineering/powergamermitts
+	access_view = NONE
+
+/datum/supply_pack/engineering/pacman
+	access_view = NONE
+
+/datum/supply_pack/engineering/tools
+	access_view = NONE

--- a/modular_nova/modules/colony_fabricator/code/machines/rtg.dm
+++ b/modular_nova/modules/colony_fabricator/code/machines/rtg.dm
@@ -2,10 +2,11 @@
 	name = "High-Temperature Self-Contained Reaction Generator"
 	desc = "The ultimate in 'middle of nowhere' power generation. Unlike standard RTGs, this particular \
 		design of generator uses a volatile compound reacting with unstable elements to create a constant trickle of power \
-		There's a label on the side reminding operators that the contents are under heavy pressure, and that impacts should be avoided at all costs."
+		There's a label on the side reminding operators that the contents are under heavy pressure, and that impacts should be avoided at all costs. \
+		It has a yellow radioactive warning, minor radiation posibility. Do not store tomatos nearby."
 	icon = 'modular_nova/modules/colony_fabricator/icons/machines.dmi'
 	circuit = null
-	power_gen = 15 KILO WATTS // 50% more efficient as a Plastitanium Solar
+	power_gen = 10 KILO WATTS // same as a Plastitanium Solar or winded turbine, 
 	max_integrity = 40
 	/// What we turn into when we are repacked
 	var/repacked_type = /obj/item/flatpacked_machine/rtg
@@ -13,6 +14,7 @@
 /obj/machinery/power/rtg/portable/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/repackable, repacked_type, 2 SECONDS)
+	AddElement(/datum/element/radioactive, 1, RAD_LIGHT_INSULATION, URANIUM_IRRADIATION_CHANCE * 0.5, URANIUM_RADIATION_MINIMUM_EXPOSURE_TIME * 5)
 	AddElement(/datum/element/manufacturer_examine, COMPANY_FRONTIER)
 	if(!mapload)
 		flick("rtg_deploy", src)
@@ -48,7 +50,7 @@
 	type_to_deploy = /obj/machinery/power/rtg/portable
 	custom_materials = list(
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 5,
-		/datum/material/uranium = SHEET_MATERIAL_AMOUNT * 5,
+		/datum/material/uranium = SHEET_MATERIAL_AMOUNT,
 		/datum/material/plasma = SHEET_MATERIAL_AMOUNT * 5,
 		/datum/material/gold = SHEET_MATERIAL_AMOUNT,
 	)

--- a/modular_nova/modules/colony_fabricator/code/machines/solid_fuel_generator.dm
+++ b/modular_nova/modules/colony_fabricator/code/machines/solid_fuel_generator.dm
@@ -1,18 +1,18 @@
 /obj/machinery/power/port_gen/pacman/solid_fuel
 	name = "\improper A.W-type portable generator"
 	desc = "The second most common generator design in the galaxy, second only to the P.A.C.M.A.N. \
-		This new and improved Akhter design of the A.W (Atomic Whisperer) is similar to other micro fission reactors in its use, however instead of using a water moderated design, \
-		this design opts for spinning panels used to absorb radiation using an advanced decay process to turn the radiation into harmless room temperature helium. \
+		This new and improved Akhter design of the A.W (Atomic Whisperer) is similar to other micro fission reactors in its use, using a hybrid temperature moderated design, \
+		this design opts for spinning panels used to absorb radiation using an advanced decay process to turn the radiation into 520C helium and water. \
 		This however comes at a cost of being more resource intensive to produce and must be <b>bolted to the ground<b> in order to function. \
-		A massive warning label indicates to not tell cargo technicians about the possibility of exporting the helium gas."
+		A massive warning label indicates to have capacitated supervision when trying to harvest and export the profitable byproduct gasses."
 	icon = 'modular_nova/modules/colony_fabricator/icons/machines.dmi'
 	icon_state = "fuel_generator_0"
 	base_icon_state = "fuel_generator"
 	circuit = null
 	anchored = TRUE
-	max_sheets = 25
-	time_per_sheet = parent_type::time_per_sheet * (2) //100% better
-	power_gen = parent_type::power_gen * 3.2
+	max_sheets = 25 // 50% worse than pacman, 25% better than superpacman
+	time_per_sheet = parent_type::time_per_sheet // pacman is 180, superpacman is 60, this make it thrice as efficient as the super pacman
+	power_gen = parent_type::power_gen *2 // superpacman is 3, but, one sheet is consumed thrice as fast and they have a limit of 20 sheets.
 	drag_slowdown = 1.5
 	sheet_path = /obj/item/stack/sheet/mineral/uranium
 	/// The item we turn into when repacked
@@ -43,7 +43,8 @@
 	. = ..()
 	if(active)
 		var/turf/where_we_spawn_air = get_turf(src)
-		where_we_spawn_air.atmos_spawn_air("helium=5;TEMP=293.15") // Advanced fission decay of Krypton and Xenon, short lived isotopes of nuclear fission reactions.
+		where_we_spawn_air.atmos_spawn_air("water_vapor=9;TEMP=840") // Mid-range steam output temp for nuclear reactors is around 520C or 840K
+		where_we_spawn_air.atmos_spawn_air("helium=1;TEMP=840") // Advanced fission decay of Krypton and Xenon, short lived isotopes of nuclear fission reactions.
 
 // Item for creating the generator or carrying it around
 
@@ -53,9 +54,9 @@
 	icon_state = "fuel_generator_packed"
 	type_to_deploy = /obj/machinery/power/port_gen/pacman/solid_fuel
 	custom_materials = list(
-		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 15,
-		/datum/material/glass = SHEET_MATERIAL_AMOUNT,
-		/datum/material/titanium = SHEET_MATERIAL_AMOUNT,
+		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 10,
+		/datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT,
+		/datum/material/titanium = SHEET_MATERIAL_AMOUNT * 2,
 		/datum/material/gold = HALF_SHEET_MATERIAL_AMOUNT,
 	)
 /obj/machinery/power/port_gen/pacman/solid_fuel/Initialize(mapload)

--- a/modular_nova/modules/powerator/powerator.dm
+++ b/modular_nova/modules/powerator/powerator.dm
@@ -1,5 +1,6 @@
 
 #define TECHWEB_NODE_POWERATOR "powerator"
+#define NOVA_POWER_MULTI 2
 
 /obj/item/circuitboard/machine/powerator
 	name = "Powerator"
@@ -10,15 +11,14 @@
 		/obj/item/stack/sheet/glass = 1,
 		/obj/item/stack/ore/bluespace_crystal/refined = 1,
 		/obj/item/stack/cable_coil = 5,
-		/datum/stock_part/matter_bin = 2,
-		/datum/stock_part/micro_laser = 2,
-		/datum/stock_part/servo = 2,
+		/datum/stock_part/capacitor = 5,
+		/datum/stock_part/micro_laser = 1,
 	)
 	needs_anchored = TRUE
 
 /datum/supply_pack/misc/powerator
 	name = "Powerator"
-	desc = "We know the feeling of losing power and Central sending power, it is our time to do the same."
+	desc = "We know the feeling of losing power and Central sending power, it is our time to do the same. All proceeds go to the engineering budget."
 	cost = CARGO_CRATE_VALUE * 50 // 10,000
 	contains = list(/obj/item/circuitboard/machine/powerator)
 	crate_name = "Powerator Circuitboard Crate"
@@ -32,7 +32,7 @@
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING,
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO | DEPARTMENT_BITFLAG_ENGINEERING
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
 
 /datum/techweb_node/powerator
 	id = TECHWEB_NODE_POWERATOR
@@ -40,13 +40,12 @@
 	description = "We've been saved by it in the past, we should send some power ourselves!"
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_3_POINTS)
 	announce_channels = list(RADIO_CHANNEL_ENGINEERING)
-	hidden = TRUE
-	experimental = TRUE
 	prereq_ids = list(TECHWEB_NODE_PARTS_ADV)
 	design_ids = list(
 		"powerator",
 	)
 
+// This produces 62 per 2 seconds, taxed to 49, which gives us 24-25 per second.
 /obj/machinery/powerator
 	name = "powerator"
 	desc = "Beyond the ridiculous name, it is the standard for transporting and selling energy to power networks that require additional sources!"
@@ -60,17 +59,20 @@
 	/// the current amount of power that we are trying to process
 	var/current_power = 10 KILO WATTS
 
-	/// the max amount of power that can be sent per process, from 100 KW (t1) to 10000 KW (t4)
-	var/max_power = 100 KILO WATTS
+	/// the max amount of power that can be sent per process, this var should be base + rating*5 at start to keep consistency. so goes from 3.25MJ to 10MJ as of this writting.
+	var/max_power = 3250 KILO WATTS
+
+	/// the base starting ratio for power
+	var/power_base = 1000 KILO WATTS
 
 	/// the rating change for the max power (upgrades)
-	var/power_rating = 1650 KILO WATTS
+	var/power_rating = 450 KILO WATTS
+	
+	/// power cap, if its 0 it will be ignored, otherwise caps the max power the system will have (better than using taxes for small operations)
+	var/power_cap = 0
 
-	/// how much the current_power is divided by to determine the profit
-	var/divide_ratio = 0.00001
-
-	// the rating change for the divide ratio (upgrade)
-	var/divide_rating = 0.000005
+	/// how much power is needed to get 1 credit per two seconds. (And the mininum power you need to get credits.)
+	var/divide_ratio = 160 KILO WATTS
 
 	/// the attached cable to the machine
 	var/obj/structure/cable/attached_cable
@@ -79,10 +81,13 @@
 	var/credits_made = 0
 
 	/// What account is assigned to this?
-	var/credits_account_1 = ACCOUNT_CAR
+	var/credits_account_1 = ACCOUNT_ENG
 
 	/// What second account is assigned (IF THERE IS ONE, otherwise use null)
-	var/credits_account_2 = ACCOUNT_ENG
+	var/credits_account_2 = null
+	
+	/// Percent of tax we deduct from people using the powerator, allowing easy adjustment for VV admins.
+	var/tax = 20
 
 /obj/machinery/powerator/Initialize(mapload)
 	. = ..()
@@ -120,23 +125,19 @@
 	else
 		. += span_notice("There is a power cable underneath.")
 
-	. += span_notice("Current Power: [display_power(current_power)]/[display_power(max_power)]")
+	. += span_notice("Current Power: [display_power(current_power, FALSE)]/[display_power(max_power, FALSE)]")
 	. += span_notice("This machine has made [credits_made] credits from selling power so far.")
+	. += span_notice("This machine makes 1 credit every two seconds per [display_power(divide_ratio, FALSE)] sent outward.")
+	. += span_notice("This machine is taxed [tax]% credits by the SolFed Power Ministry.")
 
 /obj/machinery/powerator/RefreshParts()
 	. = ..()
 
-	var/efficiency = -2 //set to -2 so that tier 1 parts do nothing
-	max_power = 100 KILO WATTS
-	for(var/datum/stock_part/micro_laser/laser_part in component_parts)
-		efficiency += laser_part.tier
-	max_power += (efficiency * power_rating)
+	var/power_efficiency = 0
+	for(var/datum/stock_part/capacitor/capacitor_part in component_parts)
+		power_efficiency += capacitor_part.tier
+	max_power = power_base + (power_efficiency * power_rating)
 
-	efficiency = -2
-	divide_ratio = 0.00001
-	for(var/datum/stock_part/servo/servo_part in component_parts)
-		efficiency += servo_part.tier
-	divide_ratio += (efficiency * divide_rating)
 
 /obj/machinery/powerator/update_overlays()
 	. = ..()
@@ -149,7 +150,7 @@
 		add_overlay("cable")
 		return
 
-	if(!attached_cable.avail(current_power))
+	if(!attached_cable.avail(current_power * NOVA_POWER_MULTI))
 		add_overlay("power")
 		return
 
@@ -163,22 +164,23 @@
 	if(current_power < 0)
 		current_power = 0 //this is just for the fringe case, wouldn't want it to somehow produce power for money! unless...
 
-	if(!attached_cable.avail(current_power))
+	if(!attached_cable.avail(current_power * NOVA_POWER_MULTI))
 		if(!attached_cable.newavail())
 			return
+		current_power = attached_cable.newavail() / NOVA_POWER_MULTI
 
-		current_power = attached_cable.newavail()
-
+	if (power_cap)
+		max_power = clamp(max_power, 0, power_cap)
 	current_power = clamp(current_power, 0, max_power)
 
 	if(current_power == 0)
 		return
 
-	attached_cable.add_delayedload(current_power)
+	attached_cable.add_delayedload(current_power * NOVA_POWER_MULTI) //we do this because both add_load and add_delayedload half the power and confuses players.
 
 	///split it in half for chosen departments if there is more than one
 	var/datum/bank_account/primary_account = SSeconomy.get_dep_account(credits_account_1)
-	var/money_ratio = round(current_power * divide_ratio)
+	var/money_ratio = round(current_power * (1/divide_ratio) * ((100-tax) / 100))
 	// cut in half if we have a second account
 	if(credits_account_2)
 		money_ratio *= 0.5
@@ -189,7 +191,7 @@
 
 /obj/machinery/powerator/attack_hand(mob/living/user, list/modifiers)
 	. = ..()
-	current_power = tgui_input_number(user, "How much power (in Watts) would you like to draw? Max: [display_power(max_power)]", "Power Draw", current_power, max_power, 0)
+	current_power = tgui_input_number(user, "How much power (in Watts) would you like to draw? Max: [display_power(max_power, FALSE)]", "Power Draw", current_power, max_power, 0)
 	if(isnull(current_power))
 		return
 
@@ -254,24 +256,38 @@
 	name = "\improper Tarkon Powerator"
 	build_path = /obj/machinery/powerator/tarkon
 
+// This produces 25 per 2 seconds, no tax, so around 12 per second.
 /obj/machinery/powerator/syndicate
 	name = "\improper Syndicate Powerator"
 	credits_account_1 = ACCOUNT_DS2
 	credits_account_2 = null
+	power_cap = 2500 KILO WATTS
+	divide_ratio = 100 KILO WATTS
+	tax = 0
 	icon_state = "powerator_syndi"
 	circuit = /obj/item/circuitboard/machine/powerator/syndicate
 
+// This produces 25 per 2 seconds, taxed to 22-23, which gives us 11 per second.
 /obj/machinery/powerator/interdyne
 	name = "\improper Interdyne Powerator"
 	credits_account_1 = ACCOUNT_INT
 	credits_account_2 = null
+	power_cap = 1000 KILO WATTS
+	divide_ratio = 40 KILO WATTS
+	tax = 10
 	icon_state = "powerator_dyne"
 	circuit = /obj/item/circuitboard/machine/powerator/interdyne
 
+// This produces 40 per 2 seconds, taxed to 28, which gives us 14 per second.
 /obj/machinery/powerator/tarkon
 	name = "\improper Tarkon Powerator"
 	credits_account_1 = ACCOUNT_TI
 	credits_account_2 = null
+	power_cap = 6000 KILO WATTS
+	divide_ratio = 150 KILO WATTS
+	tax = 30
 	icon_state = "powerator_tarkon"
 	circuit = /obj/item/circuitboard/machine/powerator/tarkon
 
+#undef TECHWEB_NODE_POWERATOR
+#undef NOVA_POWER_MULTI

--- a/modular_nova/modules/powerator/powerator.dm
+++ b/modular_nova/modules/powerator/powerator.dm
@@ -16,7 +16,7 @@
 	)
 	needs_anchored = TRUE
 
-/datum/supply_pack/misc/powerator
+/datum/supply_pack/engineering/powerator
 	name = "Powerator"
 	desc = "We know the feeling of losing power and Central sending power, it is our time to do the same. All proceeds go to the engineering budget."
 	cost = CARGO_CRATE_VALUE * 50 // 10,000
@@ -47,7 +47,7 @@
 
 // This produces 62 per 2 seconds, taxed to 49, which gives us 24-25 per second.
 /obj/machinery/powerator
-	name = "powerator"
+	name = "\improper Nanotransen Powerator"
 	desc = "Beyond the ridiculous name, it is the standard for transporting and selling energy to power networks that require additional sources!"
 	icon = 'modular_nova/modules/powerator/icons/machines.dmi'
 	icon_state = "powerator"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

- Bluespace Miners and Powerators are now available on the engineering cargo console request, allowing engineering to help cargo with effort of their own. 

-  Civilian Power generators adjusted. The RTG now produces a 1 tile radiation with half chance, with their power being 10KJ from 15KJ. The Atomic Whisper was toned down in efficiency, its now thrice as much as the super pacman (formely six as much), produces twice the power of a pacman (so 20KJ instead of 32KJ per increment), and produces water vapor and helium at a 9 to 1 rate, at 520C, from room temperature helium at 5. Byproducts can still be sold of course, but it requires effort, that said, the atomic whisper does not produce radiation. Reduced their material cost a bit to reflect their nerf.

- Powerators were nerfed and made engineering only. Values for their consumption were adjusted all over,  with each company having different maximuns of production, powerator efficiency, and taxes. With NT and Tarkon having high taxes and high energy rates but having a higher cap of power selling, while the syndicate and then dyne paying less taxes or needing less power, at the cost of capping how much they can sell, making it so the more effort involved the more credits per hour achievable. Details on the PR, but the powerators will give their stats on examine.

- Fixed some powerator issues, notably their power not matching to what they were set and consuming, made them very customizable with VV and more intuitive to use by mappers and admins, players will also find their stats when examining instead of having to code dive for this information. 

- Powerator now automatically goes down to the power it has available instead of not processing. We are aware this could be a negative if the power is not constant, you might want to setup smes units in the middle.

- The portable Gravity Generator, as well as minor tools packs, were made accesible by the public at large, instead of just restricted to Engineering.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Both Bluespace miners and powerators are engineering proyects that engineering needed money or beg cargo to get, when their purpose is to help when cargo is doing badly, with most of the time these requests being denied, the proyects werent taken by engineering, but by cargo.

Civilian power gens were buffed originally knowingly they would be adjusted in the future if things made noise, they did. The RTG having no interesting mechanic as it was placed in fortresses, its power was lowered to reflect its low level of annoyance, making it as space efficient as the solars, but needing extra care. The Atomic Whisper was used in farms to just produce the helium using the infinite uranium the vents provide, and their efficiency was mistakenly confused with that of the superpacman, right now they are better than the superpacman efficiency wise, at the cost of the annoyance of dealing with atmos gasses, not overtly dangerous ones, just annoying, as just getting them to room temperature will cause slipage.

The powerators is a big one, for one, they needed some love to be less arcane and more transparent to the players how they worked, the powernet is a bit of a pain to work with due to the multipliers and what not, so those were now taken into account. The whole system was given more variables and controllers so that any mapper, admin or what not could VV them according to their nessecities, and the players will be able to examine it and see how it does. The powerator will also auto adjust if the power in the line goes down instead of not processing, this is good and bad of course, as you probably have high bursts of energy if you connect something directly, but given you can use smes to stabilize this, is not a great deal for the intended public of these, engineers.

Regarding the differences set between each powerator, they were done with what I was approved for each faction to get from powerators, as we move to the day ghost roles get more importance in the game, the more we can assess how powerful they get, the more freedom they can have, thus, 4 millons setups are sadly gone, but it does means that tarkon will still be able to make more money than dyne or ds2, but dyne powerator its the easiest to set if its the less paying one, while ds2 smuggles electricity under the nose of Sol Fed, and Tarkon pays an extra since they arent the main concession as NT is. Storytelling through mechanics. 

Finally, the tools allowed were things already accesible by individual packs or lathes all around cargo, that was just consistency. The portable Grav Gen is more in line with builds and Colonial nessecities, is honestly just to have there so its used more, as its just a really minor thing that otherwise very rarely sees the light, and I felt it was just fun to have it accesible.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

Powerator:

<img width="350" height="545" alt="image" src="https://github.com/user-attachments/assets/ed495d24-2a8e-4079-8896-ce3bc8525bac" />
  
<img width="569" height="234" alt="image" src="https://github.com/user-attachments/assets/45b8986d-8524-4b08-acf4-fa4224f26515" />

<img width="560" height="235" alt="image" src="https://github.com/user-attachments/assets/7c2eb8be-9fa4-477d-8013-7694ad8608a2" />

<img width="564" height="234" alt="image" src="https://github.com/user-attachments/assets/296eb47f-1825-42d3-85fd-97ff88984eb4" />

<img width="572" height="236" alt="image" src="https://github.com/user-attachments/assets/dee15d0d-d418-4231-b27a-25e5b78535a9" />

Engi cargo requests:

<img width="642" height="578" alt="image" src="https://github.com/user-attachments/assets/39a607f8-7759-45e7-9412-93a18ab9c2ae" />

Engineering public orders:

<img width="597" height="522" alt="image" src="https://github.com/user-attachments/assets/6ffb8e42-1739-4ea4-875a-12b8e8e2b371" />

Civilian Power Gens adjusted:

<img width="499" height="312" alt="image" src="https://github.com/user-attachments/assets/efbe0dcd-4337-4566-820a-5d7d57bf4d52" />

Atomic Whisper Gas Scan:

<img width="281" height="211" alt="image" src="https://github.com/user-attachments/assets/57937a52-19e9-4605-9747-8088c2ffd6fc" />


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

qol: Bluespace Miners and Powerators are now available on the engineering cargo console request, allowing engineering to help cargo with effort of their own. 
balance: Civilian Power generators adjusted. The RTG now produces a 1 tile radiation with half chance, with their power being 10KJ from 15KJ. The Atomic Whisper was toned down in efficiency, its now thrice as much as the super pacman (formely six as much), produces twice the power of a pacman (so 20KJ instead of 32KJ per increment), and produces water vapor and helium at a 9 to 1 rate, at 520C, from room temperature helium at 5. Byproducts can still be sold of course, but it requires effort, that said, the atomic whisper does not produce radiation. Reduced their material cost a bit to reflect their nerf.
balance: Powerators were nerfed and made engineering only. Values for their consumption were adjusted all over,  with each company having different maximuns of production, powerator efficiency, and taxes. With NT and Tarkon having high taxes and high energy rates but having a higher cap of power selling, while the syndicate and then dyne paying less taxes or needing less power, at the cost of capping how much they can sell, making it so the more effort involved the more credits per hour achievable. Details on the PR, but the powerators will give their stats on examine.
fix: Fixed some powerator issues, notably their power not matching to what they were set and consuming, made them very customizable with VV and more intuitive to use by mappers and admins, players will also find their stats when examining instead of having to code dive for this information. 
qol: Powerator now automatically goes down to the power it has available instead of not processing. We are aware this could be a negative if the power is not constant, you might want to setup smes units in the middle.
add: The portable Gravity Generator, as well as minor tools packs, were made accesible by the public at large, instead of just restricted to Engineering.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
