### PR TITLE
[Fix] Fixes our custom Screams

### DIFF
--- a/modular_nova/modules/emotes/code/scream_emote.dm
+++ b/modular_nova/modules/emotes/code/scream_emote.dm
@@ -1,6 +1,4 @@
-/datum/emote/living/scream
-	vary = TRUE
-	mob_type_blacklist_typecache = list(/mob/living/carbon/human, /mob/living/basic/slime, /mob/living/brain) //Humans get specialized scream.
+// Overwriting to get our custom screams from the character selection.
 
 /datum/emote/living/scream/get_sound(mob/living/user)
 	if(issilicon(user))
@@ -14,10 +12,24 @@
 			return pick(selected_scream.male_screamsounds)
 	if(ismonkey(user))
 		return 'modular_nova/modules/emotes/sound/voice/scream_monkey.ogg'
+	if (isdrone(user))
+		return 'modular_nova/modules/emotes/sound/voice/scream_silicon.ogg'
 	if(istype(user, /mob/living/basic/gorilla))
 		return 'sound/mobs/non-humanoids/gorilla/gorilla.ogg'
 	if(isalien(user))
 		return 'sound/mobs/non-humanoids/hiss/hiss6.ogg'
+	if(ishuman(user))
+		var/mob/living/carbon/human/human_user = user
+		var/datum/scream_type/selected_scream = human_user.selected_scream
+		if(isnull(selected_scream) || !(LAZYLEN(selected_scream.male_screamsounds) || LAZYLEN(selected_scream.female_screamsounds))) //For things that don't have a selected scream(npcs)
+			if(prob(1))
+				return 'sound/mobs/humanoids/human/scream/wilhelm_scream.ogg'
+			return human_user.dna.species.get_scream_sound(human_user)
+		if(user.gender == FEMALE && LAZYLEN(selected_scream.female_screamsounds))
+			return pick(selected_scream.female_screamsounds)
+		else
+			return pick(selected_scream.male_screamsounds)
+	return ..()
 
 /datum/emote/living/scream/can_run_emote(mob/living/user, status_check, intentional, params)
 	if(iscyborg(user))
@@ -28,18 +40,3 @@
 			return FALSE
 		robot_user.cell.use(STANDARD_CELL_CHARGE * 0.2)
 	return ..()
-
-/datum/emote/living/carbon/human/scream
-	only_forced_audio = FALSE
-
-/datum/emote/living/carbon/human/scream/get_sound(mob/living/carbon/human/user)
-	if(!istype(user))
-		return
-	if(isnull(user.selected_scream) || !(LAZYLEN(user.selected_scream.male_screamsounds) || LAZYLEN(user.selected_scream.female_screamsounds))) //For things that don't have a selected scream(npcs)
-		if(prob(1))
-			return 'sound/mobs/humanoids/human/scream/wilhelm_scream.ogg'
-		return user.dna.species.get_scream_sound(user)
-	if(user.gender == FEMALE && LAZYLEN(user.selected_scream.female_screamsounds))
-		return pick(user.selected_scream.female_screamsounds)
-	else
-		return pick(user.selected_scream.male_screamsounds)


### PR DESCRIPTION

## About The Pull Request
Adapts our modular system to the TG patch to screams.

## How This Contributes To The Nova Sector Roleplay Experience
Scream is a good emote for a lot of reasons and I like my DM's not to be filled with "I have a mouth and I cannot scream" memes

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="298" height="229" alt="image" src="https://github.com/user-attachments/assets/58378619-006b-4b51-ae5c-ca9ad3180ffe" />

<img width="251" height="221" alt="image" src="https://github.com/user-attachments/assets/58f91dd0-37f7-497b-81b0-3ce2af03b184" />

<img width="317" height="296" alt="image" src="https://github.com/user-attachments/assets/dab8ad2f-75a0-4045-af8b-a97dd25977dd" />

<img width="239" height="228" alt="image" src="https://github.com/user-attachments/assets/5f7612a6-2a8b-4e46-b8e0-acf91f18fb0b" />

<img width="170" height="161" alt="image" src="https://github.com/user-attachments/assets/024ed60c-fdbd-4ea3-bd3a-92b970873c8e" />

also an icewalker I forgot to capture, but yeah, refuse to instlal w11 for the video capture.

</details>

## Changelog
:cl:
fix: Adapts the custom screams to the new system, we can shout again.
/:cl:
