### PR TITLE
[BALANCE] CE toolbelt has T2 tools again

### DIFF
--- a/modular_nova/master_files/code/game/objects/items/storage/belt.dm
+++ b/modular_nova/master_files/code/game/objects/items/storage/belt.dm
@@ -26,7 +26,7 @@
 		user.balloon_alert(user, "no suitable space!")
 		return FALSE
 
-// CE's roundstart toolbelt
+// CE's roundstart toolbelt, with T2 tools
 /obj/item/storage/belt/utility/chief/full/PopulateContents()
 	SSwardrobe.provide_type(/obj/item/screwdriver/power, src)
 	SSwardrobe.provide_type(/obj/item/crowbar/power, src)


### PR DESCRIPTION
## About The Pull Request

Undoes an upstream (I think?) commit that nerfed the CE's toolbelt, it now has access again to T2 tools from roundstart. I placed this on the modular folder so an upstream change can't modify this again.
Thematically it makes sense for the CE to have better tools until research allows this to be available to the rest of engineers.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="616" height="124" alt="image" src="https://github.com/user-attachments/assets/6adf0cd6-aabe-4077-8cf3-076b00114d12" />

</details>

## Changelog
:cl:

balance: Restored CE's belt with T2 tools

/:cl:
