### PR TITLE
Bebop's Got Me - MOD tether but it stops teleports if embedded

### DIFF
--- a/code/modules/mod/modules/modules_engineering.dm
+++ b/code/modules/mod/modules/modules_engineering.dm
@@ -132,6 +132,10 @@
 	incompatible_modules = list(/obj/item/mod/module/tether)
 	cooldown_time = 1.5 SECONDS
 	required_slots = list(ITEM_SLOT_GLOVES)
+	// NOVA EDIT ADDITION START: editable projectile
+	/// What kind of tether projectile do we fire? This should probably be a subtype of /obj/projectile/tether.
+	var/obj/projectile/tether/tether_type = /obj/projectile/tether
+	// NOVA EDIT ADDITION END
 
 /obj/item/mod/module/tether/used()
 	if(HAS_TRAIT_FROM(mod.wearer, TRAIT_TETHER_ATTACHED, REF(src)))
@@ -144,7 +148,9 @@
 	. = ..()
 	if(!.)
 		return
-	var/obj/projectile/tether = new /obj/projectile/tether(mod.wearer.loc, src)
+	// NOVA EDIT CHANGE START: editable projectile
+	var/obj/projectile/tether = new tether_type(mod.wearer.loc, src)// NOVA EDIT CHANGE -  ORIGINAL var/obj/projectile/tether = new /obj/projectile/tether(mod.wearer.loc, src)
+	// NOVA EDIT CHANGE END
 	tether.aim_projectile(target, mod.wearer)
 	tether.firer = mod.wearer
 	playsound(src, 'sound/items/weapons/batonextend.ogg', 25, TRUE)

--- a/code/modules/mod/modules/modules_engineering.dm
+++ b/code/modules/mod/modules/modules_engineering.dm
@@ -132,10 +132,6 @@
 	incompatible_modules = list(/obj/item/mod/module/tether)
 	cooldown_time = 1.5 SECONDS
 	required_slots = list(ITEM_SLOT_GLOVES)
-	// NOVA EDIT ADDITION START: editable projectile
-	/// What kind of tether projectile do we fire? This should probably be a subtype of /obj/projectile/tether.
-	var/obj/projectile/tether/tether_type = /obj/projectile/tether
-	// NOVA EDIT ADDITION END
 
 /obj/item/mod/module/tether/used()
 	if(HAS_TRAIT_FROM(mod.wearer, TRAIT_TETHER_ATTACHED, REF(src)))
@@ -148,13 +144,8 @@
 	. = ..()
 	if(!.)
 		return
-	// NOVA EDIT CHANGE START: editable projectile
-	var/obj/projectile/tether = new tether_type(mod.wearer.loc, src)// NOVA EDIT CHANGE -  ORIGINAL var/obj/projectile/tether = new /obj/projectile/tether(mod.wearer.loc, src)
-	// NOVA EDIT CHANGE END
+	var/obj/projectile/tether = new tether_type(mod.wearer.loc, src) // NOVA EDIT CHANGE - editable projectile - ORIGINAL var/obj/projectile/tether = new /obj/projectile/tether(mod.wearer.loc, src)
 	tether.aim_projectile(target, mod.wearer)
-	tether.firer = mod.wearer
-	playsound(src, 'sound/items/weapons/batonextend.ogg', 25, TRUE)
-	INVOKE_ASYNC(tether, TYPE_PROC_REF(/obj/projectile, fire))
 	drain_power(use_energy_cost)
 
 /obj/item/mod/module/tether/get_configuration()

--- a/code/modules/mod/modules/modules_engineering.dm
+++ b/code/modules/mod/modules/modules_engineering.dm
@@ -146,6 +146,9 @@
 		return
 	var/obj/projectile/tether = new tether_type(mod.wearer.loc, src) // NOVA EDIT CHANGE - editable projectile - ORIGINAL var/obj/projectile/tether = new /obj/projectile/tether(mod.wearer.loc, src)
 	tether.aim_projectile(target, mod.wearer)
+	tether.firer = mod.wearer
+	playsound(src, 'sound/items/weapons/batonextend.ogg', 25, TRUE)
+	INVOKE_ASYNC(tether, TYPE_PROC_REF(/obj/projectile, fire))
 	drain_power(use_energy_cost)
 
 /obj/item/mod/module/tether/get_configuration()

--- a/modular_nova/master_files/code/modules/research/designs/mechfabricator_designs.dm
+++ b/modular_nova/master_files/code/modules/research/designs/mechfabricator_designs.dm
@@ -14,3 +14,17 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
 	research_icon_state = "security-plating"
+
+/datum/design/module/mod_tether_grounded
+	name = "Grounded Apprehension Module"
+	id = "mod_tether_grounded"
+	materials = list(
+		/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT,
+		/datum/material/silver = HALF_SHEET_MATERIAL_AMOUNT,
+		/datum/material/gold = HALF_SHEET_MATERIAL_AMOUNT,
+		/datum/material/bluespace = SMALL_MATERIAL_AMOUNT * 3,
+	)
+	build_path = /obj/item/mod/module/tether/anti_teleport
+	category = list(
+		RND_CATEGORY_MODSUIT_MODULES + RND_SUBCATEGORY_MODSUIT_MODULES_SECURITY
+	)

--- a/modular_nova/master_files/code/modules/research/techweb/all_nodes.dm
+++ b/modular_nova/master_files/code/modules/research/techweb/all_nodes.dm
@@ -341,5 +341,6 @@
 /datum/techweb_node/mod_security/New()
 	design_ids += list(
 		"mod_plating_security",
+		"mod_tether_grounded",
 	)
 	return ..()

--- a/modular_nova/modules/teleport_counters/anchor_tether.dm
+++ b/modular_nova/modules/teleport_counters/anchor_tether.dm
@@ -1,5 +1,5 @@
 /obj/item/mod/module/tether/anti_teleport
-	name = "MOD grounded apprehension module"
+	name = "MOD grounding apprehension module"
 	desc = "A custom-built grappling-hook powered by a winch capable of hauling the user. \
 		The serrated edges on this variant's anchors, and the flashforged bluespace grounding circuit, \
 		mean that each tether drains much more charge when fired. It remains functional as a tether, though."
@@ -7,12 +7,12 @@
 	tether_type = /obj/projectile/tether/anti_teleport
 
 /obj/projectile/tether/anti_teleport
-	name = "grounded tether"
+	name = "grounding tether"
 	embed_type = /datum/embedding/tether_projectile/anti_teleport
 	shrapnel_type = /obj/item/tether_anchor/anti_teleport
 
 /obj/item/tether_anchor/anti_teleport
-	name = "grounded tether anchor"
+	name = "grounding tether anchor"
 	desc = "A reinforced anchor with a tether attachment point and an integrated bluespace grounding circuit. \
 		Still usable as an emergency tether, though how useful that would be is questionable."
 
@@ -34,7 +34,8 @@
 
 	to_chat(teleportee, span_holoparasite("You feel yourself teleporting, but are suddenly flung back to where you just were!"))
 
-	teleportee.apply_status_effect(/datum/status_effect/incapacitating/paralyzed, 5 SECONDS)
+	teleportee.apply_status_effect(/datum/status_effect/incapacitating/knockdown, 2 SECONDS)
+	teleportee.apply_damage(55, STAMINA)
 	var/datum/effect_system/spark_spread/quantum/spark_system = new()
 	spark_system.set_up(5, TRUE, teleportee)
 	spark_system.start()
@@ -46,7 +47,8 @@
 
 	to_chat(jaunter, span_holoparasite("As you attempt to jaunt, you slam directly into the barrier between realities and are sent crashing back into corporeality!"))
 
-	jaunter.apply_status_effect(/datum/status_effect/incapacitating/paralyzed, 5 SECONDS)
+	jaunter.apply_status_effect(/datum/status_effect/incapacitating/knockdown, 2 SECONDS)
+	jaunter.apply_damage(55, STAMINA)
 	var/datum/effect_system/spark_spread/quantum/spark_system = new()
 	spark_system.set_up(5, TRUE, jaunter)
 	spark_system.start()

--- a/modular_nova/modules/teleport_counters/anchor_tether.dm
+++ b/modular_nova/modules/teleport_counters/anchor_tether.dm
@@ -1,0 +1,56 @@
+/obj/item/mod/module/tether/anti_teleport
+	name = "MOD bluespace-grounded tether module"
+	desc = "A custom-built grappling-hook powered by a winch capable of hauling the user. \
+		The serrated edges on this variant's anchors, and the flashforged bluespace grounding circuit, \
+		mean that each tether drains much more charge when fired."
+	use_energy_cost = DEFAULT_CHARGE_DRAIN * 5
+	tether_type = /obj/projectile/tether/anti_teleport
+
+/obj/projectile/tether/anti_teleport
+	name = "grounded tether"
+	embed_type = /datum/embedding/tether_projectile/anti_teleport
+	shrapnel_type = /obj/item/tether_anchor/anti_teleport
+
+/obj/item/tether_anchor/anti_teleport
+	name = "grounded tether anchor"
+	desc = "A reinforced anchor with a tether attachment point and an integrated bluespace grounding circuit. \
+		When embedded in targets, prevents teleporting. Still usable as an emergency tether, but that's not what you're \
+		going to be using this for, are you?"
+	embed_type = /datum/embedding/tether_projectile/anti_teleport
+
+/datum/embedding/tether_projectile/anti_teleport
+	embed_chance = 90
+	rip_time = 3 SECONDS
+
+/datum/embedding/tether_projectile/anti_teleport/on_successful_embed(mob/living/carbon/victim, obj/item/bodypart/target_limb)
+	RegisterSignal(victim, COMSIG_MOVABLE_TELEPORTING, PROC_REF(on_teleport))
+	RegisterSignal(victim, COMSIG_MOB_PRE_JAUNT, PROC_REF(on_jaunt))
+
+/datum/embedding/tether_projectile/anti_teleport/stop_embedding()
+	. = ..()
+	if(owner)
+		UnregisterSignal(owner, list(COMSIG_MOVABLE_TELEPORTING, COMSIG_MOB_PRE_JAUNT))
+
+/// Signal for COMSIG_MOVABLE_TELEPORTING that blocks teleports and stuns the would-be-teleportee, adapted from implant_noteleport.dm
+/datum/embedding/tether_projectile/anti_teleport/proc/on_teleport(mob/living/teleportee, atom/destination, channel)
+	SIGNAL_HANDLER
+
+	to_chat(teleportee, span_holoparasite("You feel yourself teleporting, but are suddenly flung back to where you just were!"))
+
+	teleportee.apply_status_effect(/datum/status_effect/incapacitating/paralyzed, 5 SECONDS)
+	var/datum/effect_system/spark_spread/quantum/spark_system = new()
+	spark_system.set_up(5, TRUE, teleportee)
+	spark_system.start()
+	return TRUE
+
+/// Signal for COMSIG_MOB_PRE_JAUNT that prevents a user from entering a jaunt.
+/datum/embedding/tether_projectile/anti_teleport/proc/on_jaunt(mob/living/jaunter)
+	SIGNAL_HANDLER
+
+	to_chat(jaunter, span_holoparasite("As you attempt to jaunt, you slam directly into the barrier between realities and are sent crashing back into corporeality!"))
+
+	jaunter.apply_status_effect(/datum/status_effect/incapacitating/paralyzed, 5 SECONDS)
+	var/datum/effect_system/spark_spread/quantum/spark_system = new()
+	spark_system.set_up(5, TRUE, jaunter)
+	spark_system.start()
+	return COMPONENT_BLOCK_JAUNT

--- a/modular_nova/modules/teleport_counters/anchor_tether.dm
+++ b/modular_nova/modules/teleport_counters/anchor_tether.dm
@@ -1,8 +1,8 @@
 /obj/item/mod/module/tether/anti_teleport
-	name = "MOD bluespace-grounded tether module"
+	name = "MOD grounded apprehension module"
 	desc = "A custom-built grappling-hook powered by a winch capable of hauling the user. \
 		The serrated edges on this variant's anchors, and the flashforged bluespace grounding circuit, \
-		mean that each tether drains much more charge when fired."
+		mean that each tether drains much more charge when fired. It remains functional as a tether, though."
 	use_energy_cost = DEFAULT_CHARGE_DRAIN * 5
 	tether_type = /obj/projectile/tether/anti_teleport
 
@@ -14,9 +14,7 @@
 /obj/item/tether_anchor/anti_teleport
 	name = "grounded tether anchor"
 	desc = "A reinforced anchor with a tether attachment point and an integrated bluespace grounding circuit. \
-		When embedded in targets, prevents teleporting. Still usable as an emergency tether, but that's not what you're \
-		going to be using this for, are you?"
-	embed_type = /datum/embedding/tether_projectile/anti_teleport
+		Still usable as an emergency tether, though how useful that would be is questionable."
 
 /datum/embedding/tether_projectile/anti_teleport
 	embed_chance = 90
@@ -26,10 +24,9 @@
 	RegisterSignal(victim, COMSIG_MOVABLE_TELEPORTING, PROC_REF(on_teleport))
 	RegisterSignal(victim, COMSIG_MOB_PRE_JAUNT, PROC_REF(on_jaunt))
 
-/datum/embedding/tether_projectile/anti_teleport/stop_embedding()
+/datum/embedding/tether_projectile/anti_teleport/remove_embedding(mob/living/to_hands)
+	UnregisterSignal(owner, list(COMSIG_MOVABLE_TELEPORTING, COMSIG_MOB_PRE_JAUNT))
 	. = ..()
-	if(owner)
-		UnregisterSignal(owner, list(COMSIG_MOVABLE_TELEPORTING, COMSIG_MOB_PRE_JAUNT))
 
 /// Signal for COMSIG_MOVABLE_TELEPORTING that blocks teleports and stuns the would-be-teleportee, adapted from implant_noteleport.dm
 /datum/embedding/tether_projectile/anti_teleport/proc/on_teleport(mob/living/teleportee, atom/destination, channel)

--- a/modular_nova/modules/teleport_counters/anchor_tether.dm
+++ b/modular_nova/modules/teleport_counters/anchor_tether.dm
@@ -34,6 +34,7 @@
 
 	to_chat(teleportee, span_holoparasite("You feel yourself teleporting, but are suddenly flung back to where you just were!"))
 
+	teleportee.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH * 2, 10 SECONDS)
 	teleportee.apply_status_effect(/datum/status_effect/incapacitating/knockdown, 2 SECONDS)
 	teleportee.apply_damage(55, STAMINA)
 	var/datum/effect_system/spark_spread/quantum/spark_system = new()
@@ -47,6 +48,7 @@
 
 	to_chat(jaunter, span_holoparasite("As you attempt to jaunt, you slam directly into the barrier between realities and are sent crashing back into corporeality!"))
 
+	jaunter.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH * 2, 10 SECONDS)
 	jaunter.apply_status_effect(/datum/status_effect/incapacitating/knockdown, 2 SECONDS)
 	jaunter.apply_damage(55, STAMINA)
 	var/datum/effect_system/spark_spread/quantum/spark_system = new()

--- a/modular_nova/modules/teleport_counters/anchor_tether.dm
+++ b/modular_nova/modules/teleport_counters/anchor_tether.dm
@@ -26,20 +26,15 @@
 
 /datum/embedding/tether_projectile/anti_teleport/remove_embedding(mob/living/to_hands)
 	UnregisterSignal(owner, list(COMSIG_MOVABLE_TELEPORTING, COMSIG_MOB_PRE_JAUNT))
-	. = ..()
+	return ..()
 
 /// Signal for COMSIG_MOVABLE_TELEPORTING that blocks teleports and stuns the would-be-teleportee, adapted from implant_noteleport.dm
 /datum/embedding/tether_projectile/anti_teleport/proc/on_teleport(mob/living/teleportee, atom/destination, channel)
 	SIGNAL_HANDLER
 
 	to_chat(teleportee, span_holoparasite("You feel yourself teleporting, but are suddenly flung back to where you just were!"))
+	penalize(teleportee)
 
-	teleportee.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH * 2, 10 SECONDS)
-	teleportee.apply_status_effect(/datum/status_effect/incapacitating/knockdown, 2 SECONDS)
-	teleportee.apply_damage(55, STAMINA)
-	var/datum/effect_system/spark_spread/quantum/spark_system = new()
-	spark_system.set_up(5, TRUE, teleportee)
-	spark_system.start()
 	return TRUE
 
 /// Signal for COMSIG_MOB_PRE_JAUNT that prevents a user from entering a jaunt.
@@ -47,11 +42,16 @@
 	SIGNAL_HANDLER
 
 	to_chat(jaunter, span_holoparasite("As you attempt to jaunt, you slam directly into the barrier between realities and are sent crashing back into corporeality!"))
+	penalize(jaunter)
 
-	jaunter.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH * 2, 10 SECONDS)
-	jaunter.apply_status_effect(/datum/status_effect/incapacitating/knockdown, 2 SECONDS)
-	jaunter.apply_damage(55, STAMINA)
-	var/datum/effect_system/spark_spread/quantum/spark_system = new()
-	spark_system.set_up(5, TRUE, jaunter)
-	spark_system.start()
 	return COMPONENT_BLOCK_JAUNT
+
+/// Stuns a target, presumably the offending party/embed target/whoever was about to try teleporting.
+/datum/embedding/tether_projectile/anti_teleport/proc/penalize(mob/living/target)
+	target.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH * 2, 10 SECONDS)
+	target.Knockdown(0.2 SECONDS)
+	target.drop_all_held_items()
+	target.apply_damage(55, STAMINA)
+	var/datum/effect_system/spark_spread/quantum/spark_system = new()
+	spark_system.set_up(5, TRUE, target)
+	spark_system.start()

--- a/modular_nova/modules/teleport_counters/anchor_tether.dm
+++ b/modular_nova/modules/teleport_counters/anchor_tether.dm
@@ -1,3 +1,7 @@
+/obj/item/mod/module/tether
+	/// What kind of tether projectile do we fire? This should probably be a subtype of /obj/projectile/tether.
+	var/obj/projectile/tether/tether_type = /obj/projectile/tether
+
 /obj/item/mod/module/tether/anti_teleport
 	name = "MOD grounding apprehension module"
 	desc = "A custom-built grappling-hook powered by a winch capable of hauling the user. \

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9374,6 +9374,7 @@
 #include "modular_nova\modules\telepathy_quirk\code\telepathy_block_quirk.dm"
 #include "modular_nova\modules\telepathy_quirk\code\telepathy_quirk.dm"
 #include "modular_nova\modules\telepathy_quirk\code\telepathy_reply_emote.dm"
+#include "modular_nova\modules\teleport_counters\anchor_tether.dm"
 #include "modular_nova\modules\tesh_augments\code\all_nodes.dm"
 #include "modular_nova\modules\tesh_augments\code\limbs.dm"
 #include "modular_nova\modules\tesh_augments\code\mechfabricator_designs.dm"


### PR DESCRIPTION
## About The Pull Request

Adds the `MOD grounded apprehension module`, a modification of the MOD emergency tether that, when stuck in someone, acts like a bluespace grounding implant, stunning people who attempt to jaunt or teleport. Upon removal of the embedded anchor, the anti-teleport effect stops. As this is, ostensibly, for arresting people, it has been added to security MOD modules.

## How This Contributes To The Nova Sector Roleplay Experience

<img width="686" height="386" alt="image" src="https://github.com/user-attachments/assets/931ef408-3320-44b4-95f1-7480c3dcc6af" />

Fighting someone who can teleport sucks. Adding a method to stop them from teleporting is funny, and adds player agency and skill expression. Now you, too, can hook someone in lane for an early power spike.

## Proof of Testing

<img width="216" height="329" alt="image" src="https://github.com/user-attachments/assets/ef3ecdc4-a413-401e-b431-0fc659597a12" />

## Changelog

:cl:
add: Realizing that they can, in fact, do things, Nanotrasen has licensed Robust Corp's bluespace grounding technology for use in retooled MOD emergency tether modules. These can be found as MOD grounded apprehension modules, under Security Modular Suits.
/:cl:
