### PR TITLE
[Nerf] Interdyne no longer has access to the Golem Mining Vendor, they have their own now.

### DIFF
--- a/modular_nova/modules/mapping/code/interdyne_mining.dm
+++ b/modular_nova/modules/mapping/code/interdyne_mining.dm
@@ -15,7 +15,6 @@
 		CATEGORY_TOYS_DRONE,
 		CATEGORY_PKA,
 		CATEGORY_INTERDYNE,
-		CATEGORY_GOLEM,
 	)
 
 /obj/machinery/computer/order_console/mining/interdyne/Initialize(mapload)


### PR DESCRIPTION

## About The Pull Request
Removes the mining golem tab from interdyne mining vendor.

## How This Contributes To The Nova Sector Roleplay Experience
Interdyne shouldn't have access to the mining golem gear. That included a liberator legacy and mining ID's

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="657" height="425" alt="image" src="https://github.com/user-attachments/assets/e37cee33-d617-4d0e-88f9-2d6af2f01e09" />


</details>

## Changelog
:cl:
balance: Interdyne has lost its contract with the Free Golems, and thus they no longer have access to their wares in the interdyne mining console.
/:cl:
