### PR TITLE
Fixes some limb-related runtimes

### DIFF
--- a/modular_nova/master_files/code/modules/client/preferences/footstep_sound.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/footstep_sound.dm
@@ -37,10 +37,10 @@
 	var/obj/item/bodypart/leg/left_leg = target.get_bodypart(BODY_ZONE_L_LEG)
 	var/obj/item/bodypart/leg/right_leg = target.get_bodypart(BODY_ZONE_R_LEG)
 	if(islist(footstep_type))
-		left_leg.special_footstep_sounds = footstep_type
-		right_leg.special_footstep_sounds = footstep_type
+		left_leg?.special_footstep_sounds = footstep_type
+		right_leg?.special_footstep_sounds = footstep_type
 	else
-		left_leg.footstep_type = footstep_type
-		right_leg.footstep_type = footstep_type
+		left_leg?.footstep_type = footstep_type
+		right_leg?.footstep_type = footstep_type
 
 	target.footstep_type = footstep_type // We are most likely going to have our legs get replaced during char creation immediately, so this is necessary to apply to any subsequent legs that get added.

--- a/modular_nova/modules/customization/modules/client/augment/limbs.dm
+++ b/modular_nova/modules/customization/modules/client/augment/limbs.dm
@@ -14,6 +14,8 @@
 		var/obj/item/bodypart/new_limb = path
 		var/body_zone = initial(new_limb.body_zone)
 		var/obj/item/bodypart/old_limb = augmented.get_bodypart(body_zone)
+		if(isnull(old_limb))
+			return body_zone
 
 		if(old_limb.limb_id != BODYPART_ID_DIGITIGRADE || supports_digitigrade == FALSE) //Retain digitigrade status
 			old_limb.limb_id = initial(new_limb.limb_id)


### PR DESCRIPTION
## About The Pull Request

Limbs can be null in char creation (e.g. proteans, certain quirks)

Fixes some runtimes that assume there will always be a limb.

## How This Contributes To The Nova Sector Roleplay Experience

Bugfix

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
 

<img width="687" height="51" alt="image" src="https://github.com/user-attachments/assets/9ac380ad-0f4f-4eb4-bd0c-76166d2c2e40" />
 
</details>

## Changelog

:cl:
fix: fixes footstep sounds pref not applying in some rare cases
/:cl:
