### PR TITLE
Adjusts Cryo console to not hide buttons if item names are too long

### DIFF
--- a/tgui/packages/tgui/interfaces/CryopodConsole.jsx
+++ b/tgui/packages/tgui/interfaces/CryopodConsole.jsx
@@ -42,7 +42,7 @@ const CrewList = () => {
   const { data } = useBackend();
   const { frozen_crew } = data;
 
-  if (!frozen_crew.length) {
+  if (!frozen_crew?.length) {
     return <NoticeBox>No stored crew!</NoticeBox>;
   }
 
@@ -90,7 +90,7 @@ const ItemList = () => {
     return <NoticeBox>You are not authorized for item management.</NoticeBox>;
   }
 
-  if (!item_ref_list.length) {
+  if (!item_ref_list?.length) {
     return <NoticeBox>No stored items!</NoticeBox>;
   }
 


### PR DESCRIPTION
## About The Pull Request

Tin

## How This Contributes To The Nova Sector Roleplay Experience

People can't find the buttons this is silly

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
 
![J5b67In49X](https://github.com/user-attachments/assets/172e1860-60d1-451c-84d4-d1c86f9efe46)

</details>

## Changelog

:cl:
fix: fixes cryopod console buttons getting cut off from long item names
/:cl: