### PR TITLE
Lets you put AIs in modsuits again

### DIFF
--- a/code/modules/mod/mod_ai.dm
+++ b/code/modules/mod/mod_ai.dm
@@ -2,10 +2,6 @@
 	. = ..()
 	if(!.)
 		return
-	// NOVA EDIT ADDITION START - No AIs in MODsuits
-	if(!allow_ai)
-		return
-	// NOVA EDIT END
 	if(!open) //mod must be open
 		balloon_alert(user, "panel closed!")
 		return


### PR DESCRIPTION

## About The Pull Request
Reverts a 2 year old PR that I cannot for the life of me understand why it was done.
You can once again put a carded AI in your modsuit, as god intended.
## How This Contributes To The Nova Sector Roleplay Experience
I want my little onboard jarvis to be able to open doors I point at and order a pizza or activate my thermo-regulator when I'm too stupid to. its fun.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
 IDK really how to show it works bc I cant really... like... do that? But it compiled and seems to work so. 
 its so small I cant see how it wouldn't work.
  
</details>

## Changelog
:cl:
del: You can once again put a normal AI in a modsuit
/:cl:
