### PR TITLE
Makes plasma pulse rounds as fast as normal rounds

### DIFF
--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/ammo/pulse.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/ammo/pulse.dm
@@ -123,7 +123,7 @@
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/company_and_or_faction_based/szot_dynamica/ammo.dmi'
 	icon_state = "plasma_pulse"
 	damage = 15
-	speed = 1.25
+	speed = /obj/projectile::speed
 	wound_bonus = 5
 	exposed_wound_bonus = 10
 	light_range = 1


### PR DESCRIPTION

## About The Pull Request
Because of inheritance shenanigans and my minor oversight, the anticipated bullet speed of, "any conventional bullet-laser projectile", that plasma pulse guns were meant to have, wasn't present, since normal-sidearm plasma globs are 20% slower than any other projectiles. This should now be fixed.
## How This Contributes To The Nova Sector Roleplay Experience
Fixes being able to dodge plasma pulse rifles like you're Neo.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
It's a one line change tbh.  
</details>

## Changelog
:cl: Stalkeros
balance: Plasma pulse rounds of M/PR-15 and M/PR-16 have been sped up; now as fast as any other bullets/lasers at minimum.
/:cl:
