### PR TITLE
Fog of war can no longer be pried open

### DIFF
--- a/modular_nova/modules/bitrunning/code/virtual_domains/ancient_milsim/fog_of_war.dm
+++ b/modular_nova/modules/bitrunning/code/virtual_domains/ancient_milsim/fog_of_war.dm
@@ -41,6 +41,9 @@
 /obj/machinery/door/poddoor/ancient_milsim/screwdriver_act()
 	return
 
+/obj/machinery/door/poddoor/ancient_milsim/crowbar_act()
+	return
+
 /obj/machinery/door/poddoor/ancient_milsim/welder_act()
 	return
 


### PR DESCRIPTION

## About The Pull Request
When unpowered, clicking the fog of war with a crowbar deleted it. This no longer happens.
## How This Contributes To The Nova Sector Roleplay Experience
Fixes an oversight-turned-exploit.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  

https://github.com/user-attachments/assets/290e6415-7b04-43d6-ba1e-9f03bf5e733f


</details>

## Changelog
:cl: Stalkeros
fix: You can no longer crowbar open the fog of war.
/:cl:
