### PR TITLE
Fixes Bitrunners Not Having ORM Access on Blueshift

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -55857,8 +55857,7 @@
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
-/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/iron/dark/small,
 /area/station/cargo/miningoffice)
 "kFe" = (
@@ -110012,8 +110011,7 @@
 /obj/machinery/door/airlock/mining{
 	name = "Mining Office"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
-/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/iron/dark/small,
 /area/station/cargo/miningoffice)
 "uWe" = (


### PR DESCRIPTION
## About The Pull Request

swaps the mining to general cargo access for the room with the ORM.

## How This Contributes To The Nova Sector Roleplay Experience

bitrunners need to drop their stuff off too, apparently. nerds. they don't get mining access unless skeleton crew, and having the room gated off is a bit odd, so we're swapping those around a bit.

## Proof of Testing

n/a

## Changelog
:cl:
fix: bitrunners can now get to the orm on blueshift.
/:cl:
