### PR TITLE
Ammo pouches can now hold speedloaders

### DIFF
--- a/modular_nova/modules/modular_items/code/bags.dm
+++ b/modular_nova/modules/modular_items/code/bags.dm
@@ -52,6 +52,7 @@
 	set_holdable(list(
 		/obj/item/ammo_box/magazine,
 		/obj/item/ammo_casing,
+		/obj/item/ammo_box/speedloader,
 	))
 
 /datum/storage/casing_pouch


### PR DESCRIPTION

## About The Pull Request
Unsure if this is a bugfix or QOL, but regardless its here. Does what it says on the tin.
## How This Contributes To The Nova Sector Roleplay Experience
Why can I fit a 45 long sol mag but not a golf ball? Makes you think.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="636" height="216" alt="image" src="https://github.com/user-attachments/assets/fcfefb98-db66-4817-b277-8d503e0b3f78" />

</details>

## Changelog
:cl:
fix: Ammo pouches now hold speedloaders
/:cl:
