### PR TITLE
[FIX] Cargo borg stamps

### DIFF
--- a/modular_nova/modules/borgs/code/robot_model.dm
+++ b/modular_nova/modules/borgs/code/robot_model.dm
@@ -329,7 +329,7 @@
 /obj/item/robot_model/cargo
 	name = "Cargo"
 	basic_modules = list(
-		/obj/item/stamp,
+		/obj/item/stamp/granted,
 		/obj/item/stamp/denied,
 		/obj/item/pen/cyborg,
 		/obj/item/clipboard/cyborg,


### PR DESCRIPTION

## About The Pull Request
Resolves https://github.com/NovaSector/NovaSector/issues/6633
## How This Contributes To The Nova Sector Roleplay Experience
Allows cargo borgs to perform part of their task/role: Stamping invoices. 
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="225" height="108" alt="Capture" src="https://github.com/user-attachments/assets/c1b60dcc-381e-4134-a265-bad2d6f3b07c" />

</details>

## Changelog
:cl:
fix: Cargo borg once again has a proper 'granted' stamp.
/:cl:
