### PR TITLE
Removes the syndicate box of EMPs from Blueshift armory

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -66661,9 +66661,6 @@
 "nzR" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/item/storage/box/emps{
-	pixel_y = 11
-	},
 /obj/item/gun/energy/ionrifle,
 /turf/open/floor/iron/dark,
 /area/station/security/armory)


### PR DESCRIPTION
## About The Pull Request
Removes the EMP kit from the armory.

<img width="187" height="181" alt="image" src="https://github.com/user-attachments/assets/a0aba09f-693f-490e-b5a5-01d9fee88fda" />


## How This Contributes To The Nova Sector Roleplay Experience
Similarly to the removal I've done in Snowglobe, The box is obviously syndicate-flavored and contraband in the corp regs, having it in the open is a bit silly and most of the officers know better than to pick it up anyway. Still better off not having any clueless officers get ban-baited by it though.

## Proof of Testing
It only removes one item and should CI
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl: Hardly
map: Nanotrasen Security has no idea to why they keep bringing in a syndicate box of EMPs in Blueshift's armory. Anyway, it's gone, straight to the recycler.
/:cl:
