### PR TITLE
Prevent operation from being done in stasis units. Again.

### DIFF
--- a/code/modules/surgery/operations/_operation.dm
+++ b/code/modules/surgery/operations/_operation.dm
@@ -855,7 +855,6 @@ GLOBAL_DATUM_INIT(operations, /datum/operation_holder, new)
 			to_chat(surgeon, span_warning("[patient] cannot be operated in the [patient.buckled] while it is turned on!"))
 			return ITEM_INTERACT_BLOCKING
 	// NOVA EDIT ADDITION END
-
 	if(isitem(tool))
 		var/obj/item/realtool = tool
 		var/tool_return = SEND_SIGNAL(realtool, COMSIG_ITEM_USED_IN_SURGERY, src, operating_on, surgeon)


### PR DESCRIPTION

## About The Pull Request
After surgery rework we had a slight regression which allowed for operations to be done on stasis units. I just readded this check since it was missing. Check cant be done inside `check_availability` proc because of 'should be pure' linter define
## How This Contributes To The Nova Sector Roleplay Experience
https://github.com/NovaSector/NovaSector/pull/5944
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="1282" height="623" alt="image" src="https://github.com/user-attachments/assets/0462909c-f1d2-4c05-9303-3f9e8e983469" />

</details>

## Changelog
:cl:
balance: You once again can't perform operations on patients inside stasis units
/:cl:
