### PR TITLE
Make twitch work on synths

### DIFF
--- a/modular_nova/modules/deforest_medical_items/code/chemicals/twitch.dm
+++ b/modular_nova/modules/deforest_medical_items/code/chemicals/twitch.dm
@@ -32,7 +32,7 @@
 	overdose_threshold = 15
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	addiction_types = list(/datum/addiction/stimulants = 20)
-	process_flags = REAGENT_ORGANIC
+	process_flags = REAGENT_ORGANIC | REAGENT_SYNTHETIC
 	/// How much time has the drug been in them?
 	var/constant_dose_time = 0
 	/// What type of span class do we change heard speech to?


### PR DESCRIPTION

## About The Pull Request

Sets up a flag in the twitch chemical so Twitch can be processed by synth livers (it has code already to handle synths consuming it). It applies heating and tox damage as expected.
## How This Contributes To The Nova Sector Roleplay Experience

It potentially makes sense for the Laaca module and the drug in general to affect posi brains.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
Injected two pens with twitch, regular effects. Overheating will kill you if you don't use hercuri or are in space; toxins stacks up to +70 (healed with system cleaner).  

</details>

## Changelog
:cl:
fix: lets synths use twitch/Laaca implant
/:cl:
