### PR TITLE
i am so tired of extra skull spawns - makes spawner legions drop charred skeletons again

### DIFF
--- a/modular_nova/master_files/code/modules/mob/living/basic/lavaland/legion/legion.dm
+++ b/modular_nova/master_files/code/modules/mob/living/basic/lavaland/legion/legion.dm
@@ -1,7 +1,0 @@
-// We override /obj/effect/mob_spawn/corpse/human/legioninfested/skeleton/charred here and instead put one of the proyectile mobs that despawn naturally. For performance.
-
-/mob/living/basic/mining/legion/spawner_made
-	corpse_type = /mob/living/basic/mining/legion_brood
-
-/mob/living/basic/mining/legion/snow/spawner_made
-	corpse_type = /mob/living/basic/mining/legion_brood/snow

--- a/modular_nova/modules/ashwalkers/code/effects/ash_rituals.dm
+++ b/modular_nova/modules/ashwalkers/code/effects/ash_rituals.dm
@@ -191,13 +191,13 @@
 	name = "Incite Megafauna"
 	desc = "Causes a horrible, unrecognizable sound that will attract the large fauna from around the planet."
 	required_components = list(
-		"north" = /obj/item/organ/monster_core/regenerative_core,
+		"north" = /obj/item/organ/legion_tumour,
 		"south" = /obj/item/ash_seed/tendril,
-		"east" = /obj/item/organ/monster_core/regenerative_core,
-		"west" = /obj/item/organ/monster_core/regenerative_core,
+		"east" = /obj/item/organ/legion_tumour,
+		"west" = /obj/item/organ/legion_tumour,
 	)
 	consumed_components = list(
-		/obj/item/organ/monster_core/regenerative_core,
+		/obj/item/organ/legion_tumour,
 		/obj/item/ash_seed/tendril,
 	)
 
@@ -240,13 +240,14 @@
 	name = "Ashen Age Ceremony"
 	desc = "Those who partake in the ceremony and are ready will age, increasing their value to the kin."
 	required_components = list(
-		"north" = /obj/item/organ/monster_core/regenerative_core,
+		"north" = /obj/item/organ/legion_tumour,
 		"south" = /obj/item/organ/monster_core/regenerative_core,
 		"east" = /obj/item/stack/sheet/bone,
 		"west" = /obj/item/stack/sheet/sinew,
 	)
 	consumed_components = list(
 		/obj/item/organ/monster_core/regenerative_core,
+		/obj/item/organ/legion_tumour,
 		/obj/item/stack/sheet/bone,
 		/obj/item/stack/sheet/sinew,
 	)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7350,7 +7350,6 @@
 #include "modular_nova\master_files\code\modules\mob\living\living.dm"
 #include "modular_nova\master_files\code\modules\mob\living\living_defines.dm"
 #include "modular_nova\master_files\code\modules\mob\living\living_movement.dm"
-#include "modular_nova\master_files\code\modules\mob\living\basic\lavaland\legion\legion.dm"
 #include "modular_nova\master_files\code\modules\mob\living\basic\maintsroomdescent\custom_maintsrooms_objects.dm"
 #include "modular_nova\master_files\code\modules\mob\living\basic\maintsroomdescent\deathsquad_corpse.dm"
 #include "modular_nova\master_files\code\modules\mob\living\basic\maintsroomdescent\deathsquadtrader.dm"


### PR DESCRIPTION
## About The Pull Request

Inspired by tgstation/tgstation#93276. As legion corpses delete themselves when exposed to storms, this should address some of the performance concerns of corpses being left alone.

## How This Contributes To The Nova Sector Roleplay Experience

dude I am so tired of having legion skulls spawn on me after I blow up the host PLEASE can I not get more skulls.

## Proof of Testing

<img width="198" height="222" alt="image" src="https://github.com/user-attachments/assets/e52f50e6-4efd-493e-b578-230e5564adef" />
<img width="328" height="279" alt="image" src="https://github.com/user-attachments/assets/bf59a297-da81-4bda-a6ea-98baa6d95f5c" />

## Changelog

:cl:
balance: Spawner-made legion and snow legion now drop charred corpses again, instead of summoning another skull to get attacked by.
balance: Ashwalker rituals that formerly required human corpses, then legion cores, now require legion tumors, which can be pilfered from legion corpses.
/:cl:
