### PR TITLE
Balance: Removes the override for the contractor baton

### DIFF
--- a/modular_nova/master_files/code/game/objects/items/melee/baton.dm
+++ b/modular_nova/master_files/code/game/objects/items/melee/baton.dm
@@ -1,6 +1,3 @@
-/obj/item/melee/baton/telescopic/contractor_baton
-	stamina_damage = 115
-
 /obj/item/melee/baton/nunchaku
 	stamina_damage = 35
 	force = 21


### PR DESCRIPTION
## About The Pull Request

On the tin, this item's just too powerful and needs toned back down and putting it back to TG default's a start.

## How This Contributes To The Nova Sector Roleplay Experience

Being able to permastun multiple secoffs is probably the most depressing gameplay loop avaiable, this should hopefully be enough to discourage that but we'll see.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: removed the Nova stamina damage Buff to the contractor baton
/:cl:
