### PR TITLE
explodes the black market ammo module, tunes shotguns some more

### DIFF
--- a/modular_nova/master_files/code/modules/cargo/markets/market_items/weapons.dm
+++ b/modular_nova/master_files/code/modules/cargo/markets/market_items/weapons.dm
@@ -101,12 +101,3 @@
 	price_max = CARGO_CRATE_VALUE * 6
 	availability_prob = 40
 	stock_max = 3
-
-/datum/market_item/weapon/ammobench_lethal_super
-	name = "Ammo Fabricator Advanced Lethal Authentication Module"
-	desc = "A Gorlex Marauders-modified ammunition fabricator module, loaded with the authentication keys for causing lots and lots of problems."
-	item = /obj/item/ammo_workbench_module/lethal_super/evil
-	price_min = CARGO_CRATE_VALUE * 10
-	price_max = CARGO_CRATE_VALUE * 20
-	availability_prob = 20
-	stock_max = 1

--- a/modular_nova/modules/shotgunrebalance/code/shotgun.dm
+++ b/modular_nova/modules/shotgunrebalance/code/shotgun.dm
@@ -23,11 +23,10 @@
 	custom_materials = AMMO_MATS_SHOTGUN
 
 /obj/projectile/bullet/shotgun_slug
-	// tg stats at time of writing: 25 damage, 30 AP
-	// buffed to 50 force, nerfed to 10 AP
-	// for some parity with old stats, except the 10 AP buff
-	damage = 30
-	armour_penetration = 10
+	// tg stats at time of writing: 25 damage, 30 AP, 0 wound bonus, 15 exposed wound bonus
+	// adjustment: +10 damage, to 35, +5 wound bonus, -5 wound bonus (still total 15 wound bonus). keeps the 30 AP to give it an actual niche
+	// wound bonuses still generally favor hitting people in bare limbs for wounds
+	damage = 35
 	wound_bonus = 5
 	exposed_wound_bonus = 10
 
@@ -39,13 +38,14 @@
 
 /obj/projectile/bullet/shotgun_slug/milspec
 	// tg stats at time of writing: 50 damage, 30 AP (inherited from base slugs)
-	// buffed to 60 force, keeps the 30 AP to give it an edge over base, easily produced slugs
-	// also gets extra speed to give it another edge
-	damage = 25
+	// adjustment: -5 damage (still +10 from base slugs), +0.25 speed (tiles/sec?), +10 wound bonus, -10 exposed wound bonus (still 15 total wound bonus)
+	// frankly I think leaving it at 50 would be fine because crewside milspecs should be dead with the same PR this comment is in
+	// *shrug
+	damage = 45
 	armour_penetration = 30
 	speed = 1.5
 	wound_bonus = 10
-	exposed_wound_bonus = 10
+	exposed_wound_bonus = 5
 
 // THE BELOW TWO SLUGS ARE NOTED AS ADMIN ONLY AND HAVE ***EIGHTY*** WOUND BONUS. NOT BARE WOUND BONUS. FLAT WOUND BONUS.
 /obj/item/ammo_casing/shotgun/executioner
@@ -113,7 +113,6 @@
 
 /obj/projectile/bullet/pellet/shotgun_buckshot
 	damage = 5
-	weak_against_armour = TRUE
 	wound_bonus = 5
 	exposed_wound_bonus = 10
 
@@ -125,12 +124,11 @@
 	custom_materials = AMMO_MATS_HEAVY_FAST
 
 /obj/projectile/bullet/pellet/shotgun_buckshot/milspec
-	damage = 6 // 6 * 12 = 72
+	damage = 6 // 6 * 8 = 48
 	damage_falloff_tile = -0.1
 	wound_falloff_tile = -0.25
 	speed = 1.5
 	armour_penetration = 5
-	weak_against_armour = FALSE // lmao
 
 /obj/item/ammo_casing/shotgun/rubbershot
 	name = "rubber shot shell"
@@ -145,7 +143,6 @@
 /obj/projectile/bullet/pellet/shotgun_rubbershot
 	stamina = 10
 	speed = 1
-	weak_against_armour = TRUE
 
 /obj/item/ammo_casing/shotgun/incapacitate
 	name = "incapacitator shell"
@@ -167,16 +164,21 @@
 	custom_materials = AMMO_MATS_SHOTGUN_FLECH
 
 /obj/projectile/bullet/pellet/flechette
+	// tg stats at time of writing: 2 damage, 8 pellets, 30 AP, -0.2 damage falloff 1.2 speed (base projectiles at 1.25), 5 wound bonus, 5 exposed wound bonus
+	// adjustments: +2.5 damage per pellet (4*8=32 pb damage), damage falloff taken to -0.1, exposed wound buffed +5 to 10
+	// pellets, but specialized for AP/embeds. not as good for raw damage but more for making people regret running
 	name = "shredder flechette"
-	damage = 5 // 8*5 = 40 damage but you've got 30 AP which basically smokes most armor
-	damage_falloff_tile = -0.1 // less falloff/longer ranges, though
-	speed = 1.3 // you can have above average projectile speed. as a treat
+	damage = 4
+	damage_falloff_tile = -0.1
+	speed = 1.35 // you can have above average projectile speed. as a treat
 	wound_bonus = 5
 	exposed_wound_bonus = 10
-	// embeds staying untouched because i think they're evil and deserve to wreak havoc
+
+/datum/embedding/bullet/flechette
+	embed_chance = 40 // +15 from tg base (25 embed chance)
 
 /obj/item/ammo_casing/shotgun/flechette/donk
-	ammo_categories = AMMO_CLASS_NONE
+	ammo_categories = AMMO_CLASS_NONE // i mean technically it's lethal or lethal gimmick but... it's a microplastic injection
 
 /obj/item/ammo_casing/shotgun/ion
 	can_be_printed = FALSE // techshell. assumed intended balance being a pain to assemble


### PR DESCRIPTION
## About The Pull Request

About what it says on the tin.
- The milspec ammo module in the black market no longer exists, greatly reducing the amount of milspec ammo that crewside gets to use, because putting it in there was a joke was not the greatest idea.
- Shotgun slugs were brought more line with their TG iteration (which is 30 damage 30 AP) with a +5 damage buff, up from 30 damage 10 AP
    - stats at time of writing: 35 damage 30 AP, 5 wound bonus 10 exposed wound bonus (up from 30 damage, 10 AP, 
- milspec slugs also brought more in line with their TG iteration (which is 50 damage 30 AP), but tuned a bit downward (-5 damage)
    - stats at time of writing: 45 damage, 30 AP, 10 wound bonus 5 exposed wound bonus
- buckshot and rubber shot are no longer weak against armor because everything else was downtuned
- shredder flechettes nerfed a bit from 5 damage to 4 damage (still up from their TG iteration, at 2) but they still have good wounding. also buffed their embed chance to give them their niche of "explodes armor. embeds well. less pure damage than buckshot but the second order effects will hurt you badly"
    - stats at time of writing: 4 damage, 8 pellets, 32 theoretical max on PB, -0.1 damage lost per tile, 5 wound bonus 10 exposed wound bonus

Wounding chances on these probably need a lot of downtuning, though.

## How This Contributes To The Nova Sector Roleplay Experience

Blowing up the marauder ammo bench: If we take the infinite evil super ammo away from crewside, maybe they won't be so inclined to run the evil super ammo so consistently.

A general comment on shotguns: Crewside ballistics making everything into an alpha strike simulator was a bad thing, so the first downtune pass was needed, even if I don't strictly agree with a lot of the downtuning. However, it made shotguns literally do less damage than the handcannon ammo (.585 Trappiste) that every metamancer and their dog runs. This sucks. I hate the Johnny Silverhand LARP gun.

Shotgun slugs: tuning them more in line with TG's iteration gives it more of an actual niche, like "good for dealing with armor". Same for milspec slugs. Why would the evil super ammo do less damage than the base variant? Why even run milspecs at that point. This sucks. It's stupid and it sucks.

Buckshot/rubbershot losing armor weakness: Makes it so that running magnum blockshot is no longer a strict necessity for dealing with armor anywhere above "sneezing kills you". Magbuck keeps its 5 AP, so does milspec buck.

Shredder/black flechette tuning: Makes shredder flechettes the anti-armor pelletshot they were meant to be. Probably could use more experimenting with embedding.

Wound chances across the board for ammo (and guns, probably) should probably be adjusted, though this may be out of scope.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
<img width="500" height="357" alt="image" src="https://github.com/user-attachments/assets/b691e1c3-a10e-4a20-8b5b-194a574109ce" />

</details>

## Changelog

:cl:
balance: The Gorlex Marauders have redoubled efforts to reduce pilfering from their ammo workbench module resupply shipments, effectively taking the marauder advanced lethal ammo workbench module off the frontier's black markets.
balance: Shotgun shells have been adjusted, with the most drastic change being on shotgun slugs, going from 30 damage 10 AP to 35 damage 30 AP, giving them more of an anti-armor niche. Some other shotguns may have been touched, see PR 6371 for details as they come along.
/:cl:
