### PR TITLE
[MODULAR] BSA Firing Shakes the Area Around it

### DIFF
--- a/modular_nova/modules/bsa_overhaul/code/bsa_cannon.dm
+++ b/modular_nova/modules/bsa_overhaul/code/bsa_cannon.dm
@@ -289,7 +289,7 @@
 	// Anything that blocks the BSA beam, if it's blocked, it hits that thing
 	var/atom/movable/blocker
 	// Intensity of the screen shake, capping at 0.75 with maximum charge, with a minimum of 0.25
-	var/camera_shake_intensity = ((round((capacitor_power / 50000000), 1)) + 1) / 4
+	var/camera_shake_intensity = ((round((capacitor_power / (50 * BSA_FIRE_POWER_THRESHOLD)), 1)) + 1) / 4
 	// Now we absolutely destroy everything in the beams path.
 	for(var/turf/iterating_turf as anything in get_line(get_step(point, dir), target))
 		if(SEND_SIGNAL(iterating_turf, COMSIG_ATOM_BSA_BEAM) & COMSIG_ATOM_BLOCKS_BSA_BEAM)


### PR DESCRIPTION
## About The Pull Request

During the BSA fire sequence, the camera will now shake for people seven tiles away from the source, the maximum range being a tile in front of the bore and three tiles behind the generator. The shake will last for the duration of the beam while it is firing, and its intensity is dependent on the amount of expended charge. At a minimum, it will have an intensity of 0.25, going up to 0.5 at a minimum of 25 MW, and 0.75 with at least 75 MW supplied to the shot.

## How This Contributes To The Nova Sector Roleplay Experience

Adds more cool factor to the firing process of the BSA. Considering it is a BIG GUN, and it is only ever fired once in a blue moon, it should feel like one in every which way, especially when you push it to its maximum limit.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
Below 25 MW

https://github.com/user-attachments/assets/039111a2-2f61-40d8-bc4c-8eb145f557f8

Between 25-75 MW

https://github.com/user-attachments/assets/465e5303-faa6-45ca-acdf-a821fadf891d

Above 75 MW

https://github.com/user-attachments/assets/185e1c68-c6a8-4fb8-96d3-55bdbfb54674

</details>

## Changelog
:cl:
add: Due to aggressive cost-cutting measures, many shock stabilizers in BSA devices were removed. Leading NT bluespace engineers say the resulting localized tremors are "cooler."
/:cl:
