### PR TITLE
Adds Mending Touch to Genetic Quirks

### DIFF
--- a/modular_nova/master_files/code/datums/quirks/positive_quirks/genetic_freak.dm
+++ b/modular_nova/master_files/code/datums/quirks/positive_quirks/genetic_freak.dm
@@ -10,6 +10,7 @@ GLOBAL_LIST_INIT(genetic_mutation_choice, list(
 	"Transcendent Olfaction" = /datum/mutation/olfaction,
 	"Elastic Arms" = /datum/mutation/elastic_arms,
 	"Webbing" = /datum/mutation/webbing,
+	"Mending Touch" = /datum/mutation/lay_on_hands,
 ))
 
 /datum/quirk/genetic_mutation


### PR DESCRIPTION

## About The Pull Request
This allows people to choose mending touch/lay on hands as a genetic quirk, I'm hoping it can be enjoyed as a feature for new character ideas which enrich roleplay.
## How This Contributes To The Nova Sector Roleplay Experience
Enables people to play into a supportive archetype that I'm so hopeful isn't just mechanically unbalanced.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="577" height="282" alt="Screenshot 2025-12-27 172612" src="https://github.com/user-attachments/assets/bdf4701c-bb8d-4149-9d43-fd83aae1a97d" />

</details>

## Changelog
:cl:
add: Added mending touch to genetic mutation quirk
/:cl:
