### PR TITLE
Fix loadout item custom descriptions

### DIFF
--- a/code/modules/loadout/loadout_items.dm
+++ b/code/modules/loadout/loadout_items.dm
@@ -285,6 +285,13 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 		equipped_item.name = trim(item_details[INFO_NAMED], PREVENT_CHARACTER_TRIM_LOSS(MAX_NAME_LEN))
 		ADD_TRAIT(equipped_item, TRAIT_WAS_RENAMED, "Loadout")
 
+		// NOVA EDIT ADDITION START
+		equipped_item.on_loadout_custom_named()
+	if((loadout_flags & LOADOUT_FLAG_ALLOW_NAMING) && item_details?[INFO_DESCRIBED] && !visuals_only)
+		equipped_item.desc = item_details[INFO_DESCRIBED]
+		ADD_TRAIT(equipped_item, TRAIT_WAS_RENAMED, "Loadout")
+		equipped_item.on_loadout_custom_described()
+		// NOVA EDIT ADDITION END
 	if((loadout_flags & LOADOUT_FLAG_ALLOW_RESKIN) && item_details?[INFO_RESKIN])
 		var/skin_chosen = item_details[INFO_RESKIN]
 		if(skin_chosen in equipped_item.unique_reskin)


### PR DESCRIPTION

## About The Pull Request
Simply restores some code lost in a merge conflict.
Fixes #6339
Fixes #6450
Fixes #6454
## Proof of Testing

<img width="315" height="70" alt="Screenshot_20251115_041640" src="https://github.com/user-attachments/assets/8c572a64-0727-457a-9332-f5a2e7277d7e" />


## Changelog
:cl:
fix: Loadout items can have custom descriptions again
/:cl:
