### PR TITLE
Adds round id to the byond window text

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -106,7 +106,7 @@ GLOBAL_VAR(command_name)
 
 	var/config_server_name = CONFIG_GET(string/servername)
 	if(config_server_name)
-		world.name = "[config_server_name][config_server_name == GLOB.station_name ? "" : ": [html_decode(GLOB.station_name)]"]"
+		world.name = "[config_server_name][config_server_name == GLOB.station_name ? "" : ": [html_decode(GLOB.station_name)]"][GLOB.round_id ? " (Round: [GLOB.round_id])" : ""]" // NOVA EDIT CHANGE - ORIGINAL: world.name = "[config_server_name][config_server_name == GLOB.station_name ? "" : ": [html_decode(GLOB.station_name)]"]"
 	else
 		world.name = html_decode(GLOB.station_name)
 


### PR DESCRIPTION
## About The Pull Request

Tin

## How This Contributes To The Nova Sector Roleplay Experience

Being able to see it at a glance is nice.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
<img width="505" height="55" alt="dreamseeker_wVXlIdwvR7" src="https://github.com/user-attachments/assets/910afb77-088d-49d3-a9fa-42de62dd1e4f" />

</details>

## Changelog

:cl:
qol: Round ID now shows in the top byond window text
/:cl: