### PR TITLE
Grammatical adjustment on nod2 emote

### DIFF
--- a/modular_nova/modules/emotes/code/emotes.dm
+++ b/modular_nova/modules/emotes/code/emotes.dm
@@ -26,8 +26,8 @@
 /datum/emote/living/nodnod
 	key = "nod2"
 	key_third_person = "nod2s"
-	message = "nods, nods."
-	message_param = "nods, nods at %t."
+	message = "nods twice."
+	message_param = "nods twice at %t."
 
 /datum/emote/living/blush
 	sound = 'modular_nova/modules/emotes/sound/emotes/blush.ogg'


### PR DESCRIPTION
## About The Pull Request
An attempt at a grammatical fix to an emote made in an joke pr.
Changing the emote **from** 'John Greytide nodnods.' **to** ~~John Greytide nods repeatedly. John Greytide nods, nods.~~ 'John Greytide nods twice.'

## How This Contributes To The Nova Sector Roleplay Experience
For a quick emote of doing *nod2, it should provide something of a complex emote but done swiftly. Plus, I think it it should be as grammatically correct as it can reasonably be. 
Nodnods is more of a quickly done /me and not everyone wants a quick emote to present something of fast shorthand typing.

Ideas I've considered:
 'nods repeatedly' is explicitly descriptive. 
 'nods, nods' follow a bit more of the original intention, and implies a deliberate, repeated action.
-> 'nods twice' simple and direct to the point. Matches the *snap2 emote.
 Ideally avoided: 'nodnods'.  It is something from an informal, quick emote without formal grammar. That should be avoided for actual *emotes but is acceptable in a /me.

## Proof of Testing
Two line changes, nothing big done.
## Changelog
:cl:
spellcheck: Improved the grammar on the nod2 emote
/:cl:
