### PR TITLE
Police Whistles can be added to the sec belt

### DIFF
--- a/code/datums/storage/subtypes/belts.dm
+++ b/code/datums/storage/subtypes/belts.dm
@@ -112,7 +112,7 @@
 		/obj/item/restraints/handcuffs,
 		/obj/item/restraints/legcuffs/bola,
 		/obj/item/gun, // NOVA EDIT - ADDITION
-		/obj/item/clothing/mask/whistle,
+		/obj/item/clothing/mask/whistle, // NOVA EDIT - ADDITION
 	))
 
 ///Webbing security belt


### PR DESCRIPTION

## About The Pull Request

adds the police whistle to the list of accepted items for the security belt
## How This Contributes To The Nova Sector Roleplay Experience

i should be able to put a small whistle in my belt
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  

https://github.com/user-attachments/assets/50f80926-9bba-44b6-954c-1998a4cee8db


</details>

## Changelog
:cl:
add: police whistles can now be added to security belts
/:cl:
