### PR TITLE
heretic jaunt nerfs + feast of owls nerf

### DIFF
--- a/code/modules/antagonists/heretic/magic/space_crawl.dm
+++ b/code/modules/antagonists/heretic/magic/space_crawl.dm
@@ -21,7 +21,7 @@
 
 	jaunt_type = /obj/effect/dummy/phased_mob/spell_jaunt/space
 	///List of traits that are added to the heretic while in space phase jaunt
-	var/static/list/jaunting_traits = list(TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTCOLD, TRAIT_NOBREATH)
+	var/static/list/jaunting_traits = list() // NOVA EDIT CHANGE - ORIGINAL var/static/list/jaunting_traits = list(TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTCOLD, TRAIT_NOBREATH)
 
 /datum/action/cooldown/spell/jaunt/space_crawl/Grant(mob/grant_to)
 	. = ..()

--- a/modular_nova/master_files/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/modular_nova/master_files/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -1,0 +1,3 @@
+/datum/heretic_knowledge/feast_of_owls
+	is_starting_knowledge = FALSE
+	abstract_parent_type = /datum/heretic_knowledge/feast_of_owls

--- a/modular_nova/master_files/code/modules/antagonists/heretic/magic/ash_jaunt.dm
+++ b/modular_nova/master_files/code/modules/antagonists/heretic/magic/ash_jaunt.dm
@@ -1,0 +1,2 @@
+/datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash
+	cooldown_time = 30 SECONDS

--- a/modular_nova/master_files/code/modules/antagonists/heretic/magic/space_crawl.dm
+++ b/modular_nova/master_files/code/modules/antagonists/heretic/magic/space_crawl.dm
@@ -1,12 +1,14 @@
 /datum/action/cooldown/spell/jaunt/space_crawl
 	/// Have we successfully casted a jaunt? Used for triggering a cooldown when we exit Space Phase.
 	var/successful_jaunt = FALSE
+	/// What cooldown do we inflict when exiting jaunt?
+	var/jaunt_cooldown = 30 SECONDS
 
 /datum/action/cooldown/spell/jaunt/space_crawl/after_cast(atom/cast_on)
 	. = ..()
 	successful_jaunt = !successful_jaunt
 	if(!successful_jaunt)
-		StartCooldown(30 SECONDS)
+		StartCooldown(jaunt_cooldown)
 
 /obj/effect/dummy/phased_mob/spell_jaunt/space/set_jaunter(atom/movable/new_jaunter)
 	. = ..()

--- a/modular_nova/master_files/code/modules/antagonists/heretic/magic/space_crawl.dm
+++ b/modular_nova/master_files/code/modules/antagonists/heretic/magic/space_crawl.dm
@@ -1,6 +1,12 @@
-/datum/action/cooldown/spell/jaunt/space_crawl/on_jaunt_exited(obj/effect/dummy/phased_mob/jaunt, mob/living/unjaunter)
+/datum/action/cooldown/spell/jaunt/space_crawl
+	/// Have we successfully casted a jaunt? Used for triggering a cooldown when we exit Space Phase.
+	var/successful_jaunt = FALSE
+
+/datum/action/cooldown/spell/jaunt/space_crawl/after_cast(atom/cast_on)
 	. = ..()
-	addtimer(CALLBACK(src, PROC_REF(StartCooldown), 30 SECONDS), 0 SECONDS)
+	successful_jaunt = !successful_jaunt
+	if(!successful_jaunt)
+		StartCooldown(30 SECONDS)
 
 /obj/effect/dummy/phased_mob/spell_jaunt/space/set_jaunter(atom/movable/new_jaunter)
 	. = ..()

--- a/modular_nova/master_files/code/modules/antagonists/heretic/magic/space_crawl.dm
+++ b/modular_nova/master_files/code/modules/antagonists/heretic/magic/space_crawl.dm
@@ -1,6 +1,2 @@
 /datum/action/cooldown/spell/jaunt/space_crawl
 	cooldown_time = 15 SECONDS
-	jaunting_traits = list()
-	jaunt_in_time = 2 SECONDS
-	jaunt_in_type = /obj/effect/temp_visual/wizard
-	jaunt_out_type = /obj/effect/temp_visual/wizard/out

--- a/modular_nova/master_files/code/modules/antagonists/heretic/magic/space_crawl.dm
+++ b/modular_nova/master_files/code/modules/antagonists/heretic/magic/space_crawl.dm
@@ -11,6 +11,11 @@
 
 /obj/effect/dummy/phased_mob/spell_jaunt/space/phased_check(mob/living/user, direction)
 	. = ..()
-	if(. && !isspaceturf(.))
-		to_chat(user, span_warning("You can't phase through anything but space."))
-		return FALSE
+	var/turf/my_turf = get_turf(owner)
+	if(isspaceturf(my_turf))
+		return TRUE
+	var/area/my_area = get_area(owner)
+	if (isopenturf(my_turf) && my_area.outdoors && lavaland_equipment_pressure_check(my_turf))
+		return TRUE
+	to_chat(user, "You can only traverse space or low-pressure outdoors areas while space crawling!")
+	return FALSE

--- a/modular_nova/master_files/code/modules/antagonists/heretic/magic/space_crawl.dm
+++ b/modular_nova/master_files/code/modules/antagonists/heretic/magic/space_crawl.dm
@@ -1,2 +1,16 @@
-/datum/action/cooldown/spell/jaunt/space_crawl
-	cooldown_time = 15 SECONDS
+/datum/action/cooldown/spell/jaunt/space_crawl/Grant(mob/grant_to)
+	. = ..()
+	RegisterSignal(grant_to, COMSIG_MOB_AFTER_EXIT_JAUNT, PROC_REF(apply_cooldown))
+
+/datum/action/cooldown/spell/jaunt/space_crawl/Remove(mob/remove_from)
+	. = ..()
+	UnregisterSignal(remove_from, COMSIG_MOB_AFTER_EXIT_JAUNT)
+
+/datum/action/cooldown/spell/jaunt/space_crawl/proc/apply_cooldown()
+	addtimer(CALLBACK(src, PROC_REF(StartCooldown), 30 SECONDS), 0.1 SECONDS)
+
+/obj/effect/dummy/phased_mob/spell_jaunt/space/phased_check(mob/living/user, direction)
+	. = ..()
+	if(. && !isspaceturf(.))
+		to_chat(user, span_warning("You can't phase through anything but space."))
+		return FALSE

--- a/modular_nova/master_files/code/modules/antagonists/heretic/magic/space_crawl.dm
+++ b/modular_nova/master_files/code/modules/antagonists/heretic/magic/space_crawl.dm
@@ -11,10 +11,10 @@
 
 /obj/effect/dummy/phased_mob/spell_jaunt/space/phased_check(mob/living/user, direction)
 	. = ..()
-	var/turf/my_turf = get_turf(owner)
+	var/turf/my_turf = get_turf(user)
 	if(isspaceturf(my_turf))
 		return TRUE
-	var/area/my_area = get_area(owner)
+	var/area/my_area = get_area(user)
 	if (isopenturf(my_turf) && my_area.outdoors && lavaland_equipment_pressure_check(my_turf))
 		return TRUE
 	to_chat(user, "You can only traverse space or low-pressure outdoors areas while space crawling!")

--- a/modular_nova/master_files/code/modules/antagonists/heretic/magic/space_crawl.dm
+++ b/modular_nova/master_files/code/modules/antagonists/heretic/magic/space_crawl.dm
@@ -1,0 +1,6 @@
+/datum/action/cooldown/spell/jaunt/space_crawl
+	cooldown_time = 15 SECONDS
+	jaunting_traits = list()
+	jaunt_in_time = 2 SECONDS
+	jaunt_in_type = /obj/effect/temp_visual/wizard
+	jaunt_out_type = /obj/effect/temp_visual/wizard/out

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7098,6 +7098,7 @@
 #include "modular_nova\master_files\code\modules\antagonists\cult\cult_items.dm"
 #include "modular_nova\master_files\code\modules\antagonists\ert\ert.dm"
 #include "modular_nova\master_files\code\modules\antagonists\heretic\knowledge\general_side.dm"
+#include "modular_nova\master_files\code\modules\antagonists\heretic\knowledge\starting_lore.dm"
 #include "modular_nova\master_files\code\modules\antagonists\heretic\magic\ash_jaunt.dm"
 #include "modular_nova\master_files\code\modules\antagonists\heretic\magic\space_crawl.dm"
 #include "modular_nova\master_files\code\modules\antagonists\malf_ai\malf_ai_modules.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7098,6 +7098,8 @@
 #include "modular_nova\master_files\code\modules\antagonists\cult\cult_items.dm"
 #include "modular_nova\master_files\code\modules\antagonists\ert\ert.dm"
 #include "modular_nova\master_files\code\modules\antagonists\heretic\knowledge\general_side.dm"
+#include "modular_nova\master_files\code\modules\antagonists\heretic\magic\ash_jaunt.dm"
+#include "modular_nova\master_files\code\modules\antagonists\heretic\magic\space_crawl.dm"
 #include "modular_nova\master_files\code\modules\antagonists\malf_ai\malf_ai_modules.dm"
 #include "modular_nova\master_files\code\modules\antagonists\ninja\outfit.dm"
 #include "modular_nova\master_files\code\modules\antagonists\ninja\space_ninja.dm"


### PR DESCRIPTION
## About The Pull Request

- ash jaunt CD doubled from 15s -> 30s
- space crawl given a cooldown of 30s that applies when you cast it
- space crawl no longer grants space immunity
- space crawl only works on space/outdoors - if you can't start spacecrawl in it, you can't traverse it
- feast of owls is no longer learnable

## Proof of Testing
<img width="288" height="175" alt="image" src="https://github.com/user-attachments/assets/994b2db3-88a3-4239-80ca-8d37da071c16" />
<img width="556" height="54" alt="image" src="https://github.com/user-attachments/assets/6e1c4209-1fef-4db9-9c17-5e2498f4af60" />


## How This Contributes To The Nova Sector Roleplay Experience

Jaunts are deeply unfun to fight. Space phase is egregious because it's an ability with no cooldown, free usability, high movespeed, space immunity, et cetera. Ashen passage... could be worse, honestly, but it's still annoying to fight. In an ideal world, moderating the player, not the toolkit, would be the move, but as a stopgap measure, this PR exists.

Giving space crawl a long cooldown, no space immunity, and only working in outdoors areas makes it only good for rotating the outside of the station, and with a time limit if you're not space immune.

Feast of owls was killed off using the same logic as https://github.com/Bubberstation/Bubberstation/pull/4936 (tl;dr you get banned if you ascend anyway so logically you just do this for 3 free points).

## Changelog

:cl:
balance: Space Phase now has a cooldown of 30 seconds, up from 0, that applies when you exit Space Phase.
balance: Space Phase no longer grants space immunity and only allows traversal on space or low-pressure outdoors turfs.
balance: Ashen Passage cooldown doubled to 30 seconds, up from 15.
balance: Feast of Owls is no longer a roundstart knowledge.
/:cl:
