### PR TITLE
Fix chima jeogori clothing flags

### DIFF
--- a/modular_nova/master_files/code/modules/clothing/under/costume.dm
+++ b/modular_nova/master_files/code/modules/clothing/under/costume.dm
@@ -177,6 +177,7 @@
 	greyscale_config = /datum/greyscale_config/chima_jeogori
 	greyscale_config_worn = /datum/greyscale_config/chima_jeogori/worn
 	greyscale_colors = "#a52f29#2ba396#545461#88242d#eeeeee"
+	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	alternate_worn_layer = UNDER_SUIT_LAYER
 	flags_1 = IS_PLAYER_COLORABLE_1
 


### PR DESCRIPTION

## About The Pull Request
Sets the dress's flags correctly.
## How This Contributes To The Nova Sector Roleplay Experience
Fixes this small issue:
<img width="265" height="256" alt="изображение" src="https://github.com/user-attachments/assets/eaaeb6fd-7368-4046-8292-90be7a0b6360" />
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
Male sprite.

<img width="167" height="132" alt="изображение" src="https://github.com/user-attachments/assets/f34f2066-f674-4cf7-b1bf-48ccf0f5ac28" />
Female sprite.

<img width="144" height="110" alt="изображение" src="https://github.com/user-attachments/assets/5303b8db-6c58-4c17-bacc-1dd3c354dbfc" />
</details>

## Changelog
:cl: Stalkeros
fix: Chima jeogori now crops properly on female characters.
/:cl:
