### PR TITLE
[FIX] modify contactor kit 

### DIFF
--- a/modular_nova/modules/traitor-uplinks/overwrites/contractor.dm
+++ b/modular_nova/modules/traitor-uplinks/overwrites/contractor.dm
@@ -6,10 +6,10 @@
 /datum/uplink_item/bundles_tc/contract_kit
 	cost = CONTRACTOR_KIT_PRICE
 	desc = "The Syndicate have offered you the chance to become a contractor, take on kidnapping contracts for TC \
-	and cash payouts. Upon purchase, you'll be granted your own contract uplink embedded within the supplied \
-	tablet computer. Additionally, you'll be granted standard contractor gear to help with your mission - \
-	comes supplied with the tablet, chameleon jumpsuit and mask, agent card, \
-	and a specialised contractor baton."
+		and cash payouts. Upon purchase, you'll be granted your own contract uplink embedded within the supplied \
+		tablet computer. Additionally, you'll be granted standard contractor gear to help with your mission - \
+		comes supplied with the tablet, chameleon jumpsuit and mask, agent card, \
+		and a specialised contractor baton."
 //	cost = 20
 
 #undef CONTRACTOR_KIT_REMAINING_TC


### PR DESCRIPTION
## About The Pull Request

the contractor kit says on the tin it includes a space suit when it doesnt. This PR fixes the description to avoid confusion for players that try this kit for the first time.

## How This Contributes To The Nova Sector Roleplay Experience

You are a Contactor, Harry.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Contractor kit description modified to specify it doesn't come with a modsuit.
/:cl:
