### PR TITLE
Fixes Visitor Quirk Removing Assistants from Manifest

### DIFF
--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -111,6 +111,10 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 	set waitfor = FALSE
 	if(!(person.mind?.assigned_role.job_flags & JOB_CREW_MANIFEST))
 		return
+	// NOVA EDIT ADDITION START - Visitor ID -> no manifest
+	if(person.has_quirk(/datum/quirk/visitor) || ("Visitor ID" in person_client?.prefs.all_quirks))
+		return inject_guest(person, person_client)
+	// NOVA EDIT ADDITION END
 
 	// Attempt to get assignment from ID, otherwise default to mind.
 	var/obj/item/card/id/id_card = person.get_idcard(hand_first = FALSE)

--- a/modular_nova/master_files/code/datums/quirks/negative_quirks/visitor/code/visitor.dm
+++ b/modular_nova/master_files/code/datums/quirks/negative_quirks/visitor/code/visitor.dm
@@ -84,10 +84,3 @@
 	new_id.update_icon()
 	//here's your new id sir or ma'am :)
 	visitor_id = new_id
-
-/datum/manifest/inject(mob/living/carbon/human/person, atom/appearance_proxy, client/person_client)
-	if(!(person.mind?.assigned_role.job_flags & JOB_CREW_MANIFEST))
-		return
-	if(person.has_quirk(/datum/quirk/visitor))
-		return inject_guest(person, person_client)
-	return ..()

--- a/modular_nova/master_files/code/datums/quirks/negative_quirks/visitor/code/visitor.dm
+++ b/modular_nova/master_files/code/datums/quirks/negative_quirks/visitor/code/visitor.dm
@@ -26,7 +26,6 @@
 		return
 	tweak_manifest()
 	var/mob/living/carbon/human/quirk_human = quirk_holder
-	quirk_human.mind.assigned_role.job_flags &= ~(JOB_CREW_MANIFEST|JOB_ANNOUNCE_ARRIVAL)
 	quirk_human.update_ID_card()
 
 /datum/quirk/visitor/remove(return_id = TRUE, erase_new = TRUE) //these flags are for VV
@@ -85,3 +84,10 @@
 	new_id.update_icon()
 	//here's your new id sir or ma'am :)
 	visitor_id = new_id
+
+/datum/manifest/inject(mob/living/carbon/human/person, atom/appearance_proxy, client/person_client)
+	if(!(person.mind?.assigned_role.job_flags & JOB_CREW_MANIFEST))
+		return
+	if(person.has_quirk(/datum/quirk/visitor))
+		return inject_guest(person, person_client)
+	return ..()


### PR DESCRIPTION

## About The Pull Request

People taking the visitor quirk break assistant records because the job datum is a singleton, and currently it's removing the announce and manifest entries from the datum.

Clears the line that removes the job flags, and adds a small override to keep non-visitors on the manifest, visitors off. (Thank Fluffles for this part.)
  
TM this.

## Changelog
:cl:
fix: visitor quirk no longer removes all assistant records.
/:cl:
