### PR TITLE
changes bowie knife sheath to be normal-sized

### DIFF
--- a/modular_nova/modules/knives/knives.dm
+++ b/modular_nova/modules/knives/knives.dm
@@ -22,7 +22,7 @@
 	icon = 'modular_nova/modules/knives/icons/bowiepocket.dmi'
 	icon_state = "bowiesheath"
 	slot_flags = ITEM_SLOT_POCKETS
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = FLAMMABLE
 	interaction_flags_click = NEED_DEXTERITY
 	storage_type = /datum/storage/bowie


### PR DESCRIPTION


## About The Pull Request

Changes the bowie knife sheath to be normal, instead of bulky, i can't even remember why I made it bulky

## How This Contributes To The Nova Sector Roleplay Experience
<img width="308" height="505" alt="image" src="https://github.com/user-attachments/assets/7b9dd250-f84e-4739-bf01-ae066a26495c" />

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: The bowie knife sheath is normal-sized now, rejoice!
/:cl:
