### PR TITLE
Fixes Soda Dispensers T2 Upgrades

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -728,8 +728,8 @@
 		/datum/reagent/consumable/peachjuice,
 		/datum/reagent/consumable/sol_dry
 	)
+	upgrade_reagents = list()
 	//NOVA EDIT ADDITION END
-	upgrade_reagents = null
 	/// The default list of emagged reagents dispensable by the soda dispenser
 	var/static/list/drink_emagged_reagents = list(
 		/datum/reagent/consumable/ethanol/thirteenloko,

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -729,7 +729,7 @@
 		/datum/reagent/consumable/sol_dry
 	)
 	//NOVA EDIT ADDITION END
-	//upgrade_reagents = null // NOVA EDIT CHANGE - TG doesn't give the soda dispenser upgrades but we do. Commenting this so we fall back to the parent type assignment.
+	upgrade_reagents = null
 	/// The default list of emagged reagents dispensable by the soda dispenser
 	var/static/list/drink_emagged_reagents = list(
 		/datum/reagent/consumable/ethanol/thirteenloko,
@@ -740,7 +740,7 @@
 	base_reagent_purity = 0.5
 
 /obj/machinery/chem_dispenser/drinks/Initialize(mapload)
-	if(dispensable_reagents != null && !dispensable_reagents.len)
+	if(type == /obj/machinery/chem_dispenser/drinks || upgrade_reagents != null && !upgrade_reagents.len) //NOVA EDIT CHANGE - if(dispensable_reagents != null && !dispensable_reagents.len)
 		dispensable_reagents = drinks_dispensable_reagents
 	if(emagged_reagents != null && !emagged_reagents.len)
 		emagged_reagents = drink_emagged_reagents

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -730,7 +730,7 @@
 	)
 	//NOVA EDIT ADDITION END
 	//upgrade_reagents = null // NOVA EDIT CHANGE - TG doesn't give the soda dispenser upgrades but we do. Commenting this so we fall back to the parent type assignment.
-// The default list of emagged reagents dispensable by the soda dispenser
+	// The default list of emagged reagents dispensable by the soda dispenser
 	var/static/list/drink_emagged_reagents = list(
 		/datum/reagent/consumable/ethanol/thirteenloko,
 		/datum/reagent/consumable/ethanol/whiskey_cola,

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -728,9 +728,9 @@
 		/datum/reagent/consumable/peachjuice,
 		/datum/reagent/consumable/sol_dry
 	)
-	upgrade_reagents = list()
 	//NOVA EDIT ADDITION END
-	/// The default list of emagged reagents dispensable by the soda dispenser
+	//upgrade_reagents = null // NOVA EDIT CHANGE - TG doesn't give the soda dispenser upgrades but we do. Commenting this so we fall back to the parent type assignment.
+// The default list of emagged reagents dispensable by the soda dispenser
 	var/static/list/drink_emagged_reagents = list(
 		/datum/reagent/consumable/ethanol/thirteenloko,
 		/datum/reagent/consumable/ethanol/whiskey_cola,

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -730,7 +730,7 @@
 	)
 	//NOVA EDIT ADDITION END
 	//upgrade_reagents = null // NOVA EDIT CHANGE - TG doesn't give the soda dispenser upgrades but we do. Commenting this so we fall back to the parent type assignment.
-	// The default list of emagged reagents dispensable by the soda dispenser
+	/// The default list of emagged reagents dispensable by the soda dispenser
 	var/static/list/drink_emagged_reagents = list(
 		/datum/reagent/consumable/ethanol/thirteenloko,
 		/datum/reagent/consumable/ethanol/whiskey_cola,


### PR DESCRIPTION

## About The Pull Request

Noticed the t2 upgrades weren't being properly added in on drink machines. The `upgrade_reagents` was set to `null` so the init logic never passed for t2 parts. 

<img width="385" height="482" alt="image" src="https://github.com/user-attachments/assets/7641122c-2fca-4b69-b550-9bcc32d3c059" />


## How This Contributes To The Nova Sector Roleplay Experience

Bugfix good.


## Changelog
:cl:
fix: Soda dispensers now get their T2 upgrades applied properly. Apple, pumpkin, and vanilla return.
/:cl:
