### PR TITLE
Nukes the floor light switch from Ouroboros Medical Lobby

### DIFF
--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -27699,9 +27699,6 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /obj/effect/mapping_helpers/airlock/access/any/medical/morgue,
-/obj/machinery/light_switch/directional/north{
-	pixel_x = -8
-	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/medbay/lobby)
 "ibY" = (
@@ -33544,6 +33541,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "jJu" = (


### PR DESCRIPTION
## About The Pull Request
Title

## How This Contributes To The Nova Sector Roleplay Experience
Gets rid of unintended stuff

<img width="238" height="141" alt="image" src="https://github.com/user-attachments/assets/faeeeae4-5105-4c76-b35a-6ee0eaf4b0db" />


## Proof of Testing
I have not tested this at all but all I did was move the light from a tile to another.
<details>
<summary>Screenshots/Videos</summary>
  
<img width="637" height="437" alt="image" src="https://github.com/user-attachments/assets/e6bd4706-ae38-413f-aec7-23ec91690436" />

</details>

## Changelog
:cl: Hardly
fix: The light switch in medical lobby is no longer on the floor.
/:cl:
