### PR TITLE
Fixes dermagen bricking the examine panel

### DIFF
--- a/modular_nova/modules/customization/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/modular_nova/modules/customization/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -48,8 +48,7 @@
 	if(show_message)
 		to_chat(scarred, span_danger("The scars on your body start to fade and disappear."))
 	if(reac_volume >= DERMAGEN_SCAR_FIX_AMOUNT)
-		for(var/i in scarred.all_scars)
-			qdel(i)
+		QDEL_LAZYLIST(scarred.all_scars)
 
 #undef DERMAGEN_SCAR_FIX_AMOUNT
 


### PR DESCRIPTION
## About The Pull Request

Tin, if this removes scars it leaves a null in the list which causes examine to runtime, resulting in no examine closer link being generated.

## How This Contributes To The Nova Sector Roleplay Experience

Bugfix

## Changelog

:cl:
fix: fixes a bug where using dermagen to erase scars would also erase your identity and make you unexaminable
/:cl: