### PR TITLE
Hyperoxia and some N2O changes

### DIFF
--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -52,8 +52,8 @@
 	///How much breath partial pressure is a safe amount of plasma. 0 means that we are immune to plasma.
 	var/safe_plasma_max = 0.05
 	var/n2o_detect_min = 0.08 //Minimum n2o for effects
-	var/n2o_para_min = 5 //NOVA EDIT CHANGE - N2O nerf
-	var/n2o_sleep_min = 15 //NOVA EDIT CHANGE - N2O nerf
+	var/n2o_para_min = 5 //Sleeping agent // NOVA EDIT CHANGE - N2O nerf - ORIGINAL: var/n2o_para_min = 1 //Sleeping agent
+	var/n2o_sleep_min = 15 //Sleeping agent // NOVA EDIT CHANGE - N2O nerf - ORIGINAL: var/n2o_sleep_min = 5 //Sleeping agent
 	var/BZ_trip_balls_min = 1 //BZ gas
 	var/BZ_brain_damage_min = 10 //Give people some room to play around without killing the station
 	var/gas_stimulation_min = 0.002 // For, Pluoxium, Nitrium and Freon


### PR DESCRIPTION
Changed N2O and O2 Thresholds
## About The Pull Request
Adds Hyperoxia back, I suppose. Also it should take more N2O to fall asleep.
## How This Contributes To The Nova Sector Roleplay Experience
I'm still trying to figure out the thresholds, but in theory we should get more work for medical and N2O that you can actually can turn into the laugh gas mixture and not just into sleep gas mixture.

I'm making it a PR so I can hear opinions on this.
## Proof of Testing
WIP, so I don't see a reason to test it now
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
balance: You can now overdose on O2, being O2 breathing. 
balance: It now takes more pp of N2O to knock you down.
/:cl:
