### PR TITLE
Tarkon Driver issue fix

### DIFF
--- a/_maps/shuttles/nova/ruin_tarkon_driver.dmm
+++ b/_maps/shuttles/nova/ruin_tarkon_driver.dmm
@@ -340,9 +340,6 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)
 "Pn" = (
-/obj/machinery/power/smes/engineering{
-	input_level = 5000
-	},
 /obj/machinery/power/smes/tarkon_driver,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/tarkon_driver)


### PR DESCRIPTION
## About The Pull Request
This PR removes one in two SMESes on Tarkon Driver which located on the single tile.

<img width="373" height="328" alt="image" src="https://github.com/user-attachments/assets/ed4d94cb-b61a-4017-a6f9-c00b4b5884ef" />

## How This Contributes To The Nova Sector Roleplay Experience
It fixes old Tarkon Driver issue.

## Proof of Testing
There is nothing to test, i think.

## Changelog

:cl:
fix: Tarkon Driver now don't have two SMESes on the same tile
/:cl:

