### PR TITLE
[Balance] Makes .585 speedloader small sized

### DIFF
--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/trappiste_fabriek/ammo.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/trappiste_fabriek/ammo.dm
@@ -108,5 +108,6 @@
 	ammo_type = /obj/item/ammo_casing/c585trappiste
 	max_ammo = 6
 	caliber = CALIBER_585TRAPPISTE
+	w_class = WEIGHT_CLASS_SMALL
 	ammo_band_icon = "+sl585_band"
 	ammo_band_color = null


### PR DESCRIPTION

## About The Pull Request
Adds to the .585 speedloader the small size, from the parent normal size

## How This Contributes To The Nova Sector Roleplay Experience
It's a 6 shoots speedloader for a normal sized weapon, it should be small, not normal, otherwise we would end up with buccaneer tactics

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="428" height="134" alt="image" src="https://github.com/user-attachments/assets/5905aecf-1c43-42b0-b0fb-1ecade6b227d" />

  
</details>

## Changelog
:cl:
balance: .585 speed loaders are small sized now, as originally intended.
/:cl:
