### PR TITLE
Adds Cone to Loadout Headwear

### DIFF
--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_heads.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_heads.dm
@@ -226,6 +226,11 @@
 	item_path = /obj/item/clothing/head/cone_of_shame
 	group = "Miscellaneous"
 
+/datum/loadout_item/head/warning_cone
+	name = "Warning Cone"
+	item_path = /obj/item/clothing/head/cone
+	group = "Miscellaneous"
+
 /datum/loadout_item/head/wig //TG overwrite so that we can have both fake/natural wigs
 	name = "Wig"
 	item_path = /obj/item/clothing/head/wig


### PR DESCRIPTION

## About The Pull Request
Adds the Warning Cone hat to loadout
## How This Contributes To The Nova Sector Roleplay Experience
More customization and increased safety across the galaxy*
*Increased safety not guaranteed results may vary.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  <img width="913" height="582" alt="Screenshot 2026-03-17 082539" src="https://github.com/user-attachments/assets/4adfe030-21aa-4e1d-9052-01430ec5645d" />
<img width="916" height="780" alt="Screenshot 2026-03-17 083326" src="https://github.com/user-attachments/assets/751d68a7-c7fb-46b6-a4f4-ba4904e93bdc" />
</details>

## Changelog
:cl:
add: Added Warning Cone to Loadout
/:cl:
