### PR TITLE
db schema warning fix

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -20,7 +20,7 @@
  *
  * make sure you add an update to the schema_version stable in the db changelog
  */
-#define DB_MINOR_VERSION 36 // NOVA EDIT CHANGE - ORIGINAL: #define DB_MINOR_VERSION 32
+#define DB_MINOR_VERSION 37 // NOVA EDIT CHANGE - ORIGINAL: #define DB_MINOR_VERSION 33
 
 
 //! ## Timing subsystem


### PR DESCRIPTION

## About The Pull Request

bumps subsystem.dm's db shema version to 5.37 -- the schema was already updated but this file was still on .36. one less admin warning at round start.

## Changelog
not player facing.
