### PR TITLE
fix: interdyne folded flag name

### DIFF
--- a/modular_nova/modules/aesthetics/flag/code/signs_flags.dm
+++ b/modular_nova/modules/aesthetics/flag/code/signs_flags.dm
@@ -173,7 +173,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/flag/interdyne, 32)
 	sign_path = /obj/structure/sign/flag/syndicate
 
 /obj/item/sign/flag/interdyne
-	name = "folded flag of the Syndicate"
+	name = "folded flag of the Interdyne"
 	desc = "The folded flag of Interdyne Pharmaceutics."
 	icon_state = "folded_coder"
 	sign_path = /obj/structure/sign/flag/interdyne


### PR DESCRIPTION
## About The Pull Request
Fixes folded interdyne flag name

## Proof of Testing
<details>
<summary>Screenshots</summary>
<img width="268" height="123" alt="Screenshot_9" src="https://github.com/user-attachments/assets/60c6d5e5-ae95-4dbd-a387-862c61f6ad75" />
<img width="266" height="125" alt="Screenshot_10" src="https://github.com/user-attachments/assets/2c2b75f5-29ce-41fc-b1d6-a4f7a578a538" />
</details>

## Changelog

:cl:
fix: folded interdyne flag name no longer named as folded flag of the Syndicate
/:cl: