### PR TITLE
Rewrites pixel tilting to work for modifier hotkeys

### DIFF
--- a/modular_nova/modules/pixel_tilt/code/pixel_tilt.dm
+++ b/modular_nova/modules/pixel_tilt/code/pixel_tilt.dm
@@ -96,4 +96,3 @@
 
 /mob/living/add_pixel_tilt_component()
 	AddComponent(/datum/component/pixel_tilt)
-


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/6853

Allows tilting component to work regardless of if keyboard up/down is pressed. Now it's more of a toggle, in that the way to get out of the 'tilting' mode is to just move north/south.

## How This Contributes To The Nova Sector Roleplay Experience

Fixes an oversight.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![dreamseeker_NufC9mf1xH](https://github.com/user-attachments/assets/9d9df9fd-e2a6-4cfa-9107-4ac8d0706d68)
 
</details>

## Changelog

:cl:
fix: fixed tilting not working with shift/ctrl + bindings.
qol: tilting is now a toggle, to exit tilting just press the hotkey again or move up or down. adds feedback in the form of a balloon alert.
/:cl: