### PR TITLE
Readds the extreme height options

### DIFF
--- a/modular_nova/modules/height_scaling/code/preferences.dm
+++ b/modular_nova/modules/height_scaling/code/preferences.dm
@@ -20,7 +20,6 @@
 
 /datum/preference/choiced/height_scaling/init_possible_values()
 	return list(
-		HUMAN_HEIGHT_SHORTEST,
 		HUMAN_HEIGHT_SHORT, 
 		HUMAN_HEIGHT_MEDIUM, 
 		HUMAN_HEIGHT_TALL, 


### PR DESCRIPTION
## About The Pull Request

Readds the more extreme height options in char prefs, namely shortest, taller and tallest. I tested locally and it seems to work fine scaling the sprite. The original comments specified they were removed because they constantly generated artifacts; I didn't notice them during my testing
## How This Contributes To The Nova Sector Roleplay Experience

More liberty when deciding the char's appearance.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
  <img width="193" height="100" alt="image" src="https://github.com/user-attachments/assets/a7a21a91-1532-45cc-86d7-3c51014dbc21" />
  
  shortest and tallest
  
  
</details>

## Changelog
:cl:
add: shortest, taller and tallest readded into the char pref options
/:cl:
