### PR TITLE
Fixes multi-cell chargers not accepting cells

### DIFF
--- a/modular_nova/modules/multicellcharger/code/multi_cell_charger.dm
+++ b/modular_nova/modules/multicellcharger/code/multi_cell_charger.dm
@@ -78,7 +78,7 @@
 			if(!user.transferItemToLoc(attacking_item,src))
 				return
 
-			charging_batteries += attacking_item
+			LAZYADD(charging_batteries, attacking_item)
 			user.visible_message(span_notice("[user] inserts a cell into [src]."), span_notice("You insert a cell into [src]."))
 			update_appearance()
 	else
@@ -204,4 +204,4 @@
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING + DEPARTMENT_BITFLAG_SCIENCE
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE


### PR DESCRIPTION
## About The Pull Request
Was broken because of https://github.com/NovaSector/NovaSector/pull/6554. I have added a single missing lazylist macros to fix it.
## How This Contributes To The Nova Sector Roleplay Experience
you literally cannot RP without multi-cell chargers
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
 
<img width="95" height="98" alt="image" src="https://github.com/user-attachments/assets/e9069c33-41d1-451d-bde1-c9a48acfc3a8" />

</details>

## Changelog
:cl:
fix: fixed multi cell chargers not accepting cells
/:cl:
