### PR TITLE
Nerfs stealth box implant by removing its bonus movement speed

### DIFF
--- a/code/game/objects/items/implants/implant_stealth.dm
+++ b/code/game/objects/items/implants/implant_stealth.dm
@@ -25,7 +25,7 @@
 	desc = "It's so normal that you didn't notice it before."
 	icon_state = "agentbox"
 	max_integrity = 1 // "This dumb box shouldn't take more than one hit to make it vanish."
-	move_speed_multiplier = parent_type::move_speed_multiplier // NOVA EDIT CHANGE - nerfs agent box granting you movement speed when hurt or wounded, old code: 0.5
+	move_speed_multiplier = parent_type::move_speed_multiplier // NOVA EDIT CHANGE - nerfs agent box granting you movement speed when hurt or wounded - ORIGINAL: move_speed_multiplier = 0.5
 	enable_door_overlay = FALSE
 
 /obj/structure/closet/cardboard/agent/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

I think this item should be removed wholesale because all the alternatives are better, more fun, and healthier for the server.
I was told to nerf it instead of remove it instead. Oh well.

Removes the bonus movement speed you get regardless of wounding/health.

## How This Contributes To The Nova Sector Roleplay Experience

People use this thing to run away and make fights super tedious. The less of that the better.
You can still move way faster than youre supposed to with this item, but whatever I guess.

## Proof of Testing


## Changelog
:cl:
balance: The agent stealth box no longer makes you much faster, it only makes you a little faster now.
/:cl:
