### PR TITLE
Fixes ghost cafe borg chameleon module

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -59,6 +59,10 @@
 	. = ..()
 	robot = loc
 	if(!istype(robot))
+		// NOVA EDIT ADDITION START - Disguise picker needs to be able to temporarily spawn models, to copy their appearance. No modules needed
+		if(isnull(robot))
+			return
+		// NOVA EDIT ADDITION END
 		stack_trace("Robot model ([src]) initialized outside of a robot at [AREACOORD(robot)]! \
 			This should never happen, make sure this item is not map-placed.")
 		return INITIALIZE_HINT_QDEL

--- a/modular_nova/modules/borgs/code/robot_items.dm
+++ b/modular_nova/modules/borgs/code/robot_items.dm
@@ -659,7 +659,7 @@
 			f = user.filters[start+i]
 			animate(f, offset=f:offset, time=0, loop=3, flags=ANIMATION_PARALLEL)
 			animate(offset=f:offset-1, time=rand()*20+10)
-		if (do_after(user, 5 SECONDS, target=user) && user.cell.use(activationCost))
+		if (do_after(user, 5 SECONDS, target=user) && (!activationCost || user.cell.use(activationCost)))
 			playsound(src, 'sound/effects/bamf.ogg', 100, TRUE, -6)
 			to_chat(user, span_notice("You are now disguised."))
 			activate(user)
@@ -696,7 +696,7 @@
 	return TRUE
 
 /obj/item/borg_shapeshifter/process()
-	if (user && !user.cell?.use(activationUpkeep))
+	if (user && activationUpkeep && !user.cell?.use(activationUpkeep))
 		disrupt(user)
 	else
 		return PROCESS_KILL


### PR DESCRIPTION

## About The Pull Request
This was an interesting one, two-part issue. Robot models (abstract item representing the type of cyborg you pick) were recently changed to not be allowed outside of actual robots. This makes sense, as they attempt to spawn a bunch of items inside the robot, which is bad if there isn't one.

However the chameleon module relies on those models in order to copy their visual information without copying their supplied items. So, we'll allow these to exist in nullspace as the primary concern were these models being placed in maps. 

Also, `used()` will return the amount of power actually used from an operation. Trying to use 0 power will return 0, a falsey value, making it appear that there isn't enough power to run your tools.
Fixes #6444
## Proof of Testing
<img width="814" height="622" alt="Screenshot_20251115_045327" src="https://github.com/user-attachments/assets/858420ed-0de2-4398-bf67-94314bc44467" />


## Changelog
:cl:
fix: Ghost cafe borg's chameleon module is functional again
/:cl:
