### PR TITLE
Reduces the weight class of the PK Railgun from huge to bulky

### DIFF
--- a/modular_nova/modules/mining_pka/code/kinetic_accelerator.dm
+++ b/modular_nova/modules/mining_pka/code/kinetic_accelerator.dm
@@ -42,7 +42,7 @@
 	icon_state = "kineticrailgun"
 	base_icon_state = "kineticrailgun"
 	inhand_icon_state = "kineticgun"
-	w_class = WEIGHT_CLASS_HUGE
+	w_class = WEIGHT_CLASS_BULKY
 	pin = /obj/item/firing_pin/wastes
 	recharge_time = 3 SECONDS
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic/railgun)


### PR DESCRIPTION

## About The Pull Request

This reduces the weight class of the PK Railgun from huge to bulky - the main difference being this allows you to carry it in the suit storage of mining armors. Still can't fit in backpacks, outside of maybe a bag of holding, just means it's slightly less nitpicky about slots.

Like, both my belt and suit storage can carry a big-ass cleaving saw, why not a big-ass railgun?

## How This Contributes To The Nova Sector Roleplay Experience

Less inventory management hell is always nice.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="558" height="392" alt="image" src="https://github.com/user-attachments/assets/86693ad3-fe36-4b9f-93bc-11d16d4f952f" />
  
</details>

## Changelog
:cl:
qol: You can now carry the Proto-Kinetic Railgun in the suit storage of mining armors - i.e explorer suits, berserker armor, etc.
/:cl:
