### PR TITLE
Sets operating thetres air alarms to contaminated + adds shuttle creation kits on all nova maps (all but ouroboros)

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -15842,6 +15842,7 @@
 	name = "medbay camera";
 	network = list("ss13","medbay")
 	},
+/obj/effect/mapping_helpers/airalarm/surgery,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "cZh" = (
@@ -37951,6 +37952,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/effect/mapping_helpers/airalarm/surgery,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "hmD" = (
@@ -119512,8 +119514,8 @@
 /area/station/security/prison/workout)
 "wLD" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/random/techstorage/arcade_boards,
 /obj/item/radio/intercom/directional/north,
+/obj/effect/spawner/random/techstorage/custom_shuttle,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "wLE" = (

--- a/_maps/map_files/SerenityStation/SerenityStation.dmm
+++ b/_maps/map_files/SerenityStation/SerenityStation.dmm
@@ -6010,6 +6010,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
+/obj/effect/mapping_helpers/airalarm/surgery,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
 "bIK" = (
@@ -14159,10 +14160,7 @@
 	dir = 1
 	},
 /obj/structure/table/reinforced,
-/obj/item/electronics/firealarm,
-/obj/item/electronics/firealarm,
-/obj/item/electronics/firelock,
-/obj/item/electronics/firelock,
+/obj/effect/spawner/random/techstorage/custom_shuttle,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "edn" = (
@@ -39453,6 +39451,7 @@
 	name = "medbay camera";
 	network = list("ss13","medbay")
 	},
+/obj/effect/mapping_helpers/airalarm/surgery,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "lnx" = (

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -53960,6 +53960,7 @@
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/blue/anticorner,
 /obj/structure/closet/secure_closet/medical2,
+/obj/effect/mapping_helpers/airalarm/surgery,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 1
 	},
@@ -77385,6 +77386,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot_red,
+/obj/effect/mapping_helpers/airalarm/surgery,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 1
 	},

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -26169,6 +26169,7 @@
 /obj/item/clothing/gloves/latex,
 /obj/item/clothing/suit/apron/surgical,
 /obj/item/reagent_containers/spray/cleaner,
+/obj/effect/mapping_helpers/airalarm/surgery,
 /turf/open/floor/iron/freezer,
 /area/station/medical/surgery)
 "hAA" = (
@@ -39826,7 +39827,6 @@
 /area/station/maintenance/department/science/xenobiology)
 "lkS" = (
 /obj/structure/rack/shelf,
-/obj/effect/spawner/random/techstorage/service_all,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -39834,6 +39834,7 @@
 	dir = 4
 	},
 /obj/machinery/newscaster/directional/east,
+/obj/effect/spawner/random/techstorage/medical_all,
 /turf/open/floor/pod/dark,
 /area/station/engineering/storage/tech)
 "lkY" = (
@@ -40199,12 +40200,10 @@
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
 "lqx" = (
-/obj/structure/table,
-/obj/item/wirecutters,
-/obj/item/multitool,
-/obj/item/screwdriver,
 /obj/machinery/light/warm/directional/west,
 /obj/machinery/status_display/ai/directional/west,
+/obj/effect/spawner/random/techstorage/custom_shuttle,
+/obj/structure/rack,
 /turf/open/floor/pod/dark,
 /area/station/engineering/storage/tech)
 "lqz" = (
@@ -66301,10 +66300,10 @@
 /area/station/engineering/power_room)
 "sys" = (
 /obj/structure/rack/shelf,
-/obj/effect/spawner/random/techstorage/security_all,
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
+/obj/effect/spawner/random/techstorage/engineering_all,
 /turf/open/floor/pod/dark,
 /area/station/engineering/storage/tech)
 "syE" = (


### PR DESCRIPTION
## About The Pull Request

- Adds air alarm helper to set scrubbers to contaminated in surgical rooms (which is mostly just a single room per map or two rooms in case of blueshift)
- Add shuttle kits in to tech storage rooms for any map but Snowglobe (as it already has dedicated shuttle construction place). Reshuffled Voidraptor circuits in a process to add missing medical and engineering boards and to remove duplicated service and security one.
## How This Contributes To The Nova Sector Roleplay Experience
Brings our map closer to standards plus makes engies and med players lives a bit easier
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  Blueshift
  
<img width="993" height="685" alt="image" src="https://github.com/user-attachments/assets/146920b6-ab15-4314-8b57-e9c48c42e9f9" />
<img width="847" height="650" alt="image" src="https://github.com/user-attachments/assets/1b56a7b0-640a-4550-a279-288d0b3b5fcb" />

voidraptor
<img width="519" height="680" alt="image" src="https://github.com/user-attachments/assets/e08ecd39-e4ca-4da5-a56f-e462607f91fc" />

<img width="499" height="671" alt="image" src="https://github.com/user-attachments/assets/82cfc069-2c60-4c20-91c4-5b63ceedd68f" />

serenity

<img width="1012" height="715" alt="image" src="https://github.com/user-attachments/assets/22c62682-3486-4650-b4db-543f3e402ef4" />

<img width="1044" height="528" alt="image" src="https://github.com/user-attachments/assets/ec6f7b70-8b9f-4c59-b9ed-c8196378ba52" />

</details>

## Changelog
:cl:
add: Surgical rooms will now start with their scrubbers set to contaminated mode (sucking nitrous by default) (related only to Nova maps)
add: Added shuttle creation kits to tech storage rooms (same as above, related only to Nova maps)
/:cl:
