### PR TITLE
Adds more loadout stuff into the clothesmate and autodrobe

### DIFF
--- a/modular_nova/modules/modular_vending/code/autodrobe.dm
+++ b/modular_nova/modules/modular_vending/code/autodrobe.dm
@@ -41,6 +41,10 @@
 				/obj/item/clothing/mask/masquerade/two_colors = 25,
 				/obj/item/clothing/mask/masquerade/feathered = 25,
 				/obj/item/clothing/mask/masquerade/two_colors/feathered = 25,
+				/obj/item/clothing/neck/greyscaled = 5,
+				/obj/item/clothing/neck/greyscaled/seecloak = 5,
+				/obj/item/clothing/neck/greyscaled/matroncloak = 5,
+				/obj/item/clothing/neck/greyscaled/xylixcloak = 5,
 			),
 		),
 		list(
@@ -95,6 +99,10 @@
 		/obj/item/clothing/under/rank/captain/nova/imperial/generic/red = 5,
 		/obj/item/clothing/under/rank/captain/nova/imperial/generic/grey = 5,
 		/obj/item/clothing/under/rank/captain/nova/imperial/generic = 5,
+		/obj/item/clothing/head/costume/maid_headband/syndicate/loadout_headband = 5,
+		/obj/item/clothing/gloves/tactical_maid = 5,
+		/obj/item/clothing/under/syndicate/nova/maid/loadout_maid = 5,
+		/obj/item/clothing/accessory/maidcorset/syndicate/loadout_corset = 5,
 	)
 
 	premium_nova = list(

--- a/modular_nova/modules/modular_vending/code/clothesmate.dm
+++ b/modular_nova/modules/modular_vending/code/clothesmate.dm
@@ -142,6 +142,13 @@
 				/obj/item/clothing/suit/crop_jacket/sleeveless/long = 5,
 				/obj/item/clothing/suit/big_jacket = 5,
 				/obj/item/clothing/suit/dagger_mantle = 5,
+				/obj/item/clothing/under/greyscale/turtleneck = 5,
+				/obj/item/clothing/under/greyscale/turtleneck/skirt = 5,
+				/obj/item/clothing/under/greyscale/overalls = 5,
+				/obj/item/clothing/under/greyscale/overalls/skirt = 5,
+				/obj/item/clothing/suit/apron/overalls_loneskirt = 5,
+				/obj/item/clothing/suit/nova/sweater = 5,
+				/obj/item/clothing/suit/nova/overcoat = 5,
 			),
 		),
 

--- a/modular_nova/modules/tacti_maid_loadout/tactimaid.dm
+++ b/modular_nova/modules/tacti_maid_loadout/tactimaid.dm
@@ -30,7 +30,7 @@
 	attach_accessory(A)
 
 /obj/item/clothing/accessory/maidcorset/syndicate/loadout_corset
-	name = "syndicate maid apron"
+	name = "tactical maid apron"
 	desc = "Practical? No. Tactical? Also no. Cute? Most definitely yes."
 	icon = 'modular_nova/master_files/icons/obj/clothing/accessories.dmi'
 	worn_icon = 'modular_nova/master_files/icons/mob/clothing/accessories.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds the following to the vendors

* All cableknit sweaters with their overall variants
* Big sweater
* Regal Overcoat (no armor or anything)
* Overalls suit
* Roguetown cloaks to autodrobe's fancy tab
* (Fake) Tactical maid stuff to the contraband tab of autodrobe

I also named the apron from syndicate maid apron to tactical maid apron

There's definitely more room to add more loadout drip but I dunno what else is missing.
With that being said @ coders please remember to put your sick drip to the vendors it's a win win for everyone involved!!!

## How This Contributes To The Nova Sector Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
You can currently only get all of that only in loadout which sucks when it inevitably burns, or you just want to switch to a new drip halfway into the round.

I also renamed the apron to tactical to follow the standards that the other syndie themed clothing usually have.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
<img width="427" height="562" alt="image" src="https://github.com/user-attachments/assets/7f74fc75-4847-4210-a3a7-c416d239d6b0" />

<img width="417" height="558" alt="image" src="https://github.com/user-attachments/assets/01cb5533-211d-4e72-a711-9d64a4b7e66c" />

<img width="426" height="556" alt="image" src="https://github.com/user-attachments/assets/ceac6de0-f942-4959-956f-bc6b9a7bc34e" />

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Hardly
code: You can now buy big sweaters, all cableknit sweater variants, overalls and regal overcoat from the clothesmate
code: You can now buy the medieval cloaks and the tactical maid through the autodrobe, although you'll have to hack it for the latter.
text: Changed "syndicate maid apron" to "tactical maid apron"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
