### PR TITLE
Increases shuttle size

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -511,4 +511,4 @@
 	default = 6
 
 /datum/config_entry/number/max_shuttle_size
-	default = 250
+	default = 350 // NOVA EDIT: Increased to 350 to allowe bigger, cooler shuttles. Originally 250.


### PR DESCRIPTION

## About The Pull Request
250 is enough to make a shuttle, but the halls are cramped and doesn't allow for much stylization
Increased to 350 to allow bigger, luxury shuttle construction
Most of our go-home shuttle are about that size, if not much bigger (Raven) so it shouldn't be an issue.
## How This Contributes To The Nova Sector Roleplay Experience
No longer will you layout a cool design and see "sorry too much fun" appear.
Allows much more creativity and player choice regarding shuttles and design.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

one var change did not get tested but it compiled because why wouldn't it.  

</details>

## Changelog
:cl:
config: Shuttle max size increased to 350 from 250
/:cl:
