### PR TITLE
Reverts belt size from bulky to normal

### DIFF
--- a/modular_nova/master_files/code/game/objects/items/storage/belt.dm
+++ b/modular_nova/master_files/code/game/objects/items/storage/belt.dm
@@ -1,0 +1,8 @@
+/*
+	Belt overrides live here!
+*/
+/obj/item/storage/belt
+	w_class = WEIGHT_CLASS_NORMAL
+
+/obj/item/storage/belt/sheath
+	w_class = WEIGHT_CLASS_BULKY

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7101,6 +7101,7 @@
 #include "modular_nova\master_files\code\game\objects\items\stacks\sheets\sheet_types.dm"
 #include "modular_nova\master_files\code\game\objects\items\stacks\tiles\tile_types.dm"
 #include "modular_nova\master_files\code\game\objects\items\storage\backpack.dm"
+#include "modular_nova\master_files\code\game\objects\items\storage\belt.dm"
 #include "modular_nova\master_files\code\game\objects\items\storage\boxes.dm"
 #include "modular_nova\master_files\code\game\objects\items\storage\duffelbags.dm"
 #include "modular_nova\master_files\code\game\objects\items\storage\holsters.dm"


### PR DESCRIPTION
## About The Pull Request

Reverts https://github.com/tgstation/tgstation/pull/66927
But keeps some belts bulky!

## How This Contributes To The Nova Sector Roleplay Experience

I'm kind of stunned that we never did this sooner. We love storage, we have many storage items that essentially fulfill a similar role.

Besides lets be honest, belts fit in bags.

## Proof of Testing


## Changelog
:cl:
balance: Most belts are now normal size instead of bulky, as it was back before May 2022. Some may still be bulky!
/:cl:

