### PR TITLE
rebuffs the SKS but only to 0.8x up from 0.5x

### DIFF
--- a/modular_nova/master_files/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/modular_nova/master_files/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -1,2 +1,2 @@
 /obj/item/gun/ballistic/rifle/sks
-	projectile_damage_multiplier = 0.5
+	projectile_damage_multiplier = 0.8


### PR DESCRIPTION
## About The Pull Request
(is it still a partial revert if it's a fraction of the original buff?)
Rebuffs the SKS to 0.8x damage mult, up from 0.5x, which is still down from the original rebuff's 1x.

## How This Contributes To The Nova Sector Roleplay Experience

Funny

compare/contrast your .310 options:
- regular Sakhno, 5rnd internal magazine, 1x damage mult (45 base damage), regular firedelay, bolt-action
- Rengo precision rifle, 10rnd detachable magazine, 1x damage mult, regular firedelay, bolt-action
- Lanca battle rifle, 10rnd detachable magazine, 1x damage mult, increased firedelay/reduced firerate, semiauto
- rebuffed SKS, 10rnd internal magazine (needs 2 clips to feed fully), 0.8x damage mult (36 base damage), regular firedelay, semiauto

## Changelog

:cl:
balance: The Sakhno SKS's damage multiplier was moved to 0.8x, up from 0.5x.
/:cl:
