### PR TITLE
Tweak hearthkin fragment's item description for clarity.

### DIFF
--- a/modular_nova/modules/tribal_extended/code/weapons/tribal_crushers.dm
+++ b/modular_nova/modules/tribal_extended/code/weapons/tribal_crushers.dm
@@ -135,7 +135,7 @@
 
 /obj/item/hearthkin_ship_fragment_inactive
 	name = "dormant fragment of the Stjarndrakkr"
-	desc = "A dormant piece of ancient tech, carbon-dated to roughly 300 years ago. One side is etched with strange symbols resembling Ættmál runes. Perhaps the natives could uncover its purpose."
+	desc = "A dormant piece of ancient tech, carbon-dated to roughly 300 years ago. One side is etched with strange symbols resembling Ættmál runes, their lines worn and shallow. Tribes whisper that only by carving them anew with a chisel can its purpose be revealed."
 	icon = 'icons/obj/antags/cult/items.dmi'
 	icon_state = "cult_sharpener_used"
 	drop_sound = SFX_STONE_DROP


### PR DESCRIPTION
## About The Pull Request

This PR updates the description of the dormant fragment of the Stjarndrakkr item. The new text clarifies that the fragment’s faded runes can be re‑engraved by a hearthkin using a chisel, making its intended interaction more intuitive for players. No mechanical changes are introduced.
## How This Contributes To The Nova Sector Roleplay Experience

The previous description left some players uncertain about how to interact with the fragment, which caused confusion. By explicitly mentioning the chisel in an immersive, in‑character way, the item now better communicates its purpose without breaking the atmosphere.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
spellcheck: Changed the dormant fragment of the Stjarndrakkr's description to give an usage hint.
/:cl:
