### PR TITLE
Flavor(and other) obscure override

### DIFF
--- a/modular_nova/master_files/code/modules/mob/living/examine_tgui.dm
+++ b/modular_nova/master_files/code/modules/mob/living/examine_tgui.dm
@@ -98,8 +98,8 @@
 
 	if(ishuman(holder))
 		var/mob/living/carbon/human/holder_human = holder
-		var/obscure_override = holder == user || (user?.client?.holder && isobserver(user)) // A variable for bypassing data hide due to a mask, for the player themselves (against themselves) or for the administration as an observer.
-		obscured = !obscure_override && ((holder_human.wear_mask && (holder_human.wear_mask.flags_inv & HIDEFACE)) || (holder_human.head && (holder_human.head.flags_inv & HIDEFACE)))
+		var/can_bypass_obscure = holder == user || (user?.client?.holder && isobserver(user)) // A variable for bypassing data hide due to a mask, for the player themselves (against themselves) or for the administration as an observer.
+		obscured = !can_bypass_obscure && ((holder_human.wear_mask && (holder_human.wear_mask.flags_inv & HIDEFACE)) || (holder_human.head && (holder_human.head.flags_inv & HIDEFACE)))
 		custom_species = obscured ? "Obscured" : holder_human.dna.species.lore_protected ? holder_human.dna.species.name : holder_human.dna.features["custom_species"]
 		flavor_text = obscured ? "Obscured" : holder_human.dna.features[EXAMINE_DNA_FLAVOR_TEXT]
 		flavor_text_nsfw = obscured ? "Obscured" : holder_human.dna.features[EXAMINE_DNA_FLAVOR_TEXT_NSFW]


### PR DESCRIPTION

## About The Pull Request


Allows administrators (as observers) and the player themselves to see the information hidden by the mask on the mob.

## How This Contributes To The Nova Sector Roleplay Experience

Players don't need to go into the pref panel, and admins don't need to go into VV.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  

https://github.com/user-attachments/assets/038f7970-87db-404c-aa9b-a2912d83f780


</details>

## Changelog
:cl: Vishenka0704
qol: You can now view your own examine panel and flavor text even when wearing a mask.
admin: Admins in ghost mode can now view obscured information in player examine panels.
/:cl:
