### PR TITLE
Fix Medipens

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -178,6 +178,7 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpack/traitor
 	desc = "A modified stimulants autoinjector for use in combat situations. Has a mild healing effect."
 	list_reagents = list(/datum/reagent/medicine/stimulants = 10, /datum/reagent/medicine/omnizine = 10)
+	volume = 20
 
 /obj/item/reagent_containers/hypospray/medipen/stimulants
 	name = "stimulant medipen"
@@ -203,6 +204,7 @@
 	inhand_icon_state = "morphen"
 	base_icon_state = "morphen"
 	list_reagents = list(/datum/reagent/medicine/morphine = 10)
+	volume = 10
 
 /obj/item/reagent_containers/hypospray/medipen/oxandrolone
 	name = "oxandrolone medipen"
@@ -211,6 +213,7 @@
 	inhand_icon_state = "oxapen"
 	base_icon_state = "oxapen"
 	list_reagents = list(/datum/reagent/medicine/oxandrolone = 10)
+	volume = 10
 
 /obj/item/reagent_containers/hypospray/medipen/penacid
 	name = "pentetic acid medipen"
@@ -219,6 +222,7 @@
 	inhand_icon_state = "penacid"
 	base_icon_state = "penacid"
 	list_reagents = list(/datum/reagent/medicine/pen_acid = 10)
+	volume = 10
 
 /obj/item/reagent_containers/hypospray/medipen/salacid
 	name = "salicylic acid medipen"
@@ -227,6 +231,7 @@
 	inhand_icon_state = "salacid"
 	base_icon_state = "salacid"
 	list_reagents = list(/datum/reagent/medicine/sal_acid = 10)
+	volume = 10
 
 /obj/item/reagent_containers/hypospray/medipen/salbutamol
 	name = "salbutamol medipen"
@@ -235,6 +240,7 @@
 	inhand_icon_state = "salpen"
 	base_icon_state = "salpen"
 	list_reagents = list(/datum/reagent/medicine/salbutamol = 10)
+	volume = 10
 
 /obj/item/reagent_containers/hypospray/medipen/tuberculosiscure
 	name = "BVAK autoinjector"
@@ -297,6 +303,7 @@
 	inhand_icon_state = "atropen"
 	base_icon_state = "atropen"
 	list_reagents = list(/datum/reagent/medicine/atropine = 10, /datum/reagent/medicine/coagulant = 2)
+	volume = 12
 
 /obj/item/reagent_containers/hypospray/medipen/snail
 	name = "snail shot"
@@ -306,6 +313,7 @@
 	base_icon_state = "snail"
 	list_reagents = list(/datum/reagent/snail = 10)
 	label_examine = FALSE
+	volume = 10
 
 /obj/item/reagent_containers/hypospray/medipen/magillitis
 	name = "experimental autoinjector"
@@ -362,3 +370,4 @@
 	inhand_icon_state = "atropen"
 	base_icon_state = "atropen"
 	list_reagents = list(/datum/reagent/medicine/c2/penthrite = 10)
+	volume = 10


### PR DESCRIPTION

## About The Pull Request

Certain medipens do not have a specified volume, which means when they are used injuction with the medipen refiller, they refill improper amounts. The medipen takes too much and doesn't actually fill it up. In order to fix this, I've added volumes to the medipens that don't have volumes in order to ensure that the medipen refiller accurately refills.

This should solve this [issue](https://github.com/NovaSector/NovaSector/issues/6757). 
## How This Contributes To The Nova Sector Roleplay Experience

It's a fix.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
 <img width="530" height="133" alt="image" src="https://github.com/user-attachments/assets/1ea28380-a484-48de-8ff1-e46430a718f2" />
<img width="517" height="124" alt="image" src="https://github.com/user-attachments/assets/d7dcc07e-5216-4d29-9073-2d1c60f8627d" />
<img width="355" height="47" alt="image" src="https://github.com/user-attachments/assets/90ab950e-c7cc-4c50-a65b-44eba754b097" />
</details>

## Changelog
:cl:
fix: Fixed Medipens taking out too much from the refiller.
/:cl:
