### PR TITLE
Allows selection of digi legs and wings for felinids and derivatives

### DIFF
--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species.dm
@@ -72,6 +72,8 @@ GLOBAL_LIST_EMPTY(customizable_races)
 	return list(
 		FEATURE_TAIL = MUTPART_BLUEPRINT("Cat", is_randomizable = FALSE),
 		FEATURE_EARS = MUTPART_BLUEPRINT("Cat", is_randomizable = FALSE),
+		FEATURE_WINGS = MUTPART_BLUEPRINT(SPRITE_ACCESSORY_NONE, is_randomizable = FALSE),
+		FEATURE_LEGS = MUTPART_BLUEPRINT(NORMAL_LEGS, is_randomizable = FALSE, is_feature = TRUE),
 	)
 
 /datum/species/human/felinid/create_pref_unique_perks()


### PR DESCRIPTION

## About The Pull Request
I just added a default option to make them available in editor. *shrug
## How This Contributes To The Nova Sector Roleplay Experience
Mostly for consistency sake rather than artistic freedom. We can choose both options for humans, yet not for felinids and primitive demihumans. Also I just wanted an ice cat with furry legs.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  <img width="906" height="708" alt="image" src="https://github.com/user-attachments/assets/ea48e108-377f-4002-a4bf-f20175696bd0" />
</details>

## Changelog
:cl:
add: You can select digi legs and wings for felinid chars
/:cl:
