### PR TITLE
Prevent chat highlights for your own LOOC/AOOC/SOOC/Msay messages

### DIFF
--- a/modular_nova/modules/admin/code/aooc.dm
+++ b/modular_nova/modules/admin/code/aooc.dm
@@ -70,12 +70,11 @@ GLOBAL_LIST_EMPTY(ckey_to_aooc_name)
 		if(iterated_mob.client?.holder && !iterated_mob.client?.holder.deadmined && iterated_mob.client?.prefs?.chat_toggles & CHAT_OOC)
 			listeners[iterated_mob.client] = AOOC_LISTEN_ADMIN
 
-	for(var/iterated_listener in listeners)
-		var/client/iterated_client = iterated_listener
-		var/mode = listeners[iterated_listener]
+	for(var/client/iterated_client as anything in listeners)
+		var/mode = listeners[iterated_client]
 		var/color = (!anon && CONFIG_GET(flag/allow_admin_ooccolor) && iterated_client?.prefs?.read_preference(/datum/preference/color/ooc_color)) ? iterated_client?.prefs?.read_preference(/datum/preference/color/ooc_color) : GLOB.AOOC_COLOR
 		var/name = (mode == AOOC_LISTEN_ADMIN && anon) ? "([key])[keyname]" : keyname
-		to_chat(iterated_client, span_oocplain("<font color='[color]'><b><span class='prefix'>AOOC:</span> <EM>[name]:</EM> <span class='message linkify'>[msg]</span></b></font>"))
+		to_chat(iterated_client, span_oocplain("<font color='[color]'><b><span class='prefix'>AOOC:</span> <EM>[name]:</EM> <span class='message linkify'>[msg]</span></b></font>"), avoid_highlighting = (iterated_client == src))
 
 #undef AOOC_LISTEN_PLAYER
 #undef AOOC_LISTEN_ADMIN

--- a/modular_nova/modules/admin/code/sooc.dm
+++ b/modular_nova/modules/admin/code/sooc.dm
@@ -71,12 +71,11 @@ GLOBAL_LIST_EMPTY(ckey_to_sooc_name)
 				if(job_lookup[mob_mind.assigned_role?.title])
 					listeners[iterated_mob.client] = SOOC_LISTEN_PLAYER
 
-	for(var/iterated_listener in listeners)
-		var/client/iterated_client = iterated_listener
-		var/mode = listeners[iterated_listener]
+	for(var/client/iterated_client as anything in listeners)
+		var/mode = listeners[iterated_client]
 		var/color = (!anon && CONFIG_GET(flag/allow_admin_ooccolor) && iterated_client?.prefs?.read_preference(/datum/preference/color/ooc_color)) ? iterated_client?.prefs?.read_preference(/datum/preference/color/ooc_color) : GLOB.SOOC_COLOR
 		var/name = (mode == SOOC_LISTEN_ADMIN && anon) ? "([key])[keyname]" : keyname
-		to_chat(iterated_client, span_oocplain("<font color='[color]'><b><span class='prefix'>SOOC:</span> <EM>[name]:</EM> <span class='message linkify'>[msg]</span></b></font>"))
+		to_chat(iterated_client, span_oocplain("<font color='[color]'><b><span class='prefix'>SOOC:</span> <EM>[name]:</EM> <span class='message linkify'>[msg]</span></b></font>"), avoid_highlighting = (iterated_client == src))
 
 #undef SOOC_LISTEN_PLAYER
 #undef SOOC_LISTEN_ADMIN

--- a/modular_nova/modules/mentor/code/mentorsay.dm
+++ b/modular_nova/modules/mentor/code/mentorsay.dm
@@ -16,4 +16,5 @@
 		msg = span_mentor("<b><font color ='#8A2BE2'><span class='prefix'>MENTOR:</span> <EM>[key_name(src, 0, 0)]</EM>: <span class='message'>[msg]</span></font></b>")
 	else
 		msg = span_mentor("<b><font color ='#E236D8'><span class='prefix'>MENTOR:</span> <EM>[key_name(src, 0, 0)]</EM>: <span class='message'>[msg]</span></font></b>")
-	to_chat(GLOB.admins | GLOB.mentors, msg)
+	for(var/client/mentor as anything in GLOB.admins | GLOB.mentors)
+		to_chat(mentor, msg, avoid_highlighting = (mentor == src))

--- a/modular_nova/modules/verbs/code/looc.dm
+++ b/modular_nova/modules/verbs/code/looc.dm
@@ -89,10 +89,10 @@
 		if (is_holder)
 			continue //admins are handled afterwards
 
-		to_chat(hearing_client, span_looc(span_prefix("LOOC[wall_pierce ? " (WALL PIERCE)" : ""]:</span> <EM>[src.mob.name]:</EM> <span class='message'>[msg]")))
+		to_chat(hearing_client, span_looc(span_prefix("LOOC[wall_pierce ? " (WALL PIERCE)" : ""]:</span> <EM>[src.mob.name]:</EM> <span class='message'>[msg]")), avoid_highlighting = (hearing_client == src))
 
 	for(var/client/cli_client as anything in GLOB.admins)
 		if (admin_seen[cli_client])
-			to_chat(cli_client, span_looc("[ADMIN_FLW(usr)] <span class='prefix'>LOOC[wall_pierce ? " (WALL PIERCE)" : ""]:</span> <EM>[src.key]/[src.mob.name]:</EM> <span class='message'>[msg]</span>"))
+			to_chat(cli_client, span_looc("[ADMIN_FLW(usr)] <span class='prefix'>LOOC[wall_pierce ? " (WALL PIERCE)" : ""]:</span> <EM>[src.key]/[src.mob.name]:</EM> <span class='message'>[msg]</span>"), avoid_highlighting = (cli_client == src))
 		else if (cli_client.prefs.read_preference(/datum/preference/toggle/admin/see_looc))
-			to_chat(cli_client, span_rlooc("[ADMIN_FLW(usr)] <span class='prefix'>(R)LOOC[wall_pierce ? " (WALL PIERCE)" : ""]:</span> <EM>[src.key]/[src.mob.name]:</EM> <span class='message'>[msg]</span>"))
+			to_chat(cli_client, span_rlooc("[ADMIN_FLW(usr)] <span class='prefix'>(R)LOOC[wall_pierce ? " (WALL PIERCE)" : ""]:</span> <EM>[src.key]/[src.mob.name]:</EM> <span class='message'>[msg]</span>"), avoid_highlighting = (cli_client == src))


### PR DESCRIPTION

## About The Pull Request

This makes it so LOOC, AOOC, SOOC, and Mentorsay will now avoid highlighting your own messages.

was gonna pr this downstream but eh, no reason to not pr it upstream, as it's just a simple nicety.

I would've done Adminsay too but I'm too lazy to modularize the changes - thinking about it, i can just pr that upstream to tg

## How This Contributes To The Nova Sector Roleplay Experience

It's more of an OOC convenience than anything - if you have your ckey highlighted, you don't really need to highlight that in the LOOC message _that you just sent yourself._

## Proof of Testing

<img width="1033" height="120" alt="2026-03-05 (1772752419) ~ dreamseeker" src="https://github.com/user-attachments/assets/3bb22908-482f-40f6-b33d-ac674073c259" />

## Changelog
:cl:
qol: Your own LOOC, AOOC, SOOC, or Mentorsay messages will no longer trigger your highlights.
/:cl:
