### PR TITLE
[Fix] Oversight on the BRM fix as it wasnt working on the default area of icebox.

### DIFF
--- a/code/modules/mining/boulder_processing/brm.dm
+++ b/code/modules/mining/boulder_processing/brm.dm
@@ -35,6 +35,7 @@
 	/// Defines which areas this machine is allowed to operate. By default only the station but done this way in case its needed to be varedited by an admin. DO NOT ALLOW THIS FOR THE GHOST ROLES.
 	var/static/list/allowed_areas_to_work = typecacheof(list(
 		/area/station,
+		/area/mine,
 	))
 	// NOVA EDIT ADDITION END
 


### PR DESCRIPTION

## About The Pull Request
added mining area to the list of allowed areas to the brm, with the express intent it only works for station roles.

## How This Contributes To The Nova Sector Roleplay Experience
People wouldnt need to go and move the BRM from mining to cargo on icebox. 

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
before:

<img width="877" height="628" alt="image" src="https://github.com/user-attachments/assets/5f23b2dd-8b33-4bb3-b441-74625a4782ad" />


after:

<img width="358" height="381" alt="image" src="https://github.com/user-attachments/assets/a1fba2c4-de1f-4f5c-adce-607845be04b4" />


</details>

## Changelog
:cl:
fix: fixed an issue with the brm not working on icebox unless it was moved to cargo
/:cl:
