### PR TITLE
Armory Consistency Pass

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -59555,6 +59555,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
+/obj/item/gun/ballistic/automatic/battle_rifle,
 /turf/open/floor/engine,
 /area/station/security/armory)
 "qBR" = (

--- a/_maps/nova/automapper/templates/deltastation/deltastation_armory.dmm
+++ b/_maps/nova/automapper/templates/deltastation/deltastation_armory.dmm
@@ -26,6 +26,7 @@
 /obj/item/clothing/suit/hooded/ablative,
 /obj/item/gun/energy/ionrifle,
 /obj/structure/rack,
+/obj/item/gun/ballistic/automatic/battle_rifle,
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "E" = (

--- a/_maps/nova/automapper/templates/icebox/icebox_armory_middle.dmm
+++ b/_maps/nova/automapper/templates/icebox/icebox_armory_middle.dmm
@@ -27,6 +27,7 @@
 	dir = 8
 	},
 /obj/item/gun/grenadelauncher,
+/obj/item/gun/ballistic/automatic/battle_rifle,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/armory)
 "i" = (

--- a/_maps/nova/automapper/templates/metastation/metastation_armory.dmm
+++ b/_maps/nova/automapper/templates/metastation/metastation_armory.dmm
@@ -288,6 +288,7 @@
 /obj/item/storage/box/flashes{
 	pixel_x = 3
 	},
+/obj/item/gun/ballistic/automatic/battle_rifle,
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "X" = (

--- a/_maps/nova/automapper/templates/nebulastation/nebulastation_armory.dmm
+++ b/_maps/nova/automapper/templates/nebulastation/nebulastation_armory.dmm
@@ -16,6 +16,13 @@
 /obj/effect/spawner/armory_spawn/shotguns,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/armory)
+"r" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/secure_safe/directional/east,
+/obj/machinery/camera/autoname/motion/directional/east,
+/obj/structure/closet/secure_closet/armory_kiboko,
+/turf/open/floor/iron/dark/textured_large,
+/area/template_noop)
 "s" = (
 /obj/structure/rack,
 /obj/item/gun/energy/e_gun/dragnet{
@@ -155,7 +162,7 @@ a
 a
 a
 a
-a
+r
 a
 a
 a


### PR DESCRIPTION
## About The Pull Request
maps in more br38 spawns across the different map armories + adds a kiboko locker to nebula because it didn't seem to have one?

## How This Contributes To The Nova Sector Roleplay Experience
more consistency across map armories

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
i'll get around to it after wrangling the cyberheart PR maybe
</details>

## Changelog

:cl:
fix: Maps in some more BR-38 spawns across the various maps' armories for consistency's sake.
fix: Nebula should have a heavy equipment locker in the armory now (the one with the Kiboko and infantry MODs).
/:cl:
