### PR TITLE
[Tarkon] Removes all hidden gear from PT

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/port_tarkon.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/port_tarkon.dmm
@@ -1531,7 +1531,7 @@
 "WT" = (/obj/item/shard,/turf/open/floor/plating,/area/ruin/space/has_grav/port_tarkon/developement)
 "WU" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/structure/cable,/obj/effect/turf_decal/tile/neutral/half{dir = 8},/obj/structure/disposalpipe/segment{dir = 10},/turf/open/floor/iron,/area/ruin/space/has_grav/port_tarkon/forehall)
 "WV" = (/obj/machinery/cryopod{dir = 4},/obj/effect/turf_decal/tile/neutral/half{dir = 8},/turf/open/floor/iron,/area/ruin/space/has_grav/port_tarkon/forehall)
-"WW" = (/obj/machinery/shower/directional/south,/obj/structure/curtain/cloth,/turf/open/floor/iron/white,/area/ruin/space/has_grav/port_tarkon/dorms)
+"WW" = (/obj/machinery/shower/directional/south,/obj/structure/curtain/cloth,/obj/item/bikehorn/rubberducky,/turf/open/floor/iron/white,/area/ruin/space/has_grav/port_tarkon/dorms)
 "WX" = (/obj/effect/turf_decal/tile/blue/half{dir = 1},/obj/structure/chair/sofa/corp,/turf/open/floor/iron/white,/area/ruin/space/has_grav/port_tarkon/trauma)
 "WZ" = (/obj/structure/sink/directional/west,/obj/structure/mirror/directional/east,/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 1},/turf/open/floor/iron/white/diagonal,/area/ruin/space/has_grav/port_tarkon/apartment)
 "Xa" = (/obj/machinery/light/directional/south,/turf/open/floor/iron/white,/area/ruin/space/has_grav/port_tarkon/dorms)


### PR DESCRIPTION
## About The Pull Request
## How This Contributes To The Nova Sector Roleplay Experience
I removed all the floor safes from Port Tarkon, they had either copies of gear they alreayd had in possesion, like second duplicates of stuff they have in actual visible safes, like the tarkon boards and what not, to slightly higher gear like variant pka's, mosin kits, extra diamonds and bluespace crystals (on top of the already ridiculous amount tarkon starts with) to outright 50k in extra money. I would advice not reading the PR and going straight to them, as starting this moment opening those safes will be adminhelped.

I also removed the sneaked in Tarkon Powerators, we SPECIFICALLY nerfed them to 1 from 3, I am not amused they were snuck back in, specially with no documentation or asking the mantainer team.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: removed tarkon secret gamer gear. Reinstated Tarkon powerators from 3 to 1, as it was an error reverting them back to 3.
qol: added rubber duck to tarkon showers.
/:cl:
