### PR TITLE
Fixes an exploit with pixel tilting

### DIFF
--- a/modular_nova/modules/pixel_tilt/code/pixel_tilt.dm
+++ b/modular_nova/modules/pixel_tilt/code/pixel_tilt.dm
@@ -1,19 +1,21 @@
 // PIXEL TILT - Character rotation keybind for RP
-/*
 // Component
 /datum/component/pixel_tilt
 	dupe_mode = COMPONENT_DUPE_UNIQUE
+	/// Current tilt angle being requested by the player (in degrees). This represents desired rotation, not necessarily what is currently applied.
 	var/tilt_angle = 0
+	/// The last tilt angle that was actually applied to the mob's transform. Used so we can undo only our own rotation before applying a new one, without capturing or overwriting other transform changes (such as scaling)
+	var/last_applied_tilt_angle = 0
+	/// Maximum allowed tilt angle in either direction. Prevents excessive rotation and visual distortion.
 	var/maximum_tilt = 45
+	/// Amount of tilt (in degrees) added or removed per key press. Controls how quickly the character rotates while tilting.
 	var/tilt_increment = 5
-	var/matrix/original_transform
 
 /datum/component/pixel_tilt/Initialize(...)
 	. = ..()
 	if(!isliving(parent))
 		return COMPONENT_INCOMPATIBLE
 	var/mob/living/owner = parent
-	original_transform = matrix(owner.transform)
 	owner.balloon_alert(owner, "started tilting!")
 
 /datum/component/pixel_tilt/RegisterWithParent()
@@ -36,10 +38,17 @@
 /datum/component/pixel_tilt/proc/reset_tilt_and_remove()
 	SIGNAL_HANDLER
 	var/mob/living/owner = parent
+
+	var/matrix/transform_to_reset = matrix(owner.transform)
+	transform_to_reset.Turn(-last_applied_tilt_angle)
+	last_applied_tilt_angle = 0
 	tilt_angle = 0
-	animate(owner, transform = original_transform, time = 0.2 SECONDS)
+
+	animate(owner, transform = transform_to_reset, time = 0.2 SECONDS)
+
 	if(!QDELETED(owner))
 		owner.balloon_alert(owner, "stopped tilting!")
+
 	qdel(src)
 
 /datum/component/pixel_tilt/proc/pre_move_check(mob/source, new_loc, direct)
@@ -66,8 +75,15 @@
 		if(WEST)
 			tilt_angle = clamp(tilt_angle - tilt_increment, -maximum_tilt, maximum_tilt)
 
-	var/matrix/tilt_matrix = matrix(original_transform)
+	// rebuild from current transform
+	var/matrix/tilt_matrix = matrix(owner.transform)
+
+	// remove previous rotation
+	tilt_matrix.Turn(-last_applied_tilt_angle)
+
+	// apply tilt
 	tilt_matrix.Turn(tilt_angle)
+	last_applied_tilt_angle = tilt_angle
 	animate(owner, transform = tilt_matrix, time = 0.1 SECONDS, flags = ANIMATION_PARALLEL)
 
 // Keybind
@@ -96,4 +112,3 @@
 
 /mob/living/add_pixel_tilt_component()
 	AddComponent(/datum/component/pixel_tilt)
-*/

--- a/modular_nova/modules/pixel_tilt/code/pixel_tilt.dm
+++ b/modular_nova/modules/pixel_tilt/code/pixel_tilt.dm
@@ -1,5 +1,5 @@
 // PIXEL TILT - Character rotation keybind for RP
-
+/*
 // Component
 /datum/component/pixel_tilt
 	dupe_mode = COMPONENT_DUPE_UNIQUE
@@ -96,3 +96,4 @@
 
 /mob/living/add_pixel_tilt_component()
 	AddComponent(/datum/component/pixel_tilt)
+*/


### PR DESCRIPTION
## About The Pull Request

~~Quick hacky TM for now. Disables pixel tilting because of a gamebreaking bug where you can tilt -> shapeshift your size -> re-tilt -> shapeshift again. Repeating this can reduce your sprite size to zero.~~

## How This Contributes To The Nova Sector Roleplay Experience

Bugs bad.
<img width="336" height="406" alt="image" src="https://github.com/user-attachments/assets/f5584057-04cf-4c89-87bd-212ad579f1dc" />

EDIT: Fix is in, changed this PR to reflect that

![dreamseeker_rVsHQhl9XQ](https://github.com/user-attachments/assets/929e28b7-f03e-4e6b-9f39-7138af2c6931)

## Changelog

:cl: vinylspiders
fix: fixes an exploit where you could use pixel tilt to infinitely scale your character up or down
/:cl:

