### PR TITLE
Stops towel runtimes

### DIFF
--- a/modular_nova/master_files/code/modules/clothing/towels.dm
+++ b/modular_nova/master_files/code/modules/clothing/towels.dm
@@ -55,6 +55,8 @@
 	var/max_reagent_volume = 25
 	/// Are we currently wet?
 	var/wet = FALSE
+	/// So we don't runtime whenever certain things check for this
+	var/clothing_flags = NONE
 
 
 /obj/item/towel/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

<img width="573" height="73" alt="image" src="https://github.com/user-attachments/assets/1b1fb756-929d-4767-949c-8098fe14af65" />

Pretty much just adds a clothing_flags var to this so we stop getting this runtime. Since this item can be worn in clothing slots it can sometimes fall victim to not having clothing vars. Should probably just be made into an obj/item/clothing in the future.

## Changelog

Not player-facing