### PR TITLE
Medigun's long long long overdue maintenance

### DIFF
--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -29,6 +29,8 @@
 		/obj/item/storage/pill_bottle,
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/tank/internals/plasmaman,
+		/obj/item/gun/energy/cell_loaded/medigun, //NOVA EDIT ADDITION - MEDIGUNS
+		/obj/item/storage/medkit, //NOVA EDIT ADDITION
 	)
 	armor_type = /datum/armor/toggle_labcoat
 	species_exception = list(/datum/species/golem)

--- a/modular_nova/modules/cellguns/code/cellgun_cells.dm
+++ b/modular_nova/modules/cellguns/code/cellgun_cells.dm
@@ -6,14 +6,6 @@
 	w_class = WEIGHT_CLASS_SMALL
 	/// The ammo type that is added by default when inserting a cell.
 	var/ammo_type = /obj/item/ammo_casing/energy/medical
-	/// Does the cell have a secondary firing mode? For Medicells this is called "safety"
-	var/toggle_modes = FALSE
-	/// Is the secondary firing mode currently toggled?
-	var/is_toggled =  TRUE
-	/// This is default ammo ype that is used when toggle_modes is enabled. If you are not using toggle_modes, this doesn't need to be touched.
-	var/primary_mode = /obj/item/ammo_casing/energy/medical
-	/// The secondary ammo type that the cell will use when toggled in hand, this is only used if toggle_modes is enabled.
-	var/secondary_mode = /obj/item/ammo_casing/energy/medical
 	/// The name of the current firing mode.
 	var/shot_name
 	/// Enables Medigun specific examine text.
@@ -37,30 +29,10 @@
 	. = ..()
 	if(shot_name)
 		. += span_noticealien("Using this on a cell based gun will unlock the [shot_name] firing mode")
-
-	if(!toggle_modes) //Doesn't show a description if it can't be toggled in the first place.
-		return
-
-	if(medicell_examine)
-		. += span_notice("The safety measures on the Medicell, preventing clone damage, are [is_toggled ? "enabled" : "disabled"]")
-		return
-	else
-		. += span_notice("[src] is using the [is_toggled ? "primary" : "secondary"] mode.")
-
 	return .
 
 /obj/item/weaponcell/attack_self(mob/living/user)
-	if(!toggle_modes) //Is the cell abled to be toggled? If not, return.
-		return
-
-	is_toggled = !is_toggled //Changes the toggle to the reverse of what it is.
-	src.ammo_type = is_toggled ? primary_mode : secondary_mode
-	playsound(loc,is_toggled ? 'sound/machines/defib/defib_SaftyOn.ogg' : 'sound/machines/defib/defib_saftyOff.ogg', 50)
-
-	if(medicell_examine)
-		balloon_alert(user, "safety [is_toggled ? "enabled" : "disabled"]")
-		return
-	else if(refresh_shot_name())
+	if(refresh_shot_name())
 		balloon_alert(user, "set to [shot_name]")
 
 	return

--- a/modular_nova/modules/cellguns/code/medigun_cells.dm
+++ b/modular_nova/modules/cellguns/code/medigun_cells.dm
@@ -60,43 +60,27 @@
 
 	return non_medicine_chems
 
-/// Heals Brute without safety
-/obj/projectile/energy/medical/proc/healBrute(mob/living/target, amount_healed, max_clone, base_disgust)
+/// Heals Brute if it's under 30, make them gain disgust.
+/obj/projectile/energy/medical/proc/healBrute(mob/living/target, amount_healed, base_disgust)
 	if(!IsLivingHuman(target))
+		return FALSE
+
+	if(target.get_brute_loss() >= 30 )
 		return FALSE
 
 	DamageDisgust(target, target.get_brute_loss())
 	target.adjust_disgust(base_disgust)
 	target.adjust_brute_loss(-amount_healed)
 
-/// Heals Burn swithout safety
-/obj/projectile/energy/medical/proc/healBurn(mob/living/target, amount_healed, max_clone, base_disgust)
+/// Heals Burn if it's under 30, make them gain disgust.
+/obj/projectile/energy/medical/proc/healBurn(mob/living/target, amount_healed, base_disgust)
 	if(!IsLivingHuman(target))
 		return FALSE
 
-	DamageDisgust(target, target.get_fire_loss())
-	target.adjust_disgust(base_disgust)
-	target.adjust_fire_loss(-amount_healed)
-
-/// Heals Brute with safety
-/obj/projectile/energy/medical/proc/safeBrute(mob/living/target, amount_healed, base_disgust)
-	if(!IsLivingHuman(target))
+	if(target.get_fire_loss() >= 30 )
 		return FALSE
 
-	if(target.get_brute_loss() >= 50 )
-		return FALSE
-
-	target.adjust_disgust(base_disgust)
-	target.adjust_brute_loss(-amount_healed)
-
-/// Heals Burn with safety.
-/obj/projectile/energy/medical/proc/safeBurn(mob/living/target, amount_healed, base_disgust)
-	if(!IsLivingHuman(target))
-		return FALSE
-
-	if(target.get_fire_loss() >= 50 )
-		return FALSE
-
+	DamageDisgust(target, target.get_brute_loss())
 	target.adjust_disgust(base_disgust)
 	target.adjust_fire_loss(-amount_healed)
 
@@ -132,12 +116,11 @@
 	name = "brute heal shot"
 	icon_state = "red_laser"
 	var/amount_healed = 7.5
-	var/max_clone = 2/3
 	var/base_disgust = 3
 
 /obj/projectile/energy/medical/brute/on_hit(mob/living/target, blocked = 0, pierce_hit)
 	. = ..()
-	healBrute(target, amount_healed, max_clone, base_disgust)
+	healBrute(target, amount_healed, base_disgust)
 
 //The Basic Burn Heal//
 /obj/item/ammo_casing/energy/medical/burn1
@@ -149,12 +132,11 @@
 	name = "burn heal shot"
 	icon_state = "yellow_laser"
 	var/amount_healed = 7.5
-	var/max_clone = 2/3
 	var/base_disgust = 3
 
 /obj/projectile/energy/medical/burn/on_hit(mob/living/target, blocked = 0, pierce_hit)
 	. = ..()
-	healBurn(target, amount_healed, max_clone, base_disgust)
+	healBurn(target, amount_healed, base_disgust)
 
 //Basic Toxin Heal//
 /obj/item/ammo_casing/energy/medical/toxin1
@@ -171,33 +153,6 @@
 	. = ..()
 	healTox(target, amount_healed)
 
-//SAFE MODES
-/obj/item/ammo_casing/energy/medical/brute1/safe
-	projectile_type = /obj/projectile/energy/medical/safe/brute
-
-/obj/projectile/energy/medical/safe/brute
-	name = "safe brute heal shot"
-	icon_state = "red_laser"
-	var/amount_healed = 7.5
-	var/base_disgust = 3
-
-/obj/projectile/energy/medical/safe/brute/on_hit(mob/living/target, blocked = 0, pierce_hit)
-	. = ..()
-	safeBrute(target, amount_healed, base_disgust)
-
-/obj/item/ammo_casing/energy/medical/burn1/safe
-	projectile_type = /obj/projectile/energy/medical/safe/burn
-
-/obj/projectile/energy/medical/safe/burn
-	name = "safe burn heal shot"
-	icon_state = "yellow_laser"
-	var/amount_healed = 7.5
-	var/base_disgust = 3
-
-/obj/projectile/energy/medical/safe/burn/on_hit(mob/living/target, blocked = 0, pierce_hit)
-	. = ..()
-	safeBurn(target, amount_healed, base_disgust)
-
 /*
 *	TIER TWO
 */
@@ -212,7 +167,6 @@
 	name = "strong brute heal shot"
 	pass_flags =  UPGRADED_MEDICELL_PASSFLAGS
 	amount_healed = 11.25
-	max_clone = 1/3
 	base_disgust = 2
 
 //Tier II Burn Projectile
@@ -225,7 +179,6 @@
 	name = "strong burn heal shot"
 	pass_flags =  UPGRADED_MEDICELL_PASSFLAGS
 	amount_healed = 11.25
-	max_clone = 1/3
 	base_disgust = 2
 
 //Tier II Oxy Projectile
@@ -250,26 +203,6 @@
 	pass_flags =  UPGRADED_MEDICELL_PASSFLAGS
 	amount_healed = 7.5
 
-//SAFE MODES
-/obj/item/ammo_casing/energy/medical/brute2/safe
-	projectile_type = /obj/projectile/energy/medical/safe/brute/better
-
-/obj/projectile/energy/medical/safe/brute/better
-	name = "safe strong brute heal shot"
-	pass_flags =  UPGRADED_MEDICELL_PASSFLAGS
-	amount_healed = 11.25
-	base_disgust = 2
-
-/obj/item/ammo_casing/energy/medical/burn2/safe
-	projectile_type = /obj/projectile/energy/medical/safe/burn/better
-
-/obj/projectile/energy/medical/safe/burn/better
-	name = "safe strong burn heal shot"
-	pass_flags =  UPGRADED_MEDICELL_PASSFLAGS
-	amount_healed = 11.25
-	base_disgust = 2
-
-
 /*
 *	TIER THREE
 */
@@ -283,7 +216,6 @@
 /obj/projectile/energy/medical/brute/better/best
 	name = "powerful brute heal shot"
 	amount_healed = 15
-	max_clone = 1/9
 	base_disgust = 1
 
 //Tier III Burn Projectile
@@ -295,7 +227,6 @@
 /obj/projectile/energy/medical/burn/better/best
 	name = "powerful burn heal shot"
 	amount_healed = 15
-	max_clone = 1/9
 	base_disgust = 1
 
 //Tier III Oxy Projectile
@@ -321,23 +252,6 @@
 /obj/projectile/energy/medical/upgraded/toxin3/on_hit(mob/living/target, blocked = 0, pierce_hit)
 	. = ..()
 	healTox(target, 10)
-
-//SAFE MODES
-/obj/item/ammo_casing/energy/medical/brute3/safe
-	projectile_type = /obj/projectile/energy/medical/safe/brute/better/best
-
-/obj/projectile/energy/medical/safe/brute/better/best
-	name = "safe powerful brute heal shot"
-	amount_healed = 15
-	base_disgust = 1
-
-/obj/item/ammo_casing/energy/medical/burn3/safe
-	projectile_type = /obj/projectile/energy/medical/safe/burn/better/best
-
-/obj/projectile/energy/medical/safe/burn/better/best
-	name = "safe powerful burn heal shot"
-	amount_healed = 15
-	base_disgust = 1
 
 /*
 *	UTILITY CELLS

--- a/modular_nova/modules/cellguns/code/medigun_cells.dm
+++ b/modular_nova/modules/cellguns/code/medigun_cells.dm
@@ -32,7 +32,7 @@
 */
 
 /// Applies digust by damage thresholds.
-/obj/projectile/energy/medical/proc/DamageDisgust(mob/living/target, type_damage)
+/obj/projectile/energy/medical/proc/damage_disgust(mob/living/target, type_damage)
 	if(type_damage >= 100)
 		target.adjust_disgust(3)
 
@@ -68,7 +68,7 @@
 	if(target.get_brute_loss() >= 30 )
 		return FALSE
 
-	DamageDisgust(target, target.get_brute_loss())
+	damage_disgust(target, target.get_brute_loss())
 	target.adjust_disgust(base_disgust)
 	target.adjust_brute_loss(-amount_healed)
 
@@ -80,7 +80,7 @@
 	if(target.get_fire_loss() >= 30 )
 		return FALSE
 
-	DamageDisgust(target, target.get_brute_loss())
+	damage_disgust(target, target.get_brute_loss())
 	target.adjust_disgust(base_disgust)
 	target.adjust_fire_loss(-amount_healed)
 

--- a/modular_nova/modules/cellguns/code/mediguns.dm
+++ b/modular_nova/modules/cellguns/code/mediguns.dm
@@ -156,7 +156,6 @@
 	icon_state = "Burn1"
 	ammo_type = /obj/item/ammo_casing/energy/medical/burn1
 
-// Toxin I
 /obj/item/weaponcell/medical/toxin
 	name = "toxin I medicell"
 	desc = "A small cell with a slight green glow. Can be used on mediguns to enable basic toxin damage healing functionality."
@@ -206,14 +205,12 @@
 	icon_state = "Brute3"
 	ammo_type = /obj/item/ammo_casing/energy/medical/brute3
 
-
 // Burn III
 /obj/item/weaponcell/medical/burn/tier_3
 	name = "burn III medicell"
 	desc = "A small cell with an intense yellow glow and a reinforced casing. Can be used on mediguns to enable advanced burn damage healing functionality."
 	icon_state = "Burn3"
 	ammo_type = /obj/item/ammo_casing/energy/medical/burn3
-
 
 // Toxin III
 /obj/item/weaponcell/medical/toxin/tier_3

--- a/modular_nova/modules/cellguns/code/mediguns.dm
+++ b/modular_nova/modules/cellguns/code/mediguns.dm
@@ -50,18 +50,17 @@
 /obj/item/stock_parts/power_store/cell/medigun // This is the cell that mediguns from cargo will come with
 	name = "basic medigun cell"
 	maxcharge = STANDARD_CELL_CHARGE * 1.2
-	chargerate = STANDARD_CELL_CHARGE * 0.75
 
 /obj/item/stock_parts/power_store/cell/medigun/upgraded
 	name = "upgraded medigun cell"
 	maxcharge = STANDARD_CELL_CHARGE * 1.5
-	chargerate = STANDARD_CELL_CHARGE * 1.5
+	chargerate = STANDARD_CELL_CHARGE * 0.1
 	emp_damage_modifier = 5
 
 /obj/item/stock_parts/power_store/cell/medigun/experimental // This cell type is meant to be used in self charging mediguns like CMO and ERT one.
 	name = "experimental medigun cell"
 	maxcharge = STANDARD_CELL_CHARGE * 1.8
-	chargerate = STANDARD_CELL_CHARGE * 1.5
+	chargerate = STANDARD_CELL_CHARGE * 0.1
 	emp_damage_modifier = 5
 // End of power cells
 

--- a/modular_nova/modules/cellguns/code/mediguns.dm
+++ b/modular_nova/modules/cellguns/code/mediguns.dm
@@ -49,19 +49,19 @@
 // Medigun power cells
 /obj/item/stock_parts/power_store/cell/medigun // This is the cell that mediguns from cargo will come with
 	name = "basic medigun cell"
-	maxcharge = 1.2 * STANDARD_CELL_CHARGE
-	chargerate = 0.04 * STANDARD_CELL_CHARGE
+	maxcharge = STANDARD_CELL_CHARGE * 1.2
+	chargerate = STANDARD_CELL_CHARGE * 0.75
 
 /obj/item/stock_parts/power_store/cell/medigun/upgraded
 	name = "upgraded medigun cell"
-	maxcharge = 1.5 * STANDARD_CELL_CHARGE
-	chargerate = 0.08 * STANDARD_CELL_CHARGE
+	maxcharge = STANDARD_CELL_CHARGE * 1.5
+	chargerate = STANDARD_CELL_CHARGE * 1.5
 	emp_damage_modifier = 5
 
 /obj/item/stock_parts/power_store/cell/medigun/experimental // This cell type is meant to be used in self charging mediguns like CMO and ERT one.
 	name = "experimental medigun cell"
-	maxcharge = 1.8 * STANDARD_CELL_CHARGE
-	chargerate = 0.1 * STANDARD_CELL_CHARGE
+	maxcharge = STANDARD_CELL_CHARGE * 1.8
+	chargerate = STANDARD_CELL_CHARGE * 1.5
 	emp_damage_modifier = 5
 // End of power cells
 
@@ -148,20 +148,15 @@
 	name = "brute I medicell"
 	desc = "A small cell with a slight red glow. Can be used on mediguns to enable basic brute damage healing functionality."
 	icon_state = "Brute1"
-	ammo_type = /obj/item/ammo_casing/energy/medical/brute1/safe
-	secondary_mode = /obj/item/ammo_casing/energy/medical/brute1
-	primary_mode = /obj/item/ammo_casing/energy/medical/brute1/safe
-	toggle_modes = TRUE
+	ammo_type = /obj/item/ammo_casing/energy/medical/brute1
 
 // Burn I
 /obj/item/weaponcell/medical/burn
 	name = "burn I medicell"
 	desc = "A small cell with a slight yellow glow. Can be used on mediguns to enable basic burn damage healing functionality."
 	icon_state = "Burn1"
-	ammo_type = /obj/item/ammo_casing/energy/medical/burn1/safe
-	secondary_mode = /obj/item/ammo_casing/energy/medical/burn1
-	primary_mode = /obj/item/ammo_casing/energy/medical/burn1/safe
-	toggle_modes = TRUE
+	ammo_type = /obj/item/ammo_casing/energy/medical/burn1
+
 // Toxin I
 /obj/item/weaponcell/medical/toxin
 	name = "toxin I medicell"
@@ -178,18 +173,14 @@
 	name = "brute II medicell"
 	desc = "A small cell with a noticeable red glow. Can be used on mediguns to enable improved brute damage healing functionality."
 	icon_state = "Brute2"
-	ammo_type = /obj/item/ammo_casing/energy/medical/brute2/safe
-	secondary_mode = /obj/item/ammo_casing/energy/medical/brute2
-	primary_mode = /obj/item/ammo_casing/energy/medical/brute2/safe
+	ammo_type = /obj/item/ammo_casing/energy/medical/brute2
 
 // Burn II
 /obj/item/weaponcell/medical/burn/tier_2
 	name = "burn II medicell"
 	desc = "A small cell with a noticeable yellow glow. Can be used on mediguns to enable improved burn damage healing functionality."
 	icon_state = "Burn2"
-	ammo_type = /obj/item/ammo_casing/energy/medical/burn2/safe
-	secondary_mode = /obj/item/ammo_casing/energy/medical/burn2
-	primary_mode = /obj/item/ammo_casing/energy/medical/burn2/safe
+	ammo_type = /obj/item/ammo_casing/energy/medical/burn2
 
 // Toxin II
 /obj/item/weaponcell/medical/toxin/tier_2
@@ -214,18 +205,16 @@
 	name = "brute III medicell"
 	desc = "A small cell with an intense red glow and a reinforced casing. Can be used on mediguns to enable advanced brute damage healing functionality."
 	icon_state = "Brute3"
-	ammo_type = /obj/item/ammo_casing/energy/medical/brute3/safe
-	secondary_mode = /obj/item/ammo_casing/energy/medical/brute3
-	primary_mode = /obj/item/ammo_casing/energy/medical/brute3/safe
+	ammo_type = /obj/item/ammo_casing/energy/medical/brute3
+
 
 // Burn III
 /obj/item/weaponcell/medical/burn/tier_3
 	name = "burn III medicell"
 	desc = "A small cell with an intense yellow glow and a reinforced casing. Can be used on mediguns to enable advanced burn damage healing functionality."
 	icon_state = "Burn3"
-	ammo_type = /obj/item/ammo_casing/energy/medical/burn3/safe
-	secondary_mode = /obj/item/ammo_casing/energy/medical/burn3
-	primary_mode = /obj/item/ammo_casing/energy/medical/burn3/safe
+	ammo_type = /obj/item/ammo_casing/energy/medical/burn3
+
 
 // Toxin III
 /obj/item/weaponcell/medical/toxin/tier_3


### PR DESCRIPTION

## About The Pull Request

Did you know the medigun had an alt mode? Did you know this altmode was supposed to let you bypass the damage limit and apply clone damage?

Yeah clone damage has been gone since 2023 

This PR removes the secondary mode and all the clone damage related, i thought to maybe replace it with disgust for all modes but figured that may just become more annoying than it's worth so for now the secondary mode is just gone from code (it was broken anyway).

I've also finally enabled it to let you put the medigun in the normal labcoat and not just the CMO one.

## How This Contributes To The Nova Sector Roleplay Experience

These are fairly useful but due to how they've kind of rotted i'd rather we go with some simple changes before looking at other options.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="659" height="242" alt="image" src="https://github.com/user-attachments/assets/e5aa4b81-e106-4c0e-b621-a3cb8d314cd1" />


</details>

## Changelog
:cl:
qol: Mediguns can now fit inside of labcoats
balance: Medigun damage thresholds lowered from 50 to 30
refactor: Medigun clone damage has been removed from code
/:cl:
