### PR TITLE
Fixes the random ship event's random ships not spawning in

### DIFF
--- a/_maps/shuttles/nova/random_ship_hc_police.dmm
+++ b/_maps/shuttles/nova/random_ship_hc_police.dmm
@@ -122,7 +122,8 @@
 /obj/structure/reagent_dispensers/fueltank/large{
 	anchored = 1;
 	desc = "A tank full of a high quantity of liquid hydrogen fuel. Keep away from open flames and 57mm mortar shells.";
-	icon_state = "vat"
+	icon_state = "vat";
+	icon = 'icons/obj/medical/chemical_tanks.dmi'
 	},
 /turf/open/floor/plating,
 /area/shuttle/hc_cops)
@@ -952,7 +953,8 @@
 /obj/structure/reagent_dispensers/fueltank/large{
 	anchored = 1;
 	desc = "A tank full of a high quantity of liquid hydrogen fuel. Keep away from open flames and 57mm mortar shells.";
-	icon_state = "vat"
+	icon_state = "vat";
+	icon = 'icons/obj/medical/chemical_tanks.dmi'
 	},
 /turf/open/floor/plating,
 /area/shuttle/hc_cops)

--- a/modular_nova/modules/random_ship_event/random_ship_event.dm
+++ b/modular_nova/modules/random_ship_event/random_ship_event.dm
@@ -69,10 +69,12 @@ GLOBAL_LIST_INIT(random_ship_events, init_random_ship_events())
 		event.accepted = TRUE
 		priority_announce(event.response_accepted, sender_override = event.ship_name, color_override = event.announcement_color)
 		event.on_accept()
+		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(spawn_random_ship), event), 1 MINUTES)
 	else
 		priority_announce(event.response_rejected, sender_override = event.ship_name, color_override = event.announcement_color)
 		event.on_refuse()
 
+///Spawns the random ship proper, with the follow-up effects, if you've set any up.
 /proc/spawn_random_ship(datum/random_ship_event/event)
 	if(!event || !event.accepted)
 		return
@@ -95,29 +97,8 @@ GLOBAL_LIST_INIT(random_ship_events, init_random_ship_events())
 	if(!ship.load(T))
 		CRASH("Loading random ship failed!")
 
+	event.on_ship_spawn()
 	priority_announce(event.arrival_announcement, sender_override = event.ship_name, color_override = event.announcement_color)
-
-/datum/random_ship_event/proc/spawn_ship()
-	var/template_key = "random_ship_[ship_template_id]"
-	var/datum/map_template/shuttle/random_ship/ship = SSmapping.shuttle_templates[template_key]
-	if(!ship)
-		template_key = "random_ship_default"
-		ship = SSmapping.shuttle_templates[template_key]
-		if(!ship)
-			CRASH("No valid ship template found for random ship event!")
-
-	var/x = rand(TRANSITIONEDGE, world.maxx - TRANSITIONEDGE - ship.width)
-	var/y = rand(TRANSITIONEDGE, world.maxy - TRANSITIONEDGE - ship.height)
-	var/z = SSmapping.empty_space.z_value
-	var/turf/T = locate(x, y, z)
-	if(!T)
-		CRASH("Random ship event found no turf to load in")
-
-	if(!ship.load(T))
-		CRASH("Loading random ship failed!")
-
-	on_ship_spawn()
-	priority_announce(arrival_announcement, sender_override = ship_name, color_override = announcement_color)
 
 ///Additional effects when the ship is accepted
 /datum/random_ship_event/proc/on_accept()

--- a/modular_nova/modules/random_ship_event/random_ship_event_round.dm
+++ b/modular_nova/modules/random_ship_event/random_ship_event_round.dm
@@ -29,8 +29,6 @@
 
 	// Send the initial message to the station
 	var/datum/comm_message/message = ship_event.generate_message()
-	// Set up a timer to spawn the ship after a delay, like the pirate event does
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(spawn_random_ship), ship_event), 1000)
 	GLOB.communications_controller.send_message(message, print = TRUE, unique = TRUE)
 
 /datum/round_event/random_ship_event/end()


### PR DESCRIPTION

## About The Pull Request
The spawn_ship proc wasn't called ever, as it turns out. Which is kinda weird - I recall the event working just fine befoe...
...because it was called in a pretty separate place; on a timer, as a leftover piece of the pirate code that I've overlooked. So the event, effectively, spawned on its own whim. This should be fixed now.
Also cleaned up the code a bit more; and fixed a small issue with their ship's fuel tanks appearing invisible.
## How This Contributes To The Nova Sector Roleplay Experience
Event works as anticipated.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="565" height="314" alt="изображение" src="https://github.com/user-attachments/assets/d8217cef-43fd-42e6-ba94-3a2ad0dbb246" />

<img width="525" height="146" alt="изображение" src="https://github.com/user-attachments/assets/870c2137-e2f6-4ab8-8583-0b5907f42333" />

Event properly spawning in and triggering the ship spawning sequence.

<img width="466" height="478" alt="изображение" src="https://github.com/user-attachments/assets/ed5feec8-6118-40fa-b2a4-4d4a4fb01eb3" />
Visible tanks of a ship that's spawned in.
</details>

## Changelog
:cl: Stalkeros
fix: Random ships of the random ship event now should properly spawn in.
code: Cleanes up some of the random ship event's code.
/:cl:
