### PR TITLE
[Feature] Shield DLC: Adds Shields Content, Tone down Crew Energy Sword

### DIFF
--- a/modular_nova/master_files/code/game/objects/items/melee/energy.dm
+++ b/modular_nova/master_files/code/game/objects/items/melee/energy.dm
@@ -4,3 +4,17 @@
 
 	/// The sound played when the item is turned off
 	var/disable_sound = 'sound/items/weapons/saberoff.ogg'
+
+// at the time of balancing this, chance was 75 and pain mult 10, but it was not taking Huge weight class into account.
+/datum/embedding/esword/surplus
+	embed_chance = 50
+	impact_pain_mult = 5
+
+/obj/item/melee/energy/sword/surplus
+	embed_type = /datum/embedding/esword/surplus
+
+/obj/item/melee/energy/sword/surplus/slapcraft
+	name = "\improper Type II 'Bokuto' energy sword"
+	desc = "A hand made energy sword used for live training and pest control. It can be recharged with the dynamos in the handle."
+	armour_penetration = 20 // Surplus is 35
+	block_chance = 20 // Surplus is 50

--- a/modular_nova/master_files/code/game/objects/items/shields.dm
+++ b/modular_nova/master_files/code/game/objects/items/shields.dm
@@ -1,0 +1,2 @@
+/obj/item/shield/riot/tele
+	w_class = WEIGHT_CLASS_SMALL // original: WEIGHT_CLASS_NORMAL

--- a/modular_nova/modules/blueshield/code/blueshield.dm
+++ b/modular_nova/modules/blueshield/code/blueshield.dm
@@ -117,6 +117,7 @@
 		"Custom Hellfire Laser Rifle" = /obj/item/gun/energy/laser/hellgun/blueshield,
 		"NT20 Submachinegun Gunset" = /obj/item/storage/toolbox/guncase/nova/ntspecial/nt20,
 		"Katyusha Shotgun Gunset" = /obj/item/storage/toolbox/guncase/nova/katyusha,
+		"Blueshield Energy Shield" = /obj/item/shield/energy,
 	)
 
 	return selectable_gun_types

--- a/modular_nova/modules/company_imports/code/armament_datums/nakamura_modsuits.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/nakamura_modsuits.dm
@@ -91,6 +91,9 @@
 /datum/armament_entry/company_import/nakamura_modsuits/protection_modules/emp_shield
 	item_type = /obj/item/mod/module/emp_shield
 
+/datum/armament_entry/company_import/nakamura_modsuits/protection_modules/dampener
+	item_type = /obj/item/mod/module/projectile_dampener
+
 // Medical Mods
 
 /datum/armament_entry/company_import/nakamura_modsuits/medical_modules

--- a/modular_nova/modules/company_imports/code/armament_datums/sol_defense.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/sol_defense.dm
@@ -43,10 +43,15 @@
 	name = "type I vest"
 	item_type = /obj/item/clothing/suit/armor/vest
 
-/datum/armament_entry/company_import/sol_defense/armor/combat_boots // boots
+/datum/armament_entry/company_import/sol_defense/armor/combat_boots
 	name = "Combat Boots"
 	cost = PAYCHECK_CREW * 4
 	item_type = /obj/item/clothing/shoes/combat
+
+/datum/armament_entry/company_import/sol_defense/armor/tele_shield
+	name = "Telescopic Shield"
+	cost = PAYCHECK_CREW * 4
+	item_type = /obj/item/shield/riot/tele
 
 /datum/armament_entry/company_import/sol_defense/armor_hardened
 	subcategory = "Hardened Armor"

--- a/modular_nova/modules/modular_items/code/recipes_misc.dm
+++ b/modular_nova/modules/modular_items/code/recipes_misc.dm
@@ -1,5 +1,5 @@
 /datum/crafting_recipe/surplus_esword
-	result = /obj/item/melee/energy/sword/surplus
+	result = /obj/item/melee/energy/sword/surplus/slapcraft
 	reqs = list(
 		/obj/item/wallframe/light_switch = 1,
 		/obj/item/assembly/igniter = 1,

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6957,6 +6957,7 @@
 #include "modular_nova\master_files\code\game\objects\items\RCD.dm"
 #include "modular_nova\master_files\code\game\objects\items\religion.dm"
 #include "modular_nova\master_files\code\game\objects\items\scratchingstone.dm"
+#include "modular_nova\master_files\code\game\objects\items\shields.dm"
 #include "modular_nova\master_files\code\game\objects\items\weaponry.dm"
 #include "modular_nova\master_files\code\game\objects\items\wiki_manuals.dm"
 #include "modular_nova\master_files\code\game\objects\items\circuitboards\machines\machine_circuitboards.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds the Energy Shield to the Blueshield as a selectable weapon. (Block 50%, Reflect lasers 50%, Tiny when retracted)

Buffs the Telescopic Shield, its now small as base size, and can be ordered from Sol Fed Imports. (Block 50%)

Adds the Proyectile Dampener Mod to Nakamura Mods Imports.

Makes a child of the Surplus Sword called Bokuto, with block chance 20% from 50% and AP 20 from 35. Changes this to the Slapcraft recipe and leaves the Surplus Sword (Iaito) with its original stats on the black market.

Modifies the embeed stats of the Surplus Swords Iaito and Bokuto to account for their Huge size, they were using the Esword embeed stats but those are bulky, which resulted in the aforementioned doing more damage than their TC counterparts on a throw. With the nerf to half, they are roughly the same damage (does 40 damage from 75 on a throw)

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Well, I believe the blueshield should had gotten this shield since its conception. It's a bodyguard, its a namesake, it should had always had a shield.

The popularity of the Iaito demostrated that shields are something the crew want, but they cumbersome to carry. The convenience in size mirrors our weapons adjustments, as does the availability in cargo. We will see how this fares and adjust in case things get out of hand.

The proyectile Dampener I feel its a mod that doesnt see much use and it could be useful for departamental guards or any character that focuses on defense rather than offense, its a nice support effect that doesnt hurt to have, and its generally not used much.

The Surplus swords rapidly became the meta of the game as they were effectively a combat knife on its worst and a full fledged esword on its best, with a block chance of 50% against anything, not only melee attacks, it quickly became the offhand carry of many security and departamental guards unless they were using two handed wepaons. This nerf to the slapcrafted version aims to keep the unique blackmarket version still desirable (and available to the ones that can get their hands on it!) and to reduce the impact of everyone having such an item, at 20% its still a noticeable effect, and the damage is barely modified, as we only touch the AP of it and in a low adjustment.

Lastly, the embeed values were nessesary to change, with more than half the damage in one hit of a thrown objects (which are notoriously hard to dodge), and with the embeed capable of killing after seven seconds, it leaves its target on quite the inmediate lose/lose situation, and thus, way above the power scale of something you make entirely from the autolathe.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
Blueshield Blue Shield:

<img width="707" height="515" alt="image" src="https://github.com/user-attachments/assets/97c1d62d-6e71-46bb-aed2-226143e9aef9" />

<img width="299" height="581" alt="image" src="https://github.com/user-attachments/assets/2f8fcfcb-86e6-484c-8fb4-803c4e93ff1b" />

<img width="582" height="127" alt="image" src="https://github.com/user-attachments/assets/fe6c75e8-170f-4b20-9ed0-d1484fe9c139" />

Bokuto Type II sword:

<img width="492" height="386" alt="image" src="https://github.com/user-attachments/assets/13678953-650d-46cf-95a8-6b95721ee6b7" />

<img width="574" height="154" alt="image" src="https://github.com/user-attachments/assets/f187c709-7b96-425b-a21b-0b20f559b724" />

<img width="558" height="258" alt="image" src="https://github.com/user-attachments/assets/02d7ef31-1893-438b-8aac-929ab2d04cfe" />

Telescopic Shield:

<img width="554" height="241" alt="image" src="https://github.com/user-attachments/assets/29f39d59-0be5-424d-b40c-854101dc2e0f" />

Cargo Additions:

<img width="1004" height="576" alt="image" src="https://github.com/user-attachments/assets/ccb30d33-afa4-4fc4-bebb-8766575e5dcb" />

<img width="994" height="591" alt="image" src="https://github.com/user-attachments/assets/8c712cab-9d9d-4518-ad9c-d8beb9caf677" />


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: BlueShield weapons options were expanted to add an Energy Blue Shield. It Reflects 50% of the energy proyectiles and has a block chance of 50%. And its a blue shield.
balance: The Bokuto Type II Energy Sword was introduced. This is the slapcraft Energy Sword that everyone can make with just an autolathe, with reduced stats. (20 AP from 35 AP, 20% block from 50% block). The type I is still available on the black market with its original stats.
balance: Type I and Type II energy swords got their embeed damage reduced, now they do 40 damage from 75, and their base chance to embeed was reduced by one third of their original.
balance: The telescopic shield was made one category smaller on its undeployed state. (From normal to small).
add: The telescopic shield and the projectile dampener mod are now available in the Sol Fed and Nakamura mods Imports respectively.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
