### PR TITLE
Fixes stamp implant's approval stamp

### DIFF
--- a/modular_nova/modules/roundstart_implants/code/loadout_implants.dm
+++ b/modular_nova/modules/roundstart_implants/code/loadout_implants.dm
@@ -264,7 +264,7 @@
 /obj/item/organ/cyberimp/arm/toolkit/bureaucracy
 	name = "bureaucrat's 'Jacent' toolset implant"
 	desc = "Popular amongst coreworld corporates, this integrated toolset includes a wrist-sheathed four-colour pen, a special motorized sheaf hollow for holding up to ten pieces of galactic-standard A4 paper and a set of two fingertip stamps for approving and denying things. Does not replenish."
-	items_to_create = list(/obj/item/pen/fourcolor/integrated, /obj/item/paper_bin/integrated, /obj/item/stamp/integrated, /obj/item/stamp/denied/integrated)
+	items_to_create = list(/obj/item/pen/fourcolor/integrated, /obj/item/paper_bin/integrated, /obj/item/stamp/granted/integrated, /obj/item/stamp/denied/integrated)
 
 /obj/item/organ/cyberimp/arm/toolkit/bureaucracy/emp_act(severity)
 	. = ..()

--- a/modular_nova/modules/roundstart_implants/code/tool_subtypes.dm
+++ b/modular_nova/modules/roundstart_implants/code/tool_subtypes.dm
@@ -120,7 +120,7 @@
 	name = "integrated boxcutter"
 	desc = "Stolen from old Terran databanks, the design for this integration was originally some kind of wrist-sheathed assassin tool released into the public domain by an unnamed bitrunner. The FTU found that it worked great as a box cutter, and so authorized it for inclusion in their Deckhand toolset."
 
-/obj/item/stamp/integrated
+/obj/item/stamp/granted/integrated
 	name = "fingertip 'GRANTED' stamp"
 	desc = "Designed to swivel out of a specialized finger-pad mount, this stamp is the bane of budget-crunchers everywhere - for wherever it dares to touch, a loss of credits is sure to follow."
 


### PR DESCRIPTION

## About The Pull Request
Fixes #6677
One more missed repath from the recent stamp changes, that I missed because it was a subtype. Drat! 
## Proof of Testing
<img width="305" height="219" alt="image" src="https://github.com/user-attachments/assets/66a06825-7509-4ca8-9c30-59ba72db5e08" />

## Changelog
:cl:
fix: Bureaucrat implant's approval stamp is a real stamp again
/:cl:
