### PR TITLE
Fix armor on some modular jumpsuits

### DIFF
--- a/modular_nova/modules/customization/modules/clothing/under/security.dm
+++ b/modular_nova/modules/customization/modules/clothing/under/security.dm
@@ -12,7 +12,7 @@
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
 
 /obj/item/clothing/under/rank/security/detective/cowboy/armorless //Donator variant, just uses the sprite.
-	armor_type = /datum/armor/clothing_under/none
+	armor_type = /datum/armor/clothing_under
 
 /obj/item/clothing/suit/cowboyvest
 	name = "blonde cowboy vest"

--- a/modular_nova/modules/customization/modules/clothing/~donator/donator_clothing.dm
+++ b/modular_nova/modules/customization/modules/clothing/~donator/donator_clothing.dm
@@ -342,8 +342,6 @@
 	name = "feathered serenity hood"
 	icon_state = "paddedhoodalt"
 
-/datum/armor/clothing_under/none
-
 /obj/item/clothing/shoes/jackboots/heel
 	name = "high-heeled jackboots"
 	desc = "Almost like regular jackboots... why are they on a high heel?"

--- a/modular_nova/modules/syndie_edits/code/syndie_edits.dm
+++ b/modular_nova/modules/syndie_edits/code/syndie_edits.dm
@@ -155,7 +155,7 @@
 	name = "tactical maid outfit"
 	desc = "A 'tactical' skirtleneck fashioned to the likeness of a maid outfit. Why the Syndicate has these, you'll never know."
 	icon_state = "syndimaid"
-	armor_type = /datum/armor/clothing_under/none
+	armor_type = /datum/armor/clothing_under
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	dying_key = DYE_REGISTRY_JUMPSKIRT
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON

--- a/modular_nova/modules/tacti_maid_loadout/tactimaid.dm
+++ b/modular_nova/modules/tacti_maid_loadout/tactimaid.dm
@@ -19,7 +19,7 @@
 	desc = "A 'tactical' skirtleneck fashioned to the likeness of a maid outfit"
 	has_sensor = HAS_SENSORS
 	icon_state = "syndimaid"
-	armor_type = /datum/armor/clothing_under/none
+	armor_type = /datum/armor/clothing_under
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	dying_key = DYE_REGISTRY_JUMPSKIRT
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON


### PR DESCRIPTION
## About The Pull Request

Someone made /datum/armor/clothing_under/none as an attempt to provide no armor to a subtyped item, such as defanged syndie clothing.

However, a blank subtype just inherits from the parent.

Changes it to be an explicit definition of the expected default armor value

## Why It's Good For The Game

Things don't inadvertently get armor they're not supposed to

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
 
<img width="1025" height="444" alt="image" src="https://github.com/user-attachments/assets/d2efd2ef-90a3-46ab-9674-6ec7adf46b24" />

</details>

## Changelog

:cl: LT3
fix: Fixed a few under clothing items inheriting incorrect armor values
/:cl: