### PR TITLE
drake, where's the magazine - sawed off m64 shotguns drop to 4+1 capacity

### DIFF
--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/shotgun.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/shotgun.dm
@@ -58,6 +58,11 @@
 
 	. = ..()
 
+/obj/item/gun/ballistic/shotgun/riot/sol/sawoff(mob/user, obj/item/saw, handle_modifications)
+	. = ..()
+	magazine.max_ammo = 4 // capacity drops to 4+1 because Where's The Rest Of The Magazine, Bro
+	// possible todo short inhands?
+
 /obj/item/ammo_box/magazine/internal/shot/sol
 	ammo_type = /obj/item/ammo_casing/shotgun/rubbershot
 	max_ammo = 8


### PR DESCRIPTION
## About The Pull Request

Sawing off an M64 shotgun reduces the magazine's capacity from 8 to 4, reducing the shotgun's capacity to a theoretical maximum of 4+1.

## How This Contributes To The Nova Sector Roleplay Experience

<img width="551" height="270" alt="image" src="https://github.com/user-attachments/assets/370012ea-2638-4337-b18c-188e55af536d" />

## Proof of Testing

<img width="1039" height="261" alt="image" src="https://github.com/user-attachments/assets/d8fa6762-06ab-4317-991d-47afd1296869" />

## Changelog

:cl:
balance: Sawed-off M64s now only have a maximum capacity of 4+1, because you are not fitting eight shells in a halved shotgun magazine tube.
/:cl:
