### PR TITLE
[Balance] Floor Safes are now visible with a T Ray Scanner

### DIFF
--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -305,7 +305,7 @@ FLOOR SAFES
 
 /obj/structure/safe/floor/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/undertile)
+	AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE) // NOVA EDIT CHANGE - ORIGINAL: AddElement(/datum/element/undertile)
 
 /obj/structure/safe/floor/open
 	open = TRUE


### PR DESCRIPTION

## About The Pull Request
Changes the element of floor safes to be T ray detectable.

## How This Contributes To The Nova Sector Roleplay Experience

We had some incidents with hidden floor safes by mapers that you wouldnt find if you didnt opened the map files and checked it was there. This is to address that problem, and will curtail any attempt to hide gamer gear in select corners without assistants eventually finding it out. 
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="711" height="716" alt="image" src="https://github.com/user-attachments/assets/79f56bf3-44fe-4141-85dc-1f0fa8deb0e9" />


</details>

## Changelog
:cl:
balance: Floor safes can now be detected with t ray scanners.
/:cl:
