### PR TITLE
Boxcutting wrapped packages returns less wrap

### DIFF
--- a/code/game/objects/items/stacks/wrap.dm
+++ b/code/game/objects/items/stacks/wrap.dm
@@ -230,6 +230,11 @@
 	amount = 5
 	merge_type = /obj/item/stack/package_wrap/small
 
+//NOVA EDIT START
+/obj/item/stack/package_wrap/one
+	amount = 1
+//NOVA EDIT END
+
 /obj/item/c_tube
 	name = "cardboard tube"
 	desc = "A tube... of cardboard."

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -37,7 +37,7 @@
 		new /obj/effect/decal/cleanable/wrapping(turf_loc)
 	else
 		playsound(loc, 'sound/items/box_cut.ogg', 50, TRUE)
-		new /obj/item/stack/package_wrap(turf_loc)
+		new /obj/item/stack/package_wrap/one(turf_loc)
 	for(var/atom/movable/movable_content as anything in contents)
 		movable_content.forceMove(turf_loc)
 


### PR DESCRIPTION

## About The Pull Request

Currently, when you use boxcutters to cut open wrapped packages, you get a full stack (25) of wrapping paper back, even though it takes at most 3 wrapping paper to wrap it in the first place, meaning you can make the paper multiply infinitely. This PR changes that so you only get one wrapping paper back.
## How This Contributes To The Nova Sector Roleplay Experience

No more immersion ruining infinite paper mills. 
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  Here is me standing next to the one paper I got back from cutting open a package.
<img width="1900" height="1001" alt="image" src="https://github.com/user-attachments/assets/f39c1f3e-9045-4168-a36b-58020a5cb542" />

</details>

## Changelog
:cl:
fix: fixed an oversight with package wrappers
/:cl:
