### PR TITLE
Reduce boulder rate generation

### DIFF
--- a/code/controllers/subsystem/ore_generation.dm
+++ b/code/controllers/subsystem/ore_generation.dm
@@ -1,7 +1,7 @@
 
 SUBSYSTEM_DEF(ore_generation)
 	name = "Ore Generation"
-	wait = 60 SECONDS
+	wait = 2 MINUTES // NOVA EDIT CHANGE: Original: wait = 60 SECONDS
 	dependencies = list(
 		/datum/controller/subsystem/atoms,
 	)

--- a/code/controllers/subsystem/ore_generation.dm
+++ b/code/controllers/subsystem/ore_generation.dm
@@ -1,7 +1,7 @@
 
 SUBSYSTEM_DEF(ore_generation)
 	name = "Ore Generation"
-	wait = 2 MINUTES // NOVA EDIT CHANGE: Original: wait = 60 SECONDS
+	wait = 5 MINUTES // NOVA EDIT CHANGE: Original: wait = 60 SECONDS
 	dependencies = list(
 		/datum/controller/subsystem/atoms,
 	)

--- a/code/modules/mining/boulder_processing/boulder.dm
+++ b/code/modules/mining/boulder_processing/boulder.dm
@@ -201,7 +201,7 @@
 /obj/item/boulder/proc/convert_to_ore(atom/target_destination)
 	for(var/datum/material/picked in custom_materials)
 		var/obj/item/stack/ore/cracked_ore // Take the associated value and convert it into ore stacks...
-		var/quantity = clamp(round((custom_materials[picked] - SHEET_MATERIAL_AMOUNT)/SHEET_MATERIAL_AMOUNT), 1, 7) //but less resources than if they processed it by hand. // NOVA EDIT CHANGE - ORIGINAL: var/quantity = clamp(round((custom_materials[picked] - SHEET_MATERIAL_AMOUNT)/SHEET_MATERIAL_AMOUNT), 1, 10) //but less resources than if they processed it by hand.
+		var/quantity = clamp(round((custom_materials[picked] - SHEET_MATERIAL_AMOUNT)/SHEET_MATERIAL_AMOUNT), 1, 10) //but less resources than if they processed it by hand.
 
 		var/cracked_ore_type = picked.ore_type
 		if(isnull(cracked_ore_type))

--- a/code/modules/mining/boulder_processing/boulder.dm
+++ b/code/modules/mining/boulder_processing/boulder.dm
@@ -201,7 +201,7 @@
 /obj/item/boulder/proc/convert_to_ore(atom/target_destination)
 	for(var/datum/material/picked in custom_materials)
 		var/obj/item/stack/ore/cracked_ore // Take the associated value and convert it into ore stacks...
-		var/quantity = clamp(round((custom_materials[picked] - SHEET_MATERIAL_AMOUNT)/SHEET_MATERIAL_AMOUNT), 1, 10) //but less resources than if they processed it by hand.
+		var/quantity = clamp(round((custom_materials[picked] - SHEET_MATERIAL_AMOUNT)/SHEET_MATERIAL_AMOUNT), 1, 7) //but less resources than if they processed it by hand. // NOVA EDIT CHANGE - ORIGINAL: var/quantity = clamp(round((custom_materials[picked] - SHEET_MATERIAL_AMOUNT)/SHEET_MATERIAL_AMOUNT), 1, 10) //but less resources than if they processed it by hand.
 
 		var/cracked_ore_type = picked.ore_type
 		if(isnull(cracked_ore_type))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR edits the ore_generation subsystem so it triggers every 5 minutes instead of 1, effectively reducing production rate to 1/5.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Current boulder rate is balanced for tg rounds, that are a lot faster compared to Nova's. This PR addresses this by reducing by half the productivity of vents. Station shouldn't be overflowing with all resource types 20 minutes in.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  I just doubled the trigger time of the ore_generation subsystem, should work fine.
  
  
<img width="280" height="301" alt="image" src="https://github.com/user-attachments/assets/81e43e5a-cc95-4552-b22f-c37ceceac5e1" />
Boulders are there
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The tendrils of the Necropolis fight against NT mining efforts, mining on ore vents has become less productive. (Boulder Rate has been changed from 1 minute to 2 minutes, affecting all vents globally, be it in lavaland, icemoon or asteroids)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
