### PR TITLE
[Tarkon] Removes Tarkon Secret Safes and restore Powerator to 1

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/port_tarkon.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/port_tarkon.dmm
@@ -1025,11 +1025,6 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 4
 	},
-/obj/structure/safe/floor,
-/obj/item/circuitboard/machine/circuit_imprinter,
-/obj/item/circuitboard/machine/protolathe/tarkon,
-/obj/item/circuitboard/computer/tarkon_driver,
-/obj/item/circuitboard/machine/rdserver/tarkon,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/comms)
@@ -1107,12 +1102,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/centerhall)
-"eT" = (
-/obj/structure/safe/floor,
-/obj/item/gun/ballistic/shotgun/doublebarrel,
-/obj/item/crafting_conversion_kit/mosin_pro,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/port_tarkon/secoff)
 "eU" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/brown/half{
@@ -1120,18 +1109,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/storage)
-"eV" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 1
-	},
-/obj/structure/safe/floor,
-/obj/item/flatpacked_machine/ore_thumper,
-/obj/item/flatpacked_machine/ore_thumper,
-/obj/item/flatpacked_machine/ore_thumper,
-/obj/item/flatpacked_machine/ore_thumper,
-/obj/item/pipe_dispenser/bluespace,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/port_tarkon/atmos)
 "eW" = (
 /obj/structure/flora/tree/jungle/small/style_random,
 /turf/open/floor/grass,
@@ -1239,12 +1216,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/port_tarkon/trauma)
-"ft" = (
-/obj/structure/safe/floor,
-/obj/item/book/granter/crafting_recipe/donk_secret_recipe,
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/port_tarkon/kitchen)
 "fu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -1252,15 +1223,6 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/kitchen)
-"fx" = (
-/obj/structure/safe/floor,
-/obj/item/mod/module/medbeam,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/meta,
-/obj/item/reagent_containers/cup/beaker/meta,
-/obj/item/reagent_containers/cup/beaker/meta,
-/turf/open/floor/iron/white,
-/area/ruin/space/has_grav/port_tarkon/trauma)
 "fy" = (
 /obj/structure/spawner/tarkon_xenos/common,
 /turf/open/floor/plating,
@@ -1853,9 +1815,6 @@
 /turf/open/misc/asteroid/airless,
 /area/ruin/space/has_grav)
 "hX" = (
-/obj/structure/safe/floor,
-/obj/item/blueprints/tarkon,
-/obj/item/circuitboard/machine/bluespace_miner,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/power1)
 "hZ" = (
@@ -6056,20 +6015,6 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/port_tarkon/engineering)
-"Ai" = (
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
-	},
-/obj/structure/safe/floor,
-/obj/item/stack/sheet/mineral/diamond{
-	amount = 10
-	},
-/obj/item/stack/sheet/bluespace_crystal{
-	amount = 5
-	},
-/obj/item/mod/module/jetpack/advanced,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/port_tarkon/developement)
 "Al" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
@@ -6813,8 +6758,6 @@
 /obj/item/circuitboard/machine/circulator,
 /obj/item/circuitboard/machine/circulator,
 /obj/item/circuitboard/machine/thermoelectric_generator,
-/obj/item/circuitboard/machine/powerator/tarkon,
-/obj/item/circuitboard/machine/powerator/tarkon,
 /obj/item/circuitboard/machine/powerator/tarkon,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
@@ -8202,15 +8145,6 @@
 /obj/structure/marker_beacon/burgundy,
 /turf/open/misc/asteroid,
 /area/ruin/space/has_grav)
-"Jv" = (
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 8
-	},
-/obj/structure/safe/floor,
-/obj/item/gun/energy/recharge/kinetic_accelerator,
-/obj/item/gun/energy/recharge/kinetic_accelerator/variant/shotgun,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/port_tarkon/mining)
 "Jw" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron/dark,
@@ -9096,18 +9030,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/port_tarkon/trauma)
-"Nt" = (
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 4
-	},
-/obj/item/stack/spacecash/c10000,
-/obj/item/stack/spacecash/c10000,
-/obj/item/stack/spacecash/c10000,
-/obj/item/stack/spacecash/c10000,
-/obj/structure/safe/floor,
-/obj/item/stack/spacecash/c10000,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/port_tarkon/storage)
 "Nu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11433,6 +11355,7 @@
 "WW" = (
 /obj/machinery/shower/directional/south,
 /obj/structure/curtain/cloth,
+/obj/item/bikehorn/rubberducky,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/port_tarkon/dorms)
 "WX" = (
@@ -11737,13 +11660,6 @@
 	},
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/port_tarkon/atmos)
-"Yq" = (
-/obj/item/tape/ruins/tarkon/celebration,
-/obj/structure/safe/floor,
-/obj/item/reagent_containers/cup/glass/bottle/absinthe/premium,
-/obj/item/market_uplink/blackmarket,
-/turf/open/floor/iron/dark/smooth_large,
-/area/ruin/space/has_grav/port_tarkon/apartment)
 "Yr" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -15106,7 +15022,7 @@ Lq
 yW
 JY
 mZ
-Ai
+EW
 nG
 yW
 yW
@@ -15209,7 +15125,7 @@ vM
 Er
 kP
 ms
-eV
+DR
 tu
 tU
 kB
@@ -15362,7 +15278,7 @@ fR
 Fu
 LO
 XR
-fx
+QV
 Zg
 PY
 Es
@@ -17150,7 +17066,7 @@ fd
 lX
 iP
 fd
-eT
+fd
 fd
 YQ
 pl
@@ -17717,7 +17633,7 @@ Bc
 Bc
 Bc
 Lz
-Nt
+jt
 gz
 wY
 kN
@@ -18790,14 +18706,14 @@ fr
 pp
 Jw
 mW
-ft
+Jw
 Jw
 Jw
 VU
 QG
 Zv
 yh
-Jv
+AP
 SW
 pc
 Hb
@@ -19118,7 +19034,7 @@ yB
 Md
 SG
 Iu
-Yq
+rF
 OW
 Bo
 mq


### PR DESCRIPTION
## About The Pull Request

I removed all the floor safes from Port Tarkon, they had either copies of gear they alreayd had in possesion, like second duplicates of stuff they have in actual visible safes, like the tarkon boards and what not, to slightly higher gear like variant pka's, mosin kits, extra diamonds and bluespace crystals (on top of the already ridiculous amount tarkon starts with) to outright 50k in extra money. I would advice not reading the PR and going straight to them, as starting this moment opening those safes will be adminhelped.

I also removed the sneaked in Tarkon Powerators, we SPECIFICALLY nerfed them to 1 from 3, I am not amused they were snuck back in, specially with no documentation or asking the mantainer team.

Actually used Strong DMM to modifity them now.

## How This Contributes To The Nova Sector Roleplay Experience

Ghost Roles already start ridicously strong, giving them even more strenght on top of being hidden so only _select_ players get the stuff is antiethical. Either have it on the open for anyone that plays the role to find or not at all. 

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
all the secret floor safes that were deleted:

<img width="704" height="384" alt="image" src="https://github.com/user-attachments/assets/d1fe4bb4-8b35-44fb-b9c2-c82c149f1944" />

<img width="822" height="305" alt="image" src="https://github.com/user-attachments/assets/876369be-d9d4-427c-96d2-8a20976a5a28" />

<img width="617" height="366" alt="image" src="https://github.com/user-attachments/assets/f407741f-a9fb-4dc0-b6a5-2a9074c56e80" />

<img width="823" height="352" alt="image" src="https://github.com/user-attachments/assets/03ed4ec0-cbd8-455f-b072-9df29771c796" />

<img width="735" height="326" alt="image" src="https://github.com/user-attachments/assets/087af26b-da70-4616-ba20-010c673b3a1c" />

<img width="793" height="347" alt="image" src="https://github.com/user-attachments/assets/e6f85c0b-e707-4f09-bcc6-e5e31ac0b11c" />

<img width="859" height="431" alt="image" src="https://github.com/user-attachments/assets/650dd88a-4bba-4489-9b98-85e80c9e6652" />

<img width="683" height="329" alt="image" src="https://github.com/user-attachments/assets/ffeb22ea-6687-4530-a514-4bf9fefe450c" />

<img width="840" height="353" alt="image" src="https://github.com/user-attachments/assets/06d3dc9e-66a7-4ece-a43b-6ffa0752ee7e" />

<img width="785" height="384" alt="image" src="https://github.com/user-attachments/assets/4110da69-e794-42f3-bdfa-6ef3f2ff046c" />

Rubber ducky:

<img width="444" height="489" alt="image" src="https://github.com/user-attachments/assets/77cde63f-c1e8-4a53-a7d2-6436f80179cd" />


</details>

## Changelog
:cl:
balance: removed tarkon secret gamer gear. Reinstated Tarkon powerators from 3 to 1, as it was an error reverting them back to 3.
qol: added rubber duck to tarkon showers.
/:cl:
