### PR TITLE
Fix a couple more instances of abstract stamps being created

### DIFF
--- a/modular_nova/modules/goofsec/code/outfits.dm
+++ b/modular_nova/modules/goofsec/code/outfits.dm
@@ -14,7 +14,7 @@
 	backpack_contents = list(
 		/obj/item/stamp/solfed,
 		/obj/item/stamp/denied,
-		/obj/item/stamp,
+		/obj/item/stamp/granted,
 	)
 	id_trim = /datum/id_trim/solfed/official
 

--- a/modular_nova/modules/xenoarchartifacts/machines/artifact_analyzer.dm
+++ b/modular_nova/modules/xenoarchartifacts/machines/artifact_analyzer.dm
@@ -111,7 +111,7 @@
 		artifact_report.add_raw_text("[scanned_object] -- [results]")
 		artifact_report.update_icon()
 
-		var/obj/item/stamp/our_stamp = new
+		var/obj/item/stamp/granted/our_stamp = new
 		var/stamp_data = our_stamp.get_writing_implement_details()
 		artifact_report.add_stamp(stamp_data["stamp_class"], rand(0, 300), rand(0, 400), rand(0, 360), stamp_data["stamp_icon_state"])
 		playsound(src, 'sound/machines/printer.ogg', 25, FALSE)

--- a/modular_nova/modules/xenoarchartifacts/machines/geosample_analyzer.dm
+++ b/modular_nova/modules/xenoarchartifacts/machines/geosample_analyzer.dm
@@ -89,7 +89,7 @@
 		artifact_report.name = "[src] report"
 		artifact_report.add_raw_text(data)
 		artifact_report.update_icon()
-		var/obj/item/stamp/our_stamp = new
+		var/obj/item/stamp/granted/our_stamp = new
 		var/stamp_data = our_stamp.get_writing_implement_details()
 		artifact_report.add_stamp(stamp_data["stamp_class"], rand(0, 300), rand(0, 400), rand(0, 360), stamp_data["stamp_icon_state"])
 		playsound(src, 'sound/machines/printer.ogg', 25, FALSE)


### PR DESCRIPTION

## About The Pull Request
Updates some instances of `/obj/item/stamp` to the newly-pathed `/obj/item/stamp/granted`
## Changelog
:cl:
fix: Solfed officials get their proper "approved" stamp instead of an abstract variant
/:cl:
