### PR TITLE
Loadout items examinable from examine panel

### DIFF
--- a/modular_nova/master_files/code/game/atom/atom_examine.dm
+++ b/modular_nova/master_files/code/game/atom/atom_examine.dm
@@ -1,6 +1,12 @@
 /mob/living/basic/drone
 	examine_thats = "This is"
 
+/obj/item/examine_title(mob/user, thats = FALSE)
+	. = ..()
+	if(thats || !HAS_TRAIT_FROM(src, TRAIT_WAS_RENAMED, "Loadout"))
+		return
+	return "<a href='byond://?src=[REF(user)];loadout_examine=[REF(src)]'>[.]</a>"
+
 // Species examine
 /mob/living/carbon/human/examine_title(mob/user, thats = FALSE)
 	. = ..()

--- a/modular_nova/modules/customization/modules/mob/living/living.dm
+++ b/modular_nova/modules/customization/modules/mob/living/living.dm
@@ -1,7 +1,13 @@
-/mob/living/Topic(href, href_list)
+/mob/living/Topic(href, list/href_list)
 	. = ..()
 	if(href_list["temporary_flavor"])
 		show_temp_ftext(usr)
+		return
+	if(href_list["loadout_examine"])
+		var/obj/item/examined_atom = locate(href_list["loadout_examine"])
+		if(!istype(examined_atom) || !HAS_TRAIT_FROM(examined_atom, TRAIT_WAS_RENAMED, "Loadout"))
+			return
+		run_examinate(examined_atom)
 
 /mob/living/proc/show_temp_ftext(mob/user)
 	if(temporary_flavor_text)


### PR DESCRIPTION

## About The Pull Request
Loadout items that have a custom description set, can be examined via a character's loadout window. 
## How This Contributes To The Nova Sector Roleplay Experience
Some people's loadouts are as much a part of their character's lore as the character itself. With how much effort can go into the descriptions of these items, it's a shame to have to go up and shove your gear in someone's face for them even know its special in the first place, let alone see the actual custom descriptions.
## Proof of Testing
<img width="509" height="425" alt="image" src="https://github.com/user-attachments/assets/7486997d-f31d-469f-b8ce-795798b66986" />


## Changelog
:cl:
add: Loadout items with custom descriptions can be examined by others while worn by yourself
/:cl:
