### PR TITLE
no more butchering the marked one

### DIFF
--- a/modular_nova/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_nova/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -15,7 +15,7 @@
 	bonus_value = 15
 
 /obj/item/crusher_trophy/gladiator/effect_desc()
-	return "the crusher to have a <b>[bonus_value]%</b> chance to block incoming attacks."
+	return "the crusher to have a <b>[bonus_value]%</b> chance to block incoming attacks"
 
 /obj/item/crusher_trophy/gladiator/add_to(obj/item/kinetic_crusher/incomingchance, mob/living/user)
 	. = ..()

--- a/modular_nova/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
+++ b/modular_nova/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
@@ -45,8 +45,8 @@
 	maxHealth = 4000 //for contrast, bubblegum and the colossus both have 2500 health
 	movement_type = GROUND
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
-	loot = list(/obj/structure/closet/crate/necropolis/gladiator)
-	crusher_loot = list(/obj/structure/closet/crate/necropolis/gladiator/crusher)
+	loot = list(/obj/structure/closet/crate/necropolis/gladiator, /obj/structure/dead_gladiator)
+	crusher_loot = list(/obj/structure/closet/crate/necropolis/gladiator/crusher, /obj/structure/dead_gladiator)
 	/// Boss phase, from 1 to 3
 	var/phase = MARKED_ONE_FIRST_PHASE
 	/// People we have introduced ourselves to - WEAKREF list
@@ -90,10 +90,6 @@
 			if(!(friend_or_foe_ref in introduced) && (friend_or_foe.stat != DEAD))
 				introduction(friend_or_foe)
 				break
-
-/mob/living/simple_animal/hostile/megafauna/gladiator/drop_loot(drop_loc)
-	new /obj/structure/dead_gladiator(loc)
-	. = ..()
 
 /mob/living/simple_animal/hostile/megafauna/gladiator/Found(atom/A)
 	//We only attack when pissed off
@@ -537,8 +533,8 @@
 /obj/structure/dead_gladiator
 	name = "solemn remains"
 	desc = "An ancient miner lost to time, chosen and changed by the Necropolis, encased in a suit of armor. Only a chosen few \
-	can match his speed and strength... and it appears someone or something has. Unearthly energies bind the body to its place \
-	of defeat, and you cannot move it."
+		can match his speed and strength... and it appears someone or something has. Unearthly energies bind the body to its place \
+		of defeat, and you cannot move it."
 	icon = 'modular_nova/modules/gladiator/icons/markedone.dmi'
 	icon_state = "marked_dying"
 	gender = MALE
@@ -549,6 +545,7 @@
 	anchored = TRUE
 	density = FALSE
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | INDESTRUCTIBLE
+	/// Name of the GPS signal we set when this structure initializes.
 	var/gps_name = "Fading Signal"
 
 /obj/structure/dead_gladiator/Initialize(mapload)

--- a/modular_nova/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
+++ b/modular_nova/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
@@ -536,8 +536,9 @@
 
 /obj/structure/dead_gladiator
 	name = "solemn remains"
-	desc = "An ancient miner lost to time, chosen and changed by the Necropolis, encased in a suit of armor. Only a chosen few can match his speed and strength... \
-		and it appears someone or something has. Unearthly energies bind the body to its place of defeat, and you cannot move it."
+	desc = "An ancient miner lost to time, chosen and changed by the Necropolis, encased in a suit of armor. Only a chosen few \
+	can match his speed and strength... and it appears someone or something has. Unearthly energies bind the body to its place \
+	of defeat, and you cannot move it."
 	icon = 'modular_nova/modules/gladiator/icons/markedone.dmi'
 	icon_state = "marked_dying"
 	gender = MALE

--- a/modular_nova/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
+++ b/modular_nova/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
@@ -67,6 +67,8 @@
 	var/block_chance = 50
 	/// This mob will not attack mobs randomly if not in anger, the time doubles as a check for anger
 	var/anger_timer_id = null
+	replace_crusher_drop = TRUE // prevents people from butchering him for duping chests
+	del_on_death = TRUE
 
 /mob/living/simple_animal/hostile/megafauna/gladiator/Initialize(mapload)
 	. = ..()
@@ -88,6 +90,10 @@
 			if(!(friend_or_foe_ref in introduced) && (friend_or_foe.stat != DEAD))
 				introduction(friend_or_foe)
 				break
+
+/mob/living/simple_animal/hostile/megafauna/gladiator/drop_loot(drop_loc)
+	new /obj/structure/dead_gladiator(loc)
+	. = ..()
 
 /mob/living/simple_animal/hostile/megafauna/gladiator/Found(atom/A)
 	//We only attack when pissed off
@@ -527,6 +533,26 @@
 				INVOKE_ASYNC(src, PROC_REF(teleport), target)
 				INVOKE_ASYNC(src, PROC_REF(stomp))
 				ranged_cooldown += 1 SECONDS
+
+/obj/structure/dead_gladiator
+	name = "solemn remains"
+	desc = "An ancient miner lost to time, chosen and changed by the Necropolis, encased in a suit of armor. Only a chosen few can match his speed and strength... \
+		and it appears someone or something has. Unearthly energies bind the body to its place of defeat, and you cannot move it."
+	icon = 'modular_nova/modules/gladiator/icons/markedone.dmi'
+	icon_state = "marked_dying"
+	gender = MALE
+	pixel_x = -32
+	pixel_y = -9
+	base_pixel_x = -32
+	base_pixel_y = -9
+	anchored = TRUE
+	density = FALSE
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | INDESTRUCTIBLE
+	var/gps_name = "Fading Signal"
+
+/obj/structure/dead_gladiator/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/gps, gps_name)
 
 #undef MARKED_ONE_STUN_DURATION
 #undef MARKED_ONE_ANGER_DURATION


### PR DESCRIPTION
## About The Pull Request

Marked One is no longer butcherable after being killed, preventing duplicating the loot. To facilitate this, his corpse is now a structure.

## How This Contributes To The Nova Sector Roleplay Experience

no more loot dupes

## Proof of Testing

<img width="546" height="125" alt="image" src="https://github.com/user-attachments/assets/7f655b7c-5a2b-452d-80e0-cd32db06ab10" />

## Changelog

:cl:
fix: The Marked One is no longer butcherable when killed with a crusher to drop two chests instead of one.
/:cl: