### PR TITLE
(Drifting) Contractor MODsuit/Gear Nth Pass ft. Legally Distinct Soporific Ammo

### DIFF
--- a/modular_nova/modules/ammo_workbench/code/ammo_bench_defines.dm
+++ b/modular_nova/modules/ammo_workbench/code/ammo_bench_defines.dm
@@ -19,6 +19,8 @@ unlocked in the ammo bench.
 #define AMMO_CLASS_NONE			0
 /// This ammo is nonlethal, less-lethal, or otherwise unremarkable in regards to turning men into corpses, but has some niche applications.
 #define AMMO_CLASS_NICHE_LTL	(AMMO_CATEGORY_NICHE)
+/// This ammo is nonlethal, less-lethal, or otherwise unremarkable in regards to turning men into corpses, but is meant to perform better than conventional nonlethal ammunition.
+#define AMMO_CLASS_SUPER_LTL	(AMMO_CATEGORY_SUPER)
 
 // --- Separator between less lethal classes above and lethal classes below. ---
 

--- a/modular_nova/modules/clothing_improvements/code/webbings.dm
+++ b/modular_nova/modules/clothing_improvements/code/webbings.dm
@@ -47,6 +47,9 @@
 		"White" = "thigh_white",
 	)
 
+/obj/item/clothing/accessory/webbing/pouch/black
+	icon_state = "thigh_black"
+
 /obj/item/clothing/accessory/webbing/pilot
 	name = "storage rigging"
 	icon_state = "pilot_webbing1"

--- a/modular_nova/modules/contractor/code/datums/midround/outfit.dm
+++ b/modular_nova/modules/contractor/code/datums/midround/outfit.dm
@@ -16,11 +16,12 @@
 	ears = /obj/item/radio/headset/syndicate/alt
 	l_pocket = /obj/item/modular_computer/pda/contractor
 	id = /obj/item/card/id/advanced/chameleon/elite
+	// this mostly gets set in pre_equip()
 	backpack_contents = list(
 		/obj/item/storage/box/survival/syndie,
 		/obj/item/storage/box/syndicate/contract_kit/midround,
 		/obj/item/storage/box/syndicate/contractor_loadout/stealth_contractor,
-		/obj/item/knife/combat/survival,
+		/obj/item/trench_tool,
 		/obj/item/pinpointer/crew/contractor,
 	)
 
@@ -48,7 +49,7 @@
 		/obj/item/storage/box/syndicate/contractor_loadout/tools,
 		/obj/item/storage/box/syndicate/contract_kit/midround,
 		/obj/item/storage/box/syndicate/contractor_loadout/stealth_contractor,
-		/obj/item/knife/combat/survival,
+		/obj/item/trench_tool, // multipurpose! digging graves. mining rocks. caving in faces. matches survival knife for force
 		/obj/item/pinpointer/crew/contractor,
 	)
 

--- a/modular_nova/modules/contractor/code/datums/midround/outfit.dm
+++ b/modular_nova/modules/contractor/code/datums/midround/outfit.dm
@@ -4,11 +4,13 @@
 	glasses = /obj/item/clothing/glasses/night
 	mask = /obj/item/clothing/mask/neck_gaiter/syndicate
 	back = /obj/item/mod/control/pre_equipped/contractor/upgraded
-	r_pocket = /obj/item/tank/internals/emergency_oxygen/engi
+	box = /obj/item/storage/box/survival/syndie
+	r_pocket = /obj/item/tank/internals/emergency_oxygen/double
 	internals_slot = ITEM_SLOT_RPOCKET
 	belt = /obj/item/storage/belt/military
 
 	uniform = /obj/item/clothing/under/syndicate/nova/tactical
+	accessory = /obj/item/clothing/accessory/webbing/pouch/black
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
 	ears = /obj/item/radio/headset/syndicate/alt
@@ -28,13 +30,31 @@
 
 	id_trim = /datum/id_trim/chameleon/contractor
 
-/datum/outfit/contractor/pre_equip(mob/living/carbon/human/user)
+/datum/outfit/contractor/pre_equip(mob/living/carbon/human/user, visuals_only)
+	. = ..()
 	if(user.jumpsuit_style == PREF_SKIRT)
 		uniform = /obj/item/clothing/under/syndicate/nova/tactical/skirt
 
-/datum/outfit/contractor/post_equip(mob/living/carbon/human/user, visualsOnly)
+	var/obj/item/storage/medkit/suitable_medkit = /obj/item/storage/medkit/tactical_lite
+	var/cyber_limb_amount = 0
+	for(var/obj/item/bodypart/limb as anything in user.bodyparts)
+		if(limb.bodytype & BODYTYPE_ROBOTIC)
+			cyber_limb_amount += 1
+	if(issynthetic(user) || cyber_limb_amount >= 3)
+		suitable_medkit = /obj/item/storage/medkit/robotic_repair/preemo/stocked
+	//set the backpack contents
+	backpack_contents = list(
+		suitable_medkit,
+		/obj/item/storage/box/syndicate/contractor_loadout/tools,
+		/obj/item/storage/box/syndicate/contract_kit/midround,
+		/obj/item/storage/box/syndicate/contractor_loadout/stealth_contractor,
+		/obj/item/knife/combat/survival,
+		/obj/item/pinpointer/crew/contractor,
+	)
+
+/datum/outfit/contractor/post_equip(mob/living/carbon/human/user, visuals_only)
 	. = ..()
-	if(visualsOnly)
+	if(visuals_only)
 		return
 	handlebank(user)
 

--- a/modular_nova/modules/contractor/code/items/boxes.dm
+++ b/modular_nova/modules/contractor/code/items/boxes.dm
@@ -1,4 +1,4 @@
-#define SMALL_ITEM_AMOUNT 3
+#define SMALL_ITEM_AMOUNT 2
 
 /obj/item/storage/box/syndicate/contract_kit
 	desc = "It's just an ordinary box."
@@ -25,22 +25,13 @@
 
 /obj/item/storage/box/syndicate/contract_kit/midround/PopulateContents()
 	var/static/list/item_list = list(
-		/obj/item/storage/backpack/duffelbag/syndie/x4,
 		/obj/item/storage/box/syndie_kit/throwing_weapons,
-		/obj/item/gun/syringe/syndicate,
 		/obj/item/pen/edagger,
 		/obj/item/pen/sleepy,
 		/obj/item/flashlight/emp,
-		/obj/item/reagent_containers/syringe/mulligan,
-		/obj/item/storage/medkit/tactical,
-		/obj/item/clothing/glasses/thermal/syndi,
-		/obj/item/slimepotion/slime/sentience/nuclear,
-		/obj/item/storage/box/syndie_kit/imp_radio,
-		/obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot,
 		/obj/item/reagent_containers/hypospray/medipen/stimulants,
 		/obj/item/storage/box/syndie_kit/imp_freedom,
 		/obj/item/crowbar/power/syndicate,
-		/obj/item/clothing/gloves/tackler/combat/insulated,
 		/obj/item/storage/box/syndie_kit/emp,
 		/obj/item/shield/energy,
 		/obj/item/healthanalyzer/rad_laser,
@@ -49,10 +40,11 @@
 	for(var/iteration in 1 to SMALL_ITEM_AMOUNT)
 		var/obj/item/small_item = pick_n_take(item_list)
 		new small_item(src)
+	// finally. a real gun
+	new /obj/item/storage/toolbox/guncase/traitor/contractor_fisher(src)
 
 	// Paper guide
 	new /obj/item/paper/contractor_guide/midround(src)
-	new /obj/item/fake_identity_kit(src)
 	new /obj/item/reagent_containers/hypospray/medipen/atropine(src)
 	new /obj/item/jammer(src)
 	new /obj/item/storage/fancy/cigarettes/cigpack_syndicate(src)
@@ -71,3 +63,33 @@
 	new /obj/item/clothing/mask/chameleon(src)
 	new /obj/item/clothing/under/chameleon(src)
 	new /obj/item/clothing/shoes/chameleon(src)
+
+/obj/item/storage/box/syndicate/contractor_loadout/tools
+	name = "compact toolbox"
+	desc = "Only a toolbox by technicality, considering it's just a box with tools."
+
+/obj/item/storage/box/syndicate/contractor_loadout/tools/PopulateContents()
+	new /obj/item/screwdriver/nuke(src)
+	new /obj/item/wirecutters(src, "red")
+	new /obj/item/multitool(src)
+	new /obj/item/crowbar/red(src)
+	new /obj/item/wrench(src)
+	new /obj/item/weldingtool/largetank(src)
+	new /obj/item/stack/cable_coil/thirty(src) // dual purpose: cablecuffs or fixing wires. no spare gloves because you already have them
+
+/obj/item/gun/ballistic/automatic/pistol/clandestine/fisher/contractor
+	spawn_magazine_type = /obj/item/ammo_box/magazine/m10mm/downer
+
+/obj/item/storage/toolbox/guncase/traitor/contractor_fisher
+	name = "contractor gun case"
+	weapon_to_spawn = /obj/item/gun/ballistic/automatic/pistol/clandestine/fisher/contractor // preloaded with sleeper bullets
+	extra_to_spawn = /obj/item/ammo_box/magazine/m10mm/downer
+	/// What other magazine do we spawn in our case?
+	var/extra2_to_spawn = /obj/item/ammo_box/magazine/m10mm
+	ammo_box_to_spawn = /obj/item/ammo_box/c10mm/downer
+
+/obj/item/storage/toolbox/guncase/traitor/contractor_fisher/PopulateContents()
+	new weapon_to_spawn (src) // 1 pistol
+	new extra_to_spawn (src) // 1 spare sleeper mag, because oftentimes you'd rather not kill a guy
+	new extra2_to_spawn (src) // 1 spare lethal mag, because sometimes you DO have to just kill a guy
+	new ammo_box_to_spawn(src) // spare sleeper bullets

--- a/modular_nova/modules/contractor/code/items/misc.dm
+++ b/modular_nova/modules/contractor/code/items/misc.dm
@@ -42,13 +42,7 @@
 	return ..()
 
 /obj/item/pinpointer/crew/contractor
-	name = "contractor pinpointer"
-	desc = "A handheld tracking device that locks onto certain signals. Ignores suit sensors, but is much less accurate."
-	icon_state = "pinpointer_syndicate"
-	worn_icon_state = "pinpointer_black"
 	minimum_range = 15
-	has_owner = TRUE
-	ignore_suit_sensor_level = TRUE
 
 /obj/item/extraction_pack/contractor
 	name = "black fulton extraction pack"

--- a/modular_nova/modules/contractor/code/items/modsuit/modsuit.dm
+++ b/modular_nova/modules/contractor/code/items/modsuit/modsuit.dm
@@ -22,16 +22,19 @@
 /obj/item/mod/control/pre_equipped/contractor/upgraded
 	applied_cell = /obj/item/stock_parts/power_store/cell/bluespace
 	applied_modules = list(
-		/obj/item/mod/module/baton_holster/preloaded,
 		/obj/item/mod/module/dna_lock,
 		/obj/item/mod/module/emp_shield,
 		/obj/item/mod/module/shock_absorber,
 		/obj/item/mod/module/quick_cuff,
-		/obj/item/mod/module/jetpack,
+		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/storage/syndicate,
+		/obj/item/mod/module/visor/thermal,
+		/obj/item/mod/module/jetpack,
 		/obj/item/mod/module/flamethrower,
+		/obj/item/mod/module/baton_holster/preloaded,
 	)
 	default_pins = list(
+		/obj/item/mod/module/visor/thermal,
 		/obj/item/mod/module/jetpack,
 		/obj/item/mod/module/baton_holster/preloaded,
 		/obj/item/mod/module/flamethrower,

--- a/modular_nova/modules/contractor/code/items/modsuit/theme.dm
+++ b/modular_nova/modules/contractor/code/items/modsuit/theme.dm
@@ -10,6 +10,7 @@
 		A small tag hangs off of it, reading 'Property of the Gorlex Marauders, with assistance from Cybersun Industries. \
 		All rights reserved, tampering with suit will void warranty.'"
 	default_skin = "contractor"
+	complexity_max = DEFAULT_MAX_COMPLEXITY + 5
 	armor_type = /datum/armor/mod_theme_contractor
 	resistance_flags = FIRE_PROOF
 	atom_flags = PREVENT_CONTENTS_EXPLOSION_1
@@ -17,7 +18,7 @@
 	siemens_coefficient = 0
 	slowdown_deployed = 0
 	ui_theme = "syndicate"
-	inbuilt_modules = list(/obj/item/mod/module/chameleon/contractor)
+	inbuilt_modules = list(/obj/item/mod/module/chameleon/contractor, /obj/item/mod/module/welding/syndicate, /obj/item/mod/module/night, /obj/item/mod/module/hearing_protection,)
 	allowed_suit_storage = list(
 		/obj/item/flashlight,
 		/obj/item/tank/internals,

--- a/modular_nova/modules/modular_weapons/code/modular_projectiles/pistol_calibers.dm
+++ b/modular_nova/modules/modular_weapons/code/modular_projectiles/pistol_calibers.dm
@@ -223,6 +223,17 @@
 	ammo_categories = AMMO_CLASS_NONE
 	harmful = FALSE
 
+/obj/item/ammo_casing/c10mm/downer
+	name = "10mm downer bullet casing"
+	desc = "A 10mm downer bullet casing.\
+		<br><br>\
+		<i>DOWNER: Nonlethal ammo. Deals heavy stamina damage. Fully exhausted targets go to sleep. \
+		Partially exhausted targets have a chance to sleep, scaling with how much exhaustion they have. \
+		Inflicts drowsiness, regardless.</i>"
+	projectile_type = /obj/projectile/bullet/c10mm/downer
+	ammo_categories = AMMO_CLASS_SUPER_LTL
+	harmful = FALSE
+
 /obj/item/ammo_casing/c10mm/reaper
 	can_be_printed = FALSE
 	// it's a hitscan 50 damage 40 AP bullet designed to be fired out of a gun with a 2rnd burst and 1.25x damage multiplier

--- a/modular_nova/modules/modular_weapons/code/modular_projectiles/projectiles.dm
+++ b/modular_nova/modules/modular_weapons/code/modular_projectiles/projectiles.dm
@@ -151,6 +151,7 @@
 		var/mitigate_percent = 1 - (blocked / 100)
 		var/mob/living/living_guy = target
 		// make them drowsy, scaling with how much was mitigated
+		// future todo: revisit this. dizzy/mute on hit? mitigated by armor?
 		living_guy.adjust_drowsiness_up_to(6 SECONDS * mitigate_percent, 12 SECONDS)
 		// and see if we can just sleep them outright:
 		var/stamcritted_target = HAS_TRAIT_FROM(target, TRAIT_INCAPACITATED, STAMINA)
@@ -158,10 +159,12 @@
 		// if they're stamcrit, sleep them
 		if(stamcritted_target)
 			living_guy.Sleeping(10 SECONDS) // long naptime for you, buddy
+			to_chat(living_guy, span_warning("As [src] hits you, you feel the heavy burden of exhaustion quickly set in..."))
 			return
 		// or, if they're exhausted, roll to sleep them for a very short time
 		else if(prob(stamina_ratio))
 			living_guy.Sleeping(1 SECONDS * mitigate_percent) // short naptime but it throws them off something fierce
+			to_chat(living_guy, span_warning("As [src] hits you, you feel exhaustion set in."))
 			return
 
 // 4.6x30mm

--- a/modular_nova/modules/modular_weapons/code/modular_projectiles/projectiles.dm
+++ b/modular_nova/modules/modular_weapons/code/modular_projectiles/projectiles.dm
@@ -139,6 +139,31 @@
 	jostle_pain_mult = 6
 	rip_time = 1 SECONDS
 
+/obj/projectile/bullet/c10mm/downer
+	name = "10mm downer bullet"
+	damage = 45
+	damage_type = STAMINA
+	embed_type = null
+
+/obj/projectile/bullet/c10mm/downer/on_hit(atom/target, blocked = 0, pierce_hit)
+	. = ..()
+	if((blocked != 100) && isliving(target))
+		var/mitigate_percent = 1 - (blocked / 100)
+		var/mob/living/living_guy = target
+		// make them drowsy, scaling with how much was mitigated
+		living_guy.adjust_drowsiness_up_to(6 SECONDS * mitigate_percent, 12 SECONDS)
+		// and see if we can just sleep them outright:
+		var/stamcritted_target = HAS_TRAIT_FROM(target, TRAIT_INCAPACITATED, STAMINA)
+		var/stamina_ratio = (living_guy.getStaminaLoss() / living_guy.getMaxHealth()) * 50 // 100 / 2
+		// if they're stamcrit, sleep them
+		if(stamcritted_target)
+			living_guy.Sleeping(10 SECONDS) // long naptime for you, buddy
+			return
+		// or, if they're exhausted, roll to sleep them for a very short time
+		else if(prob(stamina_ratio))
+			living_guy.Sleeping(1 SECONDS * mitigate_percent) // short naptime but it throws them off something fierce
+			return
+
 // 4.6x30mm
 
 /obj/projectile/bullet/c46x30mm/rubber

--- a/modular_nova/modules/modular_weapons/code/modular_projectiles/projectiles.dm
+++ b/modular_nova/modules/modular_weapons/code/modular_projectiles/projectiles.dm
@@ -158,12 +158,12 @@
 		var/stamina_ratio = (living_guy.getStaminaLoss() / living_guy.getMaxHealth()) * 50 // 100 / 2
 		// if they're stamcrit, sleep them
 		if(stamcritted_target)
-			living_guy.Sleeping(10 SECONDS) // long naptime for you, buddy
+			living_guy.AdjustSleeping(10 SECONDS) // long naptime for you, buddy
 			to_chat(living_guy, span_warning("As [src] hits you, you feel the heavy burden of exhaustion quickly set in..."))
 			return
 		// or, if they're exhausted, roll to sleep them for a very short time
 		else if(prob(stamina_ratio))
-			living_guy.Sleeping(1 SECONDS * mitigate_percent) // short naptime but it throws them off something fierce
+			living_guy.AdjustSleeping(1 SECONDS * mitigate_percent) // short naptime but it throws them off something fierce
 			to_chat(living_guy, span_warning("As [src] hits you, you feel exhaustion set in."))
 			return
 

--- a/modular_nova/modules/sec_haul/code/guns/ammo.dm
+++ b/modular_nova/modules/sec_haul/code/guns/ammo.dm
@@ -18,9 +18,20 @@
 */
 
 /obj/item/ammo_box/c10mm/rubber
-	name = "10mm rubber box"
+	name = "ammo box (10mm rubber)"
 	ammo_type = /obj/item/ammo_casing/c10mm/rubber
 
 /obj/item/ammo_box/c10mm/ihdf
 	name = "ammo box (10mm IHDF)"
 	ammo_type = /obj/item/ammo_casing/c10mm/ihdf
+
+/obj/item/ammo_box/c10mm/downer
+	name = "ammo box (10mm downer)"
+	ammo_type = /obj/item/ammo_casing/c10mm/downer
+
+/obj/item/ammo_box/magazine/m10mm/downer
+	name = "pistol magazine (10mm downer)"
+	desc = parent_type::desc + "<br>Carries rounds which severely exhaust targets. Fully exhausted targets sleep when shot, \
+		while partially exhausted targets have a chance to go to sleep scaling with how exhausted they are."
+	ammo_band_color = COLOR_CARP_LIGHT_BLUE
+	ammo_type = /obj/item/ammo_casing/c10mm/downer


### PR DESCRIPTION
## About The Pull Request
### The MODsuit
The contractor MOD now has the same inbuilt modules (night vision, eye protection, hearing protection) as the other Syndicate MODs (redsuit and elite suit), for parity's sake. This affects both the contractor kit MOD and the drifting contractor's MOD.
The drifting contractor's MOD gets a magnetic harness and a thermal visor; the magnetic harness for the fancy new gun they get, and the thermal visor to match the free set of thermals they get on TG.

### The Gun
Drifting contractors now receive an Ansem/SC with 10mm Downer rounds, which deal a hefty chunk of stamina damage, can deal microsleeps (scaling with how much stamina damage the target has), and inflict longer sleeps if striking a stamcrit opponent. Their guncase comes with a spare 10mm Downer magazine, a regular 10mm magazine, and a spare box of 10mm downer ammo, for a total of 37 (8+1 in gun, 8 in spare mag, 20 in box) downer bullets and 8 regular bullets.

Downer ammo can be printed at an ammo bench, but is flagged as `SUPER_LTL` and thus can only be printed if you have an ammo module capable of printing milspec ammo.

### The Gear
Taking inspiration from NovaSector/NovaSector#6144, drifting contractors now spawn with a box of tools (kitted similarly to a Syndicate toolbox, dropping the spare gloves for a full cable coil), drop pouches attached to their uniform, and a medkit suitable for their biology (or, for synths, a lack thereof). Also removed a redundant false identity kit, which can be found in the stealth kit anyway.

Also they get an entrenching tool instead of a survival knife, now. The entrenching tool matches the damage dealt by the survival knife.

### The Random Goodies
The random gear pool has been trimmed down pretty severely (fun fact: on TG, they don't even have a random gear pool, and in return just consistently have thermals. Perhaps there's a lesson there?). In order to not frontload their gear too much, though, contractors now only receive two random gear items, instead of three.
<details> <summary>Items deleted from the midround's random gear pool</summary>

- X4 duffel (these blow up some pretty significant holes and thus might not be great for retrieving targets alive)
- Dart pistol (good luck finding spare syringes for this, I guess?)
- Mulligan syringe (I feel really indifferent about this item and could reintroduce it as a "bad" loot item.)
- Combat medkit (Somewhat redundant by the combat first aid kit provided as standard. It has more items, yes, but it's still kinda redundant.)
- Thermals (Redundant, suit comes with thermals consistently now.)
- Sentience potion (Felt like a wasted slot?)
- Radio implant (Also felt like a wasted slot.)
- Riot-dart C-20r (Redundant by virtue of 10mm downers)
- Guerilla gloves (the insulated combat tacklers) (you're kinda sorta living and dying in the MOD anyway, aren't you?)
</details>

## How This Contributes To The Nova Sector Roleplay Experience

The MOD: Consistency. If the Syndicate and elite MODs get these, why not the contractor MODs?
The Gun: Contractors have a good baton, yes, but a baton is a lot less effective when you just maintain good spacing from them and give them ten new holes in their chest with a battle rifle or something. It's also oriented towards being nonlethal, anyway. (Unless you, y'know, put in the supplied lethal mag.)
The Gear: If ninjas can get some swanky quality of life starter gear, contractors should get some too.
The Goodies: Okay this one was mostly vibes. I'm open to discussion on this one.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

<img width="708" height="534" alt="image" src="https://github.com/user-attachments/assets/19f08fba-f5af-41bc-9c86-3885ece3800c" />
</details>

## Changelog

:cl:
add: The designs for 10mm "downer" ammunition, specifically for incapacitating and not killing living targets, are now being flashed onto advanced lethal variant modules around the Frontier, including those of Gorlex Marauder manufacture and issue. Downer ammunition is nonlethal, inflicts a hefty chunk of stamina damage, and conditionally makes exhausted targets sleep.
balance: Following a series of complaints from contractors, the Syndicate has updated the standard loadouts issued to their drifting contractors, who now receive a proper medkit, a box of tools, and a real, actual firearm (the Ansem/SC, loaded with 10mm Downer by default).
balance: Drifting contractors' random item pools have been trimmed down a lot, and now only receive 2 items instead of 3.
balance: The contractor MOD as issued to contractors of both drifting and non-drifting varieties now has flash protection, hearing protection, and night-vision suites comparable to their less-stealthy bretheren. Drifting contractors also receive a thermal visor.
/:cl: