### PR TITLE
Allow medal attachment on all under clothing...

### DIFF
--- a/code/modules/clothing/under/accessories/medals.dm
+++ b/code/modules/clothing/under/accessories/medals.dm
@@ -1,8 +1,3 @@
-/*
-// AWARDABLE MEDALS
-// These can be pinned onto others on the under clothes slot to 'award' them, appearing in the round-end screen
-*/
-
 /obj/item/clothing/accessory/medal
 	name = "bronze medal"
 	desc = "A bronze medal."
@@ -17,7 +12,6 @@
 	var/awarded_to
 	/// Who gave out this medal
 	var/awarder
-	attachment_slot = NONE
 
 /obj/item/clothing/accessory/medal/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
… regardless of which body part it covers
## About The Pull Request

Mostly a single line change to allow all medals to be attachable to any under clothing, regardless of which part of the body it covers..

## How This Contributes To The Nova Sector Roleplay Experience

This is a [Discord Request](https://discord.com/channels/1171566433923239977/1468744194393903115), where emphasis is on the QoL aspect this change would add to the game. While is doesn't quite make sense sprite-wise for pins to be pinned onto your chest if only wearing shorts, it does mean that RP can continue without awkwardness while Heads of staff pin your well deserved medal ~~directly onto your flesh~~ onto your shorts.

In the future we could potentially look into changing sprite appearance based off from whether the under clothes covers the chest or not, but I believe this QoL change would be good to have. Certainly wouldn't be the most immersion breaking thing we witness on shifts.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
Showing Medal of Captaincy pinning onto rolled down jumpsuit
<img width="1889" height="974" alt="2026-02-11 17_20_59-Window" src="https://github.com/user-attachments/assets/086bc327-323a-409a-945a-f7f240ac9b84" />
Showing Cargo Medal pinning onto jeans
<img width="1918" height="999" alt="2026-02-11 17_42_58-Window" src="https://github.com/user-attachments/assets/a56ffa0a-b168-4870-b268-3507527fcabc" />
</details>

## Changelog

:cl: MowLiao
qol: allowed all medals to be attached to any under clothing
/:cl: