### PR TITLE
Fix some instances of suit sensors being improperly updated

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -247,7 +247,7 @@
 
 	visible_message(span_warning("[src]'s medical sensors short out!"), blind_message = span_warning("The [src] makes an electronic sizzling sound!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	set_has_sensor(BROKEN_SENSORS)
-	sensor_mode = SENSOR_LIVING // NOVA EDIT ADDITION
+	set_sensor_mode(SENSOR_LIVING) // NOVA EDIT ADDITION
 	sensor_malfunction()
 
 /**

--- a/modular_nova/modules/colony_fabricator/code/appliances/space_heater.dm
+++ b/modular_nova/modules/colony_fabricator/code/appliances/space_heater.dm
@@ -44,7 +44,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/space_heater/wall_mounted, 29)
 		frame.cell = cell
 		cell?.forceMove(frame)
 	else
-		cell.forceMove(drop_location())
+		cell?.forceMove(drop_location())
 	cell = null
 	return ..()
 

--- a/modular_nova/modules/marauders/marauder.dm
+++ b/modular_nova/modules/marauders/marauder.dm
@@ -125,7 +125,7 @@
 		return
 	if(!uniform.has_sensor)
 		return
-	uniform.sensor_mode = NO_SENSORS
+	uniform.set_sensor_mode(SENSOR_OFF)
 
 /datum/outfit/marauder/plasmaman
 	name = "Marauder (Plasmaman)"

--- a/modular_nova/modules/marauders/marauder_outfit.dm
+++ b/modular_nova/modules/marauders/marauder_outfit.dm
@@ -17,7 +17,7 @@
 		return
 	if(!uniform.has_sensor)
 		return
-	uniform.sensor_mode = NO_SENSORS
+	uniform.set_sensor_mode(SENSOR_OFF)
 
 /obj/structure/mannequin/operative_barracks/wildcard
 

--- a/modular_nova/modules/random_ship_event/ship_outfits.dm
+++ b/modular_nova/modules/random_ship_event/ship_outfits.dm
@@ -24,9 +24,7 @@
 		outfit_id.update_icon()
 
 	var/obj/item/clothing/under/crew_uniform = equipped.w_uniform
-	if(crew_uniform)
-		crew_uniform.sensor_mode = SENSOR_OFF
-		crew_uniform.update_wearer_status()
+	crew_uniform?.set_sensor_mode(SENSOR_OFF)
 
 /datum/outfit/ship_crew/captain
 	name = "Ship Captain"


### PR DESCRIPTION

## About The Pull Request
Just modifying the variable is not enough to update suit sensor status. Using the appropriate proc should prevent runtimes where the crew monitor is trying to track people without sensors, or from it not tracking people that it should be. 
## How This Contributes To The Nova Sector Roleplay Experience
Sensor? I hardly know her!
## Changelog
Not player facing
