### PR TITLE
[not modular at all] removes auto-roundend report

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -460,7 +460,7 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 	GLOB.survivor_report = survivor_report(popcount)
 	log_roundend_report()
 	for(var/client/C in GLOB.clients)
-		show_roundend_report(C)
+		//show_roundend_report(C) NOVA EDIT - Disables this from auto-showing at the end of round, maybe
 		give_show_report_button(C)
 		CHECK_TICK
 


### PR DESCRIPTION
## About The Pull Request

Disables showing of the round-end report automatically, you can still open it manually

## How This Contributes To The Nova Sector Roleplay Experience
Limits the flow-breaking the panel popping up in your face can cause, even if it's at round-end

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
 <img width="1712" height="989" alt="image" src="https://github.com/user-attachments/assets/6d438f8c-884f-4491-8aed-368f53cd2ebf" />
</details>

## Changelog
:cl:
code: The round-end report no longer auto- opens magically! Click the button that appears in the top left instead to open it.
/:cl:
