### PR TITLE
Fix cryo announcing cafe job instead station one + borgs job tittle

### DIFF
--- a/modular_nova/modules/cryosleep/code/cryopod.dm
+++ b/modular_nova/modules/cryosleep/code/cryopod.dm
@@ -382,7 +382,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 		if(current_highpriest?.resolve() == mob_occupant)
 			reset_religion()
 
-	// NOVA MODULE EDIT: PLEXAGON_SELFSERVE
 	var/obj/item/card/id/auth_card = mob_occupant.get_idcard()
 	var/off_duty_component = auth_card?.GetComponent(/datum/component/off_duty_timer)
 	var/datum/id_trim/job/plexagon_selfserve_target_trim = /datum/computer_file/program/crew_self_serve::target_trim
@@ -390,23 +389,23 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 	var/announce_rank = null
 	// It is possible to join round from ghost cafe without leaving it. So we prioritize general manifest first to avoid ghost roles announcements IC.
 	for(var/datum/record/crew/possible_target_record as anything in GLOB.manifest.general)
-		if(possible_target_record.name == occupant_name && (occupant_rank == "N/A" || possible_target_record.trim == occupant_rank))
-			announce_rank = possible_target_record.rank
-			qdel(possible_target_record)
-			break
+		if (possible_target_record.name != occupant_name)
+			continue
 
-		// NOVA MODULE EDIT: PLEXAGON_SELFSERVE
+		var/match_rank = occupant_rank == "N/A" || possible_target_record.trim == occupant_rank
 		// Off-duty crew manifest changed to Assistant trim and assignment. It doesn't work for off-duties without ID, but oh well.
-		else if(off_duty_component && possible_target_record.name == occupant_name && possible_target_record.trim == plexagon_selfserve_target_trim.assignment)
+		var/match_offduty = off_duty_component && possible_target_record.trim == plexagon_selfserve_target_trim.assignment
+
+		if(match_rank || match_offduty)
 			announce_rank = possible_target_record.rank
 			qdel(possible_target_record)
 			break
 
 	if(!announce_rank) // No need to loop over all of those if we already found it beforehand.
-		for(var/list/record in GLOB.ghost_records)
+		for(var/list/record as anything in GLOB.ghost_records)
 			if(record["name"] == occupant_name)
 				announce_rank = record["rank"]
-				GLOB.ghost_records.Remove(list(record))
+				GLOB.ghost_records -= record
 				break
 
 	// Borgs job var is null for some reason, and they are not in records, so we handle them separately.


### PR DESCRIPTION
## About The Pull Request
You can join ghost cafe
Then respawn ingame and leave via cryo.
It will search through ghost records first and will handle it before station ones.
Announce and remove ghost cafe job. So this should fix it...

Also it will announce borgs job with their designation
Because borgs not on manifest at all.

Look changelog
## How This Contributes To The Nova Sector Roleplay Experience
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: Cryo pod will report borgs job instead of [NO DATA]
fix: Cryo pod SHOULD stop reporting crew members by ghost role titles... No guaranties though. 
qol: Cryo pod will announce punched out crew jobs correctly.
/:cl:
