### PR TITLE
paperwork crate usability and xenoarch rock brushing changes

### DIFF
--- a/modular_nova/master_files/code/modules/paperwork/folders_premade.dm
+++ b/modular_nova/master_files/code/modules/paperwork/folders_premade.dm
@@ -1,0 +1,12 @@
+/obj/item/folder/ancient_paperwork/five
+	name = "packed dusty folder"
+	desc = "You're pretty sure folders shouldn't be packed this full, especially if they look this old."
+
+/obj/item/folder/ancient_paperwork/five/Initialize(mapload)
+	. = ..()
+	// as we inherit the previous init, which generates one ancient paperwork, we initialize 4 more for 5 total
+	new /obj/item/paperwork/ancient(src)
+	new /obj/item/paperwork/ancient(src)
+	new /obj/item/paperwork/ancient(src)
+	new /obj/item/paperwork/ancient(src)
+	update_appearance()

--- a/modular_nova/modules/cargo/code/goodies.dm
+++ b/modular_nova/modules/cargo/code/goodies.dm
@@ -85,7 +85,8 @@
 			attempts at intellectual posturing, nor any actual job experience as a curator."
 	cost = PAYCHECK_CREW * 15 // 750 credits but you also theoretically print a lot of money if you consistently get/scan relics
 	contains = list(/obj/item/skillchip/xenoarch_magnifier,
-				/obj/item/glassblowing/magnifying_glass,)
+				/obj/item/glassblowing/magnifying_glass,
+			)
 
 /datum/supply_pack/goody/scratching_stone
 	name = "Scratching Stone"

--- a/modular_nova/modules/cargo/code/goodies.dm
+++ b/modular_nova/modules/cargo/code/goodies.dm
@@ -78,12 +78,14 @@
 	contains = list(/obj/item/paper_bin)
 
 /datum/supply_pack/goody/xenoarch_intern
-	name = "Xenoarchaeology Intern Skillchip"
-	desc = "A skillchip with all the information required to start dabbling in the fine art of interpreting xenoarchaeological finds. \
-			Does not come with actual xenoarchaeological tools, nor the ability to actually make anyone pay attention to one's \
+	name = "Xenoarchaeology Intern Skillchip Set"
+	desc = "A skillchip with all the information required to start dabbling in the fine art of interpreting xenoarchaeological finds, \
+			and a magnifying glass for actually analyzing your finds. \
+			Does not come with actual excavation tools, nor the ability to actually make anyone pay attention to one's \
 			attempts at intellectual posturing, nor any actual job experience as a curator."
-	cost = PAYCHECK_CREW * 35 // 1750 credit goody? do bounties
-	contains = list(/obj/item/skillchip/xenoarch_magnifier)
+	cost = PAYCHECK_CREW * 15 // 750 credits but you also theoretically print a lot of money if you consistently get/scan relics
+	contains = list(/obj/item/skillchip/xenoarch_magnifier,
+				/obj/item/glassblowing/magnifying_glass,)
 
 /datum/supply_pack/goody/scratching_stone
 	name = "Scratching Stone"

--- a/modular_nova/modules/cargo/code/packs.dm
+++ b/modular_nova/modules/cargo/code/packs.dm
@@ -790,7 +790,7 @@
 	desc = "Hey, we've apparently got a backlog of paperwork here. It's pretty bad. \
 		If you guys could pay the shuttle guys to look the other way, and help us fill it out so we can file this stuff away, \
 		it'll look a lot nicer on our quarterly reports... which means we can justify putting a few extra credits in your budget. \
-		Thanks."
+		Thanks. For your convenience, we've repacked it into a single large folder. Be careful with it."
 	cost = CARGO_CRATE_VALUE * 5
 	/*
 	one properly stamped paperwork is CARGO_CRATE_VALUE * 4.
@@ -799,7 +799,7 @@
 	5 paperworks for 20 crates (4000cr), initial cost of 5 crates (1000cr), profit of 15 crates (3000cr)
 	*/
 	contains = list(
-		/obj/item/folder/ancient_paperwork = 5
+		/obj/item/folder/ancient_paperwork/five,
 	)
 
 /*

--- a/modular_nova/modules/xenoarch/code/modules/research/xenoarch/strange_rock.dm
+++ b/modular_nova/modules/xenoarch/code/modules/research/xenoarch/strange_rock.dm
@@ -131,24 +131,26 @@
 /obj/item/xenoarch/strange_rock/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	if(istype(tool, /obj/item/xenoarch/hammer))
 		var/obj/item/xenoarch/hammer/xeno_hammer = tool
-		to_chat(user, span_notice("You begin carefully using your hammer."))
+		user.balloon_alert(user, "carefully hammering...")
 		var/skill_modifier = user.mind?.get_skill_modifier(/datum/skill/archeology, SKILL_SPEED_MODIFIER)
 		if(!do_after(user, xeno_hammer.dig_speed * skill_modifier, target = src))
-			to_chat(user, span_warning("You interrupt your careful planning, damaging the rock in the process!"))
+			user.balloon_alert(user, "interrupted, rock damaged!")
 			dug_depth += rand(1,5)
 			return ITEM_INTERACT_BLOCKING
 
 		switch(try_dig(xeno_hammer.dig_amount))
 			if(DIG_UNDEFINED)
+				user.balloon_alert(user, "something broke (oops)!")
 				message_admins("Tell coders something broke with xenoarch hammers and dig amount.")
 				return ITEM_INTERACT_BLOCKING
 
 			if(DIG_DELETE)
+				user.balloon_alert(user, "rock crumbles badly!")
 				to_chat(user, span_warning("The rock crumbles, leaving nothing behind."))
 				return ITEM_INTERACT_BLOCKING
 
 			if(DIG_ROCK)
-				to_chat(user, span_notice("You successfully dig around the item."))
+				user.balloon_alert(user, "item excavated successfully")
 				user.mind?.adjust_experience(/datum/skill/archeology, 5)
 				return ITEM_INTERACT_BLOCKING
 
@@ -156,64 +158,69 @@
 
 	if(istype(tool, /obj/item/xenoarch/brush))
 		var/obj/item/xenoarch/brush/xeno_brush = tool
-		to_chat(user, span_notice("You begin carefully using your brush."))
+		user.balloon_alert(user, "carefully brushing...")
 		var/skill_modifier = user.mind?.get_skill_modifier(/datum/skill/archeology, SKILL_SPEED_MODIFIER)
 		if(!do_after(user, xeno_brush.dig_speed * skill_modifier, target = src))
-			to_chat(user, span_warning("You interrupt your careful planning, damaging the rock in the process!"))
+			user.balloon_alert(user, "interrupted, rock damaged!")
 			dug_depth += rand(1,5)
 			return ITEM_INTERACT_BLOCKING
 
 		switch(try_uncover())
 			if(BRUSH_DELETE)
-				to_chat(user, span_warning("The rock crumbles, leaving nothing behind."))
+				user.balloon_alert(user, "rock crumbles badly!")
 				return ITEM_INTERACT_BLOCKING
 
 			if(BRUSH_UNCOVER)
-				to_chat(user, span_notice("You successfully brush around the item, fully revealing the item!"))
+				user.balloon_alert(user, "item extracted successfully")
 				user.mind?.adjust_experience(/datum/skill/archeology, 10)
 				return ITEM_INTERACT_BLOCKING
 
 			if(BRUSH_NONE)
-				to_chat(user, span_notice("You brush around the item, but it wasn't revealed... hammer some more."))
+				user.balloon_alert(user, "rock needs more brushing")
 				user.mind?.adjust_experience(/datum/skill/archeology, 2)
 				return ITEM_INTERACT_BLOCKING
 
 		return ITEM_INTERACT_BLOCKING
 
 	if(tool.type == /obj/item/xenoarch)
-		to_chat(user, span_notice("You begin carefully using your measuring tape."))
+		if(measured)
+			user.balloon_alert(user, "rock already marked!")
+			return ITEM_INTERACT_BLOCKING
+
+		user.balloon_alert(user, "affixing holo measuring tape...")
 		var/skill_modifier = user.mind?.get_skill_modifier(/datum/skill/archeology, SKILL_SPEED_MODIFIER)
 		if(!do_after(user, 4 SECONDS * skill_modifier, target = src))
-			to_chat(user, span_warning("You interrupt your careful planning, damaging the rock in the process!"))
+			user.balloon_alert(user, "interrupted, rock damaged!")
 			dug_depth += rand(1,5)
 			return ITEM_INTERACT_BLOCKING
 
 		if(get_measured())
-			to_chat(user, span_notice("You successfully attach a holo measuring tape to the strange rock; the strange rock will now report its dug depth always!"))
+			user.balloon_alert(user, "rock reporting excavation")
 			user.mind?.adjust_experience(/datum/skill/archeology, 5)
 			return ITEM_INTERACT_BLOCKING
 
-		to_chat(user, span_warning("The strange rock was already marked with a holo measuring tape."))
-		return ITEM_INTERACT_BLOCKING
 
 	if(istype(tool, /obj/item/xenoarch/handheld_scanner))
 		var/obj/item/xenoarch/handheld_scanner/item_scanner = tool
-		to_chat(user, span_notice("You begin to scan [src] using [item_scanner]."))
+		user.balloon_alert(user, "scanning...")
 		var/skill_modifier = user.mind?.get_skill_modifier(/datum/skill/archeology, SKILL_SPEED_MODIFIER)
 		if(!do_after(user, item_scanner.scanning_speed * skill_modifier, target = src))
-			to_chat(user, span_warning("You interrupt your scanning, damaging the rock in the process!"))
+			user.balloon_alert(user, "interrupted, rock damaged!")
 			dug_depth += rand(1,5)
 			return ITEM_INTERACT_BLOCKING
 
 		if(get_scanned(item_scanner.scan_advanced))
-			to_chat(user, span_notice("You successfully attach a holo scanning module to the strange rock; the strange rock will now report its depth information always!"))
+			var/report_string = "rock scanned"
 			user.mind?.adjust_experience(/datum/skill/archeology, 5)
 			if(adv_scanned)
-				to_chat(user, span_notice("The rock's item depth is being reported!"))
-
+				report_string += ", reporting depth"
+				if(get_measured())
+					report_string += " and excavation"
+					user.mind?.adjust_experience(/datum/skill/archeology, 5)
+			user.balloon_alert(user, report_string)
 			return ITEM_INTERACT_BLOCKING
 
-		to_chat(user, span_warning("The strange rock was already marked with a holo scanning module."))
+		user.balloon_alert(user, "rock already tagged!")
 		return ITEM_INTERACT_BLOCKING
 
 //turfs

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7346,6 +7346,7 @@
 #include "modular_nova\master_files\code\modules\pai\card.dm"
 #include "modular_nova\master_files\code\modules\paperwork\employment_contract.dm"
 #include "modular_nova\master_files\code\modules\paperwork\fax.dm"
+#include "modular_nova\master_files\code\modules\paperwork\folders_premade.dm"
 #include "modular_nova\master_files\code\modules\paperwork\paperplane.dm"
 #include "modular_nova\master_files\code\modules\paperwork\stamps.dm"
 #include "modular_nova\master_files\code\modules\power\cable.dm"


### PR DESCRIPTION
## About The Pull Request
- The paperwork in paperwork crates now only comes in one big folder. It still comes with five ancient paperworks, though.
- Xenoarch rock brushing now uses balloon alerts instead of to_chats.
- Scanning xenoarch rocks with the advanced scanner now also gives the measurement like the measuring tape.
- The xenoarch internship skillchip is now much cheaper and gives a magnifying glass.

## How This Contributes To The Nova Sector Roleplay Experience
The paperwork thing is because having a bajillion folders kinda sucks, honestly, that was my bad.
The rock brushing things are just because they annoyed me, especially the advanced scanner not giving dig size.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

<img width="401" height="213" alt="image" src="https://github.com/user-attachments/assets/e882c28f-5591-478c-a99c-4707adcd8b1a" />

</details>

## Changelog

:cl:
qol: Xenoarch rock brushing now uses balloon alerts instead of to_chats.
qol: The handheld xenoarch advanced scanner now also gives the dig measurement, as if you used a measuring tape on it.
balance: The xenoarch intern skillchip in the goodies tab now gives you a magnifying glass as well.
/:cl:
