### PR TITLE
Adds big brother trim in to ID painter

### DIFF
--- a/modular_nova/master_files/code/datums/id_trim/jobs.dm
+++ b/modular_nova/master_files/code/datums/id_trim/jobs.dm
@@ -29,6 +29,10 @@
 	minimal_access |= ACCESS_WEAPONS
 	return ..()
 
+/datum/id_trim/job/human_ai/New()
+	template_access  |= ACCESS_CAPTAIN
+	return ..()
+
 /datum/id_trim/job/blueshield
 	assignment = "Blueshield"
 	trim_icon = 'modular_nova/master_files/icons/obj/card.dmi'


### PR DESCRIPTION

## About The Pull Request
As shrimple as that. Adds a trim for use of AI shell or whoever else (it barely has any access anyways)
## How This Contributes To The Nova Sector Roleplay Experience
Some unique trim that can be used by AI humanoid shells to be distinguishable on huds.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  i tested it, trust me, i just cant upload any screenshots
</details>

## Changelog
:cl:
add: Added big brother trim in ID painter
/:cl:
