### PR TITLE
Fixes gauze overlay failing to be removed when gauze is removed

### DIFF
--- a/modular_nova/modules/medical/code/carbon_update_icons.dm
+++ b/modular_nova/modules/medical/code/carbon_update_icons.dm
@@ -7,7 +7,7 @@
 	for(var/b in bodyparts)
 		var/obj/item/bodypart/BP = b
 		var/obj/item/stack/medical/gauze/our_gauze = BP.current_gauze
-		if (!our_gauze)
+		if (QDELETED(our_gauze))
 			continue
 		overlays.add_overlay(our_gauze.get_overlay_prefix())
 


### PR DESCRIPTION
## About The Pull Request

When gauze overlays were being updated, they would only check if the gauze was null, not if it was in the process of being qdel'ed, resulting in the overlay staying after the object was deleted. This remedies that.

## How This Contributes To The Nova Sector Roleplay Experience

Gauze overlays actually dissapear

## Proof of Testing
![dreamseeker_M7PySblGW1](https://github.com/user-attachments/assets/b40f1758-85c2-40b2-a2d8-3a05322b6f67)


## Changelog

:cl:
fix: makes gauze overlays remove when gauze is removed
/:cl:
