### PR TITLE
[Fix] Fixes Cargo bug caused by upstream optimizations

### DIFF
--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -281,8 +281,12 @@
 				if(dept_choice == "Cargo Budget")
 					personal_department = null
 					uses_cargo_budget = TRUE // NOVA EDIT ADDITION
+			// NOVA EDIT ADDITION START
+			else
+				uses_cargo_budget = TRUE // NOVA EDIT ADDITION
+			// NOVA EDIT ADDITION END
 
-	if((!self_paid && (pack.goody && !pack.departamental_goody))) // NOVA EDIT CHANGE - ORIGINAL: if(pack.goody && !self_paid)
+	if((pack.goody && (!pack.departamental_goody || uses_cargo_budget)) && (!self_paid || !requestonly)) // NOVA EDIT CHANGE - ORIGINAL: if(pack.goody && !self_paid)
 		playsound(src, 'sound/machines/buzz/buzz-sigh.ogg', 50, FALSE)
 		say("ERROR: Small crates may only be purchased by private accounts.")
 		return
@@ -297,8 +301,9 @@
 		account = personal_department
 		// NOVA EDIT ADDITION START
 		if ((uses_cargo_budget || !requestonly) && pack.goody && pack.departamental_goody)
-			pack.goody = FALSE
-			account = null
+			playsound(src, 'sound/machines/buzz/buzz-sigh.ogg', 50, FALSE)
+			say("ERROR: Small crates may only be purchased by private accounts.")
+			return
 		// NOVA EDIT ADDITION END
 
 	amount = clamp(amount, 1, CARGO_MAX_ORDER - similar_count)

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -272,8 +272,12 @@
 					if(dept_choice == "Cargo Budget")
 						personal_department = null
 						uses_cargo_budget = TRUE // NOVA EDIT ADDITION
+				// NOVA EDIT ADDITION START
+				else
+					uses_cargo_budget = TRUE // NOVA EDIT ADDITION
+				// NOVA EDIT ADDITION END
 
-			if((pack.goody && !pack.departamental_goody) && !self_paid) // NOVA EDIT CHANGE - ORIGINAL: if(pack.goody && !self_paid)
+			if((pack.goody && (!pack.departamental_goody || uses_cargo_budget)) && !self_paid) // NOVA EDIT CHANGE - ORIGINAL: if(pack.goody && !self_paid)
 				playsound(computer, 'sound/machines/buzz/buzz-sigh.ogg', 50, FALSE)
 				computer.say("ERROR: Small crates may only be purchased by private accounts.")
 				return
@@ -285,11 +289,6 @@
 
 			if(!self_paid)
 				account = personal_department
-			// NOVA EDIT ADDITION START - We do this to avoid the creation of departamental Cargo Budget goody lockboxes.
-			if (uses_cargo_budget && pack.goody && pack.departamental_goody)
-				pack.goody = FALSE
-				account = null
-			// NOVA EDIT ADDITION END
 
 			var/turf/T = get_turf(computer)
 			var/datum/supply_order/SO = new(pack, name, rank, ckey, reason, account)


### PR DESCRIPTION
## About The Pull Request
Adapts the code to the new optimizations presented by upstream to cargo. We tried to keep the old system but after three days of work it was deemed more healthy to fall in line with upstream, and restrict goody items from cargo budget buys. 

In short, it restrict players from using the cargo budget to buy the cargo imports goodies, unless they use the express console. Non cargo budgets and private orders are unafected too!

## How This Contributes To The Nova Sector Roleplay Experience
New Upstream optimizations makes the cargo orders fasters to process, but have some incompatibilities with our old behaviours, causing unintended consecuences that affect the gameplay. As the intended behaviour of TG is for goody items to be only ordered by the express consoles, ended up deciding to go that route rather than to alter the _several_ systems in place giving it a special behaviour, and thus risking future bugs as the one that just sidetracked me.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="431" height="521" alt="image" src="https://github.com/user-attachments/assets/5dae28d6-cd22-49ec-b6b3-309081372b16" />

<img width="724" height="399" alt="image" src="https://github.com/user-attachments/assets/9b9fdfa2-8c34-4a8b-ae40-8d1afcc21356" />

<img width="565" height="213" alt="image" src="https://github.com/user-attachments/assets/4decd722-40a3-4fd6-983c-dd4466c9378a" />

<img width="553" height="556" alt="image" src="https://github.com/user-attachments/assets/042c45d2-0134-49c1-bede-df441687d9bc" />

</details>

## Changelog
:cl:
fix: Due to incompatibilities with  intergalactic trade [we had bugs], Cargo imports will no longer be able to be ordered directly from the cargo budget, unless the express consoles are used, as it was previously stipulated with other Goody types imports. [Lots of bugs, and avoiding future bugs, we tried.]
/:cl:
