### PR TITLE
Gives RCF the ability to print Factorio stuff

### DIFF
--- a/modular_nova/modules/colony_fabricator/code/design_datums/fabricator_flag_additions/machine_boards.dm
+++ b/modular_nova/modules/colony_fabricator/code/design_datums/fabricator_flag_additions/machine_boards.dm
@@ -1,88 +1,87 @@
 /datum/design/board/hydroponics/New()
-	. = ..()
 	build_type |= COLONY_FABRICATOR
+	return ..()
 
 /datum/design/board/cyborgrecharger/New()
-	. = ..()
 	build_type |= COLONY_FABRICATOR
+	return ..()
 
 /datum/design/board/processor/New()
-	. = ..()
 	build_type |= COLONY_FABRICATOR
+	return ..()
 
 /datum/design/board/suit_storage_unit/New()
-	. = ..()
 	build_type |= COLONY_FABRICATOR
+	return ..()
 
 /datum/design/board/reagentgrinder/New()
-	. = ..()
 	build_type |= COLONY_FABRICATOR
+	return ..()
 
 /datum/design/board/fishing_portal_generator/New()
-	. = ..()
 	build_type |= COLONY_FABRICATOR
+	return ..()
 
 // Turbine Stuff
 
 /datum/design/board/turbine_computer/New()
-	. = ..()
 	build_type |= COLONY_FABRICATOR
+	return ..()
 
 /datum/design/board/turbine_compressor/New()
-	. = ..()
 	build_type |= COLONY_FABRICATOR
+	return ..()
 
 /datum/design/board/turbine_rotor/New()
-	. = ..()
 	build_type |= COLONY_FABRICATOR
+	return ..()
 
 /datum/design/board/turbine_stator/New()
-	. = ..()
 	build_type |= COLONY_FABRICATOR
+	return ..()
 
 /datum/design/turbine_part_compressor/New()
-	. = ..()
 	build_type |= COLONY_FABRICATOR
+	return ..()
 
 /datum/design/turbine_part_stator/New()
-	. = ..()
 	build_type |= COLONY_FABRICATOR
+	return ..()
 
 /datum/design/turbine_part_rotor/New()
-	. = ..()
 	build_type |= COLONY_FABRICATOR
+	return ..()
 
 // Factory machines
 
 /datum/design/board/big_manipulator/New()
-	. = ..()
 	build_type |= COLONY_FABRICATOR
+	return ..()
 
 /datum/design/board/manulathe/New()
-	. = ..()
 	build_type |= COLONY_FABRICATOR
+	return ..()
 
 /datum/design/board/manucrafter/New()
-	. = ..()
 	build_type |= COLONY_FABRICATOR
+	return ..()
 
 /datum/design/board/manucrusher/New()
-	. = ..()
 	build_type |= COLONY_FABRICATOR
+	return ..()
 
 /datum/design/board/manurouter/New()
-	. = ..()
 	build_type |= COLONY_FABRICATOR
+	return ..()
 
 /datum/design/board/manusorter/New()
-	. = ..()
 	build_type |= COLONY_FABRICATOR
+	return ..()
 
 /datum/design/board/manuunloader/New()
-	. = ..()
 	build_type |= COLONY_FABRICATOR
+	return ..()
 
 /datum/design/board/manusmelter/New()
-	. = ..()
 	build_type |= COLONY_FABRICATOR
-
+	return ..()


### PR DESCRIPTION

## About The Pull Request
Adds Manufactorio boards into the RCFs:
* Big Manipulator
* Manuctorio Lathe
* Manuctorio Crafter
* Manuctorio Crusher
* Manuctorio Router (Splitter)
* Manuctorio Sorter
* Manuctorio Unloader
* Manuctorio Smelter

## How This Contributes To The Nova Sector Roleplay Experience
Building colonies tend to be fairly time consuming and I believe allowing the user to automate the boring crafting bits (mainly floor tiles, reinforced windows, machine boards, or hell, a repeater factory) to be something that could potentially help.

This will also mean your average assistant will get to easily make factories in the station, but they always could by just asking cargo/engineering/science for the boards. I don't think this will impact inter-departmental interactions much since factories are already fairly rare to come across, and you'll still have to interact with science for the better parts, materials and RPED.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="427" height="407" alt="image" src="https://github.com/user-attachments/assets/0bc3db3e-1675-44ce-84c1-0eccb10bf699" />

</details>

## Changelog
:cl: Hardly
add: The Rapid Colony Fabricator now has the ability to fabricate factory boards. The factory must grow.
/:cl:
