### PR TITLE
HC inspectors loadout adjustments

### DIFF
--- a/modular_nova/modules/random_ship_event/random_ships/heliostatic_inspectors/code/outfit.dm
+++ b/modular_nova/modules/random_ship_event/random_ships/heliostatic_inspectors/code/outfit.dm
@@ -24,7 +24,7 @@
 		/obj/item/modular_computer/pda/hc_police = 1,
 		/obj/item/stack/spacecash/c1000 = 1,
 	)
-	l_pocket = null
+	l_pocket = /obj/item/folder/blue/hc_cop
 	r_pocket = /obj/item/storage/pouch/ammo
 
 	id = /obj/item/card/id/advanced/hc_police
@@ -87,11 +87,11 @@
 /obj/item/storage/box/nri_survival_pack/inspector/PopulateContents()
 	new /obj/item/oxygen_candle(src)
 	new /obj/item/tank/internals/emergency_oxygen(src)
-	new /obj/item/storage/pill_bottle/iron(src)
+	new /obj/item/clothing/mask/breath(src)
+	new /obj/item/reagent_containers/hypospray/medipen/blood_loss(src)
 	new /obj/item/reagent_containers/hypospray/medipen(src)
 	new /obj/item/flashlight/flare(src)
 	new /obj/item/crowbar/red(src)
-	new /obj/item/clipboard(src)
 
 /obj/item/folder/blue/hc_cop
 	name = "HC police SOPs"


### PR DESCRIPTION

## About The Pull Request
SOP folder's back in their pocket.
Iron pill bottle has been replaced with a blood-refiilling medipen, for being subjectively cooler.
Clipboard's also removed from their box.
## How This Contributes To The Nova Sector Roleplay Experience
Having spare copies of SOP is always good, and having them available immediately's going to help a lot with making sure everyone remains up to speed. It's also a fix of me miscommunicating on Discord a bit whoops.
Medipen, again, is objectively cooler than a box of pills.
Clipboard's redundant and wouldn't fit in the box, given that their new ship already has a lot of office supplies available.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="712" height="169" alt="изображение" src="https://github.com/user-attachments/assets/3e575a6a-5b9f-40ea-ba5e-a974adcb32fc" />
<img width="557" height="187" alt="изображение" src="https://github.com/user-attachments/assets/07fa2a18-9d5e-4f47-abbc-24b5b4024b13" />

</details>

## Changelog
:cl: Stalkeros
qol: HC cops' loadouts have been slightly rejiggled into a more appropriate shape.
/:cl:
