### PR TITLE
The Microwave has been removed from Void Raptor

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -12776,10 +12776,6 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -2
-	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/starboard/greater)
 "dLo" = (


### PR DESCRIPTION

## About The Pull Request
<img width="558" height="293" alt="изображение" src="https://github.com/user-attachments/assets/0535a166-4d50-4079-8dfc-acd7e8989ff9" />
<img width="428" height="241" alt="изображение" src="https://github.com/user-attachments/assets/f188bd68-3b38-40c5-9e49-579e14816fd3" />

It's gone.
## How This Contributes To The Nova Sector Roleplay Experience
Removes a mapping mistake that's been there for **a stupidly long while**. You can now enter into public hydro through maintenance.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
Screenshots above. 
</details>

## Changelog
:cl: Stalkeros
map: I stole a microwave from Void Raptor. The one blocking Public Garden's maintenance.
/:cl:
