### PR TITLE
Fixes the Robotic Lizard Voicebox

### DIFF
--- a/modular_nova/modules/organs/code/tongue.dm
+++ b/modular_nova/modules/organs/code/tongue.dm
@@ -88,7 +88,7 @@
 	taste_sensitivity = 25 // not as good as an organic tongue
 	liked_foodtypes = NONE
 	disliked_foodtypes = NONE
-	organ_traits = list(TRAIT_SILICON_EMOTES_ALLOWED)
+	organ_traits = list(TRAIT_SILICON_EMOTES_ALLOWED, TRAIT_SPEAKS_CLEARLY)
 	voice_filter = "alimiter=0.9,acompressor=threshold=0.2:ratio=20:attack=10:release=50:makeup=2,highpass=f=1000"
 
 /obj/item/organ/tongue/lizard/robot/can_speak_language(language)


### PR DESCRIPTION

## About The Pull Request

Lets the robo liz voicebox speak clearly again.

## How This Contributes To The Nova Sector Roleplay Experience

I GUESS THEYD LIKE TO COMMUNICATE NORMALLY. 

from:

<img width="1122" height="61" alt="image" src="https://github.com/user-attachments/assets/f7b4ab50-def8-44f9-b507-a789b9d79a0d" />

to

<img width="1033" height="18" alt="image" src="https://github.com/user-attachments/assets/bbe7df07-c15b-42c5-a327-bba9e0999159" />



## Changelog
:cl:
fix: robotic lizard voicebox now can communicate properly again.
/:cl:
