### PR TITLE
Hemophage Char Pref lore adjustment

### DIFF
--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_species.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_species.dm
@@ -79,7 +79,7 @@
 
 				"All of this renders the infected individual into a new, conjoined being with its symbiont not long after infection. Separation of the two becomes next to impossible due to how rapidly and thoroughly the symbiont's tendrils spread into the host's systems. Some claim mastery of hidden, expensive, or painful procedures to 'cure' one of the symbiosis but the results these range from actively damaging to the host, to utterly useless.",
 
-				"The exact benefits, transferrance methods, features, and side-effects of symbiosis have been documented to be exceptionally variable, depending on which specific clade a host's progenitor originates from. Some feature blackened blood and are wracked with constant pain, others find themselves largely unaffected outside of the craving for blood, others still hear the whisperings of others constantly in the back of their mind.",
+				"The exact benefits, transference methods, features, and side-effects of symbiosis have been documented to be exceptionally variable, depending on which specific clade a host's progenitor originates from. Some feature blackened blood and are wracked with constant pain, others find themselves largely unaffected outside of the craving for blood, others still hear the whisperings of others constantly in the back of their mind.",
 	)
 
 


### PR DESCRIPTION

## About The Pull Request

Reduces hemophage lore blurb down from ~1500 words to ~500 words with adjusted up-to-date lore. Blurb length now matches closer other species' blurb lengths. 

## How This Contributes To The Nova Sector Roleplay Experience

Reduces excess fluff text to be closer in quantity to other species

## Proof of Testing
<details>
<img width="1415" height="890" alt="image" src="https://github.com/user-attachments/assets/1d9cbc9f-59c4-4bc5-86ad-128b09bde8e7" />
  
</details>

## Changelog

N/A

