### PR TITLE
ammo stack updates (credits to doppler)

### DIFF
--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -187,7 +187,10 @@
 		for(var/obj/item/ammo_casing/casing in other_box.ammo_list())
 			var/did_load = give_round(casing, replace_spent)
 			if(did_load)
-				other_box.stored_ammo -= casing
+				// NOVA EDIT START - turns out ammo handfuls like to runtime so let's do a qdeleted check
+				if(!QDELETED(other_box))
+					other_box.stored_ammo -= casing
+				// NOVA EDIT END | original other_box.stored_ammo -= casing
 				num_loaded++
 			// failed to load (full already? ran out of ammo?)
 			if(!did_load)

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -187,10 +187,7 @@
 		for(var/obj/item/ammo_casing/casing in other_box.ammo_list())
 			var/did_load = give_round(casing, replace_spent)
 			if(did_load)
-				// NOVA EDIT START - turns out ammo handfuls like to runtime so let's do a qdeleted check
-				if(!QDELETED(other_box))
-					other_box.stored_ammo -= casing
-				// NOVA EDIT END | original other_box.stored_ammo -= casing
+				other_box.stored_ammo -= casing
 				num_loaded++
 			// failed to load (full already? ran out of ammo?)
 			if(!did_load)

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -187,7 +187,11 @@
 		for(var/obj/item/ammo_casing/casing in other_box.ammo_list())
 			var/did_load = give_round(casing, replace_spent)
 			if(did_load)
-				other_box.stored_ammo -= casing
+				// NOVA EDIT START - turns out ammo handfuls like to runtime when moving the last casing out (and then deleting itself) so let's do a qdeleted check
+				// other_box.stored_ammo -= casing // original
+				if(!QDELETED(other_box))
+					other_box.stored_ammo -= casing
+				// NOVA EDIT END
 				num_loaded++
 			// failed to load (full already? ran out of ammo?)
 			if(!did_load)

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -187,11 +187,7 @@
 		for(var/obj/item/ammo_casing/casing in other_box.ammo_list())
 			var/did_load = give_round(casing, replace_spent)
 			if(did_load)
-				// NOVA EDIT START - turns out ammo handfuls like to runtime when moving the last casing out (and then deleting itself) so let's do a qdeleted check
-				// other_box.stored_ammo -= casing // original
-				if(!QDELETED(other_box))
-					other_box.stored_ammo -= casing
-				// NOVA EDIT END
+				other_box.stored_ammo -= casing
 				num_loaded++
 			// failed to load (full already? ran out of ammo?)
 			if(!did_load)

--- a/modular_nova/modules/ammo_stacks/code/ammo_stack_base.dm
+++ b/modular_nova/modules/ammo_stacks/code/ammo_stack_base.dm
@@ -55,6 +55,7 @@
 	if(!ammo_count(TRUE) && !QDELING(src))
 		qdel(src)
 
+/// Iterates through every casing in this ammo stack, scattering it and moving it out of the ammo stack, in the event this was thrown.
 /obj/item/ammo_box/magazine/ammo_stack/proc/scatter(atom/hit_atom, pixel_distance = 48)
 	var/turf/scatter_turf = get_turf(hit_atom)
 	if(!hit_atom.CanPass(src, get_dir(src, hit_atom))) //Object is too dense to fall apart on
@@ -69,6 +70,7 @@
 	playsound(scatter_turf, 'sound/items/weapons/gun/general/mag_bullet_remove.ogg', 60, TRUE)
 	check_empty()
 
+/// Scatters an individual casing, bouncing and pixel-moving it about.
 /obj/item/ammo_box/magazine/ammo_stack/proc/scatter_individual_casing(obj/item/ammo_casing/scattered_casing, pixel_x_offset = 0, pixel_y_offset = 0)
 	if(prob(50)) // Randomize order, avoid bias to one axis if stepping is blocked
 		pixelmove_casing(scattered_casing, pixel_y_offset, x_axis = FALSE)
@@ -78,6 +80,7 @@
 		pixelmove_casing(scattered_casing, pixel_y_offset, x_axis = FALSE)
 	scattered_casing.bounce_away(FALSE, rand(0, 3))
 
+/// Pixel-moves a casing around based on offsets, in tandem with casing scattering when this ammo stack is thrown.
 /obj/item/ammo_box/magazine/ammo_stack/proc/pixelmove_casing(obj/item/ammo_casing/scattered_casing, pixel_offset = 0, x_axis = TRUE)
 	var/positive_dir = x_axis ? EAST : NORTH
 	var/negative_dir = x_axis ? WEST : SOUTH

--- a/modular_nova/modules/ammo_stacks/code/ammo_stack_base.dm
+++ b/modular_nova/modules/ammo_stacks/code/ammo_stack_base.dm
@@ -32,11 +32,6 @@
 	. = ..()
 	check_empty()
 
-/obj/item/ammo_box/magazine/ammo_stack/remove_from_stored_ammo(atom/movable/gone)
-	if(QDELETED(src))
-		return
-	return ..()
-
 /obj/item/ammo_box/magazine/ammo_stack/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
 	if(.) // They caught all the bullets. Powerful.
@@ -52,7 +47,7 @@
 
 /// Checks the shells in the ammo stack to make sure it isn't empty, if it is, the stack is deleted
 /obj/item/ammo_box/magazine/ammo_stack/proc/check_empty()
-	if(!ammo_count(TRUE) && !QDELING(src))
+	if(!ammo_count(TRUE) && !QDELETED(src))
 		qdel(src)
 
 /// Iterates through every casing in this ammo stack, scattering it and moving it out of the ammo stack, in the event this was thrown.

--- a/modular_nova/modules/ammo_stacks/code/ammo_stack_base.dm
+++ b/modular_nova/modules/ammo_stacks/code/ammo_stack_base.dm
@@ -5,27 +5,16 @@
 	icon = 'modular_nova/modules/ammo_stacks/icons/ammo_stacks.dmi'
 	icon_state = "stack_regular"
 	base_icon_state = "ammo_stack"
+	appearance_flags = parent_type::appearance_flags | KEEP_TOGETHER
 	w_class = WEIGHT_CLASS_SMALL
 	multiple_sprites = AMMO_BOX_ONE_SPRITE
 	ammo_box_multiload = AMMO_BOX_MULTILOAD_NONE
 	start_empty = TRUE
 	max_ammo = 12
-	/// Every x position we use for casings, change based on the size of the casing being put into the stack
-	var/list/casing_x_positions = list(
-		-2,
-		-1,
-		0,
-		1,
-		2,
-	)
-	/// How much space vertically should we leave for casings in random casing y pixel shifts
-	var/casing_y_padding = 3
-
-/obj/item/ammo_box/magazine/ammo_stack/Initialize(mapload)
-	. = ..()
-	ammo_list() // forces ammo to load for visibility's sake
-	update_appearance() // forces icon to update so ammo handfuls do, actually, appear full
-	AddElement(/datum/element/can_shatter, number_of_shards = 0, shattering_sound = 'sound/items/weapons/gun/general/mag_bullet_remove.ogg', shatters_as_weapon = TRUE)
+	/// Spacing between random w offsets of casings. Change based on the size of the casing being put into the stack.
+	var/casing_w_spacing = 1
+	/// How much space vertically should we leave for casings in random casing z pixel shifts.
+	var/casing_z_padding = 3
 
 /obj/item/ammo_box/magazine/ammo_stack/attack_self(mob/user)
 	. = ..()
@@ -43,55 +32,120 @@
 	. = ..()
 	check_empty()
 
+/obj/item/ammo_box/magazine/ammo_stack/remove_from_stored_ammo(atom/movable/gone)
+	if(QDELETED(src))
+		return
+	return ..()
+
+/obj/item/ammo_box/magazine/ammo_stack/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+	. = ..()
+	if(.) // They caught all the bullets. Powerful.
+		return
+	scatter(hit_atom, 48)
+
+/obj/item/ammo_box/magazine/ammo_stack/onZImpact(turf/impacted_turf, levels, impact_flags)
+	. = ..()
+	scatter(impacted_turf, 48)
+
+/obj/item/ammo_box/magazine/ammo_stack/afterattack(atom/target, mob/user, list/modifiers, list/attack_modifiers)
+	scatter(target, 48)
+
 /// Checks the shells in the ammo stack to make sure it isn't empty, if it is, the stack is deleted
 /obj/item/ammo_box/magazine/ammo_stack/proc/check_empty()
 	if(!ammo_count(TRUE) && !QDELING(src))
 		qdel(src)
 
+/obj/item/ammo_box/magazine/ammo_stack/proc/scatter(atom/hit_atom, pixel_distance = 48)
+	var/turf/scatter_turf = get_turf(hit_atom)
+	if(!hit_atom.CanPass(src, get_dir(src, hit_atom))) //Object is too dense to fall apart on
+		scatter_turf = get_turf(src)
+
+	var/generator/scatter_gen = generator(GEN_CIRCLE, 0, pixel_distance, NORMAL_RAND)
+	for(var/obj/item/ammo_casing/scattered_casing as anything in ammo_list())
+		scattered_casing.forceMove(scatter_turf)
+		var/list/scatter_vector = scatter_gen.Rand()
+		scatter_individual_casing(scattered_casing, scatter_vector[1], scatter_vector[2])
+
+	playsound(scatter_turf, 'sound/items/weapons/gun/general/mag_bullet_remove.ogg', 60, TRUE)
+	check_empty()
+
+/obj/item/ammo_box/magazine/ammo_stack/proc/scatter_individual_casing(obj/item/ammo_casing/scattered_casing, pixel_x_offset = 0, pixel_y_offset = 0)
+	if(prob(50)) // Randomize order, avoid bias to one axis if stepping is blocked
+		pixelmove_casing(scattered_casing, pixel_y_offset, x_axis = FALSE)
+		pixelmove_casing(scattered_casing, pixel_x_offset, x_axis = TRUE)
+	else
+		pixelmove_casing(scattered_casing, pixel_x_offset, x_axis = TRUE)
+		pixelmove_casing(scattered_casing, pixel_y_offset, x_axis = FALSE)
+	scattered_casing.bounce_away(FALSE, rand(0, 3))
+
+/obj/item/ammo_box/magazine/ammo_stack/proc/pixelmove_casing(obj/item/ammo_casing/scattered_casing, pixel_offset = 0, x_axis = TRUE)
+	var/positive_dir = x_axis ? EAST : NORTH
+	var/negative_dir = x_axis ? WEST : SOUTH
+	var/per_step = x_axis ? ICON_SIZE_X : ICON_SIZE_Y
+	var/half_step = per_step / 2
+
+	if(abs(pixel_offset) > half_step)
+		var/positive_offset = (pixel_offset > 0)
+		var/offset_correction = positive_offset ? -half_step : half_step
+		var/step_dir = positive_offset ? positive_dir : negative_dir
+		for(var/i in 1 to floor(abs(pixel_offset) + half_step) / per_step)
+			step(scattered_casing, step_dir)
+		pixel_offset = (pixel_offset % half_step) + offset_correction
+
+	if(x_axis)
+		scattered_casing.pixel_x = pixel_offset
+	else
+		scattered_casing.pixel_y = pixel_offset
+
 /obj/item/ammo_box/magazine/ammo_stack/update_appearance()
 	. = ..()
-	cut_overlays()
-	if(!ammo_count(TRUE))
+	if(!ammo_count())
 		return
-
 	icon_state = base_icon_state
 
-	for(var/obj/item/ammo_casing/iterated_casing in stored_ammo)
-		var/image/overlayed_item = image(icon = iterated_casing.icon, icon_state = iterated_casing.icon_state, pixel_x = pick(casing_x_positions), pixel_y = rand((-16 + casing_y_padding), (16 - casing_y_padding)))
-		add_overlay(overlayed_item)
+/obj/item/ammo_box/magazine/ammo_stack/update_overlays()
+	. = ..()
+	if(!ammo_count())
+		return
+
+	for(var/obj/item/ammo_casing/iterated_casing as anything in stored_ammo)
+		var/mutable_appearance/overlayed_casing = mutable_appearance(icon = iterated_casing.icon, icon_state = "[initial(iterated_casing.icon_state)]-live")
+		overlayed_casing.pixel_w = rand(-2, 2) * casing_w_spacing
+		var/z_offset_range = 16 - casing_z_padding
+		overlayed_casing.pixel_z = rand(-z_offset_range, z_offset_range)
+		. += overlayed_casing
 
 // Allows ammo casings to be attacked together to make a new stack
 /obj/item/ammo_casing
 	/// What this casing can be stacked into
 	var/obj/item/ammo_box/magazine/ammo_stack_type
 
-/obj/item/ammo_casing/attackby(obj/item/attacking_item, mob/user, params)
+/obj/item/ammo_casing/examine(mob/user)
 	. = ..()
+	if(ammo_stack_type)
+		. += span_notice("[src] can be stacked with other casings of a similar type.")
+	return .
 
-	if(!istype(attacking_item, /obj/item/ammo_casing))
-		return
+/obj/item/ammo_casing/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/ammo_casing))
+		return NONE
 
-	var/obj/item/ammo_casing/ammo_casing = attacking_item
-	if(!ammo_casing.ammo_stack_type)
-		balloon_alert(user, "[ammo_casing] can't stack")
-		return
+	var/obj/item/ammo_casing/used_casing = tool
+	if(!used_casing.ammo_stack_type)
+		balloon_alert(user, "used casing can't stack")
+		return ITEM_INTERACT_BLOCKING
 	if(!ammo_stack_type)
-		balloon_alert(user, "[src] can't stack")
-		return
-	if(caliber != ammo_casing.caliber)
-		balloon_alert(user, "can't stack different calibers")
-		return
-	if(ammo_stack_type != ammo_casing.ammo_stack_type)
-		balloon_alert(user, "can't stack [src] with [ammo_casing]")
-		return
-	if(!loaded_projectile || !ammo_casing.loaded_projectile)
-		balloon_alert(user, "can't stack empty casings")
-		return
+		balloon_alert(user, "target can't stack!")
+		return ITEM_INTERACT_BLOCKING
+	if(ammo_stack_type != used_casing.ammo_stack_type)
+		balloon_alert(user, "can't stack together!")
+		return ITEM_INTERACT_BLOCKING
+	if(!loaded_projectile || !used_casing.loaded_projectile)
+		balloon_alert(user, "can't stack empty casings!")
+		return ITEM_INTERACT_BLOCKING
 
 	var/obj/item/ammo_box/magazine/ammo_stack = new ammo_stack_type(drop_location())
-	user.transferItemToLoc(src, ammo_stack, silent = TRUE)
 	ammo_stack.give_round(src)
-	user.transferItemToLoc(ammo_casing, ammo_stack, silent = TRUE)
-	ammo_stack.give_round(ammo_casing)
+	ammo_stack.give_round(used_casing)
 	user.put_in_hands(ammo_stack)
 	ammo_stack.update_appearance()

--- a/modular_nova/modules/ammo_stacks/code/ammo_stack_base.dm
+++ b/modular_nova/modules/ammo_stacks/code/ammo_stack_base.dm
@@ -48,7 +48,8 @@
 /// Checks the shells in the ammo stack to make sure it isn't empty, if it is, the stack is deleted
 /obj/item/ammo_box/magazine/ammo_stack/proc/check_empty()
 	if(!ammo_count(TRUE) && !QDELETED(src))
-		qdel(src)
+		spawn(0) // We are doing this to yield execution to the rest of the call chain to avoid a race condition. Hacky but avoids nonmodular messes.
+			qdel(src)
 
 /// Iterates through every casing in this ammo stack, scattering it and moving it out of the ammo stack, in the event this was thrown.
 /obj/item/ammo_box/magazine/ammo_stack/proc/scatter(atom/hit_atom, pixel_distance = 48)

--- a/modular_nova/modules/ammo_stacks/code/stack_types.dm
+++ b/modular_nova/modules/ammo_stacks/code/stack_types.dm
@@ -9,14 +9,8 @@
 	ammo_type = /obj/item/ammo_casing/c980grenade
 	casing_phrasing = "shell"
 	max_ammo = 6
-	casing_x_positions = list(
-		-6,
-		-3,
-		0,
-		3,
-		6,
-	)
-	casing_y_padding = 9
+	casing_w_spacing = 3
+	casing_z_padding = 9
 
 /obj/item/ammo_box/magazine/ammo_stack/c980/prefilled
 	name = ".980 Tydhouer practice grenades"
@@ -52,14 +46,8 @@
 	ammo_type = /obj/item/ammo_casing/shotgun
 	casing_phrasing = "shell"
 	max_ammo = 8
-	casing_x_positions = list(
-		-6,
-		-3,
-		0,
-		3,
-		6,
-	)
-	casing_y_padding = 4
+	casing_w_spacing = 3
+	casing_z_padding = 4
 
 /obj/item/ammo_box/magazine/ammo_stack/s12gauge/prefilled
 	name = "12 gauge slug shells"
@@ -143,16 +131,8 @@
 	caliber = CALIBER_SOL35SHORT
 	ammo_type = /obj/item/ammo_casing/c35sol
 	max_ammo = 12
-	casing_x_positions = list(
-		-6,
-		-4,
-		-2,
-		0,
-		2,
-		4,
-		6,
-	)
-	casing_y_padding = 6
+	casing_w_spacing = 2
+	casing_z_padding = 6
 
 /obj/item/ammo_box/magazine/ammo_stack/c35_sol/prefilled
 	start_empty = FALSE
@@ -175,16 +155,8 @@
 	caliber = CALIBER_CESARZOWA
 	ammo_type = /obj/item/ammo_casing/c27_54cesarzowa
 	max_ammo = 18
-	casing_x_positions = list(
-		-6,
-		-4,
-		-2,
-		0,
-		2,
-		4,
-		6,
-	)
-	casing_y_padding = 6
+	casing_w_spacing = 2
+	casing_z_padding = 6
 
 /obj/item/ammo_box/magazine/ammo_stack/c27_54cesarzowa/prefilled
 	start_empty = FALSE
@@ -202,14 +174,8 @@
 	caliber = CALIBER_585TRAPPISTE
 	ammo_type = /obj/item/ammo_casing/c585trappiste
 	max_ammo = 6
-	casing_x_positions = list(
-		-4,
-		-2,
-		0,
-		2,
-		4,
-	)
-	casing_y_padding = 9
+	casing_w_spacing = 2
+	casing_z_padding = 9
 
 /obj/item/ammo_box/magazine/ammo_stack/c585_trappiste/prefilled
 	start_empty = FALSE
@@ -234,16 +200,8 @@
 	caliber = CALIBER_SOL40LONG
 	ammo_type = /obj/item/ammo_casing/c40sol
 	max_ammo = 15
-	casing_x_positions = list(
-		-6,
-		-4,
-		-2,
-		0,
-		2,
-		4,
-		6,
-	)
-	casing_y_padding = 6
+	casing_w_spacing = 2
+	casing_z_padding = 6
 
 /obj/item/ammo_box/magazine/ammo_stack/c40_sol/prefilled
 	start_empty = FALSE
@@ -274,14 +232,8 @@
 	caliber = CALIBER_STRILKA310
 	ammo_type = /obj/item/ammo_casing/strilka310
 	max_ammo = 5
-	casing_x_positions = list(
-		-4,
-		-2,
-		0,
-		2,
-		4,
-	)
-	casing_y_padding = 8
+	casing_w_spacing = 2
+	casing_z_padding = 8
 
 /obj/item/ammo_box/magazine/ammo_stack/c310_strilka/prefilled
 	start_empty = FALSE
@@ -308,14 +260,8 @@
 	caliber = CALIBER_60STRELA
 	ammo_type = /obj/item/ammo_casing/p60strela
 	max_ammo = 6
-	casing_x_positions = list(
-		-6,
-		-3,
-		0,
-		3,
-		6,
-	)
-	casing_y_padding = 9
+	casing_w_spacing = 3
+	casing_z_padding = 9
 
 /obj/item/ammo_box/magazine/ammo_stack/c60_strela/prefilled
 	start_empty = FALSE

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/bolt_fabrications/ammo.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/bolt_fabrications/ammo.dm
@@ -28,19 +28,5 @@
 	caliber = CALIBER_KINETICBALL
 	ammo_type = /obj/item/ammo_casing/kineticball
 	max_ammo = 13
-	casing_x_positions = list(
-		-7,
-		-6,
-		-5,
-		-3,
-		-2,
-		-1,
-		0,
-		1,
-		2,
-		3,
-		5,
-		6,
-		7,
-	)
-	casing_y_padding = 6
+	casing_w_spacing = 2
+	casing_z_padding = 6


### PR DESCRIPTION
## About The Pull Request
ports DopplerShift13/DopplerShift#637 and DopplerShift13/DopplerShift#692
continues the runtime fixing by doing a less-than-modular change to a tg file to avoid removing a null from a qdel'd ammo handful when reloading

<details><summary>Okay but why the tg file change</summary>

~~Downstream has~~ Ammo handfuls (implemented as a magazine subtype,`/obj/item/ammo_box/magazine/ammo_stack`) ~~which~~ are coded to delete themselves when emptied.

Unfortunately, when they're deleting themselves when emptied during reloading another magazine (e.g. loading the last shell in a handful into an ammo box), they runtime, as they're trying to remove from a list that's in a deleted object.
<img width="582" height="136" alt="image" src="https://github.com/user-attachments/assets/8c09fbda-c4de-4255-bca5-b06504924bd4" />

The QDELETED() check here prevents us from trying to remove the moved casing from the relevant ammo handful (which at that point in time has been deleted), preventing the runtime.
</details>

## How This Contributes To The Nova Sector Roleplay Experience
runtimes go boom (positive)

## Proof of Testing
<img width="137" height="87" alt="image" src="https://github.com/user-attachments/assets/c2b36b04-96a1-45d8-8ba4-5384522cbd7c" />

## Changelog

:cl: 00-Steven, Paxilmaniac
fix: Ammo stacks actually have an outline when hovered over in your inventory.
fix: A newly created ammo stack actually drops ammo when thrown.
fix: Ammo stacks no longer pixel offset into walls or other dense objects.
fix: fixes ammo stacks runtiming when emptied
/:cl: