### PR TITLE
Fixes some species checks for quirks

### DIFF
--- a/modular_nova/master_files/code/datums/quirks/neutral_quirks/breather/nitrogen_breather.dm
+++ b/modular_nova/master_files/code/datums/quirks/neutral_quirks/breather/nitrogen_breather.dm
@@ -10,7 +10,7 @@
 	breath_type = "nitrogen"
 
 /datum/quirk/item_quirk/breather/nitrogen_breather/is_species_appropriate(datum/species/mob_species)
-	if(istype(mob_species, /datum/species/vox))
+	if(ispath(mob_species, /datum/species/vox))
 		return FALSE
 	else
 		return ..()

--- a/modular_nova/master_files/code/datums/quirks/neutral_quirks/breather/plasma_breather.dm
+++ b/modular_nova/master_files/code/datums/quirks/neutral_quirks/breather/plasma_breather.dm
@@ -11,7 +11,7 @@
 
 /datum/quirk/item_quirk/breather/plasma_breather/is_species_appropriate(datum/species/mob_species)
 	// slimeppl heal their blood volume rapidly from breathing plasma, this would be op
-	if(istype(mob_species, /datum/species/jelly) || istype(mob_species, /datum/species/plasmaman))
+	if(ispath(mob_species, /datum/species/jelly) || ispath(mob_species, /datum/species/plasmaman))
 		return FALSE
 	else
 		return ..()

--- a/modular_nova/master_files/code/datums/quirks/neutral_quirks/breather/water_breather.dm
+++ b/modular_nova/master_files/code/datums/quirks/neutral_quirks/breather/water_breather.dm
@@ -13,12 +13,6 @@
 	// bonus trait
 	mob_trait = TRAIT_WATER_BREATHING
 
-/datum/quirk/item_quirk/breather/water_breather/is_species_appropriate(datum/species/mob_species)
-	if(istype(mob_species, /datum/species/akula))
-		return FALSE
-	else
-		return ..()
-
 /datum/quirk/item_quirk/breather/water_breather/add_adaptation()
 	// this proc is guaranteed to be called multiple times
 	var/obj/item/organ/lungs/target_lungs = quirk_holder.get_organ_slot(ORGAN_SLOT_LUNGS)


### PR DESCRIPTION
## About The Pull Request

The akula one is unnecessary and will be inherently checked by the default proc. The rest are istype instead of ispath which will always fail since they are checking paths not instances.

## How This Contributes To The Nova Sector Roleplay Experience

Bugfix, less chance of copy pasting wrong code

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

<img width="503" height="192" alt="image" src="https://github.com/user-attachments/assets/74650620-9857-4dcf-aec7-809920021561" />

  
</details>

## Changelog

:cl:
fix: fixes an issue where vox could select the nitrogen breather quirk, and plasmamen could select the plasma_breather quirk despite that being their default.
fix: fixes slimepeople being able to select the plasma_breather quirk, this was not intended for balance reasons but the code to prevent them from selecting it had a bug.
/:cl: