### PR TITLE
Adds lead pipe to loadout

### DIFF
--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_weapons.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_weapons.dm
@@ -24,23 +24,23 @@
 *	GHETTO GUNS
 */
 
-/datum/loadout_item/weapons/ghettoguns
-	abstract_type = /datum/loadout_item/weapons/ghettoguns
+/datum/loadout_item/weapons/ghetto_guns
+	abstract_type = /datum/loadout_item/weapons/ghetto_guns
 	group = "Improvised Ballistics"
 
-/datum/loadout_item/weapons/ghettoguns/pipegun
+/datum/loadout_item/weapons/ghetto_guns/pipegun
 	name = /obj/item/gun/ballistic/rifle/boltaction/pipegun::name
 	item_path = /obj/item/gun/ballistic/rifle/boltaction/pipegun
 
-/datum/loadout_item/weapons/ghettoguns/pipepistol
+/datum/loadout_item/weapons/ghetto_guns/pipepistol
 	name = /obj/item/gun/ballistic/rifle/boltaction/pipegun/pistol::name
 	item_path = /obj/item/gun/ballistic/rifle/boltaction/pipegun/pistol
 
-/datum/loadout_item/weapons/ghettoguns/lasermusket
+/datum/loadout_item/weapons/ghetto_guns/lasermusket
 	name = /obj/item/gun/energy/laser/musket::name
 	item_path = /obj/item/gun/energy/laser/musket
 
-/datum/loadout_item/weapons/ghettoguns/smoothbore
+/datum/loadout_item/weapons/ghetto_guns/smoothbore
 	name = /obj/item/gun/energy/disabler/smoothbore::name
 	item_path = /obj/item/gun/energy/disabler/smoothbore
 
@@ -48,35 +48,35 @@
 *	FORGE WEAPONRY
 */
 
-/datum/loadout_item/weapons/forgeweapons
-	abstract_type = /datum/loadout_item/weapons/forgeweapons
+/datum/loadout_item/weapons/forge_weapons
+	abstract_type = /datum/loadout_item/weapons/forge_weapons
 	group = "Forge Weapons"
 
-/datum/loadout_item/weapons/forgeweapons/dagger
+/datum/loadout_item/weapons/forge_weapons/dagger
 	name = /obj/item/forging/reagent_weapon/dagger::name
 	item_path = /obj/item/forging/reagent_weapon/dagger
 
-/datum/loadout_item/weapons/forgeweapons/sword
+/datum/loadout_item/weapons/forge_weapons/sword
 	name = /obj/item/forging/reagent_weapon/sword::name
 	item_path = /obj/item/forging/reagent_weapon/sword
 
-/datum/loadout_item/weapons/forgeweapons/katana
+/datum/loadout_item/weapons/forge_weapons/katana
 	name = /obj/item/forging/reagent_weapon/katana::name
 	item_path = /obj/item/forging/reagent_weapon/katana
 
-/datum/loadout_item/weapons/forgeweapons/bokken
+/datum/loadout_item/weapons/forge_weapons/bokken
 	name = /obj/item/forging/reagent_weapon/bokken::name
 	item_path = /obj/item/forging/reagent_weapon/bokken
 
-/datum/loadout_item/weapons/forgeweapons/spear
+/datum/loadout_item/weapons/forge_weapons/spear
 	name = /obj/item/forging/reagent_weapon/spear::name
 	item_path = /obj/item/forging/reagent_weapon/spear
 
-/datum/loadout_item/weapons/forgeweapons/axe
+/datum/loadout_item/weapons/forge_weapons/axe
 	name = /obj/item/forging/reagent_weapon/axe::name
 	item_path = /obj/item/forging/reagent_weapon/axe
 
-/datum/loadout_item/weapons/forgeweapons/staff
+/datum/loadout_item/weapons/forge_weapons/staff
 	name = /obj/item/forging/reagent_weapon/staff::name
 	item_path = /obj/item/forging/reagent_weapon/staff
 


### PR DESCRIPTION
## About The Pull Request

Adds the lead pipe to the weapons loadout under a new category; "Assorted Weapons" which can be used(or edited!) for any future similar additions.


## How This Contributes To The Nova Sector Roleplay Experience

https://www.youtube.com/watch?v=iDLmYZ5HqgM


## Proof of Testing

<img width="501" height="206" alt="5HTYZt6G4N" src="https://github.com/user-attachments/assets/033c70fa-fb4d-4fb1-9f3f-d197281fb756" />


## Changelog

:cl:
add: Adds the lead pipe as an optional weapon in the loadout
add: Adds the "Assorted Weapons" category in the loadout's weapon tab
/:cl:
