### PR TITLE
You Can Now Piggyback and/or Fireman Carry Oversized and Heavyset People With the Hercules/Atlas Spine Implants

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1032,7 +1032,7 @@
 	if(INCAPACITATED_IGNORING(target, INCAPABLE_GRAB) || INCAPACITATED_IGNORING(src, INCAPABLE_GRAB))
 		target.visible_message(span_warning("[target] can't hang onto [src]!"))
 		return
-	//NOVA EDIT START
+	// NOVA EDIT ADDITION START
 	var/obj/item/organ/cyberimp/chest/spine/atlas/potential_spine = get_organ_slot(ORGAN_SLOT_SPINE) // Only those with a gravity core spine implant can do the holy heavy piggyback while being smoll and light
 	if(((HAS_TRAIT(target, TRAIT_OVERSIZED) && !HAS_TRAIT(src, TRAIT_OVERSIZED)) && !istype(potential_spine)) || ((HAS_TRAIT(target, TRAIT_HEAVYSET) && !HAS_TRAIT(src, TRAIT_HEAVYSET)) && !istype(potential_spine)))
 		target.visible_message(span_warning("[target] is too heavy for [src] to carry!"))


### PR DESCRIPTION
## About The Pull Request

Regular Hercules spine users can now utilize their implants to waive the oversized/legendary athletics requirements to fireman carry oversized/heavyset people, respectively. Those using the upgraded Atlas implant can furthermore lift both oversized/heavyset people in a piggyback without getting smooshed or being big themselves.

## How This Contributes To The Nova Sector Roleplay Experience

Further provides uses for the athletic spine implants, aligning intuitively with their description and rewarding those who go out of their way to upgrade their spines to ludicrous levels. In a more practical sense, it allows medical/security/whoever-it-may-concern personnel to have another option to transport oversized/heavyset people, if they wish to put in the preparation. 

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="1181" height="455" alt="image" src="https://github.com/user-attachments/assets/e0d5caba-0535-4868-8ce4-56487f053b18" />

</details>

## Changelog
:cl:
qol: The Hercules and Atlas spinal implants now allow you to fireman carry your oversized or heavyset coworkers, with the latter going even further as to allow experimental intermodal combined transport (piggybacking).
/:cl:
