### PR TITLE
Interactions menu info panel will no longer display unless you have certain interactions available

### DIFF
--- a/tgui/packages/tgui/interfaces/InteractionPanel/index.tsx
+++ b/tgui/packages/tgui/interfaces/InteractionPanel/index.tsx
@@ -24,12 +24,13 @@ export function InteractionPanel () {
     self,
     use_subtler,
     erp_interaction,
+    has_erp_interaction,
   } = data;
 
   return (
     <Window width={500} height={600} title={`Interact - ${self}`}>
       <Window.Content scrollable>
-          {erp_interaction && (
+          {!!erp_interaction && !!has_erp_interaction && (
             <Section>
               <Stack vertical fill>
                   <Stack.Item grow>


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/6794

The info panel will only display if you have erp interactions available. So no more seeing it while you are just trying to wave at someone.

Also cleans up and optimizes the ui_data proc a little bit

## How This Contributes To The Nova Sector Roleplay Experience

Immersion

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![dreamseeker_tBIhohGCQ6](https://github.com/user-attachments/assets/8458b61b-9ce5-4d03-a539-7aaa9f9b6e75)


</details>

## Changelog

:cl:
fix: the interactions panel 'info' section (pleasure, pain, etc) will only display if you have erp interactions available
/:cl: