### PR TITLE
Fixes a merge skew

### DIFF
--- a/code/modules/loadout/loadout_items.dm
+++ b/code/modules/loadout/loadout_items.dm
@@ -406,7 +406,7 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 		UNTYPED_LIST_ADD(reskins, list(
 			"name" = skin,
 			"tooltip" = skin,
-			"skin_icon_state" = cached_reskin_options[skin],
+			"skin_icon_state" = can_be_greyscale ? item_path::icon_state : cached_reskin_options[skin], // NOVA EDIT CHANGE - Get rid of the error icons - ORIGINAL: "skin_icon_state" = cached_reskin_options[skin]
 		))
 
 	return reskins


### PR DESCRIPTION
## About The Pull Request

Fixes another mistake from https://github.com/NovaSector/NovaSector/pull/6290/commits/1f50a0e639f593a48bcd7e4c49befb50fc108dc7

`can_be_greyscale` was removed in favor of a flag system but instead of switch over to the flag system they removed the modular edit

## How This Contributes To The Nova Sector Roleplay Experience

Error icons in loadout begone

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
<img width="463" height="475" alt="image" src="https://github.com/user-attachments/assets/46972058-c3f0-4d26-b72c-abfa2cfb9ee8" />

</details>

## Changelog

:cl:
fix: reskin icons will no longer show as error in the loadout reskin selection menu
/:cl: