### PR TITLE
[Feature] Adds some Forgotten bed recipes

### DIFF
--- a/modular_nova/master_files/code/modules/antagonists/_common/antag_datum.dm
+++ b/modular_nova/master_files/code/modules/antagonists/_common/antag_datum.dm
@@ -26,7 +26,6 @@
 		/datum/crafting_recipe/ash_recipe/ash_robes,
 		/datum/crafting_recipe/ash_recipe/ash_plates,
 		/datum/crafting_recipe/ash_recipe/ash_plates/decorated,
-		/datum/crafting_recipe/thatch_bed,
 	)
 
 /datum/antagonist/heretic

--- a/modular_nova/modules/ashwalkers/code/items/ash_furniture.dm
+++ b/modular_nova/modules/ashwalkers/code/items/ash_furniture.dm
@@ -1,4 +1,4 @@
-// Ashwalker Exclusive Bed
+// Ashwalker Bed
 /obj/structure/bed/double/thatch
 	name = "thatch bed"
 	desc = "A rustic bed, made from thatch."
@@ -11,9 +11,7 @@
 	max_integrity = 100
 	integrity_failure = 0.35
 	max_buckled_mobs = 2
-	// What material this bed is made of
 	build_stack_type = /obj/item/stack/tile/grass/thatch
-	// How many mats to drop when deconstructed
 	build_stack_amount = 4
 
 /obj/structure/bed/double/thatch/atom_deconstruct(disassembled = TRUE)
@@ -24,7 +22,7 @@
 	name = "Thatch Bed"
 	category = CAT_FURNITURE
 	//recipe given to ashwalkers as part of their spawner/team setting
-	crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_MUST_BE_LEARNED | CRAFT_ONE_PER_TURF | CRAFT_ON_SOLID_GROUND
+	crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ONE_PER_TURF | CRAFT_ON_SOLID_GROUND
 
 	reqs = list(
 		/obj/item/stack/tile/grass/thatch = 4,

--- a/modular_nova/modules/modular_items/code/furniture.dm
+++ b/modular_nova/modules/modular_items/code/furniture.dm
@@ -1,0 +1,99 @@
+/obj/structure/bed/double/pelt/synthetic
+	name = "white pelts bed"
+	desc = "A luxurious double bed, made with synthetic white wolf pelts."
+	icon_state = "pelt_bed_white"
+	icon = 'modular_nova/modules/tribal_extended/icons/tribal_beds.dmi'
+	anchored = TRUE
+	can_buckle = TRUE
+	buckle_lying = 90
+	resistance_flags = FLAMMABLE
+	max_integrity = 100
+	integrity_failure = 0.35
+	max_buckled_mobs = 2
+	build_stack_type = /obj/item/stack/sheet/leather
+	build_stack_amount = 4
+
+/obj/structure/bed/double/pelt/atom_deconstruct(disassembled = TRUE)
+	. = ..()
+	new /obj/item/stack/sheet/mineral/wood(loc, build_stack_amount)
+
+/datum/crafting_recipe/synth_white_pelt_bed
+	name = "Synthetic White Pelts Bed"
+	category = CAT_FURNITURE
+	crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ONE_PER_TURF | CRAFT_ON_SOLID_GROUND
+
+	reqs = list(
+		/obj/item/stack/sheet/leather = 4,
+		/obj/item/stack/sheet/mineral/wood = 4,
+	)
+
+	result = /obj/structure/bed/double/pelt/synthetic
+
+/obj/structure/bed/double/pelt/synthetic/black
+	name = "black pelts bed"
+	desc = "A luxurious double bed, made with synthetic black wolf pelts."
+	icon_state = "pelt_bed_black"
+	icon = 'modular_nova/modules/tribal_extended/icons/tribal_beds.dmi'
+
+/datum/crafting_recipe/synth_black_pelt_bed
+	name = "Synthetic Black Pelts Bed"
+	category = CAT_FURNITURE
+	crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ONE_PER_TURF | CRAFT_ON_SOLID_GROUND
+
+	reqs = list(
+		/obj/item/stack/sheet/leather = 4,
+		/obj/item/stack/sheet/mineral/wood = 4,
+	)
+
+	result = /obj/structure/bed/double/pelt/synthetic/black
+
+// Medieval oversized beds
+/obj/structure/bed/oversized
+	name = "single oversized bed"
+	desc = "A luxurious bed, inviting you to rest on it, oh traveler."
+	icon = 'modular_nova/master_files/icons/obj/medieval/structures_64x64.dmi'
+	icon_state = "bed_1x2"
+	anchored = TRUE
+	can_buckle = TRUE
+	buckle_lying = 90
+	resistance_flags = FLAMMABLE
+	max_integrity = 150
+	integrity_failure = 0.35
+	max_buckled_mobs = 2
+	build_stack_type = /obj/item/stack/sheet/cloth
+	build_stack_amount = 4
+
+/obj/structure/bed/oversized/atom_deconstruct(disassembled = TRUE)
+	. = ..()
+	new /obj/item/stack/sheet/mineral/wood(loc, build_stack_amount)
+
+/datum/crafting_recipe/oversized_bed
+	name = "Single Oversized Bed"
+	category = CAT_FURNITURE
+	crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ONE_PER_TURF | CRAFT_ON_SOLID_GROUND
+
+	reqs = list(
+		/obj/item/stack/sheet/cloth = 4,
+		/obj/item/stack/sheet/mineral/wood = 4,
+	)
+
+	result = /obj/structure/bed/oversized
+
+/obj/structure/bed/oversized/double
+	name = "double oversized bed"
+	icon = 'modular_nova/master_files/icons/obj/medieval/structures_64x64.dmi'
+	icon_state = "bed_2x2"
+	max_buckled_mobs = 2
+	build_stack_amount = 8
+
+/datum/crafting_recipe/oversized_bed_double
+	name = "Double Oversized Bed"
+	category = CAT_FURNITURE
+	crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ONE_PER_TURF | CRAFT_ON_SOLID_GROUND
+
+	reqs = list(
+		/obj/item/stack/sheet/cloth = 8,
+		/obj/item/stack/sheet/mineral/wood = 8,
+	)
+
+	result = /obj/structure/bed/oversized/double

--- a/modular_nova/modules/modular_items/code/recipes_misc.dm
+++ b/modular_nova/modules/modular_items/code/recipes_misc.dm
@@ -20,7 +20,7 @@
 		/obj/item/stack/sheet/iron = 4,
 		/obj/item/stack/sheet/cloth = 1,
 	)
-	time = 60
+	time = 6 SECONDS
 	category = CAT_MISC
 
 /datum/crafting_recipe/makeshift/screwdriver
@@ -31,7 +31,7 @@
 		/obj/item/stack/sheet/cloth = 2,
 		/obj/item/stack/rods = 2,
 	)
-	time = 60
+	time = 6 SECONDS
 	category = CAT_MISC
 
 /datum/crafting_recipe/makeshift/welder
@@ -44,7 +44,7 @@
 		/obj/item/stack/sheet/iron = 6,
 		/obj/item/lighter = 1,
 	)
-	time = 60
+	time = 6 SECONDS
 	category = CAT_MISC
 
 /datum/crafting_recipe/makeshift/wirecutters
@@ -53,7 +53,7 @@
 	tool_behaviors = list(TOOL_SCREWDRIVER)
 	result = /obj/item/wirecutters/makeshift
 	reqs = list(/obj/item/stack/rods = 4)
-	time = 60
+	time = 6 SECONDS
 	category = CAT_MISC
 
 /datum/crafting_recipe/makeshift/wrench
@@ -66,5 +66,5 @@
 		/obj/item/stack/rods = 1,
 		/obj/item/stack/sheet/cloth = 2,
 	)
-	time = 60
+	time = 6 SECONDS
 	category = CAT_MISC

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8574,6 +8574,7 @@
 #include "modular_nova\modules\modular_items\code\designs.dm"
 #include "modular_nova\modules\modular_items\code\fan.dm"
 #include "modular_nova\modules\modular_items\code\fock.dm"
+#include "modular_nova\modules\modular_items\code\furniture.dm"
 #include "modular_nova\modules\modular_items\code\makeshift.dm"
 #include "modular_nova\modules\modular_items\code\materials.dm"
 #include "modular_nova\modules\modular_items\code\modular_glasses.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds the Oversized beds used in the condos (not the same in case they are used specifically and so they follow the bed structure and I dont step on any toes, etc etc)

Adds Variants of the heartkin beds that are made with synthetic leather, and are not the authentic thing, otherwise looks the same.

Deciphers the intricate secret of Ashwalkers Thatch beds that were brought back by the legendary warrior, Jai-Nator.

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Its more customization, allows players to build their own little thematic things, expanding options is good for the game and the players creativity.

Also, there is no secret to a damn pile of thatch.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
<img width="374" height="301" alt="image" src="https://github.com/user-attachments/assets/57dfcedf-6eaf-417b-b777-1c42953101bf" />

<img width="519" height="360" alt="image" src="https://github.com/user-attachments/assets/d4a2ad43-4f74-4d66-86ef-eaa61cec9daf" />

<img width="375" height="435" alt="image" src="https://github.com/user-attachments/assets/910b915a-c80e-4ba8-a0ea-e4d13b03cb17" />

<img width="284" height="220" alt="image" src="https://github.com/user-attachments/assets/b1c11a1e-0223-4b30-af93-f8ccd7f2cd34" />

<img width="521" height="349" alt="image" src="https://github.com/user-attachments/assets/f6a7f23c-bb13-4cbb-b88e-82d6972efaa9" />

<img width="233" height="234" alt="image" src="https://github.com/user-attachments/assets/e7046ec1-f311-41a9-b5c8-996b7b02a773" />

<img width="468" height="168" alt="image" src="https://github.com/user-attachments/assets/b044225d-895b-436e-98b9-6ecad661c542" />


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds Two Oversized variants for beds (craft menu, 4/8 cloth and wood), an universal, synthetic, variant of the wolf pelt beds (craft menu, 4 leather and wood) and liberates the recipe for the thatch bed (craft menu, 4 wood and thatch, which is made by putting grass in a dehidratator)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
