### PR TITLE
minor gladiator code touchups

### DIFF
--- a/modular_nova/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_nova/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -210,12 +210,7 @@
 	new /obj/item/clothing/neck/warrior_cape(src)
 
 /obj/structure/closet/crate/necropolis/gladiator/crusher/PopulateContents()
-	if(prob(5))
-		new /obj/item/claymore/dragonslayer/very_fucking_loud(src)
-	else
-		new /obj/item/claymore/dragonslayer(src)
-	new /obj/item/clothing/suit/hooded/berserker/gatsu(src)
-	new /obj/item/clothing/neck/warrior_cape(src)
+	..()
 	new /obj/item/crusher_trophy/gladiator(src)
 
 #undef BERSERK_MAX_CHARGE

--- a/modular_nova/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
+++ b/modular_nova/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
@@ -47,6 +47,7 @@
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
 	loot = list(/obj/structure/closet/crate/necropolis/gladiator, /obj/structure/dead_gladiator)
 	crusher_loot = list(/obj/structure/closet/crate/necropolis/gladiator/crusher, /obj/structure/dead_gladiator)
+	replace_crusher_drop = TRUE
 	/// Boss phase, from 1 to 3
 	var/phase = MARKED_ONE_FIRST_PHASE
 	/// People we have introduced ourselves to - WEAKREF list
@@ -71,8 +72,7 @@
 	var/next_intro_scan = 0
 	/// Used for avoiding chasms
 	var/static/list/chasm_avoid_offsets
-	replace_crusher_drop = TRUE // prevents people from butchering him for duping chests
-	del_on_death = TRUE
+	del_on_death = TRUE // prevents people from butchering him for duping chests
 
 /mob/living/simple_animal/hostile/megafauna/gladiator/Initialize(mapload)
 	. = ..()
@@ -224,22 +224,22 @@
 		// The gladiator hates non-humans, he especially hates ash walkers.
 		if(targetspecies.id == SPECIES_HUMAN)
 			var/static/list/human_messages = list(
-									"Is this all that is left?",
-									"Show the necropolis it was wrong to choose me.",
-									"Ironic that I become what I once fought like you.",
-									"Sometimes, the abyss gazes back.",
-									"Show me a good time, miner!",
-									"I'll give you the first hit.",
-								)
+				"Is this all that is left?",
+				"Show the necropolis it was wrong to choose me.",
+				"Ironic that I become what I once fought like you.",
+				"Sometimes, the abyss gazes back.",
+				"Show me a good time, miner!",
+				"I'll give you the first hit.",
+			)
 			INVOKE_ASYNC(src, TYPE_PROC_REF(/atom/movable, say), message = pick(human_messages))
 			introduced[mob_ref] = TRUE
 		else if(targetspecies.id == SPECIES_LIZARD_ASH)
 			var/static/list/ashie_messages = list(
-									"Foolishness, ash walker!",
-									"I've had enough of you for a lifetime!",
-									"I don't need a crusher to KICK YOUR ASS!",
-									"GET OVER HERE!!",
-								)
+				"Foolishness, ash walker!",
+				"I've had enough of you for a lifetime!",
+				"I don't need a crusher to KICK YOUR ASS!",
+				"GET OVER HERE!!",
+			)
 
 			INVOKE_ASYNC(src, TYPE_PROC_REF(/atom/movable, say), message = pick(ashie_messages), language = /datum/language/ashtongue)
 			introduced[mob_ref] = TRUE
@@ -247,12 +247,12 @@
 			GiveTarget(target)
 		else
 			var/static/list/other_humanoid_messages = list(
-									"I will smite you!",
-									"I will show you true power!",
-									"Let us see how worthy you are!",
-									"You will make a fine rug!",
-									"For the necropolis!"
-									)
+				"I will smite you!",
+				"I will show you true power!",
+				"Let us see how worthy you are!",
+				"You will make a fine rug!",
+				"For the necropolis!",
+			)
 			INVOKE_ASYNC(src, TYPE_PROC_REF(/atom/movable, say), message = pick(other_humanoid_messages))
 			introduced[mob_ref] = TRUE
 			get_angry()
@@ -312,16 +312,16 @@
 	if(!istype(our_turf))
 		return
 	var/static/list/spin_messages = list(
-							"Duck!",
-							"I'll break your legs!",
-							"Plain, dead, simple!",
-							"SWING AND A MISS!",
-							"Only one of us makes it outta here!",
-							"JUMP-ROPE!!",
-							"Slice and dice, right?!",
-							"Come on, HIT ME!",
-							"CLANG!!",
-						)
+		"Duck!",
+		"I'll break your legs!",
+		"Plain, dead, simple!",
+		"SWING AND A MISS!",
+		"Only one of us makes it outta here!",
+		"JUMP-ROPE!!",
+		"Slice and dice, right?!",
+		"Come on, HIT ME!",
+		"CLANG!!",
+	)
 	INVOKE_ASYNC(src, TYPE_PROC_REF(/atom/movable, say), message = pick(spin_messages))
 	spinning = TRUE
 	animate(src, color = "#ff6666", 1 SECONDS)
@@ -361,14 +361,14 @@
 /mob/living/simple_animal/hostile/megafauna/gladiator/proc/charge(atom/target, range = 1)
 	face_atom(target)
 	var/static/list/charge_messages = list(
-							"Heads up!",
-							"Coming through!",
-							"This ends only one way!",
-							"Hold still!",
-							"GET OVER HERE!",
-							"Looking for this?!",
-							"COME ON!!",
-						)
+		"Heads up!",
+		"Coming through!",
+		"This ends only one way!",
+		"Hold still!",
+		"GET OVER HERE!",
+		"Looking for this?!",
+		"COME ON!!",
+	)
 	INVOKE_ASYNC(src, TYPE_PROC_REF(/atom/movable, say), message = pick(charge_messages))
 	animate(src, color = "#ff6666", 0.3 SECONDS)
 	SLEEP_CHECK_DEATH(4, src)


### PR DESCRIPTION

## About The Pull Request

- Changes all lists in the gladiator's files to be the same format
- Changes the gladiator's crusher chest to just call parent for filling its non-crusher contents, like every other megafauna chest
- Changes gladiator's `replace_crusher_drop` var to be below loot, like all other megafaunas

## How This Contributes To The Nova Sector Roleplay Experience

> Changes all lists in the gladiator's files to be the same format
> Changes the gladiator's crusher chest to just call parent for filling its non-crusher contents, like every other megafauna chest
> Changes gladiator's `replace_crusher_drop` var to be below loot, like all other megafaunas
- It makes my eyes feel better, and makes the code a bit more readable. I just can't roleplay absolutelly killing a guy on lavaland without a voice in the back of my mind going "Hey, this guy has his lists take up 5 more tabs than they are supposed to".

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

There are no gameplay changes, so enjoy this screenshot of it compiling

<img width="368" height="136" alt="image" src="https://github.com/user-attachments/assets/088d10d4-83bb-4d72-9ea7-32bbb1321427" />

</details>
