### PR TITLE
Fixes Dyne and DS-2 borgs having no name, gender, access, and a defective cell.

### DIFF
--- a/modular_nova/modules/mapping/code/mob_spawns.dm
+++ b/modular_nova/modules/mapping/code/mob_spawns.dm
@@ -185,8 +185,16 @@
 	spawner_job_path = /datum/job/ds2
 	mob_type = /mob/living/silicon/robot/model/ds2
 
+/obj/effect/mob_spawn/ghost_role/robot/ds2/special(mob/living/silicon/robot/new_spawn)
+	. = ..()
+	if(new_spawn.client)
+		new_spawn.custom_name = null
+		new_spawn.updatename(new_spawn.client)
+		new_spawn.transfer_silicon_prefs(new_spawn.client)
+		new_spawn.set_gender(new_spawn.client)
+
 /mob/living/silicon/robot/model/ds2
-	faction = list(ROLE_DS2)
+	faction = list("Syndicate", ROLE_DS2)
 	bubble_icon = "syndibot"
 	req_access = list(ACCESS_SYNDICATE)
 	lawupdate = FALSE
@@ -199,7 +207,7 @@
 
 /mob/living/silicon/robot/model/ds2/Initialize(mapload)
 	. = ..()
-	cell = new /obj/item/stock_parts/power_store/cell/hyper(src, 30000)
+	cell = new /obj/item/stock_parts/power_store/cell/hyper(src)
 	//This part is because the camera stays in the list, so we'll just do a check
 	if(!QDELETED(builtInCamera))
 		QDEL_NULL(builtInCamera)
@@ -226,8 +234,16 @@
 	spawner_job_path = /datum/job/ds2
 	mob_type = /mob/living/silicon/robot/model/interdyne
 
+/obj/effect/mob_spawn/ghost_role/robot/interdyne/special(mob/living/silicon/robot/new_spawn)
+	. = ..()
+	if(new_spawn.client)
+		new_spawn.custom_name = null
+		new_spawn.updatename(new_spawn.client)
+		new_spawn.transfer_silicon_prefs(new_spawn.client)
+		new_spawn.set_gender(new_spawn.client)
+
 /mob/living/silicon/robot/model/interdyne
-	faction = list(ROLE_INTERDYNE_PLANETARY_BASE)
+	faction = list("Syndicate", ROLE_INTERDYNE_PLANETARY_BASE)
 	req_access = list(ACCESS_SYNDICATE)
 	lawupdate = FALSE
 	scrambledcodes = TRUE
@@ -239,7 +255,7 @@
 
 /mob/living/silicon/robot/model/interdyne/Initialize(mapload)
 	. = ..()
-	cell = new /obj/item/stock_parts/power_store/cell/hyper(src, 30000)
+	cell = new /obj/item/stock_parts/power_store/cell/hyper(src)
 	//This part is because the camera stays in the list, so we'll just do a check
 	if(!QDELETED(builtInCamera))
 		QDEL_NULL(builtInCamera)


### PR DESCRIPTION
## About The Pull Request

This PR closes https://github.com/NovaSector/NovaSector/issues/6182 by making DS-2 and Interdyne cyborg sleepers apply the client's name and gender preferences properly, gives cyborgs proper access to their own base, as well as making the hyper-capacity cell installed the size of an actual hyper-capacity cell.
## How This Contributes To The Nova Sector Roleplay Experience

It's good when things work as intended, instead of getting bogged down getting a renaming board and a replacement cell the moment you sign on, and still being referred to as it/its in your examine text for the whole round.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/055aa783-e053-4498-9aa1-7edce0dc2a83
  
</details>

## Changelog
:cl:
fix: DS-2 and Interdyne cyborg now have proper door access, no longer start with a defective cell, and name and gender preferences now apply properly.
/:cl:
