### PR TITLE
Lengthens Soulcatcher Room Descriptions

### DIFF
--- a/modular_nova/modules/modular_implants/code/soulcatcher/soulcatcher_tgui.dm
+++ b/modular_nova/modules/modular_implants/code/soulcatcher/soulcatcher_tgui.dm
@@ -106,7 +106,7 @@
 			return TRUE
 
 		if("redescribe_room")
-			var/new_room_desc = tgui_input_text(user,"Choose a new description for the room", name, target_room.room_description, max_length = MAX_DESC_LEN, multiline = TRUE)
+			var/new_room_desc = tgui_input_text(user,"Choose a new description for the room", name, target_room.room_description, max_length = MAX_MESSAGE_LEN, multiline = TRUE)
 			if(!new_room_desc)
 				return FALSE
 


### PR DESCRIPTION
## About The Pull Request

At one point these were long. They are now short, and 280 characters is weak when you're trying to set up a whole room's description. Especially when you're already a touch over that.

<img width="292" height="29" alt="image" src="https://github.com/user-attachments/assets/b01ee2b1-7c5b-44a3-8c58-81fa7801a59c" />


 Bumping this back to 2048.

## How This Contributes To The Nova Sector Roleplay Experience

Better roleplay potential.


## Changelog
:cl:
qol: Soulcatchers now support room descriptions of 2048 characters, up from 280.
/:cl:
