### PR TITLE
Medborg simple anti-rad medicine

### DIFF
--- a/code/game/objects/items/robot/items/hypo.dm
+++ b/code/game/objects/items/robot/items/hypo.dm
@@ -8,6 +8,7 @@
 		/datum/reagent/medicine/salglu_solution,\
 		/datum/reagent/medicine/spaceacillin,\
 		/datum/reagent/medicine/lidocaine, /* NOVA EDIT ADDITION - added Lidocaine */ \
+		/datum/reagent/medicine/potass_iodide, /* NOVA EDIT ADDITION - added Potassium Iodine */ \
 	)
 #define EXPANDED_MEDICAL_REAGENTS list(\
 		/datum/reagent/medicine/haloperidol,\


### PR DESCRIPTION

## About The Pull Request
Gives medborg potassium-iodine as standard. Outclassed later by pentetic, but they lack early antirad capabilities.
## How This Contributes To The Nova Sector Roleplay Experience
not very good for rp when someone is dying and you can do naught but stare at them when you are supposed to be the one that can fix them
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="501" height="94" alt="image" src="https://github.com/user-attachments/assets/b2b03267-06d6-47a5-b073-97b83ad9ec50" />

I loaded it up and tested it but forgot to take a picture. its fine 
</details>

## Changelog
:cl:
add: Mediborgs have antirad as standard
/:cl:
