### PR TITLE
Captain's Spare Safe Fixes [no gbp]

### DIFF
--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -56289,6 +56289,7 @@
 /obj/structure/cable,
 /obj/structure/secure_safe/caps_spare,
 /obj/effect/turf_decal/bot_white,
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "qjr" = (

--- a/_maps/map_files/SerenityStation/SerenityStation.dmm
+++ b/_maps/map_files/SerenityStation/SerenityStation.dmm
@@ -9754,15 +9754,11 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/secure_safe/caps_spare{
-	base_icon_state = "floorsafe";
-	icon_state = "floorsafe";
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/trimline/dark/filled/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/secure_safe/caps_spare,
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "cNP" = (

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -15255,11 +15255,8 @@
 "esP" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/turf_decal/tile/dark_blue/anticorner,
-/obj/structure/secure_safe/caps_spare{
-	base_icon_state = "floorsafe";
-	icon_state = "floorsafe";
-	pixel_y = 5
-	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/structure/secure_safe/caps_spare,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/bridge)
 "etd" = (


### PR DESCRIPTION

## About The Pull Request

Removes our 'floor safe' spare safes, puts them on tables. Victim of the the wallmount refactor. No CI errors but caused other issues like the safe being completely invisible.

## How This Contributes To The Nova Sector Roleplay Experience

bugs bad

## Changelog
:cl:
fix: nova-specific maps should all have proper captain's spare safes now.
/:cl:
