### PR TITLE
[Balance] Makes BRM work only on the station areas

### DIFF
--- a/code/modules/mining/boulder_processing/brm.dm
+++ b/code/modules/mining/boulder_processing/brm.dm
@@ -153,7 +153,7 @@
 	// NOVA EDIT ADDITION START
 	var/area/teleport_area = get_area(src)
 	if (!is_type_in_typecache(teleport_area, allowed_areas_to_work))
-		balloon_alert(user, "invalid area of use!")
+		balloon_alert(user, "can't use this here!")
 		return FALSE
 	// NOVA EDIT ADDITION END
 	if(!COOLDOWN_FINISHED(src, manual_teleport_cooldown))
@@ -224,7 +224,7 @@
 	// NOVA EDIT ADDITION START
 	var/area/teleport_area = get_area(src)
 	if (!is_type_in_typecache(teleport_area, allowed_areas_to_work))
-		balloon_alert(user, "invalid area of use!")
+		balloon_alert(user, "can't use this here!")
 		return FALSE
 	// NOVA EDIT ADDITION END
 	if(panel_open)


### PR DESCRIPTION
## About The Pull Request
Places checks on the BRM machine so that it doesnt teleport boulders in non station areas, with a var that allows for admins to edit in case of events.

Had to make it non modular due to linter.

## How This Contributes To The Nova Sector Roleplay Experience
Ghost roles had been abusing the BRM consistently, even after they had been granted ore thumpers, their own special kind of vents, superior mining tools, roundstart materials, no setup power, starting t4 parts, Bluespace miners, unrestricted cargo and more, further, there had been instances of players setting more than one boulder machine, with the sole purpose of limiting the station side supplies, all with no way to counter from the station side, or to detect, without actually checking their place.

Dramatization:

<img width="871" height="505" alt="image" src="https://github.com/user-attachments/assets/e4d32eeb-93cf-4931-89c1-6ade6d726192" />


## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
works in the station:

<img width="558" height="333" alt="image" src="https://github.com/user-attachments/assets/9fea327e-600d-411b-bc15-b577a00bbcd0" />

doesnt work in ds2 and similars:

<img width="769" height="478" alt="image" src="https://github.com/user-attachments/assets/d0e69bc1-51ba-4ddd-ade8-9c4eccdbeeff" />


</details>

## Changelog
:cl:
balance: the BRM now only works in station areas.
/:cl:
