### PR TITLE
Fix for plumbing liquid pumps

### DIFF
--- a/modular_nova/modules/liquids/code/liquid_systems/liquid_plumbers.dm
+++ b/modular_nova/modules/liquids/code/liquid_systems/liquid_plumbers.dm
@@ -178,9 +178,9 @@
 	icon_state = "active_input"
 	base_icon_state = "active_input"
 
-/obj/machinery/plumbing/floor_pump/input/Initialize(mapload, bolt, layer)
+/obj/machinery/plumbing/floor_pump/input/Initialize(mapload, layer)
 	. = ..()
-	AddComponent(/datum/component/plumbing/simple_supply, bolt, layer || duct_layer)
+	AddComponent(/datum/component/plumbing/simple_supply, layer)
 
 /obj/machinery/plumbing/floor_pump/input/are_reagents_ready()
 	return reagents.total_volume < reagents.maximum_volume
@@ -235,9 +235,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/plumbing/floor_pump/input/on/waste, 0
 	/// Max pressure on the turf before we stop pumping.
 	var/max_ext_kpa = WARNING_HIGH_PRESSURE
 
-/obj/machinery/plumbing/floor_pump/output/Initialize(mapload, bolt, layer)
+/obj/machinery/plumbing/floor_pump/output/Initialize(mapload, layer)
 	. = ..()
-	AddComponent(/datum/component/plumbing/simple_demand, bolt, layer || duct_layer)
+	AddComponent(/datum/component/plumbing/simple_demand, layer)
 
 /obj/machinery/plumbing/floor_pump/output/examine(mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
After one of the updates from arugement started to be passed in to plumbing component, which made it be restricted to 0 chemicals.
## How This Contributes To The Nova Sector Roleplay Experience
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  for whatever reason, im unable to upload screenshots
</details>

## Changelog
:cl:
fix: Liquid pumps for plumbing should now work.
/:cl:
