### PR TITLE
[Fix] Updates AI and borg languages

### DIFF
--- a/modular_nova/master_files/code/modules/language/language_holder.dm
+++ b/modular_nova/master_files/code/modules/language/language_holder.dm
@@ -100,6 +100,8 @@ GLOBAL_DATUM_INIT(language_holder_adjustor, /datum/language_holder_adjustor, new
 		/datum/language/vox = list(LANGUAGE_ATOM),
 		/datum/language/xerxian = list(LANGUAGE_ATOM),
 		/datum/language/yangyu = list(LANGUAGE_ATOM),
+		/datum/language/carptongue = list(LANGUAGE_ATOM),
+		/datum/language/ramatae = list(LANGUAGE_ATOM)
 	)
 	spoken_languages = list(
 		/datum/language/common = list(LANGUAGE_ATOM),
@@ -131,6 +133,8 @@ GLOBAL_DATUM_INIT(language_holder_adjustor, /datum/language_holder_adjustor, new
 		/datum/language/vox = list(LANGUAGE_ATOM),
 		/datum/language/xerxian = list(LANGUAGE_ATOM),
 		/datum/language/yangyu = list(LANGUAGE_ATOM),
+		/datum/language/carptongue = list(LANGUAGE_ATOM),
+		/datum/language/ramatae = list(LANGUAGE_ATOM)
 	)
 
 /datum/language_holder/drone_nova


### PR DESCRIPTION
## About The Pull Request
Closes https://github.com/NovaSector/NovaSector/issues/6227
Pretty much the title. Borgs and AI were missing two crew-acquirable languages: Carp tongue and move-speak.
This PR updates it so they maintain understanding over it.

I partly considered adding drone speak, ashwalker tongue, and icecat for reasons of being able to translation or general communication; but that is beyond the scope of this PR.
(Unless I am suggested to add those in by maintainer, but I assume they are not a thing for a reason? IDK)

## How This Contributes To The Nova Sector Roleplay Experience

Now they can properly understand crew members who only speak this language or translate between them and those who do not.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="701" height="605" alt="Testing" src="https://github.com/user-attachments/assets/02866ab0-41c5-4a65-9b47-74bc728cbe3d" />
<img width="354" height="228" alt="Testing2" src="https://github.com/user-attachments/assets/c2c04d00-edba-4520-89d8-3e1d34f73f78" />

</details>

## Changelog
:cl:
fix: Updates the borg/AI language list to be current
/:cl:
