### PR TITLE
Use ckey when indexing GLOB.preference_datums

### DIFF
--- a/modular_nova/modules/antag_opt_in/code/mind.dm
+++ b/modular_nova/modules/antag_opt_in/code/mind.dm
@@ -45,7 +45,7 @@ GLOBAL_LIST_INIT(optin_forcing_on_spawn_antag_categories, list(
 		mind.opt_in_initialized = TRUE
 
 /// Refreshes our ideal/on spawn antag opt in level by accessing preferences.
-/datum/mind/proc/update_opt_in(datum/preferences/preference_instance = GLOB.preferences_datums[LOWER_TEXT(key)])
+/datum/mind/proc/update_opt_in(datum/preferences/preference_instance = GLOB.preferences_datums[ckey(key)])
 	if (isnull(preference_instance))
 		return
 
@@ -59,7 +59,7 @@ GLOBAL_LIST_INIT(optin_forcing_on_spawn_antag_categories, list(
 
 /// Sends a bold message to our holder, telling them if their optin setting has been set to a minimum due to their antag preferences.
 /datum/mind/proc/send_antag_optin_reminder()
-	var/datum/preferences/preference_instance = GLOB.preferences_datums[LOWER_TEXT(key)]
+	var/datum/preferences/preference_instance = GLOB.preferences_datums[ckey(key)]
 	var/client/our_client = preference_instance?.parent // that moment when /mind doesnt have a ref to client :)
 	if (our_client)
 		var/antag_level = get_antag_opt_in_level()
@@ -83,7 +83,7 @@ GLOBAL_LIST_INIT(optin_forcing_on_spawn_antag_categories, list(
 	if (on_spawn_antag_opt_in_level > OPT_IN_NOT_TARGET)
 		return on_spawn_antag_opt_in_level
 
-	var/datum/preferences/preference_instance = GLOB.preferences_datums[LOWER_TEXT(key)]
+	var/datum/preferences/preference_instance = GLOB.preferences_datums[ckey(key)]
 	if (!isnull(preference_instance) && preference_instance.read_preference(/datum/preference/toggle/be_antag))
 		for (var/antag_category in GLOB.optin_forcing_midround_antag_categories)
 			if (antag_category in preference_instance.be_special)


### PR DESCRIPTION

## About The Pull Request

Fixes GLOB.preference_datums being indexed with `LOWER_TEXT(key)` for some reason. This issue has only affected people non-alphanumeric characters in their names. 

## Proof of Testing
Unsure how I'd be able to test this, I don't have a byond username with non-alphanumeric characters to test this with.
## Changelog
:cl:
fix: Fixed potential issue with setting opt in info on minds from users with non-alphanumeric characters in their username.
/:cl:
