### PR TITLE
fix AFADs poisoning slimes

### DIFF
--- a/modular_nova/modules/cargo/code/items/AFAD.dm
+++ b/modular_nova/modules/cargo/code/items/AFAD.dm
@@ -15,10 +15,10 @@
 	if(target.health != target.maxHealth)
 		new /obj/effect/temp_visual/heal(get_turf(target), "#80F5FF")
 	var/need_mob_update
-	need_mob_update += target.adjust_brute_loss(PHYSICAL_DAMAGE_HEALING, updating_health = FALSE)
-	need_mob_update += target.adjust_fire_loss(PHYSICAL_DAMAGE_HEALING, updating_health = FALSE)
-	need_mob_update += target.adjust_tox_loss(EXOTIC_DAMAGE_HEALING, updating_health = FALSE)
-	need_mob_update += target.adjust_oxy_loss(EXOTIC_DAMAGE_HEALING, updating_health = FALSE)
+	need_mob_update = target.adjust_brute_loss(PHYSICAL_DAMAGE_HEALING, updating_health = FALSE, forced = TRUE)
+	need_mob_update += target.adjust_fire_loss(PHYSICAL_DAMAGE_HEALING, updating_health = FALSE, forced = TRUE)
+	need_mob_update += target.adjust_tox_loss(EXOTIC_DAMAGE_HEALING, updating_health = FALSE, forced = TRUE)
+	need_mob_update += target.adjust_oxy_loss(EXOTIC_DAMAGE_HEALING, updating_health = FALSE, forced = TRUE)
 	if(need_mob_update)
 		target.updatehealth()
 	return


### PR DESCRIPTION

## About The Pull Request

this fixes AFAD medibeams causing toxin damage to toxlovers such as slimepeople... i just copy-pasted the code from normal medibeams, which don't have the issue (and fixed the values)

## Why it's Good for the Game

be nice to precious slimes

## Proof of Testing

to be fair this is literally just copy-pasting the _working_ code from normal medibeams.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: AFADs no longer poison slimes.
/:cl:
