### PR TITLE
Fixes Kobold's language prefix

### DIFF
--- a/modular_nova/master_files/code/modules/language/kobold.dm
+++ b/modular_nova/master_files/code/modules/language/kobold.dm
@@ -1,7 +1,7 @@
 /datum/language/kobold
 	name = "Kobold"
 	desc = "Yip yip."
-	key = "k"
+	key = "O"
 	space_chance = 100
 	sentence_chance = 100
 	between_word_sentence_chance = 10


### PR DESCRIPTION
## About The Pull Request
Changes kobold's conflicting prefix from ,k to ,O

closes https://github.com/NovaSector/NovaSector/issues/6345

## How This Contributes To The Nova Sector Roleplay Experience
Fixes a conflicting problem with the prefixes, allowing bilingual gamers to speak either slime or kobold consistently without speaking the other language by accident.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="200" height="48" alt="image" src="https://github.com/user-attachments/assets/ae737c96-fd1b-464e-a848-0d8dcc3f64c0" />

</details>

## Changelog
:cl: Hardly
fix: Kobold's language prefix has been changed from conflicting ",k" to ",O"
/:cl:
