### PR TITLE
Gives Snowglobe Barbers their locker

### DIFF
--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -50128,6 +50128,7 @@
 	pixel_x = 10;
 	pixel_y = 4
 	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/barber/spa)
 "ntm" = (


### PR DESCRIPTION
## About The Pull Request
Adds the missing barber locker to the snowglobe barbershop, I just went ahead and replaced the personal locker and added wall mounted storages so people don't have to worry too much about finding a spot to store their stuff for massage roleplay:tm:

Also adds a missing lamp to the south part of the room so the room isn't completely dark if the curtains are up

## How This Contributes To The Nova Sector Roleplay Experience
Barbers need that locker.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/845bbb1f-c2c4-4370-9631-067820da7527




</details>

## Changelog
:cl: Hardly
fix: Gives snowglobe Barbers the locker they need
/:cl:
