### PR TITLE
[Compliance] Nerfs Donator Items that had bonuses that didnt match guidelines.

### DIFF
--- a/modular_nova/modules/customization/modules/clothing/~donator/donator_clothing.dm
+++ b/modular_nova/modules/customization/modules/clothing/~donator/donator_clothing.dm
@@ -969,6 +969,8 @@
 	clothing_flags = parent_type::clothing_flags | VOICEBOX_DISABLED
 	flags_inv = NONE
 	interaction_flags_click = NEED_DEXTERITY
+	use_radio_beeps_tts = TRUE
+	voice_filter = /obj/item/clothing/mask/gas/sechailer::voice_filter
 
 /obj/item/clothing/mask/gas/signalis_gaiter/attack_self(mob/user)
 	adjust_visor(user)


### PR DESCRIPTION
## About The Pull Request
various cloaks were removed their redundant characteristics, they work the same at the moment but if tg reworks cloaks they will go with it and not break in the future.

/obj/item/clothing/mask/gas/CMCP_mask, /obj/item/clothing/mask/gas/signalis_gaiter and /obj/item/clothing/mask/gas/psycho_malice had both the characteristics of security hailers and proper gas masks, being small and able to use hailers like security and protecting against pepper spray. This was adjusted to a regular gas mask level.

## How This Contributes To The Nova Sector Roleplay Experience
The donator system is just to grant cosmetic advantages, if players desire for something that normally doesnt spawn for a job, they can use the reskinned items that let them use it on a non standard item and apply the reskin to it. 

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

after: 

<img width="551" height="505" alt="image" src="https://github.com/user-attachments/assets/ae78c4a1-6d58-4773-abc2-0f0961984844" />

<img width="334" height="407" alt="image" src="https://github.com/user-attachments/assets/8bf94a54-a9d6-47b7-a88b-cc2c6e73e92c" />

  
</details>

## Changelog
:cl:
balance: Removes certain Overpowered characteristics from early donator items that gave minor but unfair advantage to certain donators over regular players.
/:cl:
