### PR TITLE
Mauling, Revisited

### DIFF
--- a/modular_nova/modules/mauling_melees/mauling_element.dm
+++ b/modular_nova/modules/mauling_melees/mauling_element.dm
@@ -7,16 +7,22 @@
  * As kneecapping, mauling attacks have a wounding bonus between severe and critical+10 wound thresholds. Without some serious wound protecting
  * armour this all but guarantees a wound of some sort. The attack is directed specifically at a limb and the limb takes the damage.
  *
- * Requires the attacker to be aiming for a limb, which will be targeted specifically. They will than have a 3-second long
- * do_after before executing the attack.
+ * Requires the attacker to be aiming for a limb, which will be targeted specifically.
+ * They will than have a do_after determined by `swing_delay` before executing the attack.
+ * The attack may have a damage multiplier, determined by `mauling_damage_mult`.
  *
  * Mauling, much like kneecapping, requires the target to either be on the floor, immobilised or buckled to something. And also to have an appropriate limb.
  *
  * Passing all the checks will cancel the entire attack chain.
  */
 /datum/element/mauling
+	/// How long do we wind up our swing for?
+	var/swing_delay = 2 SECONDS
+	/// What multiplier do we apply to our force on a successful mauling?
+	var/mauling_damage_mult = 1.5
 
-/datum/element/mauling/Attach(datum/target)
+/datum/element/mauling/Attach(datum/target, swing_delay, mauling_damage_mult)
+
 	if(!isitem(target))
 		stack_trace("Mauling element added to non-item object: \[[target]\]")
 		return ELEMENT_INCOMPATIBLE
@@ -32,7 +38,10 @@
 	if(. == ELEMENT_INCOMPATIBLE)
 		return
 
-	RegisterSignal(target, COMSIG_ITEM_ATTACK_SECONDARY , PROC_REF(try_maul_target))
+	src.swing_delay = swing_delay
+	src.mauling_damage_mult = mauling_damage_mult
+
+	RegisterSignal(target, COMSIG_ITEM_ATTACK_SECONDARY, PROC_REF(try_maul_target))
 
 /datum/element/mauling/Detach(datum/target)
 	UnregisterSignal(target, COMSIG_ITEM_ATTACK_SECONDARY)
@@ -40,9 +49,9 @@
 	return ..()
 
 /**
- * Signal handler for COMSIG_ITEM_ATTACK_SECONDARY. Does checks for pacifism, zones and target state before either returning nothing
- * if the special attack could not be attempted, performing the ordinary attack procs instead - Or cancelling the attack chain if
- * the attack can be started.
+ * Signal handler for COMSIG_ITEM_ATTACK_SECONDARY. Does checks for pacifism and valid target before either returning nothing
+ * if the special attack could not be attempted, performing the ordinary attack procs instead,
+ * or cancelling the attack chain if the attack can be started.
  */
 /datum/element/mauling/proc/try_maul_target(obj/item/source, mob/living/carbon/target, mob/attacker, params)
 	SIGNAL_HANDLER
@@ -53,43 +62,49 @@
 	if(!iscarbon(target))
 		return
 
-	if(!target.buckled && !HAS_TRAIT(target, TRAIT_FLOORED) && !HAS_TRAIT(target, TRAIT_IMMOBILIZED))
-		return
-
-	var/obj/item/bodypart/limb_target = target.get_bodypart(attacker.zone_selected)
-
-	if(!limb_target)
-		return
-
 	. = COMPONENT_SECONDARY_CANCEL_ATTACK_CHAIN
 
-	INVOKE_ASYNC(src, PROC_REF(do_maul_target), source, limb_target, target, attacker)
+	INVOKE_ASYNC(src, PROC_REF(do_maul_target), source, target, attacker)
 
 /**
- * After a short do_after, attacker applies damage to the given limb with a significant wounding bonus, applying the weapon's force as damage.
+ * After a short do_after, attacker applies damage to the given limb with a significant wounding bonus,
+ * applying the weapon's force (multiplied by `mauling_damage_mult`) as damage.
  */
-/datum/element/mauling/proc/do_maul_target(obj/item/weapon, obj/item/bodypart/limb, mob/living/carbon/target, mob/attacker)
+/datum/element/mauling/proc/do_maul_target(obj/item/weapon, mob/living/carbon/target, mob/attacker)
 	if(LAZYACCESS(attacker.do_afters, weapon))
 		return
 
-	attacker.visible_message(span_warning("[attacker] carefully aims [attacker.p_their()] [weapon] at [target]'s [limb.plaintext_zone]!"), span_danger("You carefully aim \the [weapon] for a swing at [target]'s [limb.plaintext_zone]!"))
-	log_combat(attacker, target, "started aiming a swing to maul", weapon)
+	var/obj/item/bodypart/limb_target = target.get_bodypart(attacker.zone_selected)
+	if(!limb_target)
+		return
 
-	if(do_after(attacker, 3 SECONDS, target, interaction_key = weapon))
-		attacker.visible_message(span_warning("[attacker] swings [attacker.p_their()] [weapon] at [target]'s [limb.plaintext_zone]!"), span_danger("You swing \the [weapon] at [target]'s [limb.plaintext_zone]!"))
-		var/wound_to_inflict = WOUND_BLUNT
-		if(weapon.sharpness & SHARP_EDGED)
-			wound_to_inflict = WOUND_SLASH
-		else if(weapon.sharpness & SHARP_POINTY)
-			wound_to_inflict = WOUND_PIERCE
-		var/min_wound = limb.get_wound_threshold_of_wound_type(wound_to_inflict, WOUND_SEVERITY_SEVERE, return_value_if_no_wound = 30, wound_source = weapon)
-		var/max_wound = limb.get_wound_threshold_of_wound_type(wound_to_inflict, WOUND_SEVERITY_CRITICAL, return_value_if_no_wound = 50, wound_source = weapon)
+	attacker.changeNext_move(CLICK_CD_MELEE) // let's not stack swings that easily, pal
+	// question: should the windup be reduced if the target is incapacitated, somehow?
 
-		limb.receive_damage(brute = weapon.force, wound_bonus = rand(min_wound, max_wound + 10), sharpness = weapon.sharpness, damage_source = "mauling")
-		// make sure we're actually able to feel pain
-		if(!target.has_status_effect(/datum/status_effect/grouped/screwy_hud/fake_healthy))
-			target.emote("scream")
-		log_combat(attacker, target, "mauled", weapon)
-		target.update_damage_overlays()
-		attacker.do_attack_animation(target, used_item = weapon)
-		playsound(source = get_turf(weapon), soundin = weapon.hitsound, vol = weapon.get_clamped_volume(), vary = TRUE)
+	attacker.visible_message(span_warning("[attacker] carefully aims [weapon] at [target]'s [limb_target.plaintext_zone]!"), span_danger("You carefully aim [weapon] at [target]'s [limb_target.plaintext_zone]!"))
+	log_combat(attacker, target, "started aiming to maul", weapon)
+
+	if(!do_after(attacker, swing_delay, target, interaction_key = weapon))
+		return
+
+	attacker.visible_message(span_warning("[attacker] swings [weapon] at [target]'s [limb_target.plaintext_zone]!"), span_danger("You swing \the [weapon] at [target]'s [limb_target.plaintext_zone]!"))
+	var/wound_to_inflict = WOUND_BLUNT
+	if(weapon.sharpness & SHARP_EDGED)
+		wound_to_inflict = WOUND_SLASH
+	else if(weapon.sharpness & SHARP_POINTY)
+		wound_to_inflict = WOUND_PIERCE
+	else if(weapon.damtype == BURN)
+		wound_to_inflict = WOUND_BURN
+	var/min_wound = limb_target.get_wound_threshold_of_wound_type(wound_to_inflict, WOUND_SEVERITY_SEVERE, return_value_if_no_wound = 30, wound_source = weapon)
+	var/max_wound = limb_target.get_wound_threshold_of_wound_type(wound_to_inflict, WOUND_SEVERITY_CRITICAL, return_value_if_no_wound = 50, wound_source = weapon)
+
+	target.apply_damage(weapon.force * mauling_damage_mult, weapon.damtype, limb_target, wound_bonus = rand(min_wound, max_wound + 10), sharpness = weapon.sharpness, attacking_item = weapon)
+
+	// make sure we're actually able to feel pain
+	if(!target.has_status_effect(/datum/status_effect/grouped/screwy_hud/fake_healthy))
+		target.emote("scream")
+
+	log_combat(attacker, target, "mauled", weapon)
+	target.update_damage_overlays()
+	attacker.do_attack_animation(target, used_item = weapon)
+	playsound(source = get_turf(weapon), soundin = weapon.hitsound, vol = weapon.get_clamped_volume(), vary = TRUE)

--- a/modular_nova/modules/mauling_melees/mauling_melees.dm
+++ b/modular_nova/modules/mauling_melees/mauling_melees.dm
@@ -22,6 +22,7 @@
 	wound_bonus = 10
 	exposed_wound_bonus = 20
 	tool_behaviour = TOOL_KNIFE
+	icon_angle = -45
 	/*
 	20 force, 10 wb, 20 bwb = 30, 50 against bare skin
 	compare/contrast force/wound bonuses with the captain's sabre, i guess
@@ -40,7 +41,7 @@
 	// but it's good for murdering plantpeople
 	AddElement(/datum/element/bane, mob_biotypes = MOB_PLANT, damage_multiplier = 0.5, requires_combat_mode = FALSE)
 	// Kill.
-	AddElement(/datum/element/mauling)
+	AddElement(/datum/element/mauling, swing_delay = 2 SECONDS, mauling_damage_mult = 2) // 40 force on maul
 
 /obj/item/machete/afterattack(atom/target, mob/user, click_parameters)
 	. = ..()
@@ -134,4 +135,4 @@
 
 /obj/item/trench_tool/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/mauling)
+	AddElement(/datum/element/mauling, swing_delay = 2 SECONDS, mauling_damage_mult = 2)

--- a/modular_nova/modules/sec_haul/code/security_clothing/breaching_hammer.dm
+++ b/modular_nova/modules/sec_haul/code/security_clothing/breaching_hammer.dm
@@ -28,7 +28,7 @@
 
 /obj/item/melee/breaching_hammer/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/kneecapping)
+	AddElement(/datum/element/mauling, swing_delay = 2 SECONDS, mauling_damage_mult = 2)
 
 /obj/item/melee/breaching_hammer/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(!istype(interacting_with, /obj/machinery/door))


### PR DESCRIPTION
## About The Pull Request
- Machetes now have `icon_angle = -45` so they don't look so funny when attacking in melee.
- Swing delay on mauling melees is no longer hard-coded.
- Mauling melees now have a damage multiplier when used to maul people.
- Some refactoring along the way for mauling people, using fire extinguisher bash code as inspiration.
- Breaching hammers now have mauling and not just kneecapping.

## How This Contributes To The Nova Sector Roleplay Experience
Yippee for gratuitous Dispute Resolution between you and your fellow spaceman.

## Proof of Testing

<img width="138" height="95" alt="image" src="https://github.com/user-attachments/assets/5d93f508-9ecc-41e9-ab3d-a1560e02baf7" />

## Changelog

:cl:
fix: Machetes now have a defined icon angle so they don't look so silly when used in melee.
balance: Mauling melees (e-tool, machete) now have a damage multiplier when used to maul people.
balance: The breaching hammer now has mauling instead of just kneecapping, allowing it to brutalize all of a person instead of just their legs.
code: Some variables regarding mauling are no longer hard-coded.
/:cl:
