### PR TITLE
Adds Atmospherics Trainee title for newer atmosians

### DIFF
--- a/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -38,7 +38,7 @@
 /datum/job/atmospheric_technician
 	alt_titles = list(
 		"Atmospheric Technician",
-		"Atmospherics Trainee",
+		"Atmospheric Trainee",
 		"Emergency Fire Technician",
 		"Hypertorus Fusion Reactor Operator",
 		"Gas Synthesis Technician",


### PR DESCRIPTION
## About The Pull Request
Adds a new alt title for the newer atmosians

<img width="188" height="242" alt="image" src="https://github.com/user-attachments/assets/01ae34a2-cfd0-43da-b985-582dd659ccdf" />

## How This Contributes To The Nova Sector Roleplay Experience
Lets people know you're new in atmos

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl: Hardly
add: Added "Atmospheric Trainee" title for newer atmosians
/:cl:
