### PR TITLE
Fixes an exploit with crate shelves

### DIFF
--- a/modular_nova/modules/shelves/shelves.dm
+++ b/modular_nova/modules/shelves/shelves.dm
@@ -226,6 +226,7 @@
 	crate.interaction_flags_atom |= INTERACT_ATOM_MOUSEDROP_IGNORE_ADJACENT // We can't trust the mouse pull adjacency check
 	crate.forceMove(src) // Insert the crate into the shelf.
 	vis_contents += crate
+	return TRUE
 
 /// Removes a crate from the shelf
 /obj/structure/cargo_shelf/proc/remove_crate(obj/structure/closet/crate/crate)


### PR DESCRIPTION
## About The Pull Request

You could open a locked crate by taking advantage of the random chance to break. They no longer will be destroyed. But unlocked or unwelded ones may still open.

Also made the code to scatter crates more intelligent, preferring an inner ring of unblocked turfs expanding outward before falling back on the turf of the shelf itself.

## How This Contributes To The Nova Sector Roleplay Experience

Fixes an exploit.

## Proof of Testing

<details>
<summary>Working</summary>
  
![dreamseeker_RG47mMgyYV](https://github.com/user-attachments/assets/0b00f44a-f75d-48c4-8b0f-1799b9a81a3a)

</details>

## Changelog

:cl:
fix: crates will no longer have a chance to be destroyed when falling from a dismantled cargo shelf
fix: crates should no longer get stuck in shelves, and you can now unload 1 crate onto where you are standing.
/:cl: