### PR TITLE
AI can see LOOC

### DIFF
--- a/modular_nova/modules/verbs/code/looc.dm
+++ b/modular_nova/modules/verbs/code/looc.dm
@@ -51,11 +51,6 @@
 
 	mob.log_talk(msg,LOG_OOC, tag="LOOC")
 	var/list/heard
-	if(wall_pierce)
-		heard = get_hearers_in_looc_range(mob.get_top_level_mob())
-	else
-		heard = get_hearers_in_view(LOOC_RANGE, mob.get_top_level_mob())
-	heard = mob_only_listeners(heard)
 	//so the ai can post looc text
 	if(istype(mob, /mob/living/silicon/ai))
 		var/mob/living/silicon/ai/ai = mob
@@ -63,6 +58,13 @@
 			heard = get_hearers_in_looc_range(ai.eyeobj)
 		else
 			heard = get_hearers_in_view(LOOC_RANGE, ai.eyeobj)
+	else
+		if(wall_pierce)
+			heard = get_hearers_in_looc_range(mob.get_top_level_mob())
+		else
+			heard = get_hearers_in_view(LOOC_RANGE, mob.get_top_level_mob())
+
+	heard = mob_only_listeners(heard)
 
 	var/list/admin_seen = list()
 	for(var/mob/hearing as anything in heard)


### PR DESCRIPTION

## About The Pull Request
Fixes #6437
I didn't realize that the check for finding mobs around the AI eye was lower than the check for normal mobs, so the `mob_only_hearers` filter wasn't applied to them.
## Proof of Testing
<img width="1897" height="956" alt="Screenshot_20251115_043007" src="https://github.com/user-attachments/assets/9ed87c63-0b9e-4b37-a974-54ffb59ce86a" />
## Changelog
:cl:
fix: AI can hear LOOC through their remote view again.
/:cl:
