### PR TITLE
Fix uplink costs for C4's and EMP's

### DIFF
--- a/modular_nova/modules/traitor-uplinks/overwrites/explosive.dm
+++ b/modular_nova/modules/traitor-uplinks/overwrites/explosive.dm
@@ -10,11 +10,11 @@
 
 // MEDIUM COST
 /datum/uplink_item/explosives/c4bag
-	cost = /datum/uplink_item/medium_cost/explosive::cost
+	cost = /datum/uplink_item/low_cost/explosive::cost
 //	cost = 5
 
 /datum/uplink_item/explosives/emp
-	cost = /datum/uplink_item/medium_cost/explosive::cost //big step up from TG's pricing, but vastly more potent here
+	cost = /datum/uplink_item/low_cost/explosive::cost //big step up from TG's pricing, but vastly more potent here
 //	cost = 2
 
 /datum/uplink_item/explosives/detomatix


### PR DESCRIPTION

## About The Pull Request

Uplinks costs of both bag of C4's and EMP's have been lowered to 5TC
## How This Contributes To The Nova Sector Roleplay Experience

C4's costed 15TC, more than if you bought C4 units at 1TC each.. which is weird. EMP's at 15TC is crazy, they've been nerfed several times and they're not a death sentence anymore if you're hit by one.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

Changed two numbers, TC cost should be reflected in the uplink now
  
</details>

## Changelog
:cl:

balance: balanced cost of bag of c4's and emp grenades to something more sensible

/:cl:
