### PR TITLE
[Feature] Gives Medical Doctors morgue secure access during lowpop

### DIFF
--- a/modular_nova/master_files/code/datums/id_trim/jobs.dm
+++ b/modular_nova/master_files/code/datums/id_trim/jobs.dm
@@ -1,5 +1,10 @@
 // MODULAR ID TRIM ACCESS OVERRIDES GO HERE!!
 
+/datum/id_trim/job/medical_doctor/New()
+	. = ..()
+
+	extra_access  |= ACCESS_MORGUE_SECURE
+
 /datum/id_trim/job/chief_engineer/New()
 	. = ..()
 


### PR DESCRIPTION

## About The Pull Request
Adds Secure Morgue Access to doctors to their extra_access var. Which is a system that grants extra access when the population is low.

## How This Contributes To The Nova Sector Roleplay Experience
As Roboticists get this access when its low pop, it was weird for medical doctors not getting it, thus blocking them of doing the experiments needed to unlock further tech.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="796" height="840" alt="image" src="https://github.com/user-attachments/assets/3b93406c-533d-490e-8ff2-0f851908a6e9" />


</details>

## Changelog
:cl:
qol: Gives Medical doctors secure morgue access during low pop
/:cl:
