### PR TITLE
Engiborg start with a gripper

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -436,7 +436,7 @@
 		/obj/item/lightreplacer, // NOVA EDIT ADDITION - Surprised Engie borgs don't get these
 		/obj/item/construction/rtd/borg,
 		/obj/item/storage/part_replacer, // NOVA EDIT ADDITION - Borgs start with a basic RPD.
-		/obj/item/borg/apparatus/engineering // NOVA EDIT ADDITION - Borgs start with one gripper, upgrade adds a second like mediborg beakers
+		/obj/item/borg/apparatus/engineering, // NOVA EDIT ADDITION - Borgs start with one gripper, upgrade adds a second like mediborg beakers
 		/obj/item/stack/cable_coil,
 		/obj/item/airlock_painter/decal/cyborg,
 	)


### PR DESCRIPTION

## About The Pull Request
Want to install a camera? cant
Want to put a battery in? Good luck.
Want to install an APC on a wall? Well you can do this one, but its annoying

The default engiborg loadout now has one gripper. The upgrade still adds a second, much like how medborgs have one beaker on start and get a second through upgrades.
## How This Contributes To The Nova Sector Roleplay Experience
Engiborgs can do engineering related tasks, like an engineer should be able to do.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="714" height="293" alt="image" src="https://github.com/user-attachments/assets/901e1006-9d9c-46be-b17a-fef4c068f7d6" />

</details>

## Changelog
:cl:
add: Engiborgs start with a gripper. The upgrade adds a second, like mediborgs
/:cl:
