### PR TITLE
Tilt tweaks (More tilt, not inverted controls)

### DIFF
--- a/modular_nova/modules/pixel_tilt/code/pixel_tilt.dm
+++ b/modular_nova/modules/pixel_tilt/code/pixel_tilt.dm
@@ -5,7 +5,7 @@
 	dupe_mode = COMPONENT_DUPE_UNIQUE
 	var/tilt_angle = 0
 	var/tilting = TRUE
-	var/maximum_tilt = 10
+	var/maximum_tilt = 45
 	var/tilt_increment = 5
 	var/matrix/original_transform
 
@@ -69,9 +69,9 @@
 	var/mob/living/owner = parent
 	switch(direct)
 		if(EAST)
-			tilt_angle = clamp(tilt_angle - tilt_increment, -maximum_tilt, maximum_tilt)
-		if(WEST)
 			tilt_angle = clamp(tilt_angle + tilt_increment, -maximum_tilt, maximum_tilt)
+		if(WEST)
+			tilt_angle = clamp(tilt_angle - tilt_increment, -maximum_tilt, maximum_tilt)
 		if(NORTH, SOUTH)
 			tilt_angle = 0
 	var/matrix/tilt_matrix = matrix(original_transform)


### PR DESCRIPTION
## About The Pull Request

One hour into the first round with it, and it was driving me crazy.
Its kinda like... completely useless with such a low angle.
and why is it inverted? Im not in an F-15.
This fixes both
## How This Contributes To The Nova Sector Roleplay Experience
Now you can actually relax at a desk, put your feet up! Bend over a railing and look down! See whats at your feet! And more!
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="298" height="275" alt="image" src="https://github.com/user-attachments/assets/92a087d2-717b-46f9-b7e3-3d6fe4b5a5a7" />
  
</details>

## Changelog
:cl:
qol: You can tilt, but MORE (From 10 degrees up to 45 now)
fix: Tilting is now not inverted
/:cl:
