### PR TITLE
[BUGFIX] DemonEye eye color change

### DIFF
--- a/modular_nova/modules/deforest_medical_items/code/chemicals/demoneye.dm
+++ b/modular_nova/modules/deforest_medical_items/code/chemicals/demoneye.dm
@@ -62,8 +62,7 @@
 /datum/reagent/drug/demoneye/on_mob_end_metabolize(mob/living/carbon/human/our_guy)
 	. = ..()
 
-	our_guy.eye_color_left = user_left_eye_color
-	our_guy.eye_color_right = user_right_eye_color
+	our_guy.set_eye_color(user_left_eye_color,user_right_eye_color)
 	our_guy.update_body()
 
 	our_guy.sound_environment_override = NONE


### PR DESCRIPTION
## About The Pull Request
DemonEye reagent for some reason didn't update the eye colors back from red when the effect wore off, it's now fixed

## How This Contributes To The Nova Sector Roleplay Experience
Use of cool drugs, d'uh

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
 
Before 
<img width="202" height="120" alt="image" src="https://github.com/user-attachments/assets/bd57bed0-919c-4e02-a4b9-a216fffa2acf" />
After
 
<img width="203" height="117" alt="image" src="https://github.com/user-attachments/assets/0b50a1c0-67a9-46f0-ae5e-337657d04737" />

 Tested it locally, both with heterochromatic and regular chars, the colors turn back to their original one. 
  
  
</details>

## Changelog
:cl:
fix: Eyes return to their original color after DemonEye reagent leaves the mob
/:cl:
