### PR TITLE
Fix large mortar

### DIFF
--- a/modular_nova/modules/primitive_cooking_additions/code/big_mortar.dm
+++ b/modular_nova/modules/primitive_cooking_additions/code/big_mortar.dm
@@ -164,7 +164,7 @@
 						balloon_alert(user, "overflowing!")
 						break
 
-					if(target_item.grind_results())
+					if(target_item.grind_results() || target_item.reagents?.total_volume)
 						grind_target_item(target_item, user)
 
 					else
@@ -174,7 +174,7 @@
 
 		return ITEM_INTERACT_SUCCESS
 
-	if(!tool.grind_results() && !tool.juice_typepath())
+	if(!tool.grind_results() && !tool.juice_typepath() && !tool.reagents?.total_volume)
 		balloon_alert(user, "can't grind this!")
 		return ITEM_INTERACT_BLOCKING
 


### PR DESCRIPTION

## About The Pull Request

 The item acceptance check now also allows items that have reagents?.total_volume (matching the regular mortar's behavior), so items with reagents but no explicit grind/juice results can be placed in the large mortar instead of getting "can't grind this!". When grinding it no longer defaults to juicing if the item has reagents but no grinding result.
## How This Contributes To The Nova Sector Roleplay Experience
Fix of item.

## Proof of Testing


Tested locally, it works as expected.
<details>
<summary>Screenshots/Videos</summary>
<img width="2819" height="863" alt="image" src="https://github.com/user-attachments/assets/1c4a57dc-ae1c-430a-af78-b87e35633541" />

  
</details>

## Changelog
:cl:
fix: large mortar works now.
/:cl:
