### PR TITLE
HC Survival boxes are now normal sized.

### DIFF
--- a/modular_nova/master_files/code/modules/cargo/markets/market_items/clothing.dm
+++ b/modular_nova/master_files/code/modules/cargo/markets/market_items/clothing.dm
@@ -37,8 +37,8 @@
 
 /datum/market_item/clothing/military_belt
 	name = "Old Military Belt"
-	desc = "A dusty belt which used to fit a military that's no longer active, reviews state their old MREs are sometimes found within these belts."
-	item = /obj/item/storage/belt/military/nri/plus_mre
+	desc = "A dusty belt which used to fit a military that's no longer active."
+	item = /obj/item/storage/belt/military/nri
 	price_min = CARGO_CRATE_VALUE * 0.5
 	price_max = CARGO_CRATE_VALUE
 	stock_max = 3

--- a/modular_nova/modules/random_ship_event/random_ships/heliostatic_inspectors/code/outfit.dm
+++ b/modular_nova/modules/random_ship_event/random_ships/heliostatic_inspectors/code/outfit.dm
@@ -22,8 +22,9 @@
 		/obj/item/gun/ballistic/automatic/pistol/plasma_marksman = 1,
 		/obj/item/clothing/mask/gas/hc_police = 1,
 		/obj/item/modular_computer/pda/hc_police = 1,
+		/obj/item/stack/spacecash/c1000 = 1,
 	)
-	l_pocket = /obj/item/folder/blue/hc_cop
+	l_pocket = null
 	r_pocket = /obj/item/storage/pouch/ammo
 
 	id = /obj/item/card/id/advanced/hc_police
@@ -91,7 +92,6 @@
 	new /obj/item/flashlight/flare(src)
 	new /obj/item/crowbar/red(src)
 	new /obj/item/clipboard(src)
-	new /obj/item/pen(src)
 
 /obj/item/folder/blue/hc_cop
 	name = "HC police SOPs"

--- a/modular_nova/modules/random_ship_event/random_ships/heliostatic_inspectors/code/outfit.dm
+++ b/modular_nova/modules/random_ship_event/random_ships/heliostatic_inspectors/code/outfit.dm
@@ -81,13 +81,11 @@
 	), src)
 
 /obj/item/storage/box/nri_survival_pack/inspector
-	w_class = WEIGHT_CLASS_SMALL
 	desc = "A box filled with useful inspection items, supplied by the HC."
 
 /obj/item/storage/box/nri_survival_pack/inspector/PopulateContents()
 	new /obj/item/oxygen_candle(src)
 	new /obj/item/tank/internals/emergency_oxygen(src)
-	new /obj/item/stack/spacecash/c1000(src)
 	new /obj/item/storage/pill_bottle/iron(src)
 	new /obj/item/reagent_containers/hypospray/medipen(src)
 	new /obj/item/flashlight/flare(src)


### PR DESCRIPTION

## About The Pull Request
Removes the w_class override and lets the HC survival pack default to a normal weight class. Also removes the extra 1000 credit stack from it. You should not be able to buy something off the market and immediately make 800+ credits, since the price of it varies from 100-200

## How This Contributes To The Nova Sector Roleplay Experience

<img width="981" height="265" alt="image" src="https://github.com/user-attachments/assets/542dfbcb-b42c-413a-8d5d-7e820c5c410a" />

You should not be able to fit an entire toolbox in your pocket.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: HC survival packs are now normal sized.
/:cl:
