### PR TITLE
Converts drone sliding under door component to an element

### DIFF
--- a/modular_nova/modules/drones/slide_component.dm
+++ b/modular_nova/modules/drones/slide_component.dm
@@ -6,6 +6,8 @@
 	))
 
 /datum/element/sliding_under/Attach(datum/target)
+	. = ..()
+
 	// needs to be an atom
 	if(!isatom(target))
 		return ELEMENT_INCOMPATIBLE
@@ -35,7 +37,11 @@
 	if(!is_type_in_typecache(user, allowed_mobs))
 		return
 
-	//you need to have patience and can't move away
+	INVOKE_ASYNC(src, PROC_REF(try_squeezing_through), source_atom, user)
+
+/// Actually attempt the squeezing under
+/datum/element/sliding_under/proc/try_squeezing_through(atom/source_atom, mob/user)
+	// you need to have patience and can't move away
 	if(!do_after(user, 5 SECONDS, source_atom))
 		return
 


### PR DESCRIPTION
## About The Pull Request

Another needlessly stateful component that was wasting memory. 

<img width="483" height="37" alt="image" src="https://github.com/user-attachments/assets/08d71525-cf2b-4d5a-a7bc-92113c0b0e90" />

## How This Contributes To The Nova Sector Roleplay Experience

Stops doors from eating our memory on behalf of the drones.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

Not player-facing