### PR TITLE
Makes Pubby ordnance less prone to blowing up atmos

### DIFF
--- a/_maps/map_files/oceanpubby/oceanpubby.dmm
+++ b/_maps/map_files/oceanpubby/oceanpubby.dmm
@@ -19586,7 +19586,9 @@
 	},
 /area/station/hallway/secondary/entry)
 "bMq" = (
-/obj/machinery/mass_driver/ordnance,
+/obj/machinery/mass_driver/ordnance{
+	power = 4
+	},
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
 "bMu" = (


### PR DESCRIPTION

## About The Pull Request
Changes the default mass driver's power in ordnance from 1 to 4

## How This Contributes To The Nova Sector Roleplay Experience
The default power for Ordnance's mass driver is too low to the point TTVs land right next to atmos instead if it's not manually adjusted, there's already been a couple of incidents in which ordnance blew up parts of atmos and maintenance by accident. *cough*

Planetary maps such as snowglobe and icebox have their mass driver's power varedited to prevent such accidents.

<img width="294" height="341" alt="image" src="https://github.com/user-attachments/assets/83226344-35d0-4db8-a99c-1a11a6d9fdd7" />

<img width="706" height="703" alt="image" src="https://github.com/user-attachments/assets/f85bd946-c03b-4a1b-a2de-3922480cb6a3" />

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/8272a30a-2c2f-4f37-9372-7145e57f89b1
  
</details>

## Changelog
:cl: Hardly
map: Changed Pubby ordnance's mass driver to be a bit more powerful by default
/:cl:
