### PR TITLE
Restricts suppressors to be purchasable with a permit only.

### DIFF
--- a/modular_nova/modules/company_imports/code/armament_datums/vitezstvi_ammo.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/vitezstvi_ammo.dm
@@ -38,6 +38,7 @@
 
 /datum/armament_entry/company_import/vitezstvi/accessory/suppressor
 	item_type = /obj/item/suppressor/standard
+	restricted = TRUE
 
 /datum/armament_entry/company_import/vitezstvi/accessory/seclight
 	item_type = /obj/item/flashlight/seclite


### PR DESCRIPTION

## About The Pull Request
Makes it so suppressors are restricted and requires a permit in order to buy them.

## How This Contributes To The Nova Sector Roleplay Experience
The suppressor is considered contraband for anyone that doesn't have a permit so let's put it in there for consistency's sake.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="705" height="356" alt="GzFJF1MnE9" src="https://github.com/user-attachments/assets/d71b6d4c-df22-443b-8125-324e3708d2f3" />

</details>

## Changelog
:cl: Hardly
code: Suppressors are now permit restricted.
/:cl:
