### PR TITLE
[Removal] Removes IRCD goody from cargo. (leaves the engineering crate)

### DIFF
--- a/modular_nova/modules/cargo/code/goodies.dm
+++ b/modular_nova/modules/cargo/code/goodies.dm
@@ -44,15 +44,6 @@
 		/obj/item/clothing/mask/breath,
 	)
 
-/*
-*	ENGINEERING STUFF
-*/
-
-/datum/supply_pack/goody/improvedrcd
-	name = "Improved RCD"
-	desc = "An upgraded RCD featuring superior material storage. Comes with complimentary frames and circuitry upgrades to boot!"
-	cost = PAYCHECK_CREW * 38
-	contains = list(/obj/item/construction/rcd/improved)
 
 /*
 *	MISC


### PR DESCRIPTION

## About The Pull Request
Removes the IRCD from the goodies list. The engineering departamental crate with 3 ircd's is still orderable.

## How This Contributes To The Nova Sector Roleplay Experience
Well, first it was requested by a headmin. But besides that, at this moment the policy makes it a contraband piece if you arent an engineer, so, it was removed from cargo to be ordered without engineering access.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="819" height="438" alt="image" src="https://github.com/user-attachments/assets/7d9b24f1-9dc7-4f7a-947d-7be0af5e5521" />


</details>

## Changelog
:cl:
del: Removed the IRCD goody order. The 3 pack of IRCD's that requires engineering access is still available.
/:cl:
