### PR TITLE
fix capitalisation

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -3430,7 +3430,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/directional/east{
-	c_tag = "Medbay - Aft CEntral";
+	c_tag = "Medbay - Aft Central";
 	name = "medbay camera";
 	network = list("ss13","medbay")
 	},


### PR DESCRIPTION
fix #6237 

:cl:
fix: Fixed a capitalisation error on a Blueshift camera name
/:cl: