### PR TITLE
[Admin Tools] Select Equipment Warning

### DIFF
--- a/code/modules/admin/verbs/selectequipment.dm
+++ b/code/modules/admin/verbs/selectequipment.dm
@@ -1,7 +1,10 @@
 ADMIN_VERB_ONLY_CONTEXT_MENU(select_equipment, R_FUN, "Select Equipment", mob/target in world)
-	if(tgui_alert(user, "This interface is resource-intensive. Are you sure you want to open it? Tip: You can also Ctrl-click a ghost to access a lighter version.", "Server Resources Warning", list("No", "Yes", "Sorry")) == "Yes") // NOVA EDIT ADDITION
-		var/datum/select_equipment/ui = new(user, target)
-		ui.ui_interact(user.mob)
+	// NOVA EDIT ADDITION START
+	if(tgui_alert(user, "This interface is resource-intensive. Are you sure you want to open it? Tip: You can also Ctrl-click a ghost to access a lighter version.", "Server Resources Warning", list("No", "Yes", "Sorry")) != "Yes")
+		return
+	// NOVA EDIT ADDITION END
+	var/datum/select_equipment/ui = new(user, target)
+	ui.ui_interact(user.mob)
 
 /*
  * This is the datum housing the select equipment UI.


### PR DESCRIPTION

## About The Pull Request
Non modularly (tried) adds a dialog to stop staff from using the select equipment dialog accidently.

## How This Contributes To The Nova Sector Roleplay Experience
We found out the dialog is actually resource intensive, and we have a custom dialog that does the same more efficiently (without the icon preview) for observers, so the idea is that the dialogs stops you from accidently using it and informs you of the alternative, avoiding causing unnesesary load on the server if avoidable.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="642" height="212" alt="image" src="https://github.com/user-attachments/assets/275d864b-bcdb-444b-a7d5-a1b18a812a18" />

</details>

## Changelog
:cl:
admin: Places a warning check to use the more optimized ctrl-click menu on the select equipment verb
/:cl:
