### PR TITLE
[Fix] Fixes some bugs in the Ghost Spawners

### DIFF
--- a/modular_nova/master_files/code/modules/mob_spawn/mob_spawn.dm
+++ b/modular_nova/master_files/code/modules/mob_spawn/mob_spawn.dm
@@ -12,6 +12,8 @@
 	var/quirks_enabled = FALSE
 	/// Are we limited to a certain species type? LISTED TYPE
 	var/restricted_species
+	/// Do we have an outfit for Plasmaman prepared for this role?
+	var/plasmaman_outfit
 
 /obj/effect/mob_spawn/ghost_role/create(mob/mob_possessor, newname, use_loadout = FALSE)
 	var/load_prefs = FALSE
@@ -50,9 +52,13 @@
 		post_transfer_prefs(spawned_human)
 
 	if(load_prefs && loadout_enabled)
-		spawned_human?.equip_outfit_and_loadout(outfit, spawned_mob.client.prefs)
+		if(isplasmaman(spawned_human) && plasmaman_outfit)
+			spawned_human?.equip_outfit_and_loadout(plasmaman_outfit, spawned_mob.client.prefs)
+		else
+			spawned_human?.equip_outfit_and_loadout(outfit, spawned_mob.client.prefs)
 	else if (!isnull(spawned_human))
 		equip(spawned_human)
+		message_admins("called equip 1")
 		var/mutable_appearance/character_appearance = new(spawned_human.appearance)
 		GLOB.name_to_appearance[spawned_human.real_name] = character_appearance // Cache this for Character Directory
 
@@ -64,7 +70,9 @@
 	var/mob/living/spawned_mob = new mob_type(get_turf(src)) //living mobs only
 	name_mob(spawned_mob, newname)
 	special(spawned_mob, mob_possessor)
-	equip(spawned_mob)
+	// Only run equip logic if this is NOT a ghost_role spawner, as we already solve equip with loadout there.
+	if (!istype(src, /obj/effect/mob_spawn/ghost_role))
+		equip(spawned_mob)
 	spawned_mob_ref = WEAKREF(spawned_mob)
 	return spawned_mob
 

--- a/modular_nova/modules/ghostcafe/code/ghost_role_spawners.dm
+++ b/modular_nova/modules/ghostcafe/code/ghost_role_spawners.dm
@@ -49,6 +49,7 @@
 	density = FALSE
 	spawner_job_path = /datum/job/ghostcafe
 	outfit = /datum/outfit/ghostcafe
+	plasmaman_outfit = /datum/outfit/ghostcafe/plasmaman
 	you_are_text = "You are a Cafe Visitor!"
 	flavour_text = "You are off-duty and have decided to visit your favourite cafe. Enjoy yourself."
 	random_appearance = FALSE
@@ -77,12 +78,24 @@
 		return COMPONENT_CANNOT_USE_RADIO
 
 /datum/outfit/ghostcafe
-	name = "ID, jumpsuit and shoes"
+	name = "Cafe Visitor"
 	uniform = /obj/item/clothing/under/color/random
 	shoes = /obj/item/clothing/shoes/sneakers/black
 	id = /obj/item/card/id/advanced/chameleon/ghost_cafe
 	back = /obj/item/storage/backpack/chameleon
 	backpack_contents = list(/obj/item/storage/box/syndie_kit/chameleon/ghostcafe = 1)
+
+/datum/outfit/ghostcafe/plasmaman
+	name = " Cafe Visitor Plasmaman"
+	uniform = /obj/item/clothing/under/plasmaman
+	gloves = /obj/item/clothing/gloves/color/plasmaman
+	head = /obj/item/clothing/head/helmet/space/plasmaman
+	l_pocket = /obj/item/tank/internals/plasmaman/belt/full
+	internals_slot = ITEM_SLOT_LPOCKET
+
+/datum/outfit/ghostcafe/plasmaman/New()
+	..()
+	backpack_contents += list(/obj/item/tank/internals/plasmaman/belt/full = 2)
 
 /datum/action/toggle_dead_chat_mob
 	button_icon = 'icons/mob/simple/mob.dmi'
@@ -132,4 +145,3 @@
 	registered_age = null
 	trim = /datum/id_trim/admin
 	wildcard_slots = WILDCARD_LIMIT_ADMIN
-


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

/obj/effect/mob_spawn/create and /obj/effect/mob_spawn/ghost_role/create run at the same time, which causes issues since the father was running equip and duplicating the first item in their backpack content and blocking the plasmaman logic for their uniforms.

Added support to ghost_role for plasmamen outfit datums, and added the ghost cafe outfit for plasmamen (its just more starting plasmatanks)

Also changed the name of the Cafe equipment datums so admins can more easily setup people with those.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Well, this change allows players to play with plasmaman on all the ghost roles that should had supported it, but spawned them with a flamable uniform, which is important to give them that option.

Eliminating the bug of items spawning twice also helps to keep the gameplay a bit more clean.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

cafe:  

<img width="895" height="717" alt="image" src="https://github.com/user-attachments/assets/6a39bb00-b324-4bd6-9307-1cd9126577bf" />

<img width="879" height="706" alt="image" src="https://github.com/user-attachments/assets/113e9a50-0299-434d-ba2b-81e7dacf3775" />

dyne:

<img width="961" height="819" alt="image" src="https://github.com/user-attachments/assets/4bc8b326-6705-49a5-9069-93b77707b5dc" />

ds2:

<img width="895" height="710" alt="image" src="https://github.com/user-attachments/assets/a652a0fb-3ef0-4155-97c2-2cd37e4276b8" />

regular cafe human, showcasing we dont have the double item issue anymore too:

<img width="915" height="695" alt="image" src="https://github.com/user-attachments/assets/e4a67338-224e-49e5-a914-4888d92051ff" />

showing we didnt broke regular spawning:

<img width="740" height="746" alt="image" src="https://github.com/user-attachments/assets/efac0659-d5bf-4a84-884a-6784f439fc39" />

showing we didnt broke the from interlink to cafe pods:

<img width="857" height="745" alt="image" src="https://github.com/user-attachments/assets/f0b41853-8963-41ba-97a7-a7a623354858" />

<img width="797" height="377" alt="image" src="https://github.com/user-attachments/assets/b70f48e5-ef86-43ca-b670-2e4d7350c4b6" />

<img width="898" height="714" alt="image" src="https://github.com/user-attachments/assets/c79cc736-6a29-4ee8-b73a-b4ce86b32074" />



</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed the bug with ghost roles spawned with two of the same first backpack item
fix: fixed the bug with plasmamans not being able to spawn in ghost roles without inmediatly inmolating themselves. Ghost role plasmas also start with 3 extra tanks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
