### PR TITLE
Tarkon minor issues fix

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/port_tarkon.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/port_tarkon.dmm
@@ -8171,9 +8171,6 @@
 /obj/machinery/door/airlock/external/glass{
 	name = "Turbine Maintenance Door"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/port_tarkon/atmos)
 "Jf" = (
@@ -9914,7 +9911,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/port_tarkon/atmos)
 "Qu" = (


### PR DESCRIPTION
## About The Pull Request
Some minor fixes for Tarkon: 
* "/turf_decal/stripes" changed to "/turf_decal/stripes/line"
* Scrubber pipe output reconected to passive vent outside (it was disconnected due to previous remap).
* One extra alarm in atmos (near spawner) has been removed.
* Changes ore redemption access to tarkon access (it has mining access before)
* Changes stripes in a turbine maintenance tunnel a bit.

## How This Contributes To The Nova Sector Roleplay Experience
It fixes some mapping issues.

## Proof of Testing

<details>
<summary>Screenshot of turbine decal</summary> 
<img width="224" height="288" alt="image" src="https://github.com/user-attachments/assets/444e0ecc-8f1a-458d-9410-129b398e4b1f" />
</details>


## Changelog

:cl:
fix: some Tarkon issues have been fixed
/:cl:
