### PR TITLE
[QoL] Appendicitis Survivor is now a neutral Quirk

### DIFF
--- a/modular_nova/master_files/code/datums/traits/good.dm
+++ b/modular_nova/master_files/code/datums/traits/good.dm
@@ -123,7 +123,7 @@
 	name = "Appendicitis Survivor"
 	desc = "You had a run in with appendicitis in the past and no longer have an appendix."
 	icon = FA_ICON_NOTES_MEDICAL
-	value = 2
+	value = 0
 	gain_text = span_notice("You no longer have an appendix.")
 	lose_text = span_danger("Your appendix has magically.. regrown?")
 	medical_record_text = "Patient had appendicitis in the past and has had their appendix surgically removed."


### PR DESCRIPTION

## About The Pull Request
Changes the quirk value of Appendicitis survivor from 2 to 0. This makes it a neutral quirk so it doesnt count to the limit of 6 positive quirks we have.

## How This Contributes To The Nova Sector Roleplay Experience
It gives the option to those that had the appendicitis event for the 6th time to not have it roll it again, to finally show some kind of growth of accepting their appendix is not compatible with them living on the same body. This might also be the coder's salt PR regarding their scene to be interrupted for the 5th time thanks to the funny event. 

Also, got the ok from Ignari and Melon, currently headmins, we discussed in the discord thread about making changes to the event, but sadly we have at the moment too few events to put a replacement.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="925" height="520" alt="image" src="https://github.com/user-attachments/assets/7d91ac51-9280-4b2b-9131-d4856a70278f" />

</details>

## Changelog
:cl:
qol: We solved the issue with the Central Command Auto Doc machines sneaking in appendixes in people that had theirs removed. Make sure to update your medical profiles (Quirks) to set that you survived your appendix removal, and we will handle the rest.  
/:cl:
