### PR TITLE
Fix for the borg snack dispenser to not say you are putting treats in your own hand.

### DIFF
--- a/modular_nova/modules/borg_buffs/code/snack_dispensor.dm
+++ b/modular_nova/modules/borg_buffs/code/snack_dispensor.dm
@@ -113,7 +113,7 @@
 	borg.do_item_attack_animation(patron, null, snack)
 	playsound(loc, 'sound/machines/click.ogg', 10, TRUE)
 	to_chat(patron, span_notice("[borg] dispenses [snack] into your empty hand and you reflexively grasp it."))
-	to_chat(borg, span_notice("You dispense [snack] into the hand of [borg]."))
+	to_chat(borg, span_notice("You dispense [snack] into the hand of [patron]."))
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/borg_snack_dispenser/click_alt(mob/user)


### PR DESCRIPTION

## About The Pull Request
See above
## How This Contributes To The Nova Sector Roleplay Experience
self explanitory
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
uhm yes

</details>

## Changelog
:cl:
fix: Snack dispenser text fix when dispensing food.
/:cl:
