### PR TITLE
Fixes a singular typo in a completely unused nukie uplink kit

### DIFF
--- a/modular_nova/modules/moretraitoritems/code/uplink_kits.dm
+++ b/modular_nova/modules/moretraitoritems/code/uplink_kits.dm
@@ -1,4 +1,4 @@
-/obj/item/storage/box/syndie_kit/cultkisr
+/obj/item/storage/box/syndie_kit/cultkitsr
 	name = "cult construct kit"
 	desc = "A sleek, sturdy box with an ominous, dark energy inside. Yikes."
 


### PR DESCRIPTION

## About The Pull Request
Oversight of a single 't'.
## How This Contributes To The Nova Sector Roleplay Experience
Play testing go brr. This bug is like over three years old. Amazing.
## Proof of Testing
singular letter change is proof.
## Changelog
:cl:
fix: Adds a single 3+ year missing 't' to the nukie cultist soulstone kit path, making it populate correctly.
/:cl:
