### PR TITLE
You can't install suppressors on the AR2

### DIFF
--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/pulse_rifle.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/pulse_rifle.dm
@@ -17,6 +17,7 @@
 	bolt_type = BOLT_TYPE_LOCKING
 	accepted_magazine_type = /obj/item/ammo_box/magazine/pulse
 	semi_auto = FALSE
+	can_suppress = FALSE
 	fire_sound = 'modular_nova/modules/modular_weapons/sounds/pulse_shoot.ogg'
 	fire_sound_volume = 50
 	lock_back_sound = 'modular_nova/modules/modular_weapons/sounds/pulse_pull.ogg'

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/pulse_sniper.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/pulse_sniper.dm
@@ -18,6 +18,7 @@
 	bolt_type = BOLT_TYPE_LOCKING
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/pulse_sniper
 	semi_auto = FALSE
+	can_suppress = FALSE
 	fire_sound = 'modular_nova/modules/modular_weapons/sounds/pulse_shoot.ogg'
 	fire_sound_volume = 70
 	rack_sound = 'modular_nova/modules/modular_weapons/sounds/pulse_pull.ogg'


### PR DESCRIPTION

## About The Pull Request
Makes it impossible to install suppressors on the Zaibas rifles.
## How This Contributes To The Nova Sector Roleplay Experience
Uh-oh oversight; there's also no gas to suppress and all the firing sounds come from the pulse cell priming (hitting it real hard) anyways.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="247" height="156" alt="image" src="https://github.com/user-attachments/assets/3dc06f9d-48af-4286-ba9c-ced9388fcb8c" />
<img width="267" height="133" alt="image" src="https://github.com/user-attachments/assets/919a2384-d929-4be4-a92e-3f308d984eee" />
<img width="274" height="160" alt="image" src="https://github.com/user-attachments/assets/527279d9-806b-4f6a-ae2c-e0131a183f56" />

</details>

## Changelog
:cl: Stalkeros
fix: Due to a concerning amount of reports regarding molten suppressors, as well as a pending lawsuit for damaged customer equipment, Szot Dynamica had to remove muzzle threads from the Zaibas family of weapons.
fix: In layman's terms, you can't install suppressors on the Zaibases anymore.
/:cl:
