### PR TITLE
Fix manual sleeping being a bit too permenant 

### DIFF
--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -395,7 +395,7 @@
 	if(S)
 		S.duration = max(amount, S.duration)
 	else if(amount > 0 || amount == STATUS_EFFECT_PERMANENT) // NOVA EDIT CHANGE: Enhanced sleep - ORIGINAL: else if(amount > 0)
-		S = apply_status_effect(/datum/status_effect/incapacitating/sleeping, amount)
+		S = apply_status_effect(/datum/status_effect/incapacitating/sleeping, amount, is_voluntary) // NOVA EDIT CHANGE - voluntary arg - Original: S = apply_status_effect(/datum/status_effect/incapacitating/sleeping, amount)
 	return S
 
 /mob/living/proc/SetSleeping(amount)


### PR DESCRIPTION

## About The Pull Request
Another little bit lost in a merge conflict. Fixes that you couldn't resist out of voluntary forever-sleeps due to the sleep status not being tagged voluntary.
Fixes #6447
## Proof of Testing
I can't really screenshot this one but I promise
## Changelog
:cl:
fix: Manually sleeping with indefinite duration can once again be resisted out of
/:cl:
