### PR TITLE
Some list optimizations, heretic ruins optimization (#94386)

### DIFF
--- a/_maps/RandomZLevels/heretic.dmm
+++ b/_maps/RandomZLevels/heretic.dmm
@@ -4,14 +4,14 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "af" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "ah" = (
@@ -32,7 +32,7 @@
 "al" = (
 /obj/item/radio/intercom/mi13/directional/north,
 /obj/effect/turf_decal/tile/dark/opposingcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "am" = (
@@ -119,12 +119,12 @@
 "aB" = (
 /obj/item/kirbyplants/organic/plant10,
 /obj/effect/turf_decal/tile/green,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "aC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "aD" = (
@@ -184,7 +184,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "aR" = (
@@ -226,14 +226,14 @@
 /obj/effect/turf_decal/tile/dark_green/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/plating,
 /area/awaymission/caves/heretic_laboratory)
 "be" = (
 /obj/effect/turf_decal/tile/bar/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "bf" = (
@@ -271,14 +271,14 @@
 /obj/structure/bed/double{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron,
 /area/awaymission/caves/heretic_laboratory_clean)
 "bt" = (
 /obj/effect/turf_decal/tile/bar/anticorner/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "bu" = (
@@ -291,7 +291,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "by" = (
@@ -326,7 +326,7 @@
 /area/awaymission/caves/heretic_laboratory)
 "bJ" = (
 /obj/machinery/light/directional/north,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "bN" = (
@@ -380,7 +380,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "ck" = (
@@ -466,7 +466,7 @@
 /area/awaymission/caves/heretic_laboratory)
 "cK" = (
 /obj/effect/turf_decal/tile/bar/anticorner/contrasted,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "cL" = (
@@ -477,7 +477,7 @@
 /obj/effect/turf_decal/tile/bar/anticorner/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "cO" = (
@@ -517,7 +517,7 @@
 /obj/effect/turf_decal/tile/dark_green/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "cX" = (
@@ -532,7 +532,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "dd" = (
@@ -556,7 +556,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/bar/fourcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "dk" = (
@@ -586,12 +586,12 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "dr" = (
 /obj/structure/table,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory_clean)
 "du" = (
@@ -605,7 +605,7 @@
 /area/awaymission/caves/heretic_laboratory)
 "dw" = (
 /obj/machinery/light/directional/west,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory_clean)
 "dy" = (
@@ -634,7 +634,7 @@
 /obj/effect/turf_decal/tile/bar/half/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "dF" = (
@@ -665,7 +665,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "dO" = (
@@ -708,7 +708,7 @@
 /area/awaymission/beach/heretic)
 "dY" = (
 /obj/structure/bookcase/random,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory_clean)
 "eg" = (
@@ -832,7 +832,7 @@
 /obj/effect/turf_decal/tile/dark_green/half/contrasted{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "eQ" = (
@@ -847,7 +847,7 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/bar/half/contrasted,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "eT" = (
@@ -860,7 +860,7 @@
 "eW" = (
 /obj/structure/table,
 /obj/item/ammo_box/magazine/m7mm,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory_clean)
 "eY" = (
@@ -917,7 +917,7 @@
 /obj/effect/turf_decal/tile/dark_green/half/contrasted{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "fo" = (
@@ -937,7 +937,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "fu" = (
@@ -1053,7 +1053,7 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "fP" = (
@@ -1082,7 +1082,7 @@
 /obj/effect/turf_decal/tile/bar/anticorner/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "fW" = (
@@ -1144,7 +1144,7 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/plating,
 /area/awaymission/caves/heretic_laboratory)
 "gi" = (
@@ -1260,7 +1260,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar/fourcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "gK" = (
@@ -1279,7 +1279,7 @@
 	id = "crematoriumchapel";
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/plating,
 /area/awaymission/caves/heretic_laboratory_clean)
 "gQ" = (
@@ -1296,7 +1296,7 @@
 	dir = 1
 	},
 /obj/structure/door_assembly/door_assembly_highsecurity,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "gT" = (
@@ -1323,7 +1323,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "gY" = (
@@ -1566,7 +1566,7 @@
 /obj/effect/turf_decal/tile/dark{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "ij" = (
@@ -1641,7 +1641,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/dark_green/fourcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "iF" = (
@@ -1690,7 +1690,7 @@
 /obj/effect/turf_decal/tile/bar/half/contrasted{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "iO" = (
@@ -1706,7 +1706,7 @@
 "iQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/awaymission/caves/heretic_laboratory)
 "iR" = (
@@ -1729,7 +1729,7 @@
 	pixel_x = 17;
 	pixel_y = 0
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron,
 /area/awaymission/caves/heretic_laboratory_clean)
 "iW" = (
@@ -1760,7 +1760,7 @@
 /obj/effect/turf_decal/tile/bar/anticorner/contrasted{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "jc" = (
@@ -1770,7 +1770,7 @@
 /obj/effect/turf_decal/tile/dark/half{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "je" = (
@@ -1872,7 +1872,7 @@
 "jO" = (
 /obj/machinery/vending/medical,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "jP" = (
@@ -1908,7 +1908,7 @@
 /obj/effect/turf_decal/tile/dark/half{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "jX" = (
@@ -2056,7 +2056,7 @@
 "kO" = (
 /obj/structure/table,
 /obj/item/fake_items/l6_saw,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory_clean)
 "kQ" = (
@@ -2123,14 +2123,14 @@
 /obj/effect/turf_decal/tile/dark_green/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "lt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/east,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "lu" = (
@@ -2145,7 +2145,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/bar/fourcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "lz" = (
@@ -2188,7 +2188,7 @@
 "lH" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/effect/mapping_helpers/damaged_window,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/plating,
 /area/awaymission/caves/heretic_laboratory)
 "lJ" = (
@@ -2198,14 +2198,14 @@
 /obj/effect/turf_decal/tile/dark{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "lK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "lL" = (
@@ -2220,7 +2220,7 @@
 "lV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "lW" = (
@@ -2246,7 +2246,7 @@
 /obj/structure/bed/double,
 /obj/effect/spawner/random/bedsheet/double,
 /obj/effect/turf_decal/tile/bar/anticorner/contrasted,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "lZ" = (
@@ -2362,7 +2362,7 @@
 /area/awaymission/caves/heretic_laboratory)
 "mJ" = (
 /obj/machinery/suit_storage_unit/open,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory_clean)
 "mL" = (
@@ -2373,7 +2373,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "mM" = (
@@ -2466,7 +2466,7 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/plating,
 /area/awaymission/caves/heretic_laboratory)
 "nj" = (
@@ -2512,7 +2512,7 @@
 	dir = 1
 	},
 /obj/item/radio/intercom/mi13/directional/west,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "ny" = (
@@ -2526,7 +2526,7 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "nD" = (
@@ -2601,7 +2601,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "nR" = (
@@ -2704,7 +2704,7 @@
 /obj/machinery/light/floor,
 /obj/machinery/light/directional/east,
 /obj/structure/bed/double,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron,
 /area/awaymission/caves/heretic_laboratory_clean)
 "os" = (
@@ -2729,7 +2729,7 @@
 /obj/structure/rack,
 /obj/item/gun/energy/disabler/smg,
 /obj/effect/turf_decal/tile/dark/opposingcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "oC" = (
@@ -2740,7 +2740,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "oF" = (
@@ -2762,7 +2762,7 @@
 /obj/effect/turf_decal/tile/dark_green/half{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "oN" = (
@@ -2787,7 +2787,7 @@
 "oQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "oS" = (
@@ -2919,7 +2919,7 @@
 /obj/effect/turf_decal/tile/dark_red/anticorner/contrasted{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "pv" = (
@@ -2992,12 +2992,12 @@
 /area/awaymission/caves/heretic_laboratory)
 "pJ" = (
 /mob/living/basic/bot/cleanbot,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory_clean)
 "pL" = (
 /obj/machinery/light/directional/south,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "pN" = (
@@ -3037,7 +3037,7 @@
 /area/awaymission/caves/heretic_laboratory_clean)
 "pW" = (
 /obj/structure/table,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "pX" = (
@@ -3058,7 +3058,7 @@
 /obj/effect/turf_decal/tile/bar/half/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/plating,
 /area/awaymission/caves/heretic_laboratory)
 "qc" = (
@@ -3068,13 +3068,13 @@
 /obj/effect/turf_decal/tile/dark_green/half{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "qe" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/effect/spawner/random/heretic_gateway,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron,
 /area/awaymission/caves/heretic_laboratory_clean)
 "qg" = (
@@ -3192,7 +3192,7 @@
 "qL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "qM" = (
@@ -3236,7 +3236,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "qW" = (
@@ -3259,7 +3259,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "rc" = (
@@ -3271,7 +3271,7 @@
 /area/awaymission/beach/heretic)
 "rf" = (
 /obj/machinery/light/directional/west,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory_clean)
 "rh" = (
@@ -3320,13 +3320,13 @@
 /obj/structure/bed/double,
 /obj/effect/spawner/random/bedsheet/double,
 /obj/effect/turf_decal/tile/dark_green/anticorner/contrasted,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "ry" = (
 /obj/structure/table,
 /obj/item/book/bible,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory_clean)
 "rA" = (
@@ -3488,7 +3488,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/bar/half/contrasted,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "sp" = (
@@ -3606,7 +3606,7 @@
 /obj/effect/turf_decal/tile/dark_green/half{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "sZ" = (
@@ -3614,7 +3614,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "ta" = (
@@ -3655,7 +3655,7 @@
 /area/awaymission/beach/heretic)
 "tl" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/plating,
 /area/awaymission/caves/heretic_laboratory)
 "tm" = (
@@ -3678,7 +3678,7 @@
 /area/awaymission/beach/heretic)
 "ts" = (
 /obj/machinery/light/directional/west,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron,
 /area/awaymission/caves/heretic_laboratory_clean)
 "ty" = (
@@ -3745,7 +3745,7 @@
 /turf/open/water/beach,
 /area/awaymission/beach/heretic)
 "tS" = (
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "tU" = (
@@ -3775,7 +3775,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar/fourcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "uc" = (
@@ -3814,7 +3814,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "ul" = (
@@ -3944,7 +3944,7 @@
 "uQ" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/dark_green/half/contrasted,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "uR" = (
@@ -4002,7 +4002,7 @@
 /area/awaymission/beach/heretic)
 "vf" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory_clean)
 "vj" = (
@@ -4011,7 +4011,7 @@
 /turf/open/floor/iron/white,
 /area/awaymission/caves/heretic_laboratory)
 "vk" = (
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/plating,
 /area/awaymission/caves/heretic_laboratory_clean)
 "vm" = (
@@ -4074,7 +4074,7 @@
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/tile/dark/opposingcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "vw" = (
@@ -4231,7 +4231,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "ws" = (
@@ -4258,7 +4258,7 @@
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "wz" = (
@@ -4280,7 +4280,7 @@
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "wE" = (
@@ -4315,7 +4315,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "wJ" = (
@@ -4392,7 +4392,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "wY" = (
@@ -4433,7 +4433,7 @@
 /obj/effect/turf_decal/tile/bar/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "xd" = (
@@ -4456,7 +4456,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "xk" = (
@@ -4478,7 +4478,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "xn" = (
@@ -4578,7 +4578,7 @@
 /obj/structure/bed/double{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron,
 /area/awaymission/caves/heretic_laboratory_clean)
 "xJ" = (
@@ -4617,7 +4617,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "xQ" = (
@@ -4632,7 +4632,7 @@
 "xT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "xW" = (
@@ -4669,7 +4669,7 @@
 /obj/item/ammo_box/magazine/lahtimagazine{
 	anchored = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory_clean)
 "ye" = (
@@ -4771,7 +4771,7 @@
 /obj/effect/turf_decal/tile/bar/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "yJ" = (
@@ -4801,7 +4801,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/mi13/directional/west,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "yN" = (
@@ -4857,7 +4857,7 @@
 /obj/effect/turf_decal/tile/bar/half/contrasted{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "zb" = (
@@ -4922,7 +4922,7 @@
 /area/awaymission/beach/heretic)
 "zE" = (
 /obj/structure/bookcase/random,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron,
 /area/awaymission/caves/heretic_laboratory_clean)
 "zF" = (
@@ -5095,7 +5095,7 @@
 /obj/effect/turf_decal/tile/bar/half/contrasted{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "AD" = (
@@ -5105,7 +5105,7 @@
 "AG" = (
 /obj/structure/bookcase/random,
 /obj/machinery/light/directional/east,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory_clean)
 "AI" = (
@@ -5115,7 +5115,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "AJ" = (
@@ -5159,7 +5159,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "AR" = (
@@ -5267,7 +5267,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/bar/half/contrasted,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "By" = (
@@ -5295,7 +5295,7 @@
 /obj/effect/turf_decal/tile/bar/half/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "BS" = (
@@ -5303,7 +5303,7 @@
 /obj/effect/turf_decal/tile/dark_green/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "BU" = (
@@ -5359,7 +5359,7 @@
 /area/awaymission/caves/heretic_laboratory)
 "Cm" = (
 /mob/living/basic/heretic_summon/stalker,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "Cn" = (
@@ -5402,7 +5402,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/dark_green/fourcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Cy" = (
@@ -5444,7 +5444,7 @@
 /area/awaymission/caves/heretic_laboratory)
 "CG" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "CI" = (
@@ -5477,7 +5477,7 @@
 /turf/open/floor/asphalt,
 /area/awaymission/beach/heretic)
 "CT" = (
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron,
 /area/awaymission/caves/heretic_laboratory_clean)
 "CU" = (
@@ -5499,7 +5499,7 @@
 /area/awaymission/beach/heretic)
 "CX" = (
 /obj/machinery/light/directional/east,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "CZ" = (
@@ -5512,7 +5512,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "Dc" = (
@@ -5533,7 +5533,7 @@
 /area/awaymission/caves/heretic_laboratory)
 "Di" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron,
 /area/awaymission/caves/heretic_laboratory_clean)
 "Dj" = (
@@ -5569,7 +5569,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Dt" = (
@@ -5610,20 +5610,20 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar/fourcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "DC" = (
 /obj/structure/bookcase/random,
 /obj/machinery/light/directional/west,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron,
 /area/awaymission/caves/heretic_laboratory_clean)
 "DG" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "DJ" = (
@@ -5658,7 +5658,7 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 6
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/awaymission/caves/heretic_laboratory)
 "DX" = (
@@ -5675,7 +5675,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "DZ" = (
@@ -5697,7 +5697,7 @@
 /obj/effect/turf_decal/tile/bar/half/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/plating,
 /area/awaymission/caves/heretic_laboratory)
 "Ec" = (
@@ -5741,7 +5741,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "Es" = (
@@ -5884,7 +5884,7 @@
 /obj/effect/turf_decal/tile/dark_green/half/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Fa" = (
@@ -5941,7 +5941,7 @@
 /obj/effect/turf_decal/tile/bar/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/plating,
 /area/awaymission/caves/heretic_laboratory)
 "Fn" = (
@@ -5949,7 +5949,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Fr" = (
@@ -5997,13 +5997,13 @@
 /obj/effect/turf_decal/tile/dark_green/anticorner/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "FC" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/bar/half/contrasted,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "FD" = (
@@ -6011,7 +6011,7 @@
 /obj/effect/turf_decal/tile/bar/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "FF" = (
@@ -6027,7 +6027,7 @@
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/bar,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "FM" = (
@@ -6055,7 +6055,7 @@
 "FR" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/tile/dark/opposingcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "FS" = (
@@ -6095,7 +6095,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Ga" = (
@@ -6125,7 +6125,7 @@
 /obj/effect/turf_decal/tile/bar/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/plating,
 /area/awaymission/caves/heretic_laboratory)
 "Gg" = (
@@ -6159,7 +6159,7 @@
 /area/awaymission/beach/heretic)
 "Gp" = (
 /mob/living/basic/bot/medbot/mysterious,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory_clean)
 "Gq" = (
@@ -6175,7 +6175,7 @@
 /obj/effect/turf_decal/tile/dark_green/half/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Gu" = (
@@ -6206,7 +6206,7 @@
 /obj/effect/turf_decal/tile/dark_green/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Gz" = (
@@ -6229,12 +6229,12 @@
 "GE" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "GF" = (
 /obj/structure/dresser,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron,
 /area/awaymission/caves/heretic_laboratory_clean)
 "GH" = (
@@ -6314,12 +6314,12 @@
 /obj/effect/turf_decal/tile/bar/anticorner/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "GZ" = (
 /obj/structure/rack,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory_clean)
 "Hb" = (
@@ -6329,7 +6329,7 @@
 /obj/structure/table,
 /obj/machinery/light/directional/east,
 /obj/item/ammo_box/magazine/m7mm,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory_clean)
 "Hf" = (
@@ -6396,7 +6396,7 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Hr" = (
@@ -6452,7 +6452,7 @@
 /turf/open/floor/plating,
 /area/awaymission/beach/heretic)
 "HC" = (
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/awaymission/caves/heretic_laboratory)
 "HF" = (
@@ -6468,7 +6468,7 @@
 /area/awaymission/beach/heretic)
 "HJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "HL" = (
@@ -6535,7 +6535,7 @@
 /obj/effect/turf_decal/tile/dark_green/half/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/plating,
 /area/awaymission/caves/heretic_laboratory)
 "Ib" = (
@@ -6590,7 +6590,7 @@
 /area/awaymission/beach/heretic)
 "Ik" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "Il" = (
@@ -6608,7 +6608,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Io" = (
@@ -6669,7 +6669,7 @@
 /obj/effect/turf_decal/tile/dark_green/anticorner/contrasted{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "IF" = (
@@ -6683,7 +6683,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/dark_green/fourcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "II" = (
@@ -6741,7 +6741,7 @@
 /area/awaymission/caves/heretic_laboratory)
 "IZ" = (
 /obj/effect/turf_decal/tile/green/half/contrasted,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Ja" = (
@@ -6755,7 +6755,7 @@
 /obj/effect/turf_decal/tile/dark_green/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Jf" = (
@@ -6789,7 +6789,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Jp" = (
@@ -6828,7 +6828,7 @@
 /obj/effect/turf_decal/tile/bar/half/contrasted{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "JA" = (
@@ -6909,12 +6909,12 @@
 /obj/effect/turf_decal/tile/bar/half/contrasted{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "JR" = (
 /obj/effect/turf_decal/tile/dark_green/half/contrasted,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "JS" = (
@@ -6951,7 +6951,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "JY" = (
@@ -6964,7 +6964,7 @@
 /turf/open/floor/plating,
 /area/awaymission/caves/heretic_laboratory_clean)
 "Kb" = (
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory_clean)
 "Kd" = (
@@ -7036,7 +7036,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "Ku" = (
@@ -7146,7 +7146,7 @@
 /area/awaymission/caves/heretic_laboratory)
 "Le" = (
 /obj/structure/table,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory_clean)
 "Lf" = (
@@ -7167,7 +7167,7 @@
 	},
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/stripes/corner,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "Ln" = (
@@ -7188,7 +7188,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Lv" = (
@@ -7213,7 +7213,7 @@
 /obj/effect/turf_decal/tile/dark_green/half{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "LC" = (
@@ -7259,7 +7259,7 @@
 	pixel_y = 6
 	},
 /obj/structure/bed/double,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron,
 /area/awaymission/caves/heretic_laboratory_clean)
 "Ma" = (
@@ -7309,7 +7309,7 @@
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Ml" = (
@@ -7318,7 +7318,7 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/awaymission/caves/heretic_laboratory)
 "Mn" = (
@@ -7411,7 +7411,7 @@
 "ML" = (
 /obj/structure/bookcase/random,
 /obj/machinery/light/directional/west,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory_clean)
 "MP" = (
@@ -7431,7 +7431,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "MT" = (
@@ -7449,7 +7449,7 @@
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "MX" = (
@@ -7460,14 +7460,14 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "MY" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Na" = (
@@ -7478,7 +7478,7 @@
 /obj/machinery/door/airlock/security{
 	name = "Armory"
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "Nc" = (
@@ -7498,7 +7498,7 @@
 /area/awaymission/beach/heretic)
 "Nj" = (
 /obj/machinery/light/directional/west,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "Nm" = (
@@ -7557,7 +7557,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "NB" = (
@@ -7584,7 +7584,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /mob/living/basic/migo,
 /obj/effect/turf_decal/tile/bar/fourcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "NO" = (
@@ -7681,7 +7681,7 @@
 	dir = 8
 	},
 /obj/structure/sign/poster/contraband/free_tonto/directional/west,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Oq" = (
@@ -7696,7 +7696,7 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Ow" = (
@@ -7707,7 +7707,7 @@
 /obj/effect/turf_decal/tile/dark_green/half{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "Oz" = (
@@ -7809,7 +7809,7 @@
 /obj/effect/turf_decal/tile/dark/half{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "Pa" = (
@@ -7837,13 +7837,13 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Pc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/awaymission/caves/heretic_laboratory)
 "Ph" = (
@@ -7867,7 +7867,7 @@
 /area/awaymission/caves/heretic_laboratory_clean)
 "Pq" = (
 /obj/machinery/vending/sustenance,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Pw" = (
@@ -7909,7 +7909,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /mob/living/basic/faithless,
 /obj/effect/turf_decal/tile/bar/fourcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "PF" = (
@@ -7941,7 +7941,7 @@
 /obj/structure/window/spawner/directional/east,
 /obj/structure/window/spawner/directional/west,
 /obj/structure/flora/bush/jungle/c/style_random,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/misc/grass/jungle,
 /area/awaymission/caves/heretic_laboratory)
 "PN" = (
@@ -8045,7 +8045,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/dark_green/fourcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Qn" = (
@@ -8070,7 +8070,7 @@
 /obj/effect/turf_decal/tile/dark_red/anticorner/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Qx" = (
@@ -8106,7 +8106,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "QF" = (
@@ -8140,7 +8140,7 @@
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "QM" = (
@@ -8251,7 +8251,7 @@
 /area/awaymission/caves/heretic_laboratory)
 "Rv" = (
 /obj/effect/turf_decal/tile/bar/fourcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Rw" = (
@@ -8281,7 +8281,7 @@
 /obj/effect/turf_decal/tile/bar/anticorner/contrasted{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "RE" = (
@@ -8323,7 +8323,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "RR" = (
@@ -8374,7 +8374,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Sb" = (
@@ -8433,7 +8433,7 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /obj/structure/sign/poster/contraband/blood_geometer/directional/north,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
@@ -8456,7 +8456,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/dark_green/half/contrasted,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Su" = (
@@ -8487,7 +8487,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "SI" = (
@@ -8554,7 +8554,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Td" = (
@@ -8577,7 +8577,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "Ti" = (
@@ -8629,12 +8629,12 @@
 /area/awaymission/caves/heretic_laboratory)
 "Ts" = (
 /obj/effect/turf_decal/tile/bar/half/contrasted,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "TA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "TB" = (
@@ -8648,7 +8648,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/bar/fourcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "TF" = (
@@ -8658,7 +8658,7 @@
 /area/awaymission/caves/heretic_laboratory)
 "TG" = (
 /obj/machinery/light/directional/east,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron,
 /area/awaymission/caves/heretic_laboratory_clean)
 "TH" = (
@@ -8694,7 +8694,7 @@
 /obj/effect/turf_decal/tile/bar/half/contrasted{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "TN" = (
@@ -8730,7 +8730,7 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Ua" = (
@@ -8753,7 +8753,7 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Uj" = (
@@ -8776,13 +8776,13 @@
 /area/awaymission/caves/heretic_laboratory)
 "Uo" = (
 /obj/machinery/light/directional/east,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory_clean)
 "Up" = (
 /obj/machinery/vending/security,
 /obj/effect/turf_decal/tile/dark/opposingcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Uq" = (
@@ -8803,7 +8803,7 @@
 /obj/item/kirbyplants/fern,
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/green/half/contrasted,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "UA" = (
@@ -8832,7 +8832,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/random/armory/disablers,
 /obj/effect/turf_decal/tile/dark/opposingcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "UF" = (
@@ -8853,7 +8853,7 @@
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "UK" = (
@@ -8899,7 +8899,7 @@
 /obj/effect/turf_decal/tile/dark/half{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "UX" = (
@@ -8933,7 +8933,7 @@
 /obj/effect/turf_decal/tile/dark{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "Vi" = (
@@ -8952,12 +8952,12 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Vn" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Vr" = (
@@ -8982,7 +8982,7 @@
 /turf/open/floor/engine,
 /area/awaymission/caves/heretic_laboratory)
 "VA" = (
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory_clean)
 "VB" = (
@@ -9019,7 +9019,7 @@
 /obj/item/fake_items/lahti_l39{
 	pixel_x = 16
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory_clean)
 "VI" = (
@@ -9072,7 +9072,7 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "VZ" = (
@@ -9107,7 +9107,7 @@
 /turf/open/floor/iron/white,
 /area/awaymission/caves/heretic_laboratory)
 "Wj" = (
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Wk" = (
@@ -9125,7 +9125,7 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/contraband/clown/directional/east,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Wn" = (
@@ -9139,8 +9139,8 @@
 /turf/open/floor/plating,
 /area/awaymission/caves/heretic_laboratory_clean)
 "Wr" = (
-/obj/effect/blessing,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
+/obj/effect/blessing/invisible,
 /turf/open/floor/plating,
 /area/awaymission/caves/heretic_laboratory_clean)
 "Ws" = (
@@ -9239,7 +9239,7 @@
 /area/awaymission/caves/heretic_laboratory)
 "WN" = (
 /obj/item/radio/intercom/mi13/directional/east,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron,
 /area/awaymission/caves/heretic_laboratory_clean)
 "WO" = (
@@ -9249,7 +9249,7 @@
 "WP" = (
 /obj/machinery/door/airlock/hatch,
 /obj/structure/holosign/barrier/atmos/sturdy,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/plating,
 /area/awaymission/caves/heretic_laboratory_clean)
 "WR" = (
@@ -9284,7 +9284,7 @@
 /obj/effect/turf_decal/tile/dark_green/anticorner/contrasted{
 	dir = 4
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Xa" = (
@@ -9336,7 +9336,7 @@
 /obj/effect/turf_decal/tile/dark_green/half/contrasted{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Xm" = (
@@ -9407,7 +9407,7 @@
 /area/awaymission/caves/heretic_laboratory)
 "XC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "XI" = (
@@ -9442,7 +9442,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/mi13/directional/east,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "XR" = (
@@ -9450,7 +9450,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/bar/half/contrasted,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "XS" = (
@@ -9491,7 +9491,7 @@
 "Yb" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/bar/half/contrasted,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Yc" = (
@@ -9534,7 +9534,7 @@
 /obj/structure/window/spawner/directional/west,
 /obj/structure/window/spawner/directional/south,
 /obj/structure/flora/bush/jungle/c/style_random,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/misc/grass/jungle,
 /area/awaymission/caves/heretic_laboratory)
 "Yn" = (
@@ -9576,7 +9576,7 @@
 /obj/item/ammo_box/magazine/lahtimagazine{
 	anchored = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory_clean)
 "Yv" = (
@@ -9600,7 +9600,7 @@
 /obj/effect/turf_decal/tile/bar/half/contrasted{
 	dir = 1
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Yy" = (
@@ -9759,7 +9759,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "Zy" = (
@@ -9770,7 +9770,7 @@
 "ZD" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/effect/turf_decal/tile/dark/opposingcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "ZG" = (
@@ -9794,7 +9794,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/mi13/directional/west,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/small,
 /area/awaymission/caves/heretic_laboratory)
 "ZL" = (
@@ -9828,7 +9828,7 @@
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/tile/dark/opposingcorners,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/floor/iron/dark,
 /area/awaymission/caves/heretic_laboratory)
 "ZV" = (
@@ -9856,7 +9856,7 @@
 /obj/structure/window/spawner/directional/east,
 /obj/structure/window/spawner/directional/west,
 /obj/structure/flora/bush/jungle/c/style_random,
-/obj/effect/blessing,
+/obj/effect/blessing/invisible,
 /turf/open/misc/grass/jungle,
 /area/awaymission/caves/heretic_laboratory)
 

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -59,7 +59,7 @@ GLOBAL_LIST_INIT(trait_blockers_to_hud, list(
 	var/list/mob/hud_users_all_z_levels = list()
 
 	///these will be the indexes for the atom's hud_list
-	var/list/hud_icons = list()
+	var/list/hud_icons
 
 	///mobs associated with the next time this hud can be added to them
 	var/list/next_time_allowed = list()
@@ -77,6 +77,8 @@ GLOBAL_LIST_INIT(trait_blockers_to_hud, list(
 	for(var/z_level in 1 to world.maxz)
 		hud_atoms += list(list())
 		hud_users += list(list())
+	if(LAZYLEN(hud_icons))
+		hud_icons = string_list(hud_icons)
 
 	RegisterSignal(SSdcs, COMSIG_GLOB_NEW_Z, PROC_REF(add_z_level_huds))
 

--- a/code/game/atom/alternate_appearance.dm
+++ b/code/game/atom/alternate_appearance.dm
@@ -110,6 +110,7 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 	)
 
 /datum/atom_hud/alternate_appearance/basic/New(key, image/I, options = AA_TARGET_SEE_APPEARANCE)
+	signals_registering = string_list(signals_registering)
 	..()
 	transfer_overlays = options & AA_MATCH_TARGET_OVERLAYS
 	image = I

--- a/code/game/objects/effects/blessing.dm
+++ b/code/game/objects/effects/blessing.dm
@@ -6,15 +6,21 @@
 	anchored = TRUE
 	density = FALSE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	/// Is this blessing visible to those with the ability to see blessed tiles? (chaplains)
+	var/invisible
 
 /obj/effect/blessing/Initialize(mapload)
 	. = ..()
+
+	RegisterSignal(loc, COMSIG_ATOM_INTERCEPT_TELEPORTING, PROC_REF(block_cult_teleport))
+
+	if(invisible)
+		return
+
 	var/image/blessing_icon = image(icon = 'icons/effects/effects.dmi', icon_state = "blessed", layer = ABOVE_NORMAL_TURF_LAYER, loc = src)
 	blessing_icon.alpha = 64
 	blessing_icon.appearance_flags = RESET_ALPHA
 	add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/blessed_aware, "blessing", blessing_icon)
-
-	RegisterSignal(loc, COMSIG_ATOM_INTERCEPT_TELEPORTING, PROC_REF(block_cult_teleport))
 
 /obj/effect/blessing/Destroy()
 	UnregisterSignal(loc, COMSIG_ATOM_INTERCEPT_TELEPORTING)
@@ -26,3 +32,6 @@
 
 	if(channel == TELEPORT_CHANNEL_CULT)
 		return TRUE
+
+/obj/effect/blessing/invisible
+	invisible = TRUE


### PR DESCRIPTION
## ORIGINAL PR: https://github.com/tgstation/tgstation/pull/94386

## About The Pull Request

So we were investigating why downstream our load all gateways CI test was OOMing all of a sudden post-heretic ruin addition.

Some profiling uncovered this:

<img width="1012" height="31" alt="firefox_C004VjzUTS" src="https://github.com/user-attachments/assets/d6853f13-ab51-40b8-92fc-6d598bd87fc3" />

<img width="367" height="144" alt="dreamseeker_HFgGtH3xMu" src="https://github.com/user-attachments/assets/6e9371b9-b6b6-41dc-9cbe-ed0e5fb80b1a" />

<img width="789" height="350" alt="dreamseeker_TpJKbz64um" src="https://github.com/user-attachments/assets/247da741-14a5-4272-9d6a-b52e9baaabbc" />

There is a whole hallway of blessed tiles. Blessed tiles are only visible to chaplains/things with the trait that lets them see blessed tiles.

It makes an alt_appearance for each one. In this case..._1285 of them_.

Turns out these appearances are not cached or reused even if they are on the same type of turf and would look exactly the same. Which is quite stupid. That is not ok.

This PR makes that whole blessed hallway just be 'invisible', to avoid that problem. I don't really have the time to look into refactoring alternate_appearances to reuse one another but that should probably be done by someone at some point because that can turn into a memory concern fast under the right conditions.

Also string_lists() a few easy targets.

## Why It's Good For The Game

Stops wasting memory for basically no reason.

## Changelog

Not really worth putting a changelog entry here, it might be spoilery too.
