### PR TITLE
Fixes a Runtime caused by borgs having meaty thighs

### DIFF
--- a/modular_nova/modules/borgs/code/robot_model.dm
+++ b/modular_nova/modules/borgs/code/robot_model.dm
@@ -38,6 +38,7 @@
 		add_verb(cyborg, /mob/living/silicon/robot/proc/robot_lay_down)
 		add_verb(cyborg, /mob/living/silicon/robot/proc/rest_style)
 	else
+		cyborg.robot_rest_style = ROBOT_REST_NORMAL
 		cyborg.set_base_pixel_x(0)
 		remove_verb(cyborg, /mob/living/silicon/robot/proc/robot_lay_down)
 		remove_verb(cyborg, /mob/living/silicon/robot/proc/rest_style)


### PR DESCRIPTION

## About The Pull Request

Quadborgs ass so big it shatters the code, now Hemlock cant break reality.

<img width="539" height="245" alt="image" src="https://github.com/user-attachments/assets/4fa3edbb-edd8-4d4d-9cc5-e5bf6267f27c" />



## How This Contributes To The Nova Sector Roleplay Experience
## Proof of Testing

Nothing to screenshot but tested all poses 
<img width="388" height="290" alt="image" src="https://github.com/user-attachments/assets/6f856c4b-d5c8-4dc6-a895-809edf02826a" />


<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: Quadborg rear actuators now sit without causing unforseen issues.
/:cl:
