### PR TITLE
[Buff] Oversized speed buff

### DIFF
--- a/modular_nova/modules/oversized/code/oversized_quirk.dm
+++ b/modular_nova/modules/oversized/code/oversized_quirk.dm
@@ -1,3 +1,4 @@
+#define OVERSIZED_SPEED_SLOWDOWN 0.2
 #define OVERSIZED_HUNGER_MOD 1.5
 
 // Before making any changes to oversized, please see the module's readme.md file
@@ -22,7 +23,6 @@
 	if(!isdummy(human_holder))
 		human_holder.dna.update_body_size()
 	human_holder.mob_size = MOB_SIZE_LARGE
-	
 	ADD_TRAIT(quirk_holder, TRAIT_STURDY_FRAME, QUIRK_TRAIT)
 
 	RegisterSignal(human_holder, COMSIG_CARBON_POST_ATTACH_LIMB, PROC_REF(on_gain_limb)) // make sure we handle this when new ones are applied
@@ -33,6 +33,7 @@
 
 	human_holder.blood_volume_normal = BLOOD_VOLUME_OVERSIZED
 	human_holder.physiology.hunger_mod *= OVERSIZED_HUNGER_MOD //50% hungrier
+	human_holder.add_movespeed_modifier(/datum/movespeed_modifier/oversized)
 
 	human_holder.dna.species.gain_oversized_organs(human_holder, src) // handles the addition of oversized organs (species default is a plain oversized stomach)
 
@@ -42,7 +43,6 @@
 	if(!isdummy(human_holder))
 		human_holder.dna.update_body_size()
 	human_holder.mob_size = MOB_SIZE_HUMAN
-
 	REMOVE_TRAIT(quirk_holder, TRAIT_STURDY_FRAME, QUIRK_TRAIT)
 
 	var/obj/item/bodypart/arm/left/left_arm = human_holder.get_bodypart(BODY_ZONE_L_ARM)
@@ -68,6 +68,7 @@
 
 	human_holder.blood_volume_normal = BLOOD_VOLUME_NORMAL
 	human_holder.physiology.hunger_mod /= OVERSIZED_HUNGER_MOD
+	human_holder.remove_movespeed_modifier(/datum/movespeed_modifier/oversized)
 
 	for(var/obj/item/organ/organ_to_restore in old_organs)
 		old_organs -= organ_to_restore
@@ -103,4 +104,9 @@
 
 	gained.name = "oversized " + gained.name
 
+/datum/movespeed_modifier/oversized
+	multiplicative_slowdown = OVERSIZED_SPEED_SLOWDOWN
+
+
 #undef OVERSIZED_HUNGER_MOD
+#undef OVERSIZED_SPEED_SLOWDOWN


### PR DESCRIPTION

## About The Pull Request
Gives oversized holders the TRAIT_STURDY_FRAME, and reduces the slowdown from 0.5 to 0.2, similar to the settler slowdown.

## How This Contributes To The Nova Sector Roleplay Experience
So, the logic for settler and other small races to be slower is that they have short legs, by that same logic oversized characters should be faster. Gameplay wise, we dont want that, but, oversized players already have a problem that makes them _really_ easy to hit, due to the nature of tiles and 2d games, so, not only we saw no reason to keep such a significant slow down (0.5, in comparison, settler provides a 0.2 slowdown), but we also applied a trait that is used to show strenght, while not being particularly game changing. 

You still have a lot of issues to content with.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="316" height="325" alt="image" src="https://github.com/user-attachments/assets/c3790e0a-f1e2-4b59-924a-9fe7ffeb0169" />


</details>

## Changelog
:cl:
balance: Oversized slowdown reduced from 0.5 to 0.2, exactly like settler, or walking over light webs. Oversized also gain the perk Sturdy Frame, which allows them to reduce the slowdown items (ie, armors) cause by 80%, same as the settler perk!
/:cl:
