### PR TITLE
Adds UDC and gear harness to clothesmate

### DIFF
--- a/modular_nova/modules/modular_vending/code/clothesmate.dm
+++ b/modular_nova/modules/modular_vending/code/clothesmate.dm
@@ -88,6 +88,7 @@
 				/obj/item/clothing/under/dress/skirt/nova/mini_skirt = 5,
 				/obj/item/clothing/under/dress/nova/giant_scarf = 5,
 				/obj/item/clothing/under/pants/nova/shorted_overall = 5,
+				/obj/item/clothing/under/misc/nova/gear_harness = 5,
 			),
 		),
 
@@ -183,7 +184,6 @@
 				/obj/item/clothing/mask/surgical/greyscale = 5,
 				/obj/item/clothing/glasses/blindfold/color = 5,
 				/obj/item/storage/backpack/udc = 5,
-				/obj/item/clothing/under/misc/nova/gear_harness = 5,
 			)
 		)
 	)

--- a/modular_nova/modules/modular_vending/code/clothesmate.dm
+++ b/modular_nova/modules/modular_vending/code/clothesmate.dm
@@ -184,6 +184,9 @@
 				/obj/item/clothing/mask/surgical/greyscale = 5,
 				/obj/item/clothing/glasses/blindfold/color = 5,
 				/obj/item/storage/backpack/udc = 5,
+				/obj/item/storage/backpack/tinypaka = 5,
+				/obj/item/storage/backpack/tinypakb = 5,
+				/obj/item/storage/backpack/tinypakc = 5,
 			)
 		)
 	)

--- a/modular_nova/modules/modular_vending/code/clothesmate.dm
+++ b/modular_nova/modules/modular_vending/code/clothesmate.dm
@@ -182,6 +182,8 @@
 				/obj/item/clothing/mask/gas/respirator = 5,
 				/obj/item/clothing/mask/surgical/greyscale = 5,
 				/obj/item/clothing/glasses/blindfold/color = 5,
+				/obj/item/storage/backpack/udc = 5,
+				/obj/item/clothing/under/misc/nova/gear_harness = 5,
 			)
 		)
 	)


### PR DESCRIPTION

## About The Pull Request

What it says on the tin. Because of how ghost roles get their outfits, they can't get a UDC for style points, so I'm just sticking them into the ClothesMate. Gear harnesses as well, because it's awkward to have to find a dorms vending machine for the same reason.

<img width="439" height="605" alt="image" src="https://github.com/user-attachments/assets/885b2c44-a8b6-4764-81ee-02c799915130" />


screenshot from before I moved the gear harness to the proper under category.

:cl:
add: UDCs and gear harnesses have been added to the ClothesMate vending machines.
/:cl:
