### PR TITLE
Fixes latejoin tracker oversights

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -539,7 +539,10 @@ SUBSYSTEM_DEF(dynamic)
 		CRASH("queue_ruleset() was called with an invalid type: [ruleset_typepath]")
 
 	queued_rulesets += new ruleset_typepath(dynamic_config)
-	SStitle.show_title_screen() // NOVA EDIT ADDITION - menu latejoin tracker
+	// NOVA EDIT ADDITION START - menu latejoin tracker
+	if(SSticker.current_state > GAME_STATE_SETTING_UP) // Don't flash this while we are assigning roundstart antags
+		SStitle.show_title_screen()
+	// NOVA EDIT ADDITION END - menu latejoin tracker
 
 /**
  * Unqueues a ruleset because it has executed
@@ -549,7 +552,10 @@ SUBSYSTEM_DEF(dynamic)
 		CRASH("queue_ruleset() was called with an invalid type: [ruleset.type]")
 
 	queued_rulesets -= ruleset
-	SStitle.show_title_screen() // NOVA EDIT ADDITION - menu latejoin tracker
+	// NOVA EDIT ADDITION START - menu latejoin tracker
+	if(SSticker.current_state > GAME_STATE_SETTING_UP) // Don't flash this while we are assigning roundstart antags
+		SStitle.show_title_screen()
+	// NOVA EDIT ADDITION END - menu latejoin tracker
 
 /**
  * Get the cooldown between attempts to spawn a ruleset of the given type

--- a/modular_nova/modules/title_screen/code/title_screen_html.dm
+++ b/modular_nova/modules/title_screen/code/title_screen_html.dm
@@ -115,7 +115,7 @@ GLOBAL_LIST_EMPTY(startup_messages)
 			<a class="menu_button" href='byond://?src=[text_ref(src)];character_setup=1'>SETUP CHARACTER (<span id="character_slot">[uppertext(client.prefs.read_preference(/datum/preference/name/real_name))]</span>)</a>
 			<a class="menu_button" href='byond://?src=[text_ref(src)];game_options=1'>GAME OPTIONS</a>
 			<a id="be_antag" class="menu_button" href='byond://?src=[text_ref(src)];toggle_antag=1'>[client.prefs.read_preference(/datum/preference/toggle/be_antag) ? "<span class='checked'>☑</span> BE ANTAGONIST" : "<span class='unchecked'>☒</span> BE ANTAGONIST"]</a>
-			<span class="menu_button info_display">LATEJOIN QUEUE: [length(SSdynamic.queued_rulesets)]</span>
+			<span class="menu_button info_display">LATEJOIN QUEUE: [SStitle.get_latejoin_queue_count()]</span>
 			<hr>
 			<a class="menu_button" href='byond://?src=[text_ref(src)];server_swap=1'>SWAP SERVERS</a>
 		"}

--- a/modular_nova/modules/title_screen/code/title_screen_subsystem.dm
+++ b/modular_nova/modules/title_screen/code/title_screen_subsystem.dm
@@ -66,6 +66,15 @@ SUBSYSTEM_DEF(title)
 	return SS_INIT_SUCCESS
 
 /**
+ * Returns the length of the queued latejoin rulesets if we are past roundstart
+ */
+/datum/controller/subsystem/title/proc/get_latejoin_queue_count()
+	if (SSticker.current_state <= GAME_STATE_SETTING_UP)
+		return 0
+
+	return length(SSdynamic.queued_rulesets)
+
+/**
  * Make sure reference time is set up. If not, this is now time 0.
  */
 /datum/controller/subsystem/title/proc/check_progress_reference_time()


### PR DESCRIPTION
## About The Pull Request

This just stops the latejoin tracker from updating the ui when the roundstart antags are added.

## How This Contributes To The Nova Sector Roleplay Experience

Fixes an oversight

## Changelog

:cl:
fix: latejoin tracker should no longer update as the round is starting to reflect roundstart rulesets
/:cl: