### PR TITLE
Gets rid of the oranges meow again

### DIFF
--- a/code/game/sound/sound_keys/sound_keys_assoc.dm
+++ b/code/game/sound/sound_keys/sound_keys_assoc.dm
@@ -34,13 +34,11 @@
 		'sound/mobs/humanoids/human/snore/snore_mimimi2.ogg' = 1,
 	)
 
-/* // NOVA EDIT REMOVAL START - We don't want the oranges meow but can't deal with this modularly due to complications
 /datum/sound_effect/assoc/cat_meow
 	key = SFX_CAT_MEOW
 	file_paths = list(
 		'sound/mobs/non-humanoids/cat/cat_meow1.ogg' = 33,
 		'sound/mobs/non-humanoids/cat/cat_meow2.ogg' = 33,
 		'sound/mobs/non-humanoids/cat/cat_meow3.ogg' = 33,
-		'sound/mobs/non-humanoids/cat/oranges_meow1.ogg' = 1,
+		//'sound/mobs/non-humanoids/cat/oranges_meow1.ogg' = 1, // NOVA EDIT REMOVAL
 	)
-*/ // NOVA EDIT REMOVAL END

--- a/modular_nova/master_files/code/game/sound.dm
+++ b/modular_nova/master_files/code/game/sound.dm
@@ -1,12 +1,4 @@
-//! Nova's modular sound key overrides
-
-/datum/sound_effect/cat_meow // everything from tg without the fucked up oranges meow (lmao)
-	key = SFX_CAT_MEOW
-	file_paths = list(
-		'sound/mobs/non-humanoids/cat/cat_meow1.ogg',
-		'sound/mobs/non-humanoids/cat/cat_meow2.ogg',
-		'sound/mobs/non-humanoids/cat/cat_meow3.ogg',
-	)
+//! Nova's modular sound overrides
 
 /datum/sound_effect/punch
 	file_paths = list(


### PR DESCRIPTION
## About The Pull Request
Gets rid of the 1% oranges meow again, it was re-added by #5863. Just removes the line actually adding the 1% chance for the oranges meow.
## How This Contributes To The Nova Sector Roleplay Experience
It was gone before and should have been for the last two months.

The sound sucks big time, too.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: [NOVA] The 1% chance for the Oranges meow sound to play is gone again.
/:cl:
