### PR TITLE
delay to nif scan

### DIFF
--- a/modular_nova/modules/modular_implants/code/misc_devices.dm
+++ b/modular_nova/modules/modular_implants/code/misc_devices.dm
@@ -95,7 +95,6 @@
 	qdel(nifsoft_to_remove)
 	return ITEM_INTERACT_SUCCESS
 
-
 /datum/uplink_item/device_tools/nifsoft_remover
 	name = "Cybersun 'Scalpel' NIF-Cutter"
 	desc = "A modified version of a NIFSoft remover that allows the user to remove a NIFSoft and have a blank copy of the removed NIFSoft saved to a disk."


### PR DESCRIPTION
adds delay to NT nif cutter
## About The Pull Request
minor codefuckery, murdering way to abuse stuff
## How This Contributes To The Nova Sector Roleplay Experience
kills of very idea of busting tratiors by "totally accidental click" of a nif cutter, do we need to wait for it to be abused to be cut down?
syndie nif cutter got no delay, does it need it tho?
## Proof of Testing
https://youtu.be/qJAkRBEjfVw
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: NT Wrangler nif cutter now have 5 seconds delay to scan before seeing installed NIFsoft
/:cl:
