### PR TITLE
Side Cases: Detective Bounty Hustle (adds security bounties to Detective)

### DIFF
--- a/modular_nova/master_files/code/modules/jobs/job_types/detective.dm
+++ b/modular_nova/master_files/code/modules/jobs/job_types/detective.dm
@@ -13,3 +13,5 @@
 		/obj/item/pinpointer/crew = 1,
 	)
 
+/datum/job/detective
+	bounty_types = CIV_JOB_SEC


### PR DESCRIPTION

## About The Pull Request
Gives detectives access to Security's bounty pool.
## How This Contributes To The Nova Sector Roleplay Experience
They're in the security department. Why do they not have it? Granted, you could make an argument that they're meant to go undercover with the plainclothes ID, but them still not having any sec bounties under normal circumstances is stupid. 
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="506" height="113" alt="NVIDIA_Overlay_oxhfbCe830" src="https://github.com/user-attachments/assets/7a68865d-229c-4644-9618-ff24f72f987f" />
<img width="888" height="434" alt="NVIDIA_Overlay_ZTHNSwz1hy" src="https://github.com/user-attachments/assets/49625da5-8525-47b1-b16c-dabaa54b2d68" />
<img width="697" height="363" alt="NVIDIA_Overlay_UzKUBR8o8N" src="https://github.com/user-attachments/assets/316b66fc-52d1-4518-85b9-316b9971b14a" />

</details>

## Changelog
:cl:
add: Detectives now get Security bounties, since Nanotrasen remembered they are in fact part of the department.
/:cl:
