### PR TITLE
[Removal] Removes ID from basic NT corpses that are map spawned.

### DIFF
--- a/modular_nova/master_files/code/modules/mob_spawn/corpses/job_corpses.dm
+++ b/modular_nova/master_files/code/modules/mob_spawn/corpses/job_corpses.dm
@@ -1,0 +1,105 @@
+// Corpses
+
+/obj/effect/mob_spawn/corpse/human/cargo_tech
+	outfit = /datum/outfit/job/cargo_tech/corpse
+
+/obj/effect/mob_spawn/corpse/human/cook
+	outfit = /datum/outfit/job/cook/corpse
+
+/obj/effect/mob_spawn/corpse/human/doctor
+	outfit = /datum/outfit/job/doctor/corpse
+
+/obj/effect/mob_spawn/corpse/human/geneticist
+	outfit = /datum/outfit/job/geneticist/corpse
+
+/obj/effect/mob_spawn/corpse/human/engineer
+	outfit = /datum/outfit/job/engineer/gloved/corpse
+
+/obj/effect/mob_spawn/corpse/human/engineer/mod
+	outfit = /datum/outfit/job/engineer/mod/corpse
+
+/obj/effect/mob_spawn/corpse/human/clown
+	outfit = /datum/outfit/job/clown/corpse
+
+/obj/effect/mob_spawn/corpse/human/scientist
+	outfit = /datum/outfit/job/scientist/corpse
+
+/obj/effect/mob_spawn/corpse/human/miner
+	outfit = /datum/outfit/job/miner/corpse
+
+/obj/effect/mob_spawn/corpse/human/miner/mod
+	outfit = /datum/outfit/job/miner/equipped/mod/corpse
+
+/obj/effect/mob_spawn/corpse/human/miner/explorer
+	outfit = /datum/outfit/job/miner/equipped/corpse
+
+/obj/effect/mob_spawn/corpse/human/plasmaman
+	outfit = /datum/outfit/plasmaman/corpse
+
+/obj/effect/mob_spawn/corpse/human/assistant
+	outfit = /datum/outfit/job/assistant/corpse
+
+/obj/effect/mob_spawn/corpse/human/bartender
+	outfit = /datum/outfit/spacebartender/corpse
+
+/obj/effect/mob_spawn/corpse/human/prisoner
+	outfit = /datum/outfit/job/prisoner/corpse
+
+/obj/effect/mob_spawn/corpse/human/roboticist
+	outfit = /datum/outfit/job/roboticist/corpse
+
+/obj/effect/mob_spawn/corpse/human/bitrunner
+	outfit = /datum/outfit/job/bitrunner/corpse
+
+// Corpses Outfits
+
+/datum/outfit/job/cargo_tech/corpse
+	id_trim = null
+
+/datum/outfit/job/cook/corpse
+	id_trim = null
+
+/datum/outfit/job/doctor/corpse
+	id_trim = null
+
+/datum/outfit/job/geneticist/corpse
+	id_trim = null
+
+/datum/outfit/job/engineer/gloved/corpse
+	id_trim = null
+
+/datum/outfit/job/engineer/mod/corpse
+	id_trim = null
+
+/datum/outfit/job/clown/corpse
+	id_trim = null
+
+/datum/outfit/job/scientist/corpse
+	id_trim = null
+
+/datum/outfit/job/miner/corpse
+	id_trim = null
+
+/datum/outfit/job/miner/equipped/mod/corpse
+	id_trim = null
+
+/datum/outfit/job/miner/equipped/corpse
+	id_trim = null
+
+/datum/outfit/plasmaman/corpse
+	id_trim = null
+
+/datum/outfit/job/assistant/corpse
+	id_trim = null
+
+/datum/outfit/spacebartender/corpse
+	id_trim = null
+
+/datum/outfit/job/prisoner/corpse
+	id_trim = null
+
+/datum/outfit/job/roboticist/corpse
+	id_trim = null
+
+/datum/outfit/job/bitrunner/corpse
+	id_trim = null

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7282,6 +7282,7 @@
 #include "modular_nova\master_files\code\modules\mob\living\simple_animal\hostile\grabbagmob.dm"
 #include "modular_nova\master_files\code\modules\mob\living\simple_animal\hostile\zombie.dm"
 #include "modular_nova\master_files\code\modules\mob_spawn\mob_spawn.dm"
+#include "modular_nova\master_files\code\modules\mob_spawn\corpses\job_corpses.dm"
 #include "modular_nova\master_files\code\modules\mob_spawn\ghost_roles\mining_roles.dm"
 #include "modular_nova\master_files\code\modules\mod\mod_clothes.dm"
 #include "modular_nova\master_files\code\modules\mod\mod_construction.dm"


### PR DESCRIPTION

## About The Pull Request
Creates a /corpse datum outfit for the basic dead nt crew so they spawn without ID.

## How This Contributes To The Nova Sector Roleplay Experience
Avoids unintended ID's to be around, assumes that different stations get different id keys, makes it so its not a recurrent theme for people to run to a meta ruin to fetch the ID x and get access to certain departments. This accompanies an old PR that did the same by going by mapload and changing their outfits.

This was tested on voidraptor and ice box, also on bitrunning areas (to ensure we dont lose id's on bitrunning and block puzzles, we dont, dont worry!)

## Proof of Testing
lava:
<img width="696" height="467" alt="image" src="https://github.com/user-attachments/assets/7c61b91e-1811-47b6-b4f1-83be84b9e517" />

<img width="798" height="506" alt="image" src="https://github.com/user-attachments/assets/69589ced-859e-48a5-98ec-0f784d393aed" />

<img width="670" height="410" alt="image" src="https://github.com/user-attachments/assets/41e6987d-d94e-464c-a1e3-391ca87ee68a" />

<img width="666" height="470" alt="image" src="https://github.com/user-attachments/assets/b0993013-5976-4aa9-910f-5a78ba600a68" />

spawned clowns do get id:

<img width="675" height="479" alt="image" src="https://github.com/user-attachments/assets/3f525b2a-04be-434d-a5e5-882733cb6074" />

ice:

<img width="668" height="464" alt="image" src="https://github.com/user-attachments/assets/5a9a632f-5360-4838-8063-6d2a503e84c9" />

special assistant was left alone: 

<img width="748" height="440" alt="image" src="https://github.com/user-attachments/assets/9189268f-139e-4905-b1bf-a2c8604f9901" />

special id was left alone:

<img width="197" height="203" alt="image" src="https://github.com/user-attachments/assets/d70fa4b5-a921-4d68-b1ee-c1c3c636ecdd" />

bitrunning puzzles are untouched:

<img width="723" height="509" alt="image" src="https://github.com/user-attachments/assets/292be0ea-69e3-4c16-a618-2002f58fd070" />

<img width="817" height="502" alt="image" src="https://github.com/user-attachments/assets/d3c5cd8e-dbb4-44c9-ad5e-299c135fb225" />

<img width="784" height="500" alt="image" src="https://github.com/user-attachments/assets/db97939b-7720-43f4-b718-be3da29738f3" />


<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
del: Removed the ID of basic NT corpses to reflect its a different station with different set of secure keys (Also because they had been beelined to get free acces a bit too much)
/:cl:
