### PR TITLE
[Band Aid] Replaces Syndicate Modsuit Nightvision with the NV module

### DIFF
--- a/modular_nova/master_files/code/modules/mod/mod_theme.dm
+++ b/modular_nova/master_files/code/modules/mod/mod_theme.dm
@@ -1009,3 +1009,19 @@
 
 /datum/mod_theme/marines/noboost /// Marine modsuit that doenst allow you to put an armor booster in it. This makes it better than a base security hardsuit while worse than the HoS's and Captains- assuming those two have boosters in them.
 	desc = "Developed by Nanotrasen in collaboration with multiple high-profile contractors, this specialized suit was made for high-intensity combat. This one doesnt allow for an armor booster."
+
+// Replaces the Syndicate night vision for the night visors, as they are currently broken, and cannot be removed.
+/datum/mod_theme/infiltrator/New()
+	. = ..()
+	inbuilt_modules -= /obj/item/mod/module/night
+	inbuilt_modules += /obj/item/mod/module/visor/night
+
+/datum/mod_theme/syndicate/New()
+	. = ..()
+	inbuilt_modules -= /obj/item/mod/module/night
+	inbuilt_modules += /obj/item/mod/module/visor/night
+
+/datum/mod_theme/elite/New()
+	. = ..()
+	inbuilt_modules -= /obj/item/mod/module/night
+	inbuilt_modules += /obj/item/mod/module/visor/night


### PR DESCRIPTION

## About The Pull Request
The NV module its broken on TG (https://github.com/tgstation/tgstation/issues/93216), as I dont know which way they are going to fix it to, this PR is meant to patch it up so our antag experience is still viable, by changing the three base datums to use a different module.

## How This Contributes To The Nova Sector Roleplay Experience
It lets the syndicate themed modsuits start with nightvision as it was originally intended.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
Three base:

<img width="1033" height="954" alt="image" src="https://github.com/user-attachments/assets/4e496232-84c4-47e7-bf47-1d2fd50f6792" />

<img width="996" height="973" alt="image" src="https://github.com/user-attachments/assets/95143691-c9d9-4c9c-88e3-eb20676762da" />

<img width="986" height="955" alt="image" src="https://github.com/user-attachments/assets/4dcceac7-7c20-4037-b535-c4f3a433e3ee" />


DS2 stuff:

  before

<img width="1042" height="958" alt="image" src="https://github.com/user-attachments/assets/91813bcd-a0c7-49cf-b3a8-d6123716957b" />

  after

<img width="942" height="961" alt="image" src="https://github.com/user-attachments/assets/d4f00d00-3e43-4933-9aec-23f7d7bc59a5" />



</details>

## Changelog
:cl:
fix: Syndicate themed modsuits had their unique modsuit nightvision replaced with regular, as its currently working
/:cl:
