### PR TITLE
adds first aid stations (wall healers) to the interlink

### DIFF
--- a/_maps/map_files/generic/CentCom_nova_z2.dmm
+++ b/_maps/map_files/generic/CentCom_nova_z2.dmm
@@ -8209,6 +8209,13 @@
 	},
 /turf/open/floor/wood/large,
 /area/centcom/interlink)
+"ibW" = (
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 1
+	},
+/obj/machinery/wall_healer/free/directional/north,
+/turf/open/floor/iron/edge,
+/area/centcom/interlink)
 "iet" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
@@ -8275,6 +8282,13 @@
 	},
 /obj/effect/light_emitter/interlink,
 /turf/open/floor/stone,
+/area/centcom/interlink)
+"iiF" = (
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 4
+	},
+/obj/machinery/wall_healer/free/directional/east,
+/turf/open/floor/iron/dark,
 /area/centcom/interlink)
 "ikb" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -8946,6 +8960,13 @@
 "jxw" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/iron/smooth_large,
+/area/centcom/interlink)
+"jyB" = (
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 8
+	},
+/obj/machinery/wall_healer/free/directional/west,
+/turf/open/floor/iron/dark,
 /area/centcom/interlink)
 "jzL" = (
 /obj/structure/spacevine{
@@ -11476,6 +11497,10 @@
 "nvI" = (
 /obj/effect/light_emitter/interlink,
 /turf/open/floor/carpet/stellar,
+/area/centcom/interlink)
+"nwQ" = (
+/obj/machinery/wall_healer/free/directional/east,
+/turf/open/floor/iron/smooth_large,
 /area/centcom/interlink)
 "nxI" = (
 /obj/structure/chair/comfy/black{
@@ -14285,6 +14310,10 @@
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
+"rJS" = (
+/obj/machinery/wall_healer/free/directional/west,
+/turf/open/floor/iron/smooth_large,
+/area/centcom/interlink)
 "rKT" = (
 /obj/effect/turf_decal/trimline/white/filled/corner,
 /turf/open/floor/iron/dark/smooth_large,
@@ -17781,6 +17810,16 @@
 	},
 /turf/open/indestructible/carpet,
 /area/centcom/holding/cafe)
+"xjS" = (
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 8
+	},
+/obj/effect/light_emitter/interlink,
+/obj/machinery/wall_healer/free/directional/west,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/centcom/interlink)
 "xkb" = (
 /obj/machinery/mass_driver/trash{
 	dir = 1;
@@ -28435,7 +28474,7 @@ qIY
 aHL
 cFK
 wTk
-jpr
+ibW
 iKR
 oHR
 wTk
@@ -31255,7 +31294,7 @@ ubQ
 rhV
 rhV
 rhV
-rhV
+xjS
 rhV
 knB
 ubQ
@@ -31270,7 +31309,7 @@ jnu
 wmW
 wTk
 ouJ
-dbl
+rJS
 qWY
 ftB
 ftB
@@ -35896,7 +35935,7 @@ jnu
 fIY
 wTk
 dbl
-dbl
+nwQ
 qWY
 ftB
 ftB
@@ -42332,7 +42371,7 @@ jne
 qnJ
 nFS
 nFS
-lkz
+jyB
 hyW
 wTk
 aaa
@@ -47472,7 +47511,7 @@ vpb
 wSW
 sdx
 sdx
-fcG
+iiF
 sIm
 wTk
 aaa


### PR DESCRIPTION
## About The Pull Request

Adds a bunch of wall-healers to the Interlink. Because sometimes you have a few booboos and you want to address them before hitting cryo or other things. These are the free variants, though, which has to mean something.

## How This Contributes To The Nova Sector Roleplay Experience

funny (accidentally toolboxing your coworker on the interlink, apologizing, and directing them to the whatchamacallit is roleplay)

## Proof of Testing

<img width="716" height="661" alt="image" src="https://github.com/user-attachments/assets/e225c294-d42b-484c-9138-860d3931e291" />

## Changelog

:cl:
map: Following complaints from exactly one guy, Nanotrasen has paid Deforest for a handful of first-aid stations to install on the Interlink.
/:cl:
