### PR TITLE
marauder-specific voltaic nerf

### DIFF
--- a/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -29,6 +29,13 @@
 	///If the core is removable once socketed.
 	var/core_removable = TRUE
 
+	// NOVA EDIT ADD: voltaic nerfs
+	/// Do we confer EMP interception/immunity?
+	var/gives_emp_immunity = TRUE
+	/// What type of voltaic overdrive do we confer in crit?
+	var/datum/status_effect/voltaic_overdrive/overdrive_type = /datum/status_effect/voltaic_overdrive
+	// NOVA EDIT ADD END
+
 /obj/item/organ/heart/cybernetic/anomalock/Destroy()
 	QDEL_NULL(core)
 	return ..()
@@ -43,7 +50,11 @@
 		return
 	add_lightning_overlay(30 SECONDS)
 	playsound(organ_owner, 'sound/items/eshield_recharge.ogg', 40)
-	organ_owner.AddElement(/datum/element/empprotection, EMP_PROTECT_SELF|EMP_PROTECT_CONTENTS|EMP_NO_EXAMINE)
+	// NOVA EDIT START: voltaic nerf: adds a variable for EMP protection
+	// ORIGINAL - organ_owner.AddElement(/datum/element/empprotection, EMP_PROTECT_SELF|EMP_PROTECT_CONTENTS|EMP_NO_EXAMINE)
+	if(gives_emp_immunity)
+		organ_owner.AddElement(/datum/element/empprotection, EMP_PROTECT_SELF|EMP_PROTECT_CONTENTS|EMP_NO_EXAMINE)
+	// NOVA EDIT END
 	RegisterSignal(organ_owner, SIGNAL_ADDTRAIT(TRAIT_CRITICAL_CONDITION), PROC_REF(activate_survival))
 	RegisterSignal(organ_owner, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 
@@ -126,7 +137,7 @@
 	if(!COOLDOWN_FINISHED(src, survival_cooldown))
 		return
 
-	organ_owner.apply_status_effect(/datum/status_effect/voltaic_overdrive)
+	organ_owner.apply_status_effect(overdrive_type) // NOVA EDIT ORIGINAL - organ_owner.apply_status_effect(/datum/status_effect/voltaic_overdrive)
 	add_lightning_overlay(30 SECONDS)
 	COOLDOWN_START(src, survival_cooldown, survival_cooldown_time)
 	addtimer(CALLBACK(src, PROC_REF(notify_cooldown), organ_owner), COOLDOWN_TIMELEFT(src, survival_cooldown))

--- a/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -29,13 +29,6 @@
 	///If the core is removable once socketed.
 	var/core_removable = TRUE
 
-	// NOVA EDIT ADD: voltaic nerfs
-	/// Do we confer EMP interception/immunity?
-	var/gives_emp_immunity = TRUE
-	/// What type of voltaic overdrive do we confer in crit?
-	var/datum/status_effect/voltaic_overdrive/overdrive_type = /datum/status_effect/voltaic_overdrive
-	// NOVA EDIT ADD END
-
 /obj/item/organ/heart/cybernetic/anomalock/Destroy()
 	QDEL_NULL(core)
 	return ..()
@@ -50,11 +43,11 @@
 		return
 	add_lightning_overlay(30 SECONDS)
 	playsound(organ_owner, 'sound/items/eshield_recharge.ogg', 40)
-	// NOVA EDIT START: voltaic nerf: adds a variable for EMP protection
-	// ORIGINAL - organ_owner.AddElement(/datum/element/empprotection, EMP_PROTECT_SELF|EMP_PROTECT_CONTENTS|EMP_NO_EXAMINE)
+	// organ_owner.AddElement(/datum/element/empprotection, EMP_PROTECT_SELF|EMP_PROTECT_CONTENTS|EMP_NO_EXAMINE) // NOVA EDIT REMOVAL
+	// NOVA EDIT ADDITION START: voltaic nerf: adds a variable for EMP protection
 	if(gives_emp_immunity)
 		organ_owner.AddElement(/datum/element/empprotection, EMP_PROTECT_SELF|EMP_PROTECT_CONTENTS|EMP_NO_EXAMINE)
-	// NOVA EDIT END
+	// NOVA EDIT ADDITION END
 	RegisterSignal(organ_owner, SIGNAL_ADDTRAIT(TRAIT_CRITICAL_CONDITION), PROC_REF(activate_survival))
 	RegisterSignal(organ_owner, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 

--- a/modular_nova/master_files/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/modular_nova/master_files/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -1,0 +1,14 @@
+/obj/item/organ/heart/cybernetic/anomalock/weak
+	name = "scavenged voltaic combat cyberheart"
+	desc = "A cutting-edge cyberheart, pulled from an abandoned corporate scientist's corpse. \
+		Voltaic technology allows the heart to keep the body upright in dire circumstances, \
+		alongside redirecting anomalous flux energy to fully shield the user from shocks. \
+		Requires a refined flux core as a power source. Due to battle damage, does not provide immunity from EMPs and \
+		has a shortened overdrive time."
+
+	gives_emp_immunity = FALSE
+	survival_cooldown_time = 10 MINUTES
+	overdrive_type = /datum/status_effect/voltaic_overdrive/short
+
+/datum/status_effect/voltaic_overdrive/short
+	duration = 10 SECONDS

--- a/modular_nova/master_files/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/modular_nova/master_files/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -1,3 +1,9 @@
+/obj/item/organ/heart/cybernetic/anomalock
+	/// Do we confer EMP interception/immunity?
+	var/gives_emp_immunity = TRUE
+	/// What type of voltaic overdrive do we confer in crit?
+	var/datum/status_effect/voltaic_overdrive/overdrive_type = /datum/status_effect/voltaic_overdrive
+
 /obj/item/organ/heart/cybernetic/anomalock/weak
 	name = "scavenged voltaic combat cyberheart"
 	desc = "A cutting-edge cyberheart, pulled from an abandoned corporate scientist's corpse. \

--- a/modular_nova/modules/marauders/voucher_lists/implant.dm
+++ b/modular_nova/modules/marauders/voucher_lists/implant.dm
@@ -260,12 +260,12 @@
 	)
 
 /datum/voucher_set/traitor/implant/voltaic_combat_cyberheart
-	name = /obj/item/organ/heart/cybernetic/anomalock::name
-	description = /obj/item/organ/heart/cybernetic/anomalock::desc
-	icon = /obj/item/organ/heart/cybernetic/anomalock::icon
-	icon_state = /obj/item/organ/heart/cybernetic/anomalock::icon_state
+	name = /obj/item/organ/heart/cybernetic/anomalock/weak::name
+	description = /obj/item/organ/heart/cybernetic/anomalock/weak::desc
+	icon = /obj/item/organ/heart/cybernetic/anomalock/weak::icon
+	icon_state = /obj/item/organ/heart/cybernetic/anomalock/weak::icon_state
 	set_items = list(
-		/obj/item/organ/heart/cybernetic/anomalock,
+		/obj/item/organ/heart/cybernetic/anomalock/weak,
 		/obj/item/assembly/signaler/anomaly/flux,
 	)
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7491,6 +7491,7 @@
 #include "modular_nova\master_files\code\modules\surgery\organs\external\wings\wings.dm"
 #include "modular_nova\master_files\code\modules\surgery\organs\internal\appendix\_appendix.dm"
 #include "modular_nova\master_files\code\modules\surgery\organs\internal\cyberimp\augments_internal.dm"
+#include "modular_nova\master_files\code\modules\surgery\organs\internal\heart\heart_anomalock.dm"
 #include "modular_nova\master_files\code\modules\surgery\organs\internal\lungs\_lungs.dm"
 #include "modular_nova\master_files\code\modules\uplink\suits.dm"
 #include "modular_nova\master_files\code\modules\vehicles\sealed.dm"


### PR DESCRIPTION
## About The Pull Request
Compare/contrast NovaSector/NovaSector#6195.

Marauder's voltaic cyberheart gets downgraded to a "scavenged" variant, with a 10 minute overdrive cooldown (up from 5 minutes), 10 second overdrive (down from 30 seconds), and no innate EMP immunity. On-site procurement (read: stealing your own voltaic) remains doable, though, probably.

## How This Contributes To The Nova Sector Roleplay Experience

The voltaic combat cyberheart should be strong, sure, but marauders getting it for free is a bit much, considering they get all the time in the world to stack it with everything else the marauder and base gets (DIY healmixes, strong armor, good weapon options, etc. etc.). Bringing down their voltaic a few notches by removing the free EMP immunity and reducing their overdrive's uptime should make it less annoying to fight.

Nothing is stopping the marauder from stealing science's stuff and giving themselves a regular voltaic, but that's tied to in-round progression.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

<img width="377" height="50" alt="image" src="https://github.com/user-attachments/assets/eb4c3fa8-a487-4b3c-a866-87776ee6f969" />
</details>

## Changelog

:cl:
balance: Citing a sudden decrease in unattended protolathes, the Syndicate's Marauder Program has started recycling recovered voltaic combat cyberhearts from dead scientists, resulting in a reduced quality of usable anomaly-powered cybernetic hearts, with increased cooldown cycle time (10 minutes, up from 5), decreased active time (10 seconds, down from 30) and a lack of passive electromagnetic shielding.
/:cl:
