### PR TITLE
Fixes T3 scythe not requiring T2 to research

### DIFF
--- a/modular_nova/modules/space_vines/scythes.dm
+++ b/modular_nova/modules/space_vines/scythes.dm
@@ -139,7 +139,7 @@
 /datum/techweb_node/scythe_t4
 	id = TECHWEB_NODE_SCYTHE_4
 	display_name = "Scythe (Tier 4)"
-	description = "Improved scythe for efficient culling"
+	description = "The most efficient scythe for culling."
 	prereq_ids = list(TECHWEB_NODE_SCYTHE_3)
 	design_ids = list(
 		"scythet4",


### PR DESCRIPTION
## About The Pull Request
Fixes an oversight where T3 scythe could be researched without researching the lesser tiers of the scythe first. Also changes description a bit (thanks Vinylspiders!!)

## How This Contributes To The Nova Sector Roleplay Experience
Fixes unintended tech behavior, usually you'd have to research tier 1, tier 2 and so on first before getting to research higher tiers.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  

https://github.com/user-attachments/assets/2ccffecc-f9ef-43ee-b4d8-ac03ff4b062b


</details>

## Changelog
:cl: Hardly, Vinylspiders
fix: Tier 3 Scythe now requires lesser scythe to be researched
spellcheck: Gives scythe techs less vague descriptions
/:cl:
