### PR TITLE
[FIX] Fixing an issue with donator pets.

### DIFF
--- a/modular_nova/modules/customization/modules/mob/living/basic/pets/pet_holder.dm
+++ b/modular_nova/modules/customization/modules/mob/living/basic/pets/pet_holder.dm
@@ -8,7 +8,7 @@
 	// Tracks if a custom description has been provided that should override the mob's default.
 	var/redescribed = FALSE
 
-/obj/item/mob_holder/pet/pet/Initialize(mapload, mob/living/M, worn_state, head_icon, lh_icon, rh_icon, worn_slot_flags = NONE)
+/obj/item/mob_holder/pet/Initialize(mapload, mob/living/M, worn_state, head_icon, lh_icon, rh_icon, worn_slot_flags = NONE)
 	held_mob = new starting_pet(src)
 	if(renamed)
 		held_mob.name = name
@@ -19,14 +19,14 @@
 
 /// If this gets renamed, make sure to paste the new name onto the mob as well.
 /// If, for whatever reason, this gets called before Initialize, it also sets renamed = TRUE to ensure that the mob gets the custom name on initialization.
-/obj/item/mob_holder/pet/pet/on_loadout_custom_named()
+/obj/item/mob_holder/pet/on_loadout_custom_named()
 	. = ..()
 	renamed = TRUE
 	if(held_mob != null)
 		held_mob.name = name
 
 /// See above.
-/obj/item/mob_holder/pet/pet/on_loadout_custom_described()
+/obj/item/mob_holder/pet/on_loadout_custom_described()
 	. = ..()
 	redescribed = TRUE
 	if(held_mob != null)

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_inhands.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_inhands.dm
@@ -123,7 +123,7 @@
 	abstract_type = /datum/loadout_item/inhand/pet
 
 /datum/loadout_item/inhand/pet/post_equip_item(datum/preferences/preference_source, mob/living/carbon/human/equipper)
-	var/obj/item/mob_holder/pet/pet/equipped_pet = locate(item_path) in equipper.get_all_gear()
+	var/obj/item/mob_holder/pet/equipped_pet = locate(item_path) in equipper.get_all_gear()
 	equipped_pet.held_mob.befriend(equipper)
 
 /*


### PR DESCRIPTION

## About The Pull Request
Fixes an issue with donator pet that had them spawn as an un-interactable item instead of the actual pet. (I know, mr fluffle deserves more /pet/ but that was one /pet/ too many.
## How This Contributes To The Nova Sector Roleplay Experience
Bug fixing good, yes?
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  

https://github.com/user-attachments/assets/2d43f6e2-eca4-40bd-8dcd-cf6878cbd721


</details>

## Changelog
:cl:
fix: fixed an issue that turned donator pets into unmovable sprites.
/:cl:
