### PR TITLE
[S4] Security Slavic Surplus Summation - Adding the HC gear to the SecDrobe

### DIFF
--- a/modular_nova/modules/sec_haul/code/misc/vending.dm
+++ b/modular_nova/modules/sec_haul/code/misc/vending.dm
@@ -122,6 +122,5 @@
 		/obj/item/clothing/suit/armor/vest/hc_police_jacket/suit = 3,
 		/obj/item/clothing/suit/armor/vest/hc_police = 3,
 		/obj/item/clothing/suit/armor/vest/hc_police_jacket = 3,
-
 		)
 	payment_department = ACCOUNT_SEC


### PR DESCRIPTION

## About The Pull Request
Does exactly what the title says. Adds 3 of each HC police uniform item to the SecDrobe, under the premium section. 
## How This Contributes To The Nova Sector Roleplay Experience
Adds more stuff for HC Roleplayers, show your swag when the inspectors show up. Rep your colors. do NOT throw up gang signs. 
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="544" height="448" alt="NVIDIA_Overlay_hfBhnjOV1s" src="https://github.com/user-attachments/assets/2887dfe1-c250-470d-837e-0f1401e26c52" />

</details>

## Changelog
:cl:
add: Heliostatic Coalition police surplus has been added to the SecDrobe.
/:cl:
