### PR TITLE
Fixes perma microwave and grinder placement on Blueshift

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -75831,9 +75831,7 @@
 "oyB" = (
 /obj/structure/table,
 /obj/structure/cable,
-/obj/machinery/microwave{
-	pixel_y = 8
-	},
+/obj/machinery/microwave,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "oyC" = (
@@ -81984,9 +81982,7 @@
 "pKc" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
-	},
+/obj/machinery/reagentgrinder,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "pKd" = (


### PR DESCRIPTION

## About The Pull Request

fixes placement of the microwave and grinder on blueshift perma
## How This Contributes To The Nova Sector Roleplay Experience

theyre like in the windows but also you literally cant use the grinder with the placement
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="240" height="261" alt="Screenshot 2025-11-10 102301" src="https://github.com/user-attachments/assets/cdfb26dd-e397-4885-a2d0-efae4041582e" />

  
<img width="531" height="338" alt="Screenshot 2025-11-10 111121" src="https://github.com/user-attachments/assets/33adcd83-1821-421f-812b-f76c3551d44f" />

</details>

## Changelog
:cl:
fix: fixes placement of microwave and grinder on blueshift perma
/:cl:
