### PR TITLE
Fixes Blueshift's dorms zones

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -522,7 +522,7 @@
 	},
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/carpet/black,
-/area/station/commons/dorms/room5)
+/area/station/commons/dorms/room6)
 "aga" = (
 /obj/machinery/power/shuttle_engine/heater{
 	dir = 1
@@ -1230,7 +1230,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/wood,
-/area/station/commons/dorms/room5)
+/area/station/commons/dorms/room6)
 "anF" = (
 /obj/structure/table,
 /obj/item/stack/package_wrap,
@@ -2171,7 +2171,7 @@
 "axm" = (
 /obj/machinery/duct,
 /turf/open/floor/carpet/black,
-/area/station/commons/dorms/room5)
+/area/station/commons/dorms/room6)
 "axq" = (
 /obj/structure/closet/lasertag/blue,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
@@ -4464,7 +4464,7 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room6)
+/area/station/commons/dorms/room5)
 "aWL" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -6263,7 +6263,7 @@
 /obj/structure/window/spawner/directional/west,
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet/red,
-/area/station/commons/dorms/room6)
+/area/station/commons/dorms/room5)
 "bpg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -7739,7 +7739,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/item/kirbyplants/organic/plant22,
 /turf/open/floor/iron/dark,
-/area/station/commons/dorms/room6)
+/area/station/commons/dorms/room5)
 "bEy" = (
 /obj/structure/table,
 /obj/item/clothing/suit/apron/chef,
@@ -7829,7 +7829,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room6)
+/area/station/commons/dorms/room5)
 "bFd" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/structure/cable,
@@ -8359,7 +8359,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/station/commons/dorms/room1)
+/area/station/commons/dorms/room2)
 "bLj" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/access/all/security/court,
@@ -9498,7 +9498,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room5)
+/area/station/commons/dorms/room6)
 "bWo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10608,7 +10608,7 @@
 /obj/item/bedsheet/green/double,
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/carpet/green,
-/area/station/commons/dorms/room2)
+/area/station/commons/dorms/room1)
 "chS" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -11941,7 +11941,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/carpet/blue,
-/area/station/commons/dorms/room3)
+/area/station/commons/dorms/room4)
 "cuV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/curtain/cloth/fancy/mechanical{
@@ -12413,7 +12413,7 @@
 	pixel_y = 11
 	},
 /turf/open/floor/carpet/orange,
-/area/station/commons/dorms/room1)
+/area/station/commons/dorms/room2)
 "cza" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/east,
 /obj/machinery/power/shuttle_engine/heater,
@@ -12546,7 +12546,7 @@
 /obj/structure/window/spawner/directional/west,
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet/royalblack,
-/area/station/commons/dorms/room8)
+/area/station/commons/dorms/room7)
 "cAi" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -14192,7 +14192,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room5)
+/area/station/commons/dorms/room6)
 "cPZ" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -14563,7 +14563,7 @@
 /obj/machinery/shower/directional/south,
 /obj/structure/drain,
 /turf/open/floor/iron/freezer,
-/area/station/commons/dorms/room6)
+/area/station/commons/dorms/room5)
 "cUu" = (
 /obj/structure/window/spawner/directional/south,
 /obj/structure/chair/sofa/middle/brown{
@@ -14745,7 +14745,7 @@
 	},
 /obj/machinery/digital_clock/directional/north,
 /turf/open/floor/carpet/blue,
-/area/station/commons/dorms/room3)
+/area/station/commons/dorms/room4)
 "cWr" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -15898,7 +15898,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room8)
+/area/station/commons/dorms/room7)
 "djt" = (
 /obj/structure/table,
 /obj/item/surgical_drapes{
@@ -16400,7 +16400,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/wood,
-/area/station/commons/dorms/room8)
+/area/station/commons/dorms/room7)
 "dnX" = (
 /obj/structure/flora/bush/sparsegrass,
 /obj/structure/flora/bush/ferny,
@@ -16712,7 +16712,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/carpet,
-/area/station/commons/dorms/room7)
+/area/station/commons/dorms/room8)
 "drT" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
@@ -16930,7 +16930,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room7)
+/area/station/commons/dorms/room8)
 "dtC" = (
 /obj/machinery/air_sensor/carbon_tank,
 /turf/open/floor/engine/co2,
@@ -17250,7 +17250,7 @@
 /obj/structure/table,
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room5)
+/area/station/commons/dorms/room6)
 "dxQ" = (
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
@@ -19010,7 +19010,7 @@
 /obj/structure/dresser,
 /obj/machinery/digital_clock/directional/north,
 /turf/open/floor/carpet/green,
-/area/station/commons/dorms/room2)
+/area/station/commons/dorms/room1)
 "dQY" = (
 /obj/structure/closet/crate{
 	name = "Dusty security crate"
@@ -19221,7 +19221,7 @@
 	name = "curtain"
 	},
 /turf/open/floor/plating,
-/area/station/commons/dorms/room3)
+/area/station/commons/dorms/room4)
 "dSV" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -20293,7 +20293,7 @@
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/hairbrush,
 /turf/open/floor/carpet/blue,
-/area/station/commons/dorms/room3)
+/area/station/commons/dorms/room4)
 "eeU" = (
 /obj/structure/fermenting_barrel,
 /obj/effect/decal/cleanable/dirt,
@@ -20391,7 +20391,7 @@
 /obj/structure/sink/directional/west,
 /obj/structure/mirror/directional/east,
 /turf/open/floor/iron/freezer,
-/area/station/commons/dorms/room8)
+/area/station/commons/dorms/room7)
 "egb" = (
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
@@ -20602,7 +20602,7 @@
 /obj/structure/sink/directional/east,
 /obj/structure/mirror/directional/west,
 /turf/open/floor/iron/freezer,
-/area/station/commons/dorms/room7)
+/area/station/commons/dorms/room8)
 "eib" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -21396,7 +21396,7 @@
 /obj/machinery/light/small/directional/west,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
-/area/station/commons/dorms/room3)
+/area/station/commons/dorms/room4)
 "eql" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo/warehouse)
@@ -21424,7 +21424,7 @@
 "eqx" = (
 /obj/machinery/duct,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room1)
+/area/station/commons/dorms/room2)
 "eqK" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -22221,7 +22221,7 @@
 "exC" = (
 /obj/machinery/duct,
 /turf/open/floor/carpet/orange,
-/area/station/commons/dorms/room1)
+/area/station/commons/dorms/room2)
 "exJ" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -22345,7 +22345,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/carpet/green,
-/area/station/commons/dorms/room2)
+/area/station/commons/dorms/room1)
 "ezm" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/structure/railing/corner/end{
@@ -23944,7 +23944,7 @@
 "eOg" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room4)
+/area/station/commons/dorms/room3)
 "eOk" = (
 /obj/structure/table/reinforced/rglass,
 /obj/item/storage/box/syringes{
@@ -23963,7 +23963,7 @@
 /obj/structure/fireplace,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/dark,
-/area/station/commons/dorms/room6)
+/area/station/commons/dorms/room5)
 "eOv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -24075,7 +24075,7 @@
 	},
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/carpet/orange,
-/area/station/commons/dorms/room1)
+/area/station/commons/dorms/room2)
 "ePt" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/disposalpipe/segment,
@@ -25262,7 +25262,7 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room8)
+/area/station/commons/dorms/room7)
 "fbb" = (
 /obj/effect/spawner/structure/electrified_grille,
 /turf/open/floor/plating/airless,
@@ -25953,7 +25953,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/station/commons/dorms/room4)
+/area/station/commons/dorms/room3)
 "fhQ" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
@@ -26161,7 +26161,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/station/commons/dorms/room3)
+/area/station/commons/dorms/room4)
 "fkn" = (
 /obj/machinery/power/shuttle_engine/heater,
 /turf/open/floor/plating,
@@ -27806,7 +27806,7 @@
 	name = "curtain"
 	},
 /turf/open/floor/plating,
-/area/station/commons/dorms/room6)
+/area/station/commons/dorms/room5)
 "fCZ" = (
 /obj/structure/table,
 /obj/item/food/cheese/royal,
@@ -28050,7 +28050,7 @@
 	name = "curtain"
 	},
 /turf/open/floor/plating,
-/area/station/commons/dorms/room8)
+/area/station/commons/dorms/room7)
 "fGy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
@@ -28473,7 +28473,7 @@
 /obj/structure/window/spawner/directional/west,
 /obj/structure/bed/pillow_large,
 /turf/open/floor/carpet/purple,
-/area/station/commons/dorms/room4)
+/area/station/commons/dorms/room3)
 "fLb" = (
 /obj/effect/turf_decal/stripes{
 	dir = 6
@@ -30576,7 +30576,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/station/commons/dorms/room7)
+/area/station/commons/dorms/room8)
 "ggP" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -30596,7 +30596,7 @@
 "ghc" = (
 /obj/machinery/duct,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room5)
+/area/station/commons/dorms/room6)
 "ghg" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/box,
@@ -31758,7 +31758,7 @@
 "gsN" = (
 /obj/machinery/duct,
 /turf/open/floor/carpet/purple,
-/area/station/commons/dorms/room4)
+/area/station/commons/dorms/room3)
 "gsQ" = (
 /obj/machinery/telecomms/server/presets/service,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -32208,7 +32208,7 @@
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room2)
+/area/station/commons/dorms/room1)
 "gxq" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -32266,7 +32266,7 @@
 	},
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/carpet/blue,
-/area/station/commons/dorms/room3)
+/area/station/commons/dorms/room4)
 "gxT" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
@@ -32463,7 +32463,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room6)
+/area/station/commons/dorms/room5)
 "gzI" = (
 /obj/machinery/light/directional/north,
 /obj/structure/flora/bush/ferny,
@@ -33987,7 +33987,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room2)
+/area/station/commons/dorms/room1)
 "gQX" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Laundromat"
@@ -34642,7 +34642,7 @@
 	pixel_y = -25
 	},
 /turf/open/floor/wood,
-/area/station/commons/dorms/room8)
+/area/station/commons/dorms/room7)
 "gXw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -34898,7 +34898,7 @@
 /obj/structure/dresser,
 /obj/machinery/digital_clock/directional/north,
 /turf/open/floor/carpet/purple,
-/area/station/commons/dorms/room4)
+/area/station/commons/dorms/room3)
 "hbc" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Medbay Maintenance"
@@ -34983,7 +34983,7 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/wood,
-/area/station/commons/dorms/room2)
+/area/station/commons/dorms/room1)
 "hbU" = (
 /turf/open/floor/iron/dark,
 /area/station/science/robotics)
@@ -35486,7 +35486,7 @@
 /obj/structure/sink/directional/west,
 /obj/structure/mirror/directional/east,
 /turf/open/floor/iron/freezer,
-/area/station/commons/dorms/room2)
+/area/station/commons/dorms/room1)
 "hgM" = (
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron/dark/side{
@@ -36207,7 +36207,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room4)
+/area/station/commons/dorms/room3)
 "hod" = (
 /obj/machinery/holopad{
 	name = "botany requests holopad"
@@ -38590,7 +38590,7 @@
 "hOv" = (
 /obj/machinery/duct,
 /turf/open/floor/carpet/blue,
-/area/station/commons/dorms/room3)
+/area/station/commons/dorms/room4)
 "hOx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/lone,
@@ -38828,7 +38828,7 @@
 	name = "curtain"
 	},
 /turf/open/floor/plating,
-/area/station/commons/dorms/room1)
+/area/station/commons/dorms/room2)
 "hQo" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -39705,7 +39705,7 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room1)
+/area/station/commons/dorms/room2)
 "iax" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/layer_manifold/cyan/hidden{
@@ -40614,7 +40614,7 @@
 "ijR" = (
 /obj/machinery/duct,
 /turf/open/floor/carpet/green,
-/area/station/commons/dorms/room2)
+/area/station/commons/dorms/room1)
 "ijZ" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
 /obj/item/toy/plush/nukeplushie{
@@ -40918,7 +40918,7 @@
 	},
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room1)
+/area/station/commons/dorms/room2)
 "inc" = (
 /obj/effect/decal/cleanable/blood/splatter/oil,
 /turf/open/floor/iron/dark,
@@ -41767,7 +41767,7 @@
 /obj/structure/dresser,
 /obj/machinery/digital_clock/directional/south,
 /turf/open/floor/carpet/orange,
-/area/station/commons/dorms/room1)
+/area/station/commons/dorms/room2)
 "iwF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -42112,7 +42112,7 @@
 /obj/machinery/digital_clock/directional/north,
 /obj/machinery/duct,
 /turf/open/floor/carpet/red,
-/area/station/commons/dorms/room6)
+/area/station/commons/dorms/room5)
 "iAN" = (
 /obj/structure/railing{
 	dir = 1
@@ -42474,7 +42474,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/carpet,
-/area/station/commons/dorms/room7)
+/area/station/commons/dorms/room8)
 "iEF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/can/food/peaches/maint,
@@ -42504,7 +42504,7 @@
 /obj/structure/dresser,
 /obj/machinery/digital_clock/directional/south,
 /turf/open/floor/carpet,
-/area/station/commons/dorms/room7)
+/area/station/commons/dorms/room8)
 "iEO" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -43741,7 +43741,7 @@
 	name = "curtain"
 	},
 /turf/open/floor/plating,
-/area/station/commons/dorms/room7)
+/area/station/commons/dorms/room8)
 "iTQ" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/night_club)
@@ -44805,7 +44805,7 @@
 /obj/structure/window/spawner/directional/west,
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet/green,
-/area/station/commons/dorms/room2)
+/area/station/commons/dorms/room1)
 "jeu" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance/two,
@@ -45678,7 +45678,7 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/wood,
-/area/station/commons/dorms/room3)
+/area/station/commons/dorms/room4)
 "jny" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -45867,7 +45867,7 @@
 /obj/machinery/shower/directional/south,
 /obj/structure/curtain/cloth,
 /turf/open/floor/iron/freezer,
-/area/station/commons/dorms/room2)
+/area/station/commons/dorms/room1)
 "jpo" = (
 /obj/structure/holosign/barrier/engineering,
 /turf/open/floor/iron/stairs/left,
@@ -45937,7 +45937,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/wood,
-/area/station/commons/dorms/room1)
+/area/station/commons/dorms/room2)
 "jpR" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47717,7 +47717,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/carpet,
-/area/station/commons/dorms/room7)
+/area/station/commons/dorms/room8)
 "jIc" = (
 /turf/open/floor/iron/white/smooth_large,
 /area/station/command/heads_quarters/ce)
@@ -49702,7 +49702,7 @@
 "kbe" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/red,
-/area/station/commons/dorms/room6)
+/area/station/commons/dorms/room5)
 "kbf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -50092,7 +50092,7 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room2)
+/area/station/commons/dorms/room1)
 "kfB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -50379,7 +50379,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room3)
+/area/station/commons/dorms/room4)
 "khi" = (
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/engine,
@@ -50685,7 +50685,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/carpet/orange,
-/area/station/commons/dorms/room1)
+/area/station/commons/dorms/room2)
 "kkx" = (
 /obj/structure/chair/sofa/right/brown{
 	dir = 4
@@ -51894,7 +51894,7 @@
 /obj/item/bedsheet/purple/double,
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/carpet/purple,
-/area/station/commons/dorms/room4)
+/area/station/commons/dorms/room3)
 "kww" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53314,7 +53314,7 @@
 	name = "curtain"
 	},
 /turf/open/floor/plating,
-/area/station/commons/dorms/room5)
+/area/station/commons/dorms/room6)
 "kLq" = (
 /turf/open/floor/iron/dark/side{
 	dir = 1
@@ -53780,7 +53780,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
-/area/station/commons/dorms/room8)
+/area/station/commons/dorms/room7)
 "kQH" = (
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/power/tracker,
@@ -55211,7 +55211,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room1)
+/area/station/commons/dorms/room2)
 "lgw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55821,7 +55821,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room1)
+/area/station/commons/dorms/room2)
 "lnh" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -56461,7 +56461,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room6)
+/area/station/commons/dorms/room5)
 "luq" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -56539,7 +56539,7 @@
 /obj/item/bedsheet/red/double,
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/carpet/red,
-/area/station/commons/dorms/room6)
+/area/station/commons/dorms/room5)
 "lvA" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -57276,7 +57276,7 @@
 	},
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/carpet,
-/area/station/commons/dorms/room7)
+/area/station/commons/dorms/room8)
 "lDX" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 5
@@ -57485,7 +57485,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room4)
+/area/station/commons/dorms/room3)
 "lGD" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/iron,
@@ -57500,7 +57500,7 @@
 "lGJ" = (
 /obj/machinery/duct,
 /turf/open/floor/carpet/red,
-/area/station/commons/dorms/room6)
+/area/station/commons/dorms/room5)
 "lGO" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Security - Shooting Range"
@@ -58774,7 +58774,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/carpet/black,
-/area/station/commons/dorms/room5)
+/area/station/commons/dorms/room6)
 "lUf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -60310,7 +60310,7 @@
 /obj/structure/window/spawner/directional/east,
 /obj/structure/dresser,
 /turf/open/floor/carpet/blue,
-/area/station/commons/dorms/room3)
+/area/station/commons/dorms/room4)
 "mjK" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
@@ -61655,7 +61655,7 @@
 "mzv" = (
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
-/area/station/commons/dorms/room6)
+/area/station/commons/dorms/room5)
 "mzw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/decal/cleanable/blood/splatter/over_window{
@@ -63006,7 +63006,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room2)
+/area/station/commons/dorms/room1)
 "mMh" = (
 /obj/machinery/light/directional/west,
 /obj/structure/aquarium/prefilled,
@@ -63826,7 +63826,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/station/commons/dorms/room3)
+/area/station/commons/dorms/room4)
 "mUu" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -64182,7 +64182,7 @@
 /obj/machinery/duct,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
-/area/station/commons/dorms/room4)
+/area/station/commons/dorms/room3)
 "mYm" = (
 /obj/effect/turf_decal/bot_red,
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
@@ -66144,7 +66144,7 @@
 /obj/machinery/shower/directional/south,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
-/area/station/commons/dorms/room4)
+/area/station/commons/dorms/room3)
 "nvh" = (
 /obj/machinery/status_display/ai/directional/north,
 /obj/effect/spawner/random/maintenance,
@@ -69141,7 +69141,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room7)
+/area/station/commons/dorms/room8)
 "oaq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -69766,7 +69766,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room8)
+/area/station/commons/dorms/room7)
 "ogx" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "AI Chamber - Starboard";
@@ -70436,7 +70436,7 @@
 /obj/item/bedsheet/brown/double,
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/carpet/royalblack,
-/area/station/commons/dorms/room8)
+/area/station/commons/dorms/room7)
 "olW" = (
 /turf/open/floor/iron/dark/corner{
 	dir = 4
@@ -71212,7 +71212,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room8)
+/area/station/commons/dorms/room7)
 "osZ" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/structure/disposalpipe/segment,
@@ -73338,7 +73338,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/carpet/royalblack,
-/area/station/commons/dorms/room8)
+/area/station/commons/dorms/room7)
 "oOJ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -73947,7 +73947,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room5)
+/area/station/commons/dorms/room6)
 "oUN" = (
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/iron/cafeteria,
@@ -74599,7 +74599,7 @@
 /obj/machinery/light/small/directional/west,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
-/area/station/commons/dorms/room7)
+/area/station/commons/dorms/room8)
 "pcQ" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/decal/cleanable/cobweb,
@@ -75180,7 +75180,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room1)
+/area/station/commons/dorms/room2)
 "pjw" = (
 /turf/closed/wall,
 /area/station/maintenance/port/central)
@@ -76925,7 +76925,7 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room6)
+/area/station/commons/dorms/room5)
 "pCp" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage_shared)
@@ -76938,7 +76938,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/station/commons/dorms/room2)
+/area/station/commons/dorms/room1)
 "pCv" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -78116,7 +78116,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/carpet/black,
-/area/station/commons/dorms/room5)
+/area/station/commons/dorms/room6)
 "pPb" = (
 /obj/structure/rack,
 /obj/item/storage/inflatable,
@@ -82025,7 +82025,7 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room5)
+/area/station/commons/dorms/room6)
 "qBS" = (
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
@@ -82742,7 +82742,7 @@
 /obj/structure/dresser,
 /obj/machinery/digital_clock/directional/north,
 /turf/open/floor/carpet/royalblack,
-/area/station/commons/dorms/room8)
+/area/station/commons/dorms/room7)
 "qIo" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -82778,7 +82778,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/station/commons/dorms/room6)
+/area/station/commons/dorms/room5)
 "qIF" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -85575,7 +85575,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/carpet/green,
-/area/station/commons/dorms/room2)
+/area/station/commons/dorms/room1)
 "rlq" = (
 /obj/structure/railing/corner/end,
 /turf/open/floor/iron/white/side{
@@ -86120,7 +86120,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room3)
+/area/station/commons/dorms/room4)
 "rqK" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/delivery,
@@ -86711,7 +86711,7 @@
 /obj/structure/mirror/directional/east,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
-/area/station/commons/dorms/room4)
+/area/station/commons/dorms/room3)
 "rwq" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -87222,7 +87222,7 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room3)
+/area/station/commons/dorms/room4)
 "rCv" = (
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /obj/effect/turf_decal/bot/right,
@@ -87918,7 +87918,7 @@
 	},
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room7)
+/area/station/commons/dorms/room8)
 "rIM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -88182,7 +88182,7 @@
 /obj/structure/sink/directional/west,
 /obj/structure/mirror/directional/east,
 /turf/open/floor/iron/freezer,
-/area/station/commons/dorms/room6)
+/area/station/commons/dorms/room5)
 "rMc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -90193,7 +90193,7 @@
 /obj/structure/window/spawner/directional/east,
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet/orange,
-/area/station/commons/dorms/room1)
+/area/station/commons/dorms/room2)
 "sik" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_pp,
@@ -90310,7 +90310,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/carpet/purple,
-/area/station/commons/dorms/room4)
+/area/station/commons/dorms/room3)
 "sjH" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
@@ -91098,7 +91098,7 @@
 	pixel_y = 11
 	},
 /turf/open/floor/carpet/royalblack,
-/area/station/commons/dorms/room8)
+/area/station/commons/dorms/room7)
 "ssz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/binary/pump/on/layer4{
@@ -93381,7 +93381,7 @@
 "sOQ" = (
 /obj/machinery/duct,
 /turf/open/floor/carpet/royalblack,
-/area/station/commons/dorms/room8)
+/area/station/commons/dorms/room7)
 "sOS" = (
 /obj/item/stack/ore/titanium,
 /turf/open/floor/plating/airless,
@@ -93759,7 +93759,7 @@
 /obj/structure/sink/directional/east,
 /obj/structure/mirror/directional/west,
 /turf/open/floor/iron/freezer,
-/area/station/commons/dorms/room1)
+/area/station/commons/dorms/room2)
 "sTg" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/vending/wardrobe/sec_wardrobe,
@@ -93806,7 +93806,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/carpet/blue,
-/area/station/commons/dorms/room3)
+/area/station/commons/dorms/room4)
 "sTH" = (
 /obj/structure/railing,
 /obj/machinery/door/firedoor/border_only,
@@ -96060,7 +96060,7 @@
 /obj/structure/drain,
 /obj/machinery/shower/directional/south,
 /turf/open/floor/iron/freezer,
-/area/station/commons/dorms/room3)
+/area/station/commons/dorms/room4)
 "tpV" = (
 /obj/machinery/smartfridge/organ,
 /obj/machinery/firealarm/directional/north,
@@ -96350,7 +96350,7 @@
 	name = "curtain"
 	},
 /turf/open/floor/plating,
-/area/station/commons/dorms/room4)
+/area/station/commons/dorms/room3)
 "tui" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -96469,7 +96469,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/station/commons/dorms/room2)
+/area/station/commons/dorms/room1)
 "tvs" = (
 /obj/structure/table/glass,
 /obj/item/clipboard,
@@ -97522,7 +97522,7 @@
 "tEY" = (
 /obj/machinery/duct,
 /turf/open/floor/carpet,
-/area/station/commons/dorms/room7)
+/area/station/commons/dorms/room8)
 "tFa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -98150,7 +98150,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/black,
-/area/station/commons/dorms/room5)
+/area/station/commons/dorms/room6)
 "tMn" = (
 /obj/structure/table/glass,
 /obj/machinery/cell_charger,
@@ -99428,7 +99428,7 @@
 /obj/structure/window/spawner/directional/east,
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet/black,
-/area/station/commons/dorms/room5)
+/area/station/commons/dorms/room6)
 "tZj" = (
 /obj/item/food/grown/banana/bunch,
 /turf/open/floor/plating,
@@ -100617,7 +100617,7 @@
 "ukN" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room7)
+/area/station/commons/dorms/room8)
 "ukP" = (
 /obj/machinery/light_switch/directional/west,
 /obj/machinery/light/directional/west,
@@ -101024,7 +101024,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room2)
+/area/station/commons/dorms/room1)
 "uog" = (
 /turf/open/floor/iron,
 /area/station/science/explab)
@@ -101548,7 +101548,7 @@
 /obj/structure/drain,
 /obj/machinery/shower/directional/south,
 /turf/open/floor/iron/freezer,
-/area/station/commons/dorms/room5)
+/area/station/commons/dorms/room6)
 "utC" = (
 /obj/structure/bed/medical/anchored{
 	dir = 1
@@ -101845,7 +101845,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/carpet/royalblack,
-/area/station/commons/dorms/room8)
+/area/station/commons/dorms/room7)
 "uwy" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light_switch/directional/south,
@@ -102470,7 +102470,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/station/commons/dorms/room7)
+/area/station/commons/dorms/room8)
 "uCB" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/firealarm/directional/east,
@@ -102494,7 +102494,7 @@
 /obj/structure/sink/directional/east,
 /obj/structure/mirror/directional/west,
 /turf/open/floor/iron/freezer,
-/area/station/commons/dorms/room5)
+/area/station/commons/dorms/room6)
 "uCF" = (
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
@@ -102942,7 +102942,7 @@
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/structure/window/spawner/directional/west,
 /turf/open/floor/carpet/purple,
-/area/station/commons/dorms/room4)
+/area/station/commons/dorms/room3)
 "uHv" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -103691,7 +103691,7 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/wood,
-/area/station/commons/dorms/room5)
+/area/station/commons/dorms/room6)
 "uQo" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon{
@@ -104479,7 +104479,7 @@
 	pixel_y = -27
 	},
 /turf/open/floor/wood,
-/area/station/commons/dorms/room4)
+/area/station/commons/dorms/room3)
 "uYe" = (
 /obj/effect/landmark/firealarm_sanity,
 /turf/open/openspace,
@@ -104573,7 +104573,7 @@
 /obj/structure/sink/directional/east,
 /obj/structure/mirror/directional/west,
 /turf/open/floor/iron/freezer,
-/area/station/commons/dorms/room3)
+/area/station/commons/dorms/room4)
 "uZe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -108246,7 +108246,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/station/commons/dorms/room1)
+/area/station/commons/dorms/room2)
 "vIU" = (
 /obj/structure/reagent_dispensers/plumbed{
 	dir = 8
@@ -109288,7 +109288,7 @@
 "vUp" = (
 /obj/structure/chair/sofa/right/brown,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room8)
+/area/station/commons/dorms/room7)
 "vUs" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -110396,7 +110396,7 @@
 /obj/structure/window/spawner/directional/west,
 /obj/structure/table/wood/fancy/green,
 /turf/open/floor/carpet/green,
-/area/station/commons/dorms/room2)
+/area/station/commons/dorms/room1)
 "wfd" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
@@ -110525,7 +110525,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/carpet/purple,
-/area/station/commons/dorms/room4)
+/area/station/commons/dorms/room3)
 "wgj" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -111887,7 +111887,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/carpet/red,
-/area/station/commons/dorms/room6)
+/area/station/commons/dorms/room5)
 "wui" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -111926,7 +111926,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room8)
+/area/station/commons/dorms/room7)
 "wuC" = (
 /obj/structure/flora/bush/fullgrass,
 /obj/structure/flora/bush/lavendergrass,
@@ -113574,7 +113574,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/carpet/orange,
-/area/station/commons/dorms/room1)
+/area/station/commons/dorms/room2)
 "wLH" = (
 /obj/effect/landmark/start/botanist,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -114899,7 +114899,7 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room7)
+/area/station/commons/dorms/room8)
 "wZm" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -116151,7 +116151,7 @@
 /obj/structure/curtain/cloth,
 /obj/machinery/shower/directional/south,
 /turf/open/floor/iron/freezer,
-/area/station/commons/dorms/room1)
+/area/station/commons/dorms/room2)
 "xny" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/disposalpipe/segment,
@@ -116727,7 +116727,7 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room5)
+/area/station/commons/dorms/room6)
 "xtn" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Funeral Hall"
@@ -117859,7 +117859,7 @@
 	name = "curtain"
 	},
 /turf/open/floor/plating,
-/area/station/commons/dorms/room2)
+/area/station/commons/dorms/room1)
 "xFd" = (
 /obj/structure/railing,
 /obj/structure/chair/plastic{
@@ -118688,7 +118688,7 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
-/area/station/commons/dorms/room4)
+/area/station/commons/dorms/room3)
 "xND" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate{
@@ -119046,7 +119046,7 @@
 /obj/structure/dresser,
 /obj/machinery/digital_clock/directional/south,
 /turf/open/floor/carpet/black,
-/area/station/commons/dorms/room5)
+/area/station/commons/dorms/room6)
 "xRO" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -119673,7 +119673,7 @@
 /obj/structure/window/spawner/directional/east,
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet,
-/area/station/commons/dorms/room7)
+/area/station/commons/dorms/room8)
 "xYq" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -120459,7 +120459,7 @@
 /obj/machinery/light/small/directional/west,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
-/area/station/commons/dorms/room5)
+/area/station/commons/dorms/room6)
 "yfB" = (
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/wood,
@@ -206337,8 +206337,8 @@ tFl
 tFl
 tFl
 tFl
-xPd
-xPd
+bYG
+bYG
 fHi
 fHi
 fHi
@@ -206569,11 +206569,11 @@ vZR
 nai
 nbJ
 ddk
-jLC
+jdm
 xnw
-hOn
+blX
 sSX
-jLC
+jdm
 cnZ
 qhW
 cXy
@@ -206584,16 +206584,16 @@ bOY
 vNd
 khN
 dSh
-qXs
+vQb
 tpT
 eqg
 uYT
-iuJ
+cKz
 utr
 yfy
 uCD
-xPd
-oHq
+bYG
+epz
 pcM
 ehY
 fHi
@@ -206826,11 +206826,11 @@ gyh
 jyY
 mqj
 ddk
-jLC
-jLC
+jdm
+jdm
 kkv
-jLC
-jLC
+jdm
+jdm
 iOX
 exq
 nzv
@@ -206841,18 +206841,18 @@ fQk
 wmR
 sWE
 gEI
-qXs
-qXs
+vQb
+vQb
 cuT
-qXs
-iuJ
-iuJ
+vQb
+cKz
+cKz
 lTZ
-iuJ
-xPd
-xPd
+cKz
+bYG
+bYG
 drQ
-xPd
+bYG
 fHi
 reO
 gmv
@@ -207083,11 +207083,11 @@ uFD
 fyr
 gNf
 ddk
-jLC
+jdm
 ePn
 exC
 iwD
-jLC
+jdm
 qrP
 eie
 cCM
@@ -207098,15 +207098,15 @@ fQd
 wmR
 vlo
 utE
-qXs
+vQb
 cWn
 hOv
 gxL
-iuJ
+cKz
 tMh
 axm
 afX
-xPd
+bYG
 lDR
 tEY
 iEK
@@ -207340,11 +207340,11 @@ qtm
 cbZ
 gNf
 nIB
-jLC
+jdm
 cyX
 wLE
 shZ
-jLC
+jdm
 fQd
 fQd
 fQd
@@ -207355,15 +207355,15 @@ fQd
 rSK
 fHx
 fQd
-qXs
+vQb
 eeT
 sTF
 mjI
-iuJ
+cKz
 tZf
 pOV
 xRL
-xPd
+bYG
 jHZ
 iEC
 xYm
@@ -207597,7 +207597,7 @@ cbZ
 elV
 gNf
 ujq
-jLC
+jdm
 jpQ
 eqx
 vIO
@@ -207616,11 +207616,11 @@ dSS
 mUs
 rqF
 jnt
-iuJ
+cKz
 anD
 ghc
 uQl
-xPd
+bYG
 uCu
 oak
 rIK
@@ -207854,10 +207854,10 @@ uOq
 wOW
 oUF
 fBU
-jLC
+jdm
 iav
 pjt
-wyL
+aoo
 hQm
 xxH
 rvk
@@ -207870,17 +207870,17 @@ cGl
 sRt
 rkz
 dSS
-glS
-ouM
-xBR
-iuJ
+qDz
+nqH
+xkA
+cKz
 dxM
 bWn
 qBP
-xPd
+bYG
 ukN
-fXT
-lGF
+xKP
+vFA
 fHi
 xbC
 ubC
@@ -208111,7 +208111,7 @@ nTO
 hZy
 gQX
 hZy
-jLC
+jdm
 imT
 lgr
 bLh
@@ -208128,15 +208128,15 @@ sRt
 yaw
 dSS
 fkc
-ouM
+nqH
 rCo
-iuJ
+cKz
 oUM
-ocz
+upz
 xtj
-xPd
+bYG
 ggK
-fXT
+xKP
 wZg
 fHi
 lRL
@@ -208368,11 +208368,11 @@ cvc
 hcp
 icu
 pWv
-jLC
-jLC
+jdm
+jdm
 lne
-jLC
-jLC
+jdm
+jdm
 xxH
 jqe
 vXi
@@ -208383,18 +208383,18 @@ vXi
 iAN
 ljm
 fQd
-qXs
+vQb
 dSS
 khd
-qXs
-iuJ
+vQb
+cKz
 kLp
 cPX
-iuJ
-xPd
+cKz
+bYG
 iTP
 dtA
-xPd
+bYG
 fHi
 fHi
 dtK
@@ -209910,11 +209910,11 @@ eeZ
 twS
 fTa
 xGq
-jdm
-jdm
+jLC
+jLC
 uoa
-jdm
-jdm
+jLC
+jLC
 tze
 jqe
 vXi
@@ -209925,18 +209925,18 @@ vXi
 iAN
 vVu
 fQd
-vQb
+qXs
 tuf
 lGB
-vQb
-cKz
+qXs
+iuJ
 fCV
 lul
-cKz
-bYG
+iuJ
+xPd
 fGv
 wuy
-bYG
+xPd
 fQd
 fQd
 wBq
@@ -210167,7 +210167,7 @@ mqh
 mqh
 rRC
 mqh
-jdm
+jLC
 gxj
 gQW
 hbT
@@ -210184,13 +210184,13 @@ vVu
 pGo
 tuf
 eOg
-nqH
+ouM
 xNB
-cKz
+iuJ
 bEr
-upz
+ocz
 pCj
-bYG
+xPd
 vUp
 ogw
 faZ
@@ -210424,10 +210424,10 @@ sZp
 xzt
 hiO
 lPl
-jdm
+jLC
 kfA
 gQW
-aoo
+wyL
 xEX
 tFc
 foD
@@ -210440,17 +210440,17 @@ aLQ
 vVu
 naF
 tuf
-qDz
-nqH
-xkA
-cKz
+glS
+ouM
+xBR
+iuJ
 eOn
 gzH
 aWD
-bYG
+xPd
 osY
-xKP
-vFA
+fXT
+lGF
 eVg
 quF
 xsn
@@ -210681,7 +210681,7 @@ sZp
 xbb
 mQo
 mQo
-jdm
+jLC
 pCt
 mMd
 tvp
@@ -210700,11 +210700,11 @@ tuf
 fhL
 hob
 uYd
-cKz
+iuJ
 bEr
 bFc
 qIB
-bYG
+xPd
 dnV
 djm
 gXl
@@ -210938,11 +210938,11 @@ sZp
 sZp
 pSH
 tkC
-jdm
+jLC
 jes
 rlp
 wfb
-mqh
+jLC
 eFC
 mqh
 fQd
@@ -210953,15 +210953,15 @@ fQd
 fHx
 fHx
 fQd
-vQb
+qXs
 uHs
 wge
 fKW
-cKz
-cKz
+iuJ
+iuJ
 iAK
 boW
-bYG
+xPd
 qIn
 oOH
 cAg
@@ -211195,11 +211195,11 @@ lPx
 sZp
 ktv
 vtE
-jdm
+jLC
 dQV
 ijR
 chR
-mqh
+jLC
 odv
 mqh
 fwm
@@ -211210,15 +211210,15 @@ eBa
 gpu
 lvV
 oVf
-vQb
+qXs
 hbb
 gsN
 kwv
-cKz
+iuJ
 lvx
 lGJ
 kbe
-bYG
+xPd
 olT
 sOQ
 ssw
@@ -211452,11 +211452,11 @@ rZk
 sZp
 kbD
 vtE
-jdm
-jdm
+jLC
+jLC
 ezf
-jdm
-mqh
+jLC
+jLC
 mYV
 mqh
 iIf
@@ -211467,18 +211467,18 @@ dCe
 dCe
 xgv
 kJr
-vQb
-vQb
+qXs
+qXs
 sjF
-vQb
-cKz
-cKz
+qXs
+iuJ
+iuJ
 wuf
-cKz
-bYG
-bYG
+iuJ
+xPd
+xPd
 uww
-bYG
+xPd
 eVg
 quF
 qvX
@@ -211709,9 +211709,9 @@ pRa
 sZp
 sZp
 omM
-jdm
+jLC
 jpn
-blX
+hOn
 hgL
 mqh
 mQo
@@ -211724,16 +211724,16 @@ mHB
 iQP
 hhF
 baG
-vQb
+qXs
 nvb
 mYh
 rwl
-cKz
+iuJ
 cUg
 mzv
 rLU
-bYG
-epz
+xPd
+oHq
 kQz
 efW
 eVg


### PR DESCRIPTION
## About The Pull Request
Fixed a thing where some dorms rooms were mislabeled as the other number, ex dorms 3 being dorms 4 in the map and etc
Closes https://github.com/NovaSector/NovaSector/issues/6917

## How This Contributes To The Nova Sector Roleplay Experience
Fixes mapping mislabeling and probably awkward situations for paramedics breaking into the wrong dorm room to save a dying SSD person

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  

https://github.com/user-attachments/assets/0c448525-b071-4f89-9bc0-bfa28d60e7db


</details>

## Changelog
:cl: Hardly
map: Fixes mislabeled dorms rooms in Blueshift.
/:cl:
