### PR TITLE
downtunes knuckledusters by making them not sleep people for basically free (unless syndicate)

### DIFF
--- a/modular_nova/modules/modular_weapons/code/knuckleduster.dm
+++ b/modular_nova/modules/modular_weapons/code/knuckleduster.dm
@@ -36,7 +36,7 @@
 /// Sets up the martial art component and registers equipment/drop signals
 /obj/item/melee/knuckleduster/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/martial_art_giver, /datum/martial_art/boxing/street)
+	AddComponent(/datum/component/martial_art_giver, granted_style)
 	RegisterSignal(src, COMSIG_ITEM_EQUIPPED, PROC_REF(knuckle_equipped))
 	RegisterSignal(src, COMSIG_ITEM_DROPPED, PROC_REF(knuckle_dropped))
 

--- a/modular_nova/modules/modular_weapons/code/knuckleduster.dm
+++ b/modular_nova/modules/modular_weapons/code/knuckleduster.dm
@@ -1,6 +1,8 @@
+#define MARTIALART_STREET_BOXING "street boxing"
+
 /obj/item/melee/knuckleduster
 	name = "knuckleduster"
-	desc = "Weighted rings for the knuckles. While worn, you fall back on 'Evil Boxing' techniques — no rules, just results."
+	desc = "Weighted rings for the knuckles. While worn, you fistfight like a dishonorable \"street\" boxer, proving formidable in a brawl."
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/melee.dmi'
 	icon_state = "knuckleduster"
 	inhand_icon_state = null
@@ -20,8 +22,6 @@
 	exposed_wound_bonus = 20
 	body_parts_covered = HANDS
 	slot_flags = ITEM_SLOT_GLOVES
-	/// Additional force bonus applied when worn in the glove slot
-	var/glove_force_bonus = 20
 	/// Tracks whether the item is currently worn as gloves (used to manage bonuses and effects)
 	var/is_worn_as_glove = FALSE
 	/// Amount of stamina damage dealt on right-click attacks against living targets
@@ -30,11 +30,13 @@
 	var/stun_armour_penetration = 15
 	/// The armor type checked against when performing stamina attacks (defaults to MELEE)
 	var/armour_type_against_stun = MELEE
+	/// What martial art do we grant when equipped?
+	var/datum/martial_art/granted_style = /datum/martial_art/boxing/street
 
 /// Sets up the martial art component and registers equipment/drop signals
 /obj/item/melee/knuckleduster/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/martial_art_giver, /datum/martial_art/boxing/evil)
+	AddComponent(/datum/component/martial_art_giver, /datum/martial_art/boxing/street)
 	RegisterSignal(src, COMSIG_ITEM_EQUIPPED, PROC_REF(knuckle_equipped))
 	RegisterSignal(src, COMSIG_ITEM_DROPPED, PROC_REF(knuckle_dropped))
 
@@ -73,12 +75,7 @@
 		return
 
 	if(slot == ITEM_SLOT_GLOVES && !is_worn_as_glove)
-		force += glove_force_bonus
-		is_worn_as_glove = TRUE
-		ADD_TRAIT(src, TRAIT_EXAMINE_SKIP, REF(src))
 		user.add_traits(list(TRAIT_CHUNKYFINGERS), REF(src))
-		user.balloon_alert(user, "knuckledusters secured")
-		user.update_worn_gloves()
 	else if(slot != ITEM_SLOT_GLOVES && is_worn_as_glove)
 		remove_glove_effects(user)
 
@@ -103,12 +100,9 @@
  * * user - The mob that was wearing the knuckledusters
  */
 /obj/item/melee/knuckleduster/proc/remove_glove_effects(mob/user)
-	force -= glove_force_bonus
 	is_worn_as_glove = FALSE
-	REMOVE_TRAIT(src, TRAIT_EXAMINE_SKIP, REF(src))
 	if(istype(user))
 		user.remove_traits(list(TRAIT_CHUNKYFINGERS), REF(src))
-		user.update_worn_gloves()
 
 /**
  * Handles right-click attacks to perform non-lethal stamina damage instead of brute.
@@ -152,13 +146,84 @@
 	if(hitsound)
 		playsound(src, hitsound, 50, TRUE)
 
-
 /obj/item/melee/knuckleduster/traitor
 	name = "reinforced knuckleduster"
-	desc = "Reinforced knuckle-dusters for those who don't play fair. Wearing these invokes 'Evil Boxing' instincts."
+	desc = "Reinforced knuckle-dusters for those who don't play fair. The added weight and reinforcement make these quite suitable for \"evil boxing,\" \
+		with devastating knockout strikes being quite doable with enough training."
 	icon_state = "knuckleduster_syndie"
 	force = 5
 	armour_penetration = 10
 	wound_bonus = 14
 	exposed_wound_bonus = 25
-	glove_force_bonus = 35 // Enhanced bonus for traitor version
+	granted_style = /datum/martial_art/boxing/evil
+
+/// Street Boxing; for the rough-and-tumble spaceman. Has no honor, making it more lethal (and therefore unable to be used by pacifists).
+/// Not as evil as evil boxing because it doesn't sleep on crit, but does a pretty hard knockdown.
+/datum/martial_art/boxing/street
+	name = "Street Boxing"
+	id = MARTIALART_STREET_BOXING
+	pacifist_style = FALSE
+	honorable_boxer = FALSE
+	boxing_traits = list(TRAIT_BOXING_READY)
+
+/**
+ * Our crit effect.
+ * Against staggered people, if we're boxing someone who's also a boxer, we sleep for 3sec and knockdown for 6sec.
+ * If not, we check if they're baton resistant:
+ * If they are, we stagger for STAGGERED_SLOWDOWN_LENGTH and apply 20 stamina damage (respecting armor).
+ * If they *aren't*, we knock down for 5 seconds and apply 30 stamina damage (again, respecting armor).
+ * Against non-staggered people, we stagger, opening them up for further crits.
+ */
+/datum/martial_art/boxing/street/crit_effect(mob/living/attacker, mob/living/defender, armor_block = 0, damage_type = STAMINA, damage = 0)
+	if(defender.get_timed_status_effect_duration(/datum/status_effect/staggered))
+		if(HAS_TRAIT(defender, TRAIT_BOXING_READY))
+			// boxer on boxer violence results in full boxing shenanigans. ggs
+			defender.visible_message(
+				span_danger("[attacker] knocks [defender] out with a haymaker!"),
+				span_userdanger("You're knocked unconscious by [attacker]!"),
+				span_hear("You hear a sickening sound of flesh hitting flesh!"),
+				COMBAT_MESSAGE_RANGE,
+				attacker,
+			)
+			to_chat(attacker, span_danger("You knock [defender] out with a haymaker!"))
+			defender.apply_effect(6 SECONDS, EFFECT_KNOCKDOWN, armor_block)
+			defender.SetSleeping(3 SECONDS) // this is still punishing enough i think
+			log_combat(attacker, defender, "knocked out (boxing) ")
+		else
+			// otherwise, if baton resistant, more stagger and stamina damage
+			if(HAS_TRAIT(defender, TRAIT_BATON_RESISTANCE))
+				defender.visible_message(
+					span_danger("[attacker] knocks [defender] down with a haymaker!"),
+					span_userdanger("You're knocked down by [attacker]!"),
+					span_hear("You hear a sickening sound of flesh hitting flesh!"),
+					COMBAT_MESSAGE_RANGE,
+					attacker,
+				)
+				to_chat(attacker, span_danger("You knock [defender] down with a haymaker!"))
+				defender.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH, 10 SECONDS)
+				defender.apply_damage(20, STAMINA, blocked = armor_block)
+				log_combat(attacker, defender, "knocked down (boxing) ")
+			else
+			// otherwise, sit down buddy (if you got crit once you're probably lined up to eat more crits)
+				defender.visible_message(
+					span_danger("[attacker] knocks [defender] down with a haymaker!"),
+					span_userdanger("You're knocked down by [attacker]!"),
+					span_hear("You hear a sickening sound of flesh hitting flesh!"),
+					COMBAT_MESSAGE_RANGE,
+					attacker,
+				)
+				to_chat(attacker, span_danger("You knock [defender] down with a haymaker!"))
+				defender.apply_effect(5 SECONDS, EFFECT_KNOCKDOWN, armor_block)
+				defender.apply_damage(30, STAMINA, blocked = armor_block)
+				log_combat(attacker, defender, "knocked down (boxing) ")
+	else
+		defender.visible_message(
+			span_danger("[attacker] staggers [defender] with a haymaker!"),
+			span_userdanger("You're nearly knocked off your feet by [attacker]!"),
+			span_hear("You hear a sickening sound of flesh hitting flesh!"),
+			COMBAT_MESSAGE_RANGE,
+			attacker,
+		)
+		defender.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH, 10 SECONDS)
+		to_chat(attacker, span_danger("You stagger [defender] with a haymaker!"))
+		log_combat(attacker, defender, "staggered (boxing) ")


### PR DESCRIPTION
## About The Pull Request
Base knuckledusters (detective, soon to be black market) now give Street Boxing and not Evil Boxing. Street Boxing's crit effects have been downtuned heavily: only against other staggered boxers will you be rolling for sleeps on crit, while against baton-resistant folk you only get a stagger and stamina damage. Against non-baton-resistant, but non-boxer folk, you get a pretty good knockdown.

Syndicate knuckledusters keep Evil Boxing though. Because they're Evil.

## How This Contributes To The Nova Sector Roleplay Experience

Turns out being able to sleep people off a shove and a punch is bad for the combat environment. Welcome back, stungloves.

## Proof of Testing

<img width="449" height="241" alt="image" src="https://github.com/user-attachments/assets/c0102f64-44a9-4d2a-85d4-cbec78382a36" />

## Changelog

:cl:
balance: The detective's knuckledusters no longer grant Evil Boxing for free, and instead grant Street Boxing, which still allows you to punch people who aren't boxers to chain together knockdowns. Syndicate knuckledusters remain Evil, however.
/:cl: