### PR TITLE
Weird fix for tarkon turret tech always being shown as available tech node

### DIFF
--- a/modular_nova/modules/tarkon/code/misc_fluff/research.dm
+++ b/modular_nova/modules/tarkon/code/misc_fluff/research.dm
@@ -19,6 +19,7 @@
 		/obj/item/construction/rcd/tarkon,
 		/obj/item/gun/energy/recharge/resonant_system,
 	)
+	prereq_ids = list(TECHWEB_NODE_CONSTRUCTION)
 	design_ids = list(
 		"mod_plating_tarkon",
 		"arcs",
@@ -30,7 +31,7 @@
 
 /datum/techweb_node/tarkonturret //Yes. Tarkon does not start with this unlocked.
 	id = TECHWEB_NODE_TARKON_DEFENSE
-	display_name = "Tarkon Industries Technology"
+	display_name = "Tarkon Industries Automated Turrets"
 	description = "Tarkon Industries Blackrust Salvage division's defense designs."
 	prereq_ids = list(TECHWEB_NODE_TARKON, TECHWEB_NODE_BASIC_ARMS, TECHWEB_NODE_AI)
 	design_ids = list(


### PR DESCRIPTION

## About The Pull Request
Basic tarkon tech has no prereq neither is roundstart tech which means it never added inside `tiers` list (needed for tgui to sort nods between researched, available and future tabs). Because of this, tarkon turret node failed to calculate its own tier properly which in turn put it in to available tab and not in future tab

Also renamed turret node to not have same name as basic tarkon tech
## How This Contributes To The Nova Sector Roleplay Experience
science mains will stop suffering from their OCD (maybe)
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="632" height="733" alt="image" src="https://github.com/user-attachments/assets/1fddd8ee-6352-4e4c-b447-ccbc638c4837" />

<img width="648" height="205" alt="image" src="https://github.com/user-attachments/assets/eb5151fa-cbe9-451e-b8c2-41217a5f18f5" />

</details>

## Changelog
:cl:
fix: Tarkon turrets tech node will no longer be shown as available when it in fact isn't
/:cl:
