### PR TITLE
Condo Bug fix round1

### DIFF
--- a/modular_nova/modules/condos/_maps/apartment_mountainside.dmm
+++ b/modular_nova/modules/condos/_maps/apartment_mountainside.dmm
@@ -2827,10 +2827,6 @@
 /area/misc/condo)
 "rl" = (
 /obj/structure/table/wood/fancy/black,
-/obj/item/clothing/head/costume/maidheadband/syndicate{
-	pixel_x = 1;
-	pixel_y = 4
-	},
 /obj/item/reagent_containers/cup/glass/bottle/small{
 	pixel_x = 7;
 	pixel_y = 7
@@ -4520,6 +4516,7 @@
 	name = "TV remote"
 	},
 /obj/structure/table/wood,
+/obj/item/clothing/head/costume/maid_headband/syndicate,
 /turf/open/floor/iron/dark/smooth_large,
 /area/misc/condo)
 "zY" = (
@@ -7607,7 +7604,7 @@
 /area/misc/condo)
 "Tq" = (
 /obj/structure/medieval/bed_2x2{
-	dir = 8
+	dir = 4
 	},
 /obj/item/fancy_pillow{
 	icon_state = "pillow_pink_square";
@@ -7653,10 +7650,6 @@
 	dir = 5
 	},
 /obj/structure/table/wood,
-/obj/item/clothing/head/costume/maidheadband/syndicate{
-	pixel_x = 3;
-	pixel_y = 4
-	},
 /obj/item/pillow{
 	pixel_x = -5;
 	pixel_y = 7;
@@ -7676,6 +7669,7 @@
 	pixel_x = -23;
 	pixel_y = -14
 	},
+/obj/effect/turf_decal/tile/dark/full,
 /turf/open/floor/wood/parquet,
 /area/misc/condo)
 "TA" = (

--- a/modular_nova/modules/condos/_maps/apartment_skyscraper.dmm
+++ b/modular_nova/modules/condos/_maps/apartment_skyscraper.dmm
@@ -2418,10 +2418,6 @@
 	},
 /obj/structure/marker_beacon/indigo,
 /obj/structure/table/wood/fancy/blue,
-/obj/item/clothing/head/costume/maidheadband/syndicate{
-	pixel_x = 1;
-	pixel_y = 4
-	},
 /obj/item/kirbyplants/organic/plant21{
 	pixel_y = 14
 	},
@@ -2711,6 +2707,7 @@
 	},
 /obj/structure/table/wood,
 /obj/structure/marker_beacon/indigo,
+/obj/item/clothing/head/costume/maid_headband/syndicate,
 /turf/open/floor/iron/dark/smooth_large,
 /area/misc/condo)
 "sD" = (
@@ -7213,9 +7210,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 10
 	},
-/obj/structure/medieval/bed_2x2{
-	dir = 8
-	},
+/obj/structure/medieval/bed_2x2,
 /turf/open/floor/carpet/black,
 /area/misc/condo)
 "YP" = (

--- a/modular_nova/modules/condos/_maps/deepspace_pod.dmm
+++ b/modular_nova/modules/condos/_maps/deepspace_pod.dmm
@@ -416,7 +416,7 @@
 /area/misc/condo)
 "vi" = (
 /obj/structure/medieval/bed_2x2{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/marker_beacon/violet{
 	pixel_x = -16;

--- a/modular_nova/modules/condos/_maps/ship_apartment.dmm
+++ b/modular_nova/modules/condos/_maps/ship_apartment.dmm
@@ -871,10 +871,6 @@
 /area/misc/condo)
 "qZ" = (
 /obj/structure/table/wood/fancy/black,
-/obj/item/clothing/head/costume/maidheadband/syndicate{
-	pixel_x = 1;
-	pixel_y = 4
-	},
 /obj/item/reagent_containers/cup/glass/bottle/small{
 	pixel_x = 7;
 	pixel_y = 7
@@ -1426,6 +1422,7 @@
 "Ck" = (
 /obj/machinery/smartfridge/wooden/ration_shelf,
 /obj/structure/decorative/shelf,
+/obj/item/clothing/head/costume/maid_headband/syndicate,
 /turf/open/floor/iron/dark/smooth_large,
 /area/misc/condo)
 "Cv" = (
@@ -1714,7 +1711,7 @@
 	pixel_y = -16
 	},
 /obj/structure/medieval/bed_2x2{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/misc/condo)


### PR DESCRIPTION
## About The Pull Request
Some small mapping related bug fixes to some of our newer condo maps.
Went in and made the following changes

skyscraper-corrected bed dir. replaced bad turf resulting in black texture. Replaced maid headband that had bad file path.

deepspacepod- corrected bed dir

Deepspaceship- corrected bed dir, . replaced bad turf resulting in black texture. Replaced maid headband that had bad file path.

apartment mountainside.-corrected bed dir. replaced two bad turf resulting in black texture. Replaced maid headband that had bad file path.

It seems the large beds were touched recently and have their dir shuffled. this should realign the beds. They are also seemingly unanchored, however I was unable to find the code related to it and stuck with mapping related. I also replaced some turfs that were causing some black turf to display. Tested by launching four times and seen none consistently, but not guaranteed as I dont know the exact reason they were breaking like this. 

I did NOT touch the dragon den condo, which the lava is common to display as black, I attempted to fix it by creating a new turf to replaced the var edited one, but this did not work and they were still randomly displaying upon generation.

## How This Contributes To The Nova Sector Roleplay Experience

We love bug fixes and bed adjustments
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="632" height="710" alt="co1" src="https://github.com/user-attachments/assets/f5c8fe44-0cef-4702-9119-7aaac0347347" />
<img width="841" height="1139" alt="co2" src="https://github.com/user-attachments/assets/06183403-8516-4e85-bc2b-d23cc3cb0a46" />
<img width="2213" height="866" alt="co4" src="https://github.com/user-attachments/assets/5a432710-f5a8-4f21-ab83-fc115b1a5f41" />
<img width="948" height="1078" alt="co5" src="https://github.com/user-attachments/assets/795cb91d-70f3-475c-bd87-89e6060ba4a8" />
<img width="1263" height="1083" alt="co6" src="https://github.com/user-attachments/assets/7c464e29-7c0e-477d-8134-d69ffb4427b5" />

</details>

## Changelog
:cl:

map: modified some of the newer condos to fix bed rotation

/:cl:
