### PR TITLE
[Removal] Removes the recipes for the Supermatter Sword and the Event Horizon Rifle

### DIFF
--- a/modular_nova/modules/crafting/crafting.dm
+++ b/modular_nova/modules/crafting/crafting.dm
@@ -21,6 +21,11 @@
 	..()
 	crafting_flags |= CRAFT_MUST_BE_LEARNED
 
+// Makes it so only ghost roles can make it, as DS2 use it for their bounties and adds to their evil league of evil thing, item doesnt really do anything.
+/datum/design/beamrifle/New()
+	..()
+	build_type  = AWAY_LATHE
+
 /datum/crafting_recipe/armband/cargo
 	name = "Brown Armband"
 	reqs = list(/obj/item/stack/sheet/cloth = 1)


### PR DESCRIPTION
## About The Pull Request
adds the CRAFT_MUST_BE_LEARNED tag to the supermatter sword and event horizon rifle recipes, to soft lock them out of the game unless needed by the admins for any reason.

Removed the parts for the event horizon from station reach, to not confuse the players, they can still be printed on ghost roles since they use it for bounties and its assumed those players have a greater mechanical understanding. 

## How This Contributes To The Nova Sector Roleplay Experience
The rifle generates from range  5x5 delete zone and 7x7 damage one, like this one

<img width="479" height="450" alt="image" src="https://github.com/user-attachments/assets/af6250fd-9802-4c1d-a3dc-3f4ac29c0eaa" />

at range, on hitscan.

While the sword applies the SM effects of touch on anyone its used to (and desintegrates bags if put into one). Leaving no recoverable remains.

Both weapons inflict RR with no counterplay posible, and can completly overturn events or entire rounds if allowed.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
Sword before:

<img width="710" height="732" alt="image" src="https://github.com/user-attachments/assets/58f18e98-f6bb-40a9-9d71-f5673ca8751f" />

Sword after:

<img width="736" height="738" alt="image" src="https://github.com/user-attachments/assets/3ea9f309-f492-42e9-9bfe-5e5f653186a3" />

Rifle before:

<img width="712" height="733" alt="image" src="https://github.com/user-attachments/assets/156dad4f-078d-4f53-893d-96a018c1119e" />

Rifle after:

<img width="714" height="733" alt="image" src="https://github.com/user-attachments/assets/29f52d44-1499-412c-9599-f456dbd4c95d" />


Security with all tech:

<img width="899" height="649" alt="image" src="https://github.com/user-attachments/assets/b9ebaf55-0cd7-4005-8aab-d1a0183d9ea7" />

ds2:

<img width="992" height="649" alt="image" src="https://github.com/user-attachments/assets/d64a5ad0-6535-4ea4-bc04-5f3b4fbe81fc" />


</details>

## Changelog
:cl:
del: Removes the recipes for the event horizon rifle and Supermatter Sword, as they are both RR weapons capable of completly derailing a round. Removes the part from the station to not confuse players, but leaves it on ds2 as its used for bounties. It still wont let you make the funny rifle.
/:cl:
