### PR TITLE
Adds a Gas Miner beacon to the atmos technician locker. 

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -102,7 +102,7 @@
 	new /obj/item/clothing/head/utility/hardhat/welding/atmos(src)
 	new /obj/item/clothing/glasses/meson/engine/tray(src)
 	new /obj/item/extinguisher/advanced(src)
-	new /obj/item/summon_beacon/gas_miner(src) //nova edit
+	new /obj/item/summon_beacon/gas_miner(src) // NOVA EDIT ADDITION
 
 /obj/structure/closet/secure_closet/atmospherics/populate_contents_immediate()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Does what the title says. Adds one beacon to the atmos technician locker.

## How This Contributes To The Nova Sector Roleplay Experience

Having a CE is 50/50 and it sucks to have to wait for the gas miners when you just wanna do your work. This also means low pop engineers can get distro set up when otherwise wouldn't be possible.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
 
<img width="162" height="144" alt="image" src="https://github.com/user-attachments/assets/47d811e9-8b6a-41d8-818c-0036b3494156" />
</details>

## Changelog

:cl:
add: Adds a singular Gas Miner to every atmos technician locker. 
/:cl:
