### PR TITLE
small hellfire capacity shuffling

### DIFF
--- a/modular_nova/modules/blueshield/code/blueshield.dm
+++ b/modular_nova/modules/blueshield/code/blueshield.dm
@@ -89,9 +89,7 @@
 
 /// Blueshield's Custom Hellfire
 /obj/item/ammo_casing/energy/laser/hellfire/blueshield
-	projectile_type = /obj/projectile/beam/laser/hellfire
-	e_cost = LASER_SHOTS(25, STANDARD_CELL_CHARGE)
-	select_name = "maim"
+	e_cost = LASER_SHOTS(20, STANDARD_CELL_CHARGE)
 
 /obj/item/gun/energy/laser/hellgun/blueshield
 	name = "streamlined hellfire laser carbine"
@@ -109,13 +107,13 @@
 	lefthand_file = 'modular_nova/modules/modular_items/icons/inhand/mobs/lefthand_remote.dmi'
 	righthand_file = 'modular_nova/modules/modular_items/icons/inhand/mobs/righthand_remote.dmi'
 	company_source = "Nanotrasen Rapid Equipment Deployment Division"
-	company_message = span_bold("Supply Pod incoming, please stand by.")
+	company_message = span_bold("Supply pod incoming, please stand by.")
 
 /obj/item/choice_beacon/blueshield/generate_display_names()
 	var/static/list/selectable_gun_types = list(
 		"Blueshield Energy Shield" = /obj/item/shield/energy/returning/blueshield,
 		"Fendér Revolver Set" = /obj/item/storage/toolbox/guncase/nova/pistol/trappiste_small_case/bluvolva,
-		"Custom Hellfire Laser Rifle" = /obj/item/gun/energy/laser/hellgun/blueshield,
+		"Custom Hellfire Laser Carbine" = /obj/item/gun/energy/laser/hellgun/blueshield,
 		"NT20 Submachinegun Gunset" = /obj/item/storage/toolbox/guncase/nova/ntspecial/nt20,
 		"Katyusha Shotgun Gunset" = /obj/item/storage/toolbox/guncase/nova/katyusha,
 	)

--- a/modular_nova/modules/modular_weapons/code/overrides/energy.dm
+++ b/modular_nova/modules/modular_weapons/code/overrides/energy.dm
@@ -11,6 +11,9 @@
 		This pattern of laser gun became infamous for the gruesome burn wounds it caused, \
 		and was quietly pushed to the sidelines once it began to affect Allstar's reputation."
 
+/obj/item/gun/energy/laser/captain
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/hellfire/blueshield) // 20 hellfires up from 15
+
 /obj/item/gun/energy/laser/carbine
 	name = "laser auto-carbine"
 	desc = "The Allstar Lasers Star Combat 1-Auto, or \"Allstar SC-1A\", \
@@ -29,7 +32,6 @@
 /obj/item/ammo_casing/energy/laser
 	e_cost = LASER_SHOTS(20, STANDARD_CELL_CHARGE)
 	// up from LASER_SHOTS(12, STANDARD_CELL_CHARGE)
-	select_name = "kill"
 
 /obj/item/ammo_casing/energy/laser/hos
 	e_cost = LASER_SHOTS(25, STANDARD_CELL_CHARGE * 1.2)
@@ -46,7 +48,6 @@
 /obj/item/ammo_casing/energy/laser/hellfire
 	e_cost = LASER_SHOTS(15, STANDARD_CELL_CHARGE)
 	// up from LASER_SHOTS(10, STANDARD_CELL_CHARGE)
-	select_name = "maim"
 
 /obj/item/ammo_casing/energy/lasergun
 	e_cost = LASER_SHOTS(25, STANDARD_CELL_CHARGE)


### PR DESCRIPTION
## About The Pull Request

Blueshield's hellfire laser capacity dropped to 20, from 25. It's still got more shots than the standard hellfire, which has 15.
Cap's laser buffed to 20, from 15. It also still shoots hellfires.

## How This Contributes To The Nova Sector Roleplay Experience

Cap's laser requiring you to break into the captain's office and/or kill the captain to steal their gun, I think, justifies it punching above its weight class in regards to lasers.
Blueshield always having a better roundstart gun is... probably pretty questionable. However, they probably shouldn't have a laser gun with nearly double the capacity of a regular variant.

## Changelog

:cl:
balance: Blueshield's hellfire laser capacity reduced to 20 shots at full (from 25), cap's laser buffed to 20 shots at full (from 15).
/:cl:
