### PR TITLE
Adds New Condos to Nova Sector

### DIFF
--- a/modular_nova/modules/condos/_maps/apartment_mountainside.dmm
+++ b/modular_nova/modules/condos/_maps/apartment_mountainside.dmm
@@ -1793,7 +1793,7 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 1
 	},
-/turf/open/space/basic,
+/turf/open/floor/wood/large,
 /area/misc/condo)
 "kA" = (
 /obj/structure/curtain/cloth/fancy/mechanical{

--- a/modular_nova/modules/condos/_maps/apartment_mountainside.dmm
+++ b/modular_nova/modules/condos/_maps/apartment_mountainside.dmm
@@ -1793,7 +1793,7 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/space/basic,
 /area/misc/condo)
 "kA" = (
 /obj/structure/curtain/cloth/fancy/mechanical{
@@ -2804,13 +2804,13 @@
 /area/misc/condo)
 "rk" = (
 /obj/structure/fluff/bus/passable/seat{
-	desc = "stop ooming please i want to play";
 	icon = 'icons/obj/machines/telecomms.dmi';
 	icon_state = "blackbox_b";
-	name = "splurt-tg server";
+	name = "Solaris server";
 	density = 1;
 	pixel_y = 0;
-	uses_integrity = 0
+	uses_integrity = 0;
+	desc = "Sees occasional usage. It seems to be paired with a server called Nova Sector]"
 	},
 /obj/structure/marker_beacon/indigo,
 /obj/item/clothing/mask/muzzle/tape{
@@ -3626,10 +3626,10 @@
 /area/misc/condo)
 "vr" = (
 /obj/structure/fluff/bus/passable/seat{
-	desc = "Ye' ol' reliable server. 0 days without incidents!";
+	desc = "Tests all the systems to make sure they function accordingly, also tends to false positive things it doesn't like";
 	icon = 'icons/obj/machines/telecomms.dmi';
 	icon_state = "blackbox";
-	name = "splurt-tg server";
+	name = "Unit Test server";
 	density = 1;
 	pixel_y = 0;
 	uses_integrity = 0
@@ -3770,10 +3770,10 @@
 /area/misc/condo)
 "wn" = (
 /obj/structure/fluff/bus/passable/seat{
-	desc = "Ye' ol' reliable server. 0 days without incidents!";
+	desc = "Occasionallly runtimes and crashes on serenity station.";
 	icon = 'icons/obj/machines/telecomms.dmi';
 	icon_state = "blackbox";
-	name = "splurt-tg server";
+	name = "Nova Sector server";
 	density = 1;
 	pixel_y = 0;
 	uses_integrity = 0
@@ -3933,6 +3933,9 @@
 	},
 /obj/effect/turf_decal/box/white{
 	color = "#b357ff"
+	},
+/obj/machinery/computer/arcade/amputation{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/misc/condo)
@@ -4465,8 +4468,8 @@
 	density = 1;
 	pixel_y = 0;
 	uses_integrity = 0;
-	name = "Dr. Bright's homework folder";
-	desc = "400TB of SCP porn and \[REDACTED]"
+	name = "Copium Mining Server";
+	desc = "400TB of various tears and crashouts from maintainers and contributors alike, we're not sure how you got this many, but its probably best not to ask."
 	},
 /turf/open/floor/plating,
 /area/misc/condo)
@@ -7091,10 +7094,10 @@
 	pixel_y = -5
 	},
 /obj/structure/fluff/bus/passable/seat{
-	desc = "Ye' ol' reliable server. 0 days without incidents!";
+	desc = "Seems to have etched on the side 'breaks-the-prs waz here'";
 	icon = 'icons/obj/machines/telecomms.dmi';
 	icon_state = "blackbox";
-	name = "splurt-citadel server";
+	name = "Nova Sector Deployment server";
 	density = 1;
 	pixel_y = 0;
 	uses_integrity = 0;

--- a/modular_nova/modules/condos/_maps/deepspace_pod.dmm
+++ b/modular_nova/modules/condos/_maps/deepspace_pod.dmm
@@ -1,0 +1,1236 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ap" = (
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/turf_decal/siding/dark/end,
+/turf/open/floor/carpet/royalblue,
+/area/misc/condo)
+"az" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark/end{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/misc/condo)
+"cz" = (
+/obj/structure/decorative{
+	icon = 'modular_nova/modules/advanced_shuttles/icons/computer.dmi';
+	icon_state = "computer_left"
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/condo)
+"cK" = (
+/obj/structure/hedge,
+/obj/structure/window/reinforced/tinted/spawner/directional/south,
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/condo)
+"cO" = (
+/obj/structure/decorative/shelf/crates1,
+/turf/open/floor/iron/shuttle/exploration/hazard,
+/area/misc/condo)
+"cV" = (
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"eq" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	color = "#D4D4D4";
+	alpha = 255;
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	color = "#D4D4D4";
+	alpha = 255;
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/circuit/red/off,
+/area/misc/condo)
+"eC" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/machinery/light/floor{
+	pixel_y = 16;
+	bulb_colour = "#66ccff";
+	pixel_x = 16
+	},
+/turf/open/floor/iron/shuttle/exploration/uside{
+	dir = 4
+	},
+/area/misc/condo)
+"eF" = (
+/obj/effect/turf_decal/siding/wideplating_new/light{
+	color = "#3F48CC";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/light{
+	color = "#3F48CC";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"fa" = (
+/obj/structure/decorative{
+	icon = 'icons\obj\mining_zones\donkvendor.dmi';
+	icon_state = "donkvendor";
+	anchored = 1;
+	name = "Life Support Systems"
+	},
+/turf/open/floor/iron/shuttle/exploration/hazard,
+/area/misc/condo)
+"fn" = (
+/turf/open/space/mirage,
+/area/misc/condo)
+"fs" = (
+/obj/item/toy/plush/carpplushie,
+/turf/open/space/mirage,
+/area/misc/condo)
+"gr" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	color = "#D4D4D4";
+	alpha = 255;
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	color = "#D4D4D4";
+	alpha = 255;
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
+	dir = 4
+	},
+/turf/open/floor/circuit/red/off,
+/area/misc/condo)
+"gH" = (
+/obj/machinery/power/shuttle_engine/heater{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/misc/condo)
+"kk" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"kn" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/turf/open/floor/carpet/kinaris/black,
+/area/misc/condo)
+"kN" = (
+/obj/machinery/door/airlock/survival_pod{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/exploration/hazard,
+/area/misc/condo)
+"kP" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/iron/shuttle/exploration/uside{
+	dir = 4
+	},
+/area/misc/condo)
+"kZ" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	color = "#D4D4D4";
+	alpha = 255;
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner{
+	dir = 4;
+	color = "#D4D4D4";
+	alpha = 255
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4;
+	color = "#EFB341"
+	},
+/turf/open/floor/circuit/red/off,
+/area/misc/condo)
+"lm" = (
+/turf/closed/wall/r_wall/plastitanium/nodiagonal,
+/area/misc/condo)
+"lo" = (
+/obj/effect/turf_decal/siding/wideplating_new/light/end{
+	color = "#3F48CC"
+	},
+/obj/effect/turf_decal/siding/dark/end,
+/obj/structure/decorative{
+	icon_state = "intercom";
+	pixel_y = -31;
+	icon = 'icons/obj/machines/wallmounts.dmi';
+	base_icon_state = "tile_half";
+	dir = 8;
+	pixel_x = -16;
+	anchored = 1;
+	name = "Intercom";
+	desc = "An older model version of a standard intercom system"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"mD" = (
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/condo)
+"mM" = (
+/obj/structure/lattice,
+/turf/open/space/mirage,
+/area/misc/condo)
+"nZ" = (
+/obj/effect/turf_decal/siding/wood/end,
+/obj/machinery/washing_machine,
+/turf/open/floor/iron{
+	icon = 'modular_nova/modules/advanced_shuttles/icons/evac_shuttle.dmi';
+	icon_state = "8,2";
+	dir = 1
+	},
+/area/misc/condo)
+"oP" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/exploration/uside{
+	dir = 8
+	},
+/area/misc/condo)
+"pa" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/end{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"pV" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/iron/shuttle/exploration/uside{
+	dir = 4
+	},
+/area/misc/condo)
+"qK" = (
+/obj/effect/turf_decal/caution/stand_clear/white,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"rK" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/light/floor{
+	pixel_y = 16;
+	bulb_colour = "#66ccff";
+	pixel_x = 16
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/exploration/uside{
+	dir = 4
+	},
+/area/misc/condo)
+"rV" = (
+/obj/structure/decorative{
+	icon = 'modular_nova/modules/advanced_shuttles/icons/computer.dmi';
+	icon_state = "computer_right"
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/condo)
+"rX" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/turf/open/floor/carpet/kinaris/black,
+/area/misc/condo)
+"sb" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/shuttle/exploration/uside{
+	dir = 8
+	},
+/area/misc/condo)
+"sc" = (
+/obj/machinery/door/airlock/survival_pod{
+	name = "Maintenance";
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/condo)
+"tw" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/carpet/kinaris/black,
+/area/misc/condo)
+"tB" = (
+/obj/machinery/power/shuttle_engine/propulsion/right{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/misc/condo)
+"tU" = (
+/turf/closed/indestructible/hoteldoor/fakedoor,
+/area/misc/condo)
+"tV" = (
+/obj/machinery/door/airlock/survival_pod{
+	name = "Bunks";
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/condo)
+"um" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/condo)
+"uw" = (
+/obj/structure/table/bronze,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"vi" = (
+/obj/structure/medieval/bed_2x2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"vs" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/shuttle/exploration/uside{
+	dir = 4
+	},
+/area/misc/condo)
+"wc" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	color = "#D4D4D4";
+	alpha = 255;
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner{
+	color = "#D4D4D4";
+	alpha = 255
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	color = "#EFB341"
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/table/bronze,
+/turf/open/floor/circuit/red/off,
+/area/misc/condo)
+"wk" = (
+/obj/structure/decorative{
+	icon_state = "intercom";
+	pixel_y = -31;
+	icon = 'icons/obj/machines/wallmounts.dmi';
+	base_icon_state = "tile_half";
+	dir = 8;
+	anchored = 1;
+	name = "Intercom";
+	desc = "An older model version of a standard intercom system"
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/condo)
+"xI" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/iron/shuttle/exploration/uside{
+	dir = 4
+	},
+/area/misc/condo)
+"yz" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"zK" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/chem_dispenser/drinks/fullupgrade{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"zP" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/wood/parquet,
+/area/misc/condo)
+"Af" = (
+/obj/effect/turf_decal/siding/dark/end{
+	dir = 8
+	},
+/obj/structure/decorative{
+	icon_state = "intercom";
+	pixel_y = 31;
+	icon = 'icons/obj/machines/wallmounts.dmi';
+	base_icon_state = "tile_half";
+	dir = 8;
+	anchored = 1;
+	name = "Intercom";
+	desc = "An older model version of a standard intercom system"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/misc/condo)
+"AL" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/turf/open/floor/carpet/kinaris/black,
+/area/misc/condo)
+"Bq" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/iron/shuttle/exploration/uside{
+	dir = 8
+	},
+/area/misc/condo)
+"Cd" = (
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/misc/condo)
+"Ct" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/turf/open/floor/carpet/kinaris/black,
+/area/misc/condo)
+"Dg" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	color = "#D4D4D4";
+	alpha = 255
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	color = "#D4D4D4";
+	alpha = 255;
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/table/wood/fancy/royalblue,
+/obj/structure/decorative{
+	icon_state = "iron_catwalk";
+	pixel_y = 11;
+	icon = 'icons/obj/tiles.dmi';
+	base_icon_state = "iron_catwalk";
+	dir = 8;
+	pixel_x = 2;
+	anchored = 1;
+	name = "speaker"
+	},
+/turf/open/floor/circuit/red/off,
+/area/misc/condo)
+"DA" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	color = "#D4D4D4";
+	alpha = 255
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	color = "#D4D4D4";
+	alpha = 255;
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/table/wood/fancy/royalblue,
+/obj/structure/decorative{
+	icon_state = "iron_catwalk";
+	pixel_y = 11;
+	icon = 'icons/obj/tiles.dmi';
+	base_icon_state = "iron_catwalk";
+	dir = 8;
+	pixel_x = 2;
+	anchored = 1;
+	name = "speaker"
+	},
+/obj/machinery/status_display{
+	pixel_y = 13;
+	pixel_x = 16;
+	name = "TV screen";
+	desc = "An ancient, though still half-decent television screen, model M0-LDB."
+	},
+/turf/open/floor/circuit/red/off,
+/area/misc/condo)
+"DW" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/shuttle/exploration/uside{
+	dir = 8
+	},
+/area/misc/condo)
+"Eq" = (
+/obj/effect/turf_decal/siding/dark/end{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblue,
+/area/misc/condo)
+"FD" = (
+/turf/closed/wall/r_wall/plastitanium,
+/area/misc/condo)
+"FI" = (
+/obj/structure/decorative{
+	icon = 'icons/obj/mining_zones/survival_pod.dmi';
+	icon_state = "fans";
+	anchored = 1;
+	name = "Life Support Systems"
+	},
+/turf/open/floor/iron/shuttle/exploration/hazard,
+/area/misc/condo)
+"FJ" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner{
+	dir = 1;
+	color = "#D4D4D4";
+	alpha = 255
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	color = "#D4D4D4";
+	alpha = 255;
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1;
+	color = "#EFB341"
+	},
+/turf/open/floor/circuit/red/off,
+/area/misc/condo)
+"Gb" = (
+/obj/effect/turf_decal/siding/dark/end,
+/turf/open/floor/carpet/royalblue,
+/area/misc/condo)
+"GS" = (
+/obj/structure/chair/bronze{
+	dir = 1
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/condo)
+"Hc" = (
+/obj/machinery/smartfridge/wooden/ration_shelf{
+	name = "shelf"
+	},
+/obj/structure/decorative/shelf{
+	anchored = 1
+	},
+/obj/item/clothing/shoes/jackboots/frontier_colonist{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"Jc" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	color = "#D4D4D4";
+	alpha = 255;
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner{
+	dir = 8;
+	color = "#D4D4D4";
+	alpha = 255
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8;
+	color = "#EFB341"
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/circuit/red/off,
+/area/misc/condo)
+"JW" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/shuttle/exploration/uside{
+	dir = 8
+	},
+/area/misc/condo)
+"Kv" = (
+/turf/open/floor/carpet/royalblue,
+/area/misc/condo)
+"KQ" = (
+/obj/structure/decorative/shelf/milk_big,
+/turf/open/floor/iron/shuttle/exploration/hazard,
+/area/misc/condo)
+"Lg" = (
+/obj/effect/turf_decal/siding/wideplating_new/light/end{
+	color = "#3F48CC";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark/end{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"Lt" = (
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/carpet/kinaris/black,
+/area/misc/condo)
+"Mw" = (
+/obj/effect/overlay/water{
+	icon_state = "OLD_bottom"
+	},
+/obj/effect/overlay/water/top{
+	icon_state = "OLD_top"
+	},
+/turf/open/floor/iron/freezer,
+/area/misc/condo)
+"Ok" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblue,
+/area/misc/condo)
+"PK" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/carpet/kinaris/black,
+/area/misc/condo)
+"PZ" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	color = "#D4D4D4";
+	alpha = 255;
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	color = "#D4D4D4";
+	alpha = 255
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/circuit/red/off,
+/area/misc/condo)
+"Qd" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark/end,
+/obj/effect/turf_decal/siding/wood/end,
+/obj/structure/decorative{
+	icon_state = "intercom";
+	pixel_y = -31;
+	icon = 'icons/obj/machines/wallmounts.dmi';
+	base_icon_state = "tile_half";
+	dir = 8;
+	anchored = 1;
+	name = "Intercom";
+	desc = "An older model version of a standard intercom system"
+	},
+/turf/open/floor/wood/parquet,
+/area/misc/condo)
+"RA" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/misc/condo)
+"Sf" = (
+/obj/structure/table/bronze,
+/obj/structure/table/bronze,
+/obj/structure/towel_bin{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/condo)
+"Sz" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	color = "#D4D4D4";
+	alpha = 255;
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	color = "#D4D4D4";
+	alpha = 255
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/decorative{
+	icon_state = "intercom";
+	pixel_y = -31;
+	icon = 'icons/obj/machines/wallmounts.dmi';
+	base_icon_state = "tile_half";
+	dir = 8;
+	pixel_x = -16;
+	anchored = 1;
+	name = "Intercom";
+	desc = "An older model version of a standard intercom system"
+	},
+/turf/open/floor/circuit/red/off,
+/area/misc/condo)
+"Tt" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/carpet/kinaris/black,
+/area/misc/condo)
+"TW" = (
+/obj/machinery/shower/directional/north,
+/obj/effect/overlay/water{
+	icon_state = "OLD_bottom"
+	},
+/obj/effect/overlay/water/top{
+	icon_state = "OLD_top"
+	},
+/obj/structure/decorative{
+	icon_state = "drain";
+	icon = 'modular_nova/modules/liquids/icons/obj/structures/drains.dmi';
+	base_icon_state = "drain";
+	dir = 8;
+	name = "drain";
+	anchored = 1;
+	pixel_x = -1
+	},
+/turf/open/floor/iron/freezer,
+/area/misc/condo)
+"UA" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/light/floor{
+	alpha = 0
+	},
+/turf/open/floor/carpet/royalblue,
+/area/misc/condo)
+"UU" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	color = "#D4D4D4";
+	alpha = 255;
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	color = "#D4D4D4";
+	alpha = 255;
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
+	},
+/turf/open/floor/circuit/red/off,
+/area/misc/condo)
+"Va" = (
+/obj/structure/closet/cabinet,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"Vs" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/misc/condo)
+"Wm" = (
+/obj/structure/table/bronze,
+/obj/structure/decorative{
+	icon = 'modular_nova/master_files/icons/obj/skyscraper/curtains_apartments.dmi';
+	icon_state = "0,5";
+	pixel_y = 11;
+	anchored = 1;
+	name = "sink";
+	pixel_x = -10;
+	dir = 4
+	},
+/obj/item/towel{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/condo)
+"WS" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/misc/condo)
+"Yo" = (
+/turf/open/floor/iron/shuttle/exploration/hazard,
+/area/misc/condo)
+"YJ" = (
+/obj/machinery/door/airlock/survival_pod{
+	name = "Bridge"
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/condo)
+"Zr" = (
+/obj/machinery/door/airlock/survival_pod{
+	name = "Restroom";
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/condo)
+
+(1,1,1) = {"
+fn
+fn
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+tU
+lm
+lm
+"}
+(2,1,1) = {"
+lm
+lm
+lm
+FI
+FI
+FI
+KQ
+cO
+lm
+cK
+Sf
+Wm
+pa
+lm
+wc
+gr
+UU
+kZ
+lm
+Yo
+Yo
+Yo
+lm
+"}
+(3,1,1) = {"
+tB
+gH
+FD
+fa
+Yo
+Yo
+Yo
+Yo
+FD
+cK
+zP
+Vs
+Qd
+lm
+DA
+Kv
+UA
+Sz
+lm
+lm
+kN
+lm
+lm
+"}
+(4,1,1) = {"
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+sc
+lm
+lm
+az
+Mw
+TW
+lm
+Dg
+Kv
+Kv
+PZ
+lm
+Va
+kn
+rX
+lm
+"}
+(5,1,1) = {"
+fn
+mM
+fn
+fn
+fn
+lm
+lm
+mD
+wk
+lm
+Zr
+lm
+lm
+lm
+Jc
+eq
+eq
+FJ
+lm
+Va
+tw
+Lt
+lm
+"}
+(6,1,1) = {"
+fn
+mM
+fn
+fn
+fn
+um
+cz
+GS
+mD
+YJ
+xI
+rK
+vs
+pV
+rK
+vs
+pV
+eC
+kP
+kn
+PK
+Lt
+lm
+"}
+(7,1,1) = {"
+fn
+mM
+fn
+fn
+fn
+um
+rV
+GS
+mD
+YJ
+JW
+DW
+oP
+sb
+DW
+oP
+sb
+DW
+Bq
+Ct
+Tt
+Lt
+lm
+"}
+(8,1,1) = {"
+fn
+mM
+fn
+fn
+fn
+lm
+lm
+mD
+mD
+lm
+tV
+lm
+lm
+lm
+Eq
+Cd
+Cd
+ap
+lm
+nZ
+tw
+Lt
+lm
+"}
+(9,1,1) = {"
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+sc
+lm
+lm
+Af
+cV
+vi
+lm
+qK
+uw
+uw
+uw
+lm
+Hc
+Ct
+AL
+lm
+"}
+(10,1,1) = {"
+tB
+gH
+FD
+fa
+Yo
+Yo
+Yo
+Yo
+lm
+cK
+Ok
+cV
+cV
+lm
+Lg
+eF
+eF
+lo
+lm
+lm
+kN
+lm
+lm
+"}
+(11,1,1) = {"
+lm
+lm
+lm
+FI
+FI
+FI
+cO
+cO
+lm
+cK
+WS
+RA
+Gb
+lm
+kk
+kk
+zK
+yz
+lm
+Yo
+Yo
+Yo
+lm
+"}
+(12,1,1) = {"
+fn
+fs
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+lm
+tU
+lm
+lm
+"}


### PR DESCRIPTION
## About The Pull Request

Adds a few new condos for Nova Sector allowing for more personalized environments for one on one roleplay!

The custom new Condos being
* Deepspace Pod
* Deepspace Ship

## How This Contributes To The Nova Sector Roleplay Experience

This adds more places to enjoy when roleplaying in the condos system, otherwise no active gameplay advancements

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl:
map: Added a few new condos (Deepspace Pod, DeepSpace Ship)
/:cl:
