### PR TITLE
Makes "Moth (Featherful)" wings visible again

### DIFF
--- a/modular_nova/master_files/code/modules/client/preferences_savefile.dm
+++ b/modular_nova/master_files/code/modules/client/preferences_savefile.dm
@@ -3,7 +3,7 @@
  * You can't really use the non-modular version, least you eventually want asinine merge
  * conflicts and/or potentially disastrous issues to arise, so here's your own.
  */
-#define MODULAR_SAVEFILE_VERSION_MAX 15
+#define MODULAR_SAVEFILE_VERSION_MAX 16
 
 #define MODULAR_SAVEFILE_UP_TO_DATE -1
 
@@ -21,6 +21,7 @@
 #define VERSION_EMO_LONG_REMOVAL 13
 #define VERSION_TOOLKIT_IMPLANTS 14
 #define VERSION_VOCAL_BARKS 15
+#define VERSION_FEATHERY_WINGS_FIX 16
 
 #define INDEX_UNDERWEAR 1
 #define INDEX_BRA 2
@@ -314,6 +315,11 @@
 		if(current_tts_voice != TTS_VOICE_NONE && current_tts_voice != "invalid") // make sure we don't turn off TTS for people who have it on
 			write_preference(GLOB.preference_entries[/datum/preference/choiced/vocals/voice_type], "Text-to-speech")
 
+	if(current_version < VERSION_FEATHERY_WINGS_FIX)
+		var/current_wings = save_data["feature_wings"]
+		if(current_wings == "Moth (Featherful)")
+			write_preference(GLOB.preference_entries[/datum/preference/choiced/mutant_choice/wings], "Moth (Feathery)")
+
 /datum/preferences/proc/check_migration()
 	if(!tgui_prefs_migration)
 		to_chat(parent, boxed_message(span_redtext("CRITICAL FAILURE IN PREFERENCE MIGRATION, REPORT THIS IMMEDIATELY.")))
@@ -391,3 +397,4 @@
 #undef VERSION_EMO_LONG_REMOVAL
 #undef VERSION_TOOLKIT_IMPLANTS
 #undef VERSION_VOCAL_BARKS
+#undef VERSION_FEATHERY_WINGS_FIX

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/wings.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/wings.dm
@@ -349,9 +349,9 @@
 	name = "Moth (Deathshead)"
 	icon_state = "deathhead"
 
-/datum/sprite_accessory/wings/moth/featherful // Is actually 'feathery' on upstream
-	name = "Moth (Featherful)"
-	icon_state = "featherful"
+/datum/sprite_accessory/wings/moth/feathery
+	name = "Moth (Feathery)"
+	icon_state = "feathery"
 
 /datum/sprite_accessory/wings/moth/firewatch
 	name = "Moth (Firewatch)"


### PR DESCRIPTION

## About The Pull Request
Not to be confused with the regular feathery wings!

Fixes an issue in which the featherful moth wings had no sprites shown. This also changes their name to Moth (Feathery) to keep it consistent with other TG moth wings, as well as pref migration so it carries over but I'm willing to remove this if it's deemed unnecessary.

Closes https://github.com/NovaSector/NovaSector/issues/6990

## How This Contributes To The Nova Sector Roleplay Experience
Fixes a bug and keeps the wing names consistent with the rest of the upstream wings.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="220" height="403" alt="TFsdJJ5jBp" src="https://github.com/user-attachments/assets/276ccc08-eaec-4bf2-9770-bb1d8a62206d" />

</details>

## Changelog
:cl: Hardly
fix: Fixes "Moth (Featherful)" wings having no sprites and renames them to "Moth (Feathery)"
/:cl:
