### PR TITLE
Adds NTR to the game(alt title changes and cleanup)

### DIFF
--- a/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -279,7 +279,7 @@
 		"Medical Student",
 		"Clinician",
 		"Physician Assistant",
-		"General Practitioner",
+		"Emergency Physician",
 		"Registered Nurse",
 	)
 


### PR DESCRIPTION

## About The Pull Request

Shortens, changes, adds, and removes a small handful of alt titles, mostly focused on the corporate rep.

## How This Contributes To The Nova Sector Roleplay Experience

Tries to maintain some level of sanity in regards to titles actually MOSTLY fitting within the default bounds of the drop-down menu, as well as editing some titles that had poor flow or low sensibility.

## Proof of Testing

Do I really have to? No functionality has been added/removed, it it passes CI it'll work.

## Changelog

:cl:
del: After Central Command realized that they were spending an entire additional two credits per annum on ink and toner costs, they have decided to include less words in their corporate representative's job titles.
qol: Other job titles have also been changed, shortened, added, and removed.
/:cl: