### PR TITLE
Update sec locker room types

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -2073,7 +2073,6 @@
 "avI" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/red/filled/corner{
-	color = "#DE3A3A";
 	dir = 8
 	},
 /obj/item/book/manual/wiki/security_space_law,
@@ -12474,7 +12473,6 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/trimline/red/filled/corner{
-	color = "#DE3A3A";
 	dir = 8
 	},
 /obj/machinery/button/door/directional/east{
@@ -16674,7 +16672,6 @@
 	name = "Departures Lounge"
 	},
 /obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A";
 	dir = 8
 	},
 /obj/structure/sign/departments/evac/directional/south,
@@ -17911,7 +17908,6 @@
 /area/station/science/research)
 "dts" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	color = "#DE3A3A";
 	dir = 9
 	},
 /obj/item/kirbyplants/organic/plant22,
@@ -18967,12 +18963,9 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/computer/security/hos,
 /obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A"
-	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "dEU" = (
@@ -28816,12 +28809,9 @@
 /area/station/security/checkpoint/customs/auxiliary)
 "fwu" = (
 /obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A"
-	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "fwv" = (
@@ -30224,7 +30214,6 @@
 /area/station/command/heads_quarters/captain/private)
 "fMx" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	color = "#DE3A3A";
 	dir = 4
 	},
 /obj/structure/table/reinforced,
@@ -41493,7 +41482,8 @@
 	name = "Equipment Room"
 	},
 /obj/effect/turf_decal/delivery/red,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "hVk" = (
@@ -42322,12 +42312,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A"
-	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "idG" = (
@@ -45060,7 +45047,6 @@
 /area/station/hallway/secondary/entry)
 "iFg" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
-	color = "#DE3A3A";
 	dir = 8
 	},
 /obj/machinery/photocopier/prebuilt,
@@ -45894,9 +45880,7 @@
 /turf/open/floor/iron,
 /area/station/science/explab)
 "iOn" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	color = "#DE3A3A"
-	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/structure/table/reinforced,
 /obj/item/folder/red{
 	pixel_x = -7;
@@ -60342,12 +60326,9 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/computer/records/security,
 /obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A"
-	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "lBj" = (
@@ -66523,12 +66504,9 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/computer/prisoner/management,
 /obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A"
-	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "mKm" = (
@@ -71126,7 +71104,6 @@
 /area/station/medical/cryo)
 "nGg" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	color = "#DE3A3A";
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -72294,9 +72271,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "nRW" = (
-/obj/effect/turf_decal/trimline/red/filled{
-	color = "#DE3A3A"
-	},
+/obj/effect/turf_decal/trimline/red/filled,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "nRZ" = (
@@ -73905,7 +73880,6 @@
 	name = "Departures Lounge"
 	},
 /obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A";
 	dir = 8
 	},
 /obj/structure/cable,
@@ -77256,7 +77230,6 @@
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A";
 	dir = 8
 	},
 /turf/open/floor/iron/white/corner,
@@ -77357,7 +77330,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -77380,7 +77354,6 @@
 /area/station/command/bridge)
 "oMU" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	color = "#DE3A3A";
 	dir = 1
 	},
 /obj/structure/railing/corner/end{
@@ -78829,11 +78802,9 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A";
 	dir = 4
 	},
 /obj/machinery/recharger{
@@ -81130,9 +81101,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "pAz" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	color = "#DE3A3A"
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/table/reinforced,
 /obj/item/taperecorder,
 /obj/item/flashlight/seclite,
@@ -82787,7 +82756,6 @@
 /area/station/security/prison/rec)
 "pRx" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
-	color = "#DE3A3A";
 	dir = 1
 	},
 /obj/structure/railing,
@@ -83907,7 +83875,6 @@
 "qcc" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A";
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/south,
@@ -86745,7 +86712,6 @@
 /area/station/science/ordnance)
 "qCv" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	color = "#DE3A3A";
 	dir = 1
 	},
 /obj/structure/cable,
@@ -88560,7 +88526,6 @@
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A";
 	dir = 4
 	},
 /obj/machinery/light/directional/north,
@@ -90047,7 +90012,6 @@
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A";
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/north,
@@ -95308,7 +95272,6 @@
 /area/station/commons/fitness)
 "sjk" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
-	color = "#DE3A3A";
 	dir = 4
 	},
 /obj/machinery/pdapainter/security,
@@ -97296,8 +97259,8 @@
 	},
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "sCX" = (
@@ -99044,7 +99007,6 @@
 /area/station/security/prison/upper)
 "sUg" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
-	color = "#DE3A3A";
 	dir = 1
 	},
 /obj/structure/railing,
@@ -99828,9 +99790,7 @@
 /area/station/command/heads_quarters/captain/private)
 "taZ" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	color = "#DE3A3A"
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable,
 /obj/machinery/fax{
 	fax_name = "Head of Security's Office";
@@ -100475,9 +100435,7 @@
 /area/station/security/prison/upper)
 "tgl" = (
 /obj/item/kirbyplants/organic/plant22,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	color = "#DE3A3A"
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -101409,9 +101367,7 @@
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "tqo" = (
-/obj/effect/turf_decal/trimline/red/filled{
-	color = "#DE3A3A"
-	},
+/obj/effect/turf_decal/trimline/red/filled,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
@@ -101878,7 +101834,6 @@
 /area/station/engineering/storage/tech)
 "twq" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	color = "#DE3A3A";
 	dir = 8
 	},
 /obj/structure/bed/dogbed/lia,
@@ -101889,7 +101844,6 @@
 /area/station/command/heads_quarters/hos)
 "twz" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
-	color = "#DE3A3A";
 	dir = 4
 	},
 /obj/machinery/disposal/bin,
@@ -105485,7 +105439,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Gear Room"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "ueE" = (
@@ -106711,7 +106665,6 @@
 /area/station/hallway/primary/central)
 "uoC" = (
 /obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A";
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -108748,7 +108701,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron,
 /area/station/security/lockers)
 "uIq" = (
@@ -109938,7 +109891,6 @@
 /area/station/tcommsat/server)
 "uUQ" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	color = "#DE3A3A";
 	dir = 5
 	},
 /obj/item/kirbyplants/organic/plant22,
@@ -111300,7 +111252,6 @@
 	name = "HoS Privacy Blast Door"
 	},
 /obj/effect/turf_decal/trimline/red/filled/warning{
-	color = "#DE3A3A";
 	dir = 1
 	},
 /obj/structure/cable,
@@ -111945,9 +111896,7 @@
 /area/station/hallway/secondary/service)
 "vpq" = (
 /obj/structure/table,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	color = "#DE3A3A"
-	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/item/storage/box/deputy,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -114013,11 +113962,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A";
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -116805,9 +116752,7 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/auxiliary)
 "wij" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	color = "#DE3A3A"
-	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/structure/filingcabinet/security,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
@@ -122426,9 +122371,7 @@
 /area/station/ai_monitored/command/storage/eva)
 "xmE" = (
 /obj/item/kirbyplants/organic/plant22,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	color = "#DE3A3A"
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hos)
 "xmO" = (
@@ -123981,7 +123924,6 @@
 	name = "Departures Lounge"
 	},
 /obj/effect/turf_decal/tile/red{
-	color = "#DE3A3A";
 	dir = 8
 	},
 /turf/open/floor/iron/white/corner{
@@ -124335,9 +124277,7 @@
 /turf/open/floor/carpet,
 /area/station/command/meeting_room/council)
 "xFU" = (
-/obj/effect/turf_decal/trimline/red/filled/warning{
-	color = "#DE3A3A"
-	},
+/obj/effect/turf_decal/trimline/red/filled/warning,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -126620,7 +126560,6 @@
 /area/station/engineering/atmos/hfr_room)
 "ycl" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	color = "#DE3A3A";
 	dir = 4
 	},
 /turf/open/floor/iron/dark,

--- a/_maps/map_files/SerenityStation/SerenityStation.dmm
+++ b/_maps/map_files/SerenityStation/SerenityStation.dmm
@@ -8972,11 +8972,11 @@
 /area/station/maintenance/central/greater)
 "cBw" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/security/range)
 "cBI" = (
@@ -21205,7 +21205,6 @@
 /obj/machinery/door/airlock/bathroom{
 	name = "Restroom"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
@@ -30968,12 +30967,12 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Mechbay"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/dark,
 /area/station/security/mechbay)
 "iOy" = (
@@ -44058,11 +44057,11 @@
 	name = "Firing Range"
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/dark,
 /area/station/security/range)
 "mDM" = (

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -2651,8 +2651,7 @@
 	pixel_y = 7
 	},
 /obj/item/storage/toolbox/emergency{
-	pixel_x = 3;
-	pixel_y = 0
+	pixel_x = 3
 	},
 /obj/item/weldingtool{
 	pixel_x = -8;
@@ -2843,7 +2842,6 @@
 	pixel_y = 12
 	},
 /obj/item/wrench{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /turf/open/floor/plating,
@@ -3375,20 +3373,16 @@
 	dir = 10
 	},
 /obj/structure/sign/directions/medical/directional/north{
-	pixel_x = 0;
 	pixel_y = 41;
 	dir = 4
 	},
 /obj/structure/sign/directions/security/directional/north{
-	pixel_x = 0;
 	pixel_y = 35
 	},
 /obj/structure/sign/directions/command/directional/north{
-	pixel_x = 0;
 	pixel_y = 29
 	},
 /obj/structure/sign/directions/dorms/directional/north{
-	pixel_x = 0;
 	pixel_y = 23;
 	dir = 2
 	},
@@ -3472,7 +3466,6 @@
 	pixel_y = -1
 	},
 /obj/item/reagent_containers/syringe{
-	pixel_x = 0;
 	pixel_y = 10
 	},
 /turf/open/floor/iron/white/smooth_large,
@@ -3677,8 +3670,7 @@
 	pixel_y = 4
 	},
 /obj/item/multitool{
-	pixel_y = 8;
-	pixel_x = 0
+	pixel_y = 8
 	},
 /obj/item/multitool{
 	pixel_x = 5;
@@ -3999,22 +3991,18 @@
 /area/station/science/xenobiology)
 "aYF" = (
 /obj/structure/sign/directions/arrival{
-	pixel_x = 0;
 	pixel_y = -4
 	},
 /obj/structure/sign/directions/security{
 	dir = 1;
-	pixel_y = 2;
-	pixel_x = 0
+	pixel_y = 2
 	},
 /obj/structure/sign/directions/engineering{
-	pixel_y = -10;
-	pixel_x = 0
+	pixel_y = -10
 	},
 /obj/structure/sign/directions/supply{
 	dir = 8;
-	pixel_y = 8;
-	pixel_x = 0
+	pixel_y = 8
 	},
 /turf/closed/wall,
 /area/station/common/arcade)
@@ -4152,7 +4140,6 @@
 /obj/machinery/airalarm/directional/east,
 /obj/item/radio/intercom/directional/south,
 /obj/structure/bedsheetbin{
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /turf/open/floor/plastic,
@@ -5013,7 +5000,6 @@
 /obj/machinery/status_display/door_timer{
 	id = "Cell 3";
 	name = "Cell 3";
-	pixel_y = 0;
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5501,7 +5487,6 @@
 /obj/structure/rack/wooden,
 /obj/item/storage/bag/plants,
 /obj/item/storage/bag/plants{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/cultivator{
@@ -5605,7 +5590,6 @@
 	pixel_y = 3
 	},
 /obj/item/storage/belt/utility{
-	pixel_x = 0;
 	pixel_y = -6
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -5939,7 +5923,6 @@
 "bAT" = (
 /obj/structure/bookcase/random/religion,
 /obj/structure/sign/painting/library_private{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/wood/large,
@@ -5997,7 +5980,6 @@
 	pixel_x = -4
 	},
 /obj/item/clothing/mask/gas{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/clothing/mask/gas{
@@ -6025,7 +6007,6 @@
 /obj/structure/cable,
 /obj/machinery/camera/autoname/directional/south,
 /obj/structure/sign/directions/evac/directional/south{
-	pixel_x = 0;
 	pixel_y = -40;
 	dir = 1
 	},
@@ -7175,7 +7156,6 @@
 "bTf" = (
 /obj/structure/table,
 /obj/structure/towel_bin{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /turf/open/floor/iron/freezer,
@@ -7334,8 +7314,7 @@
 	pixel_y = 7
 	},
 /obj/item/reagent_containers/cup/glass/mug{
-	pixel_x = -7;
-	pixel_y = 0
+	pixel_x = -7
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
@@ -7447,7 +7426,6 @@
 	},
 /obj/machinery/door_buttons/access_button{
 	pixel_x = 25;
-	pixel_y = 0;
 	idSelf = "viro_med_control";
 	idDoor = "viro_med_external";
 	req_access = list("virology")
@@ -9209,7 +9187,6 @@
 	pixel_x = -3
 	},
 /obj/item/pen{
-	pixel_x = 0;
 	pixel_y = 8
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
@@ -10780,7 +10757,6 @@
 	pixel_y = 5
 	},
 /obj/item/toy/plush/shark{
-	pixel_x = 0;
 	pixel_y = -5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12304,11 +12280,9 @@
 /obj/structure/table,
 /obj/item/stock_parts/subspace/ansible,
 /obj/item/stock_parts/subspace/ansible{
-	pixel_x = 0;
 	pixel_y = -3
 	},
 /obj/item/stock_parts/subspace/ansible{
-	pixel_x = 0;
 	pixel_y = -6
 	},
 /obj/item/stock_parts/subspace/crystal{
@@ -12316,7 +12290,6 @@
 	pixel_y = 12
 	},
 /obj/item/stock_parts/subspace/crystal{
-	pixel_x = 0;
 	pixel_y = 12
 	},
 /obj/item/stock_parts/subspace/crystal{
@@ -13447,7 +13420,6 @@
 /obj/effect/turf_decal/trimline/white/filled/line,
 /obj/machinery/light/directional/south,
 /obj/structure/sign/directions/cryo/directional/south{
-	pixel_x = 0;
 	pixel_y = -21
 	},
 /turf/open/floor/iron/edge{
@@ -13731,7 +13703,6 @@
 	},
 /obj/structure/chair/sofa/bench/left{
 	dir = 8;
-	pixel_y = 0;
 	pixel_x = 5
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -14977,8 +14948,7 @@
 	pixel_y = 15
 	},
 /obj/item/hairbrush{
-	pixel_y = 9;
-	pixel_x = 0
+	pixel_y = 9
 	},
 /obj/item/reagent_containers/spray/barbers_aid{
 	pixel_x = 12;
@@ -15012,11 +14982,9 @@
 	},
 /obj/item/stack/cable_coil/thirty,
 /obj/item/stack/cable_coil/thirty{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/stack/cable_coil/thirty{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /turf/open/floor/iron/white/smooth_corner{
@@ -15307,8 +15275,6 @@
 "edt" = (
 /obj/structure/cable,
 /obj/structure/chair/office/light{
-	pixel_x = 0;
-	pixel_y = 0;
 	dir = 1
 	},
 /obj/effect/landmark/start/bridge_officer,
@@ -16327,7 +16293,6 @@
 	pixel_y = 6
 	},
 /obj/item/reagent_containers/cup/glass/coffee_cup{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /obj/item/reagent_containers/cup/glass/coffee_cup{
@@ -17816,7 +17781,6 @@
 	pixel_y = 1
 	},
 /obj/item/wrench{
-	pixel_x = 0;
 	pixel_y = 1
 	},
 /turf/open/floor/engine,
@@ -18502,7 +18466,6 @@
 /obj/machinery/light/directional/east,
 /obj/structure/rack/shelf,
 /obj/item/clothing/mask/surgical{
-	pixel_x = 0;
 	pixel_y = -4
 	},
 /obj/item/clothing/gloves/latex,
@@ -18666,8 +18629,7 @@
 	dir = 8
 	},
 /obj/item/flashlight{
-	pixel_x = 13;
-	pixel_y = 0
+	pixel_x = 13
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos/pumproom)
@@ -19416,7 +19378,6 @@
 	pixel_y = 9
 	},
 /obj/machinery/cell_charger{
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /turf/open/floor/iron/edge{
@@ -19613,8 +19574,7 @@
 /obj/structure/table/wood,
 /obj/effect/landmark/start/hangover,
 /obj/effect/spawner/random/food_or_drink/snack{
-	pixel_y = -7;
-	pixel_x = 0
+	pixel_y = -7
 	},
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation)
@@ -20121,7 +20081,6 @@
 /obj/machinery/button/curtain{
 	id = "dormscurtain5b";
 	pixel_x = 34;
-	pixel_y = 0;
 	name = "External Curtains"
 	},
 /turf/open/floor/wood/tile,
@@ -21085,8 +21044,7 @@
 	pixel_x = 2
 	},
 /obj/item/clothing/mask/gas{
-	pixel_x = -5;
-	pixel_y = 0
+	pixel_x = -5
 	},
 /obj/item/radio{
 	pixel_x = 8;
@@ -21387,10 +21345,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos/lesser)
 "fJG" = (
-/obj/item/stack/license_plates/empty/fifty{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/stack/license_plates/empty/fifty,
 /obj/item/stack/license_plates/empty/fifty{
 	pixel_x = -2;
 	pixel_y = 6
@@ -24947,7 +24902,6 @@
 "gHL" = (
 /obj/structure/table/wood/poker,
 /obj/item/gun/ballistic/revolver/russian{
-	pixel_x = 0;
 	pixel_y = 10
 	},
 /turf/open/floor/plating,
@@ -25832,11 +25786,9 @@
 /obj/machinery/camera/autoname/directional/south,
 /obj/item/reagent_containers/medigel/sterilizine,
 /obj/item/storage/box/lipsticks{
-	pixel_x = 0;
 	pixel_y = -4
 	},
 /obj/item/storage/box/perfume{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /turf/open/floor/iron/dark,
@@ -26828,11 +26780,11 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Gear Room"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
 "hjr" = (
@@ -27292,8 +27244,7 @@
 /obj/machinery/light/directional/west,
 /obj/machinery/button/curtain{
 	id = "psychcurtain";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/open/floor/wood/tile,
 /area/station/medical/psychology)
@@ -27632,7 +27583,6 @@
 /obj/structure/cable,
 /obj/structure/table/wood,
 /obj/item/book/bible{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/paper_bin{
@@ -28409,8 +28359,7 @@
 "hDf" = (
 /obj/structure/table,
 /obj/item/newspaper{
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /obj/item/pai_card{
 	pixel_x = 5;
@@ -28546,7 +28495,6 @@
 /obj/structure/closet/secure_closet/freezer/kitchen/all_access,
 /obj/item/storage/fancy/egg_box,
 /obj/item/storage/fancy/egg_box{
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /turf/open/floor/iron/checker,
@@ -29093,7 +29041,6 @@
 	pixel_x = 4
 	},
 /obj/item/restraints/handcuffs{
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /turf/open/floor/iron/dark/smooth_edge{
@@ -30354,12 +30301,10 @@
 	pixel_y = -3
 	},
 /obj/item/seeds/cabbage{
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /obj/item/seeds/cucumber{
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /obj/item/seeds/wheat{
 	pixel_x = -6;
@@ -30783,7 +30728,6 @@
 	},
 /obj/structure/rack/shelf,
 /obj/item/grenade/chem_grenade/smart_metal_foam{
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /obj/item/grenade/chem_grenade/smart_metal_foam{
@@ -31565,7 +31509,6 @@
 	pixel_x = -2
 	},
 /obj/item/construction/plumbing{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /turf/open/floor/iron/white/smooth_edge{
@@ -32311,8 +32254,7 @@
 	},
 /obj/item/storage/box/beakers,
 /obj/item/storage/box/beakers{
-	pixel_y = 7;
-	pixel_x = 0
+	pixel_y = 7
 	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
@@ -32416,8 +32358,7 @@
 	pixel_x = -8
 	},
 /obj/effect/spawner/random/entertainment/toy_figure{
-	pixel_x = 6;
-	pixel_y = 0
+	pixel_x = 6
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/condemned_med)
@@ -32973,7 +32914,6 @@
 	pixel_x = 6
 	},
 /obj/item/pen{
-	pixel_y = 0;
 	pixel_x = 5
 	},
 /obj/item/reagent_containers/spray/quantum_hair_dye{
@@ -33434,8 +33374,7 @@
 	pixel_y = 5
 	},
 /obj/item/storage/box/sparklers{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /obj/structure/sign/calendar/directional/south,
 /turf/open/floor/carpet/donk,
@@ -33823,8 +33762,7 @@
 	pixel_y = 4
 	},
 /obj/item/stock_parts/power_store/cell/high{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
@@ -35006,8 +34944,7 @@
 	pixel_y = 8
 	},
 /obj/item/storage/toolbox/mechanical{
-	pixel_x = 3;
-	pixel_y = 0
+	pixel_x = 3
 	},
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 4
@@ -35245,8 +35182,7 @@
 "jrt" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box{
-	pixel_y = 1;
-	pixel_x = 0
+	pixel_y = 1
 	},
 /turf/open/floor/iron/sepia,
 /area/station/service/kitchen/diner)
@@ -35639,7 +35575,6 @@
 	pixel_y = 3
 	},
 /obj/item/bouquet/sunflower{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /turf/open/floor/carpet/red,
@@ -36123,7 +36058,6 @@
 "jDP" = (
 /obj/structure/table,
 /obj/item/crowbar{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/pushbroom{
@@ -36423,15 +36357,13 @@
 	pixel_y = 2
 	},
 /obj/item/secateurs{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /obj/item/secateurs{
 	pixel_x = 5;
 	pixel_y = 5
 	},
 /obj/item/wirecutters{
-	pixel_x = 0;
 	pixel_y = -8
 	},
 /obj/item/radio/intercom/prison/directional/north,
@@ -37415,22 +37347,18 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/machinery/door/firedoor,
 /obj/structure/sign/directions/science/directional/south{
-	pixel_x = 0;
 	pixel_y = -40;
 	dir = 4
 	},
 /obj/structure/sign/directions/security/directional/south{
-	pixel_x = 0;
 	pixel_y = -22;
 	dir = 1
 	},
 /obj/structure/sign/directions/supply/directional/south{
-	pixel_x = 0;
 	pixel_y = -34;
 	dir = 8
 	},
 /obj/structure/sign/directions/command/directional/south{
-	pixel_x = 0;
 	pixel_y = -28;
 	dir = 1
 	},
@@ -37976,22 +37904,18 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/door/firedoor,
 /obj/structure/sign/directions/medical/directional/south{
-	pixel_x = 0;
 	pixel_y = -22;
 	dir = 4
 	},
 /obj/structure/sign/directions/dorms/directional/south{
-	pixel_x = 0;
 	pixel_y = -28;
 	dir = 8
 	},
 /obj/structure/sign/directions/cryo/directional/south{
-	pixel_x = 0;
 	pixel_y = -34;
 	dir = 4
 	},
 /obj/structure/sign/directions/supply/directional/south{
-	pixel_x = 0;
 	pixel_y = -40;
 	dir = 8
 	},
@@ -39142,26 +39066,22 @@
 /area/station/maintenance/department/science/xenobiology)
 "krJ" = (
 /obj/item/plunger{
-	pixel_x = 9;
-	pixel_y = 0
+	pixel_x = 9
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_art_studio)
 "krR" = (
 /obj/structure/sign/directions/engineering{
 	dir = 8;
-	pixel_y = 5;
-	pixel_x = 0
+	pixel_y = 5
 	},
 /obj/structure/sign/directions/dorms/directional{
 	dir = 8;
-	pixel_y = -1;
-	pixel_x = 0
+	pixel_y = -1
 	},
 /obj/structure/sign/directions/arrival{
 	dir = 4;
-	pixel_y = 11;
-	pixel_x = 0
+	pixel_y = 11
 	},
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage/tech)
@@ -39219,8 +39139,7 @@
 	pixel_y = 4
 	},
 /obj/effect/spawner/random/entertainment/toy_figure{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/wrestle)
@@ -39988,8 +39907,7 @@
 /area/station/cargo/miningfoyer)
 "kBZ" = (
 /obj/item/universal_scanner{
-	pixel_y = 27;
-	pixel_x = 0
+	pixel_y = 27
 	},
 /obj/machinery/disposal/delivery_chute{
 	name = "Auto Unloader"
@@ -40404,7 +40322,6 @@
 /obj/machinery/light/directional/west,
 /obj/structure/sign/directions/cryo/directional/west{
 	dir = 2;
-	pixel_x = -32;
 	pixel_y = 14
 	},
 /turf/open/floor/iron/edge{
@@ -41676,8 +41593,7 @@
 	pixel_y = 8
 	},
 /obj/effect/spawner/random/entertainment/toy_figure{
-	pixel_x = -7;
-	pixel_y = 0
+	pixel_x = -7
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
@@ -41754,12 +41670,10 @@
 /obj/machinery/status_display/ai/directional/south,
 /obj/structure/rack/shelf,
 /obj/item/wheelchair{
-	pixel_x = 0;
 	pixel_y = -5
 	},
 /obj/item/wheelchair,
 /obj/item/wheelchair{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /turf/open/floor/iron/white/smooth_corner{
@@ -41887,7 +41801,6 @@
 "lbY" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8;
-	pixel_y = 0;
 	pixel_x = 5
 	},
 /obj/item/radio/intercom/directional/south,
@@ -43676,12 +43589,10 @@
 	},
 /obj/item/radio/intercom/directional/south,
 /obj/item/clothing/gloves/latex{
-	pixel_y = 8;
-	pixel_x = 0
+	pixel_y = 8
 	},
 /obj/item/clothing/glasses/science{
-	pixel_x = -13;
-	pixel_y = 0
+	pixel_x = -13
 	},
 /obj/item/storage/bag/chemistry{
 	pixel_x = 1;
@@ -43918,8 +43829,7 @@
 	dir = 6
 	},
 /obj/item/coffee_cartridge{
-	pixel_y = 4;
-	pixel_x = 0
+	pixel_y = 4
 	},
 /obj/structure/sign/calendar/directional/east,
 /turf/open/floor/iron/white/smooth_corner{
@@ -44097,9 +44007,7 @@
 	},
 /area/station/ai_monitored/command/storage/eva)
 "lGD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/maintenance/abandon_office)
@@ -44254,8 +44162,7 @@
 	dir = 1
 	},
 /obj/item/pipe_dispenser{
-	pixel_x = -7;
-	pixel_y = 0
+	pixel_x = -7
 	},
 /turf/open/floor/iron/edge{
 	dir = 1
@@ -45092,8 +44999,7 @@
 	pixel_y = 4
 	},
 /obj/item/stock_parts/power_store/cell/high{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/ordnance_maint_lesser)
@@ -45725,7 +45631,6 @@
 	},
 /obj/item/paper_bin/carbon,
 /obj/item/pen{
-	pixel_y = 0;
 	pixel_x = 5
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -47047,8 +46952,7 @@
 	pixel_y = 7
 	},
 /obj/item/camera{
-	pixel_x = 1;
-	pixel_y = 0
+	pixel_x = 1
 	},
 /turf/open/floor/wood/parquet,
 /area/station/common/night_club/back_stage)
@@ -49242,11 +49146,9 @@
 /obj/structure/rack/shelf,
 /obj/item/circuitboard/machine/exoscanner,
 /obj/item/circuitboard/machine/exoscanner{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/item/circuitboard/machine/exoscanner{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /turf/open/floor/iron/smooth_large,
@@ -51496,7 +51398,6 @@
 "nKl" = (
 /obj/structure/rack/shelf,
 /obj/item/healthanalyzer{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/machinery/newscaster/directional/west,
@@ -52275,7 +52176,6 @@
 	dir = 4
 	},
 /obj/machinery/cell_charger_multi{
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /turf/open/floor/iron/white/smooth_half{
@@ -55033,7 +54933,6 @@
 	pixel_y = 5
 	},
 /obj/item/forging/tongs{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/item/forging/hammer{
@@ -55405,9 +55304,7 @@
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/forestarboardhall)
 "oMv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/firealarm_sanity,
 /turf/open/floor/carpet/green,
 /area/station/commons/dorms/room7)
@@ -55790,10 +55687,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos/pumproom)
@@ -56757,7 +56651,6 @@
 "pdM" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/drugs{
-	pixel_x = 0;
 	pixel_y = 8
 	},
 /turf/open/floor/plating,
@@ -58121,8 +58014,7 @@
 	pixel_y = 19
 	},
 /obj/item/airlock_painter/decal{
-	pixel_y = 1;
-	pixel_x = 0
+	pixel_y = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -58274,8 +58166,7 @@
 	pixel_x = -10
 	},
 /obj/item/reagent_containers/cup/glass/mug{
-	pixel_x = 5;
-	pixel_y = 0
+	pixel_x = 5
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
@@ -58371,12 +58262,10 @@
 "pBM" = (
 /obj/structure/table/wood,
 /obj/item/plate{
-	pixel_y = -8;
-	pixel_x = 0
+	pixel_y = -8
 	},
 /obj/item/reagent_containers/condiment/saltshaker{
-	pixel_y = 12;
-	pixel_x = 0
+	pixel_y = 12
 	},
 /obj/item/reagent_containers/condiment/peppermill{
 	pixel_x = 7;
@@ -58793,8 +58682,7 @@
 /obj/effect/turf_decal/tile/dark_green/half,
 /obj/structure/table/glass,
 /obj/item/storage/box/injectors{
-	pixel_y = 2;
-	pixel_x = 0
+	pixel_y = 2
 	},
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/virology)
@@ -59288,8 +59176,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/item/folder{
-	pixel_x = -6;
-	pixel_y = 0
+	pixel_x = -6
 	},
 /obj/item/stack/package_wrap{
 	pixel_y = 11;
@@ -59882,12 +59769,10 @@
 /obj/machinery/newscaster/directional/north,
 /obj/structure/table/wood,
 /obj/item/storage/box/mime{
-	pixel_y = 9;
-	pixel_x = 0
+	pixel_y = 9
 	},
 /obj/item/newspaper{
-	pixel_x = 15;
-	pixel_y = 0
+	pixel_x = 15
 	},
 /turf/open/floor/carpet/black,
 /area/station/service/greenroom)
@@ -60263,8 +60148,7 @@
 "qgh" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency{
-	pixel_y = 9;
-	pixel_x = 0
+	pixel_y = 9
 	},
 /obj/item/toner{
 	pixel_x = 13;
@@ -60630,8 +60514,7 @@
 	dir = 5
 	},
 /obj/item/airlock_painter/decal{
-	pixel_y = -17;
-	pixel_x = 0
+	pixel_y = -17
 	},
 /obj/item/storage/box/lights/mixed{
 	pixel_y = 11;
@@ -63732,7 +63615,6 @@
 /obj/machinery/newscaster/directional/south,
 /obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/refreshing_beverage{
-	pixel_x = 0;
 	pixel_y = 10
 	},
 /turf/open/floor/iron/dark/smooth_large,
@@ -64277,7 +64159,6 @@
 /obj/structure/table,
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/gloves/color/yellow{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/item/clothing/gloves/color/yellow,
@@ -65889,7 +65770,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door_buttons/access_button{
-	pixel_x = 0;
 	pixel_y = -21;
 	idSelf = "viro_public_control";
 	req_access = list("virology");
@@ -66712,12 +66592,10 @@
 /obj/effect/turf_decal/tile/green/diagonal_centre,
 /obj/structure/table/reinforced,
 /obj/item/paper/guides/jobs/hydroponics{
-	pixel_x = 6;
-	pixel_y = 0
+	pixel_x = 6
 	},
 /obj/item/plant_analyzer{
-	pixel_y = 19;
-	pixel_x = 0
+	pixel_y = 19
 	},
 /obj/item/plant_analyzer{
 	pixel_y = 14;
@@ -67383,7 +67261,6 @@
 /obj/structure/rack/wooden,
 /obj/machinery/newscaster/directional/north,
 /obj/item/storage/box/utensils{
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /turf/open/floor/wood/tile,
@@ -67507,8 +67384,6 @@
 /area/station/commons/fitness/recreation)
 "seE" = (
 /obj/structure/chair/office/light{
-	pixel_x = 0;
-	pixel_y = 0;
 	dir = 4
 	},
 /turf/open/floor/carpet/purple,
@@ -67996,7 +67871,6 @@
 "slq" = (
 /obj/effect/turf_decal/tile/dark_green,
 /obj/machinery/door_buttons/airlock_controller{
-	pixel_x = 0;
 	pixel_y = 24;
 	idSelf = "viro_med_control";
 	name = "Virology Medical Access Control";
@@ -68264,20 +68138,16 @@
 /obj/structure/table,
 /obj/item/stock_parts/subspace/treatment,
 /obj/item/stock_parts/subspace/treatment{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/stock_parts/subspace/transmitter,
 /obj/item/stock_parts/subspace/transmitter{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /obj/item/stock_parts/subspace/transmitter{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/stock_parts/subspace/treatment{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /turf/open/floor/iron/dark,
@@ -68602,7 +68472,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door_buttons/access_button{
-	pixel_x = 0;
 	pixel_y = -21;
 	idSelf = "viro_public_control";
 	req_access = list("virology");
@@ -68712,8 +68581,7 @@
 	pixel_y = 4
 	},
 /obj/item/stock_parts/subspace/analyzer{
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /obj/item/stock_parts/subspace/analyzer{
 	pixel_x = 7;
@@ -69030,8 +68898,7 @@
 	pixel_y = -4
 	},
 /obj/item/lightreplacer{
-	pixel_x = -5;
-	pixel_y = 0
+	pixel_x = -5
 	},
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
@@ -69208,9 +69075,7 @@
 /obj/effect/turf_decal/tile/dark/opposingcorners{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/checker,
 /area/station/security/prison/rec)
 "sAP" = (
@@ -69293,8 +69158,7 @@
 	dir = 8
 	},
 /obj/item/storage/fancy/donut_box{
-	pixel_y = 19;
-	pixel_x = 0
+	pixel_y = 19
 	},
 /obj/structure/table/glass,
 /turf/open/floor/iron/edge{
@@ -70094,8 +69958,7 @@
 	},
 /obj/structure/table,
 /obj/item/flashlight{
-	pixel_y = 10;
-	pixel_x = 0
+	pixel_y = 10
 	},
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/secondary/service)
@@ -70480,7 +70343,6 @@
 	pixel_y = 4
 	},
 /obj/effect/spawner/random/entertainment/toy_figure{
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /obj/item/stock_parts/power_store/cell/high,
@@ -70732,7 +70594,6 @@
 "sVQ" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -72442,8 +72303,7 @@
 "ttu" = (
 /obj/machinery/light/directional/west,
 /obj/item/kirbyplants/random{
-	pixel_x = -4;
-	pixel_y = 0
+	pixel_x = -4
 	},
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/bridge_officer)
@@ -73945,9 +73805,7 @@
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -74614,7 +74472,6 @@
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/sign/painting/library_private{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/wood/tile,
@@ -76550,18 +76407,15 @@
 "uxF" = (
 /obj/structure/sign/directions/security{
 	dir = 1;
-	pixel_y = 10;
-	pixel_x = 0
+	pixel_y = 10
 	},
 /obj/structure/sign/directions/command{
 	dir = 1;
-	pixel_y = 4;
-	pixel_x = 0
+	pixel_y = 4
 	},
 /obj/structure/sign/directions/dorms{
 	dir = 8;
-	pixel_y = -2;
-	pixel_x = 0
+	pixel_y = -2
 	},
 /turf/closed/wall,
 /area/station/common/arcade)
@@ -76888,7 +76742,6 @@
 	pixel_y = 6
 	},
 /obj/item/screwdriver{
-	pixel_x = 0;
 	pixel_y = -9
 	},
 /turf/open/floor/plating,
@@ -77221,7 +77074,6 @@
 	},
 /obj/structure/sign/directions/science/directional/south{
 	dir = 4;
-	pixel_x = 0;
 	pixel_y = -39
 	},
 /turf/open/floor/iron/edge{
@@ -79685,8 +79537,7 @@
 	pixel_y = 3
 	},
 /obj/item/storage/medkit/toxin{
-	pixel_x = 1;
-	pixel_y = 0
+	pixel_x = 1
 	},
 /obj/item/storage/medkit/regular{
 	pixel_x = -3;
@@ -79864,8 +79715,7 @@
 "vqe" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/medkit/combat_surgeon{
-	pixel_y = 4;
-	pixel_x = 0
+	pixel_y = 4
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning,
 /turf/open/floor/iron,
@@ -80275,7 +80125,6 @@
 "vxb" = (
 /obj/structure/table/wood,
 /obj/item/bikehorn{
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /obj/item/storage/box/ingredients/wildcard{
@@ -80699,8 +80548,7 @@
 	dir = 4
 	},
 /obj/item/newspaper{
-	pixel_x = -5;
-	pixel_y = 0
+	pixel_x = -5
 	},
 /obj/item/paper_bin{
 	pixel_y = 6;
@@ -81102,7 +80950,6 @@
 	pixel_y = 13
 	},
 /obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = 0;
 	pixel_y = 8
 	},
 /obj/item/wrench/medical{
@@ -82731,7 +82578,6 @@
 "wdn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /turf/open/floor/iron/checker,
@@ -83562,8 +83408,6 @@
 /area/station/engineering/storage_shared)
 "wpg" = (
 /obj/structure/chair/office/light{
-	pixel_x = 0;
-	pixel_y = 0;
 	dir = 1
 	},
 /obj/effect/landmark/start/bridge_officer,
@@ -84147,8 +83991,7 @@
 	pixel_y = 5
 	},
 /obj/item/stock_parts/micro_laser{
-	pixel_x = 1;
-	pixel_y = 0
+	pixel_x = 1
 	},
 /obj/item/stock_parts/micro_laser{
 	pixel_x = 5;
@@ -85635,7 +85478,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/clothing/gloves/color/yellow{
-	pixel_x = 0;
 	pixel_y = -6
 	},
 /turf/open/floor/engine,
@@ -86525,12 +86367,10 @@
 /obj/structure/rack/shelf,
 /obj/structure/bed/medical/emergency{
 	dir = 4;
-	pixel_x = 0;
 	pixel_y = 10
 	},
 /obj/structure/bed/medical/emergency{
 	dir = 4;
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /obj/structure/bed/medical/emergency{
@@ -87555,7 +87395,6 @@
 	pixel_x = 2
 	},
 /obj/item/reagent_containers/dropper{
-	pixel_y = 0;
 	pixel_x = 2
 	},
 /obj/machinery/reagentgrinder{
@@ -87851,7 +87690,6 @@
 	pixel_y = -2
 	},
 /obj/item/clothing/glasses/meson{
-	pixel_x = 0;
 	pixel_y = 1
 	},
 /obj/item/clothing/glasses/meson{
@@ -88515,7 +88353,6 @@
 /obj/structure/rack/shelf,
 /obj/item/radio/intercom/directional/east,
 /obj/item/shovel/spade{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/item/shovel/spade{
@@ -89130,7 +88967,6 @@
 /obj/machinery/button/curtain{
 	id = "dormscurtain7b";
 	pixel_x = 34;
-	pixel_y = 0;
 	name = "External Curtains"
 	},
 /turf/open/floor/wood/tile,
@@ -89492,8 +89328,7 @@
 	pixel_y = 4
 	},
 /obj/item/assembly/flash/handheld{
-	pixel_x = -5;
-	pixel_y = 0
+	pixel_x = -5
 	},
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/security/breakroom)
@@ -89617,7 +89452,6 @@
 	pixel_x = -9
 	},
 /obj/item/wrench{
-	pixel_y = 0;
 	pixel_x = 4
 	},
 /turf/open/floor/iron/dark/smooth_edge{
@@ -90512,22 +90346,18 @@
 /obj/structure/cable,
 /obj/structure/sign/directions/cryo/directional/north{
 	dir = 2;
-	pixel_x = 0;
 	pixel_y = 29
 	},
 /obj/structure/sign/directions/medical/directional/north{
 	dir = 4;
-	pixel_x = 0;
 	pixel_y = 23
 	},
 /obj/structure/sign/directions/engineering/directional/north{
 	dir = 2;
-	pixel_x = 0;
 	pixel_y = 35
 	},
 /obj/structure/sign/directions/dorms/directional/north{
 	dir = 2;
-	pixel_x = 0;
 	pixel_y = 41
 	},
 /obj/item/clothing/head/cone,
@@ -90539,7 +90369,6 @@
 /obj/structure/table/wood,
 /obj/machinery/airalarm/directional/north,
 /obj/item/storage/box/rubbershot{
-	pixel_x = 0;
 	pixel_y = 10
 	},
 /obj/item/gun/ballistic/shotgun/doublebarrel{
@@ -90658,7 +90487,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/gloves/color/yellow{
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /turf/open/floor/iron/white/smooth_half,
@@ -90815,7 +90643,6 @@
 	},
 /obj/machinery/door_buttons/access_button{
 	pixel_x = 25;
-	pixel_y = 0;
 	idSelf = "viro_med_control";
 	idDoor = "viro_med_internal";
 	req_access = list("virology")


### PR DESCRIPTION
Updates sec locker room access to /brig rather than /general. Closes #6188.

Three maps have general access to the locker room, compared to eight that don't. There is also Serenity, which was inconsistent even within itself.
I've gone with the majority and updated access to be /brig consistently across the board (apart from Catwalk station which will need to be done upstream)

:cl:
fix: Made brig access more consistent across multiple maps
/:cl:
