### PR TITLE
Minor colony fab techweb rework

### DIFF
--- a/modular_nova/master_files/code/modules/research/techweb/techweb_types.dm
+++ b/modular_nova/master_files/code/modules/research/techweb/techweb_types.dm
@@ -1,2 +1,4 @@
+/// Reference back to code/_defines/machines.dm for types, and this file's mirror for reference.
+
 /datum/techweb/autounlocking/col_fab
 	allowed_buildtypes = COLONY_FABRICATOR

--- a/modular_nova/master_files/code/modules/research/techweb/techweb_types.dm
+++ b/modular_nova/master_files/code/modules/research/techweb/techweb_types.dm
@@ -1,0 +1,2 @@
+/datum/techweb/autounlocking/col_fab
+	allowed_buildtypes = COLONY_FABRICATOR

--- a/modular_nova/master_files/code/modules/research/techweb/techweb_types.dm
+++ b/modular_nova/master_files/code/modules/research/techweb/techweb_types.dm
@@ -1,21 +1,13 @@
 /// Reference back to code/_defines/machines.dm for types, and this file's mirror for reference.
 
-/datum/techweb/autounlocking/nova // sub type to do stuff
-	/// Is the device its intended for hackable?
-	var/hackable = FALSE
+/datum/techweb/colony_fabricator
+	var/allowed_buildtypes = COLONY_FABRICATOR //Used for sorting
 
-/datum/techweb/autounlocking/nova/col_fab
-	allowed_buildtypes = COLONY_FABRICATOR
-
-/datum/techweb/autounlocking/nova/New() //Remove a few things to hopefully get this to work right.
+/datum/techweb/colony_fabricator/New() //Remove a few things to hopefully get this to work right.
 	. = ..()
-	for(var/id in SSresearch.techweb_designs)
-		var/datum/design/design = SSresearch.techweb_designs[id]
+	for(var/id, current_design in SSresearch.techweb_designs)
+		var/datum/design/design = current_design
 		if(!(design.build_type & allowed_buildtypes)) //Define hell incoming if we make more subtypes.
 			continue
-
-		if(hackable) // we make this a check incase someone wants to do funny stuff or make a device hackable
-			if(RND_CATEGORY_HACKED in design.category)
-				add_design_by_id(id, add_to = hacked_designs)
 
 		add_design_by_id(id)

--- a/modular_nova/master_files/code/modules/research/techweb/techweb_types.dm
+++ b/modular_nova/master_files/code/modules/research/techweb/techweb_types.dm
@@ -1,4 +1,21 @@
 /// Reference back to code/_defines/machines.dm for types, and this file's mirror for reference.
 
-/datum/techweb/autounlocking/col_fab
+/datum/techweb/autounlocking/nova // sub type to do stuff
+	/// Is the device its intended for hackable?
+	var/hackable = FALSE
+
+/datum/techweb/autounlocking/nova/col_fab
 	allowed_buildtypes = COLONY_FABRICATOR
+
+/datum/techweb/autounlocking/nova/New() //Remove a few things to hopefully get this to work right.
+	. = ..()
+	for(var/id in SSresearch.techweb_designs)
+		var/datum/design/design = SSresearch.techweb_designs[id]
+		if(!(design.build_type & allowed_buildtypes)) //Define hell incoming if we make more subtypes.
+			continue
+
+		if(hackable) // we make this a check incase someone wants to do funny stuff or make a device hackable
+			if(RND_CATEGORY_HACKED in design.category)
+				add_design_by_id(id, add_to = hacked_designs)
+
+		add_design_by_id(id)

--- a/modular_nova/modules/colony_fabricator/code/colony_fabricator.dm
+++ b/modular_nova/modules/colony_fabricator/code/colony_fabricator.dm
@@ -12,6 +12,8 @@
 	light_power = 5
 	allowed_buildtypes = COLONY_FABRICATOR
 	speedup_disabled = TRUE
+	/// techweb we intend to use for unlocking stuff.
+	var/techweb_path = /datum/techweb/autounlocking/nova/col_fab
 	/// The item we turn into when repacked
 	var/repacked_type = /obj/item/flatpacked_machine
 	/// The sound loop played while the fabricator is making something
@@ -30,9 +32,9 @@
 	AddElement(/datum/element/manufacturer_examine, COMPANY_FRONTIER)
 
 /obj/machinery/rnd/production/colony_lathe/proc/handle_network() //To handle the network in a modifiable way for subtypes down the way
-	if(!GLOB.autounlock_techwebs[/datum/techweb/autounlocking/col_fab])
-		GLOB.autounlock_techwebs[/datum/techweb/autounlocking/col_fab] = new /datum/techweb/autounlocking/col_fab
-	stored_research = GLOB.autounlock_techwebs[/datum/techweb/autounlocking/col_fab]
+	if(!GLOB.autounlock_techwebs[techweb_path])
+		GLOB.autounlock_techwebs[techweb_path] = new techweb_path
+	stored_research = GLOB.autounlock_techwebs[techweb_path]
 
 /obj/machinery/rnd/production/colony_lathe/Destroy()
 	QDEL_NULL(soundloop)
@@ -69,18 +71,18 @@
 /obj/machinery/rnd/production/colony_lathe/build_efficiency()
 	return 1
 
-// We take from all nodes even unresearched ones
+// Rewrite to avoid limitations
 /obj/machinery/rnd/production/colony_lathe/update_designs()
 	var/previous_design_count = cached_designs.len
 
 	cached_designs.Cut()
 
 	var/allow_any = isnull(allowed_department_flags)
-	for(var/design_id, design in SSresearch.techweb_designs)
-		var/datum/design/current_design = design
+	for(var/design_id in stored_research.researched_designs)
+		var/datum/design/design = SSresearch.techweb_design_by_id(design_id)
 
-		if(allow_any || ((current_design.departmental_flags & allowed_department_flags) && (current_design.build_type & allowed_buildtypes)))
-			cached_designs |= current_design
+		if(allow_any || ((design.departmental_flags & allowed_department_flags) && (design.build_type & allowed_buildtypes)))
+			cached_designs |= design
 
 	var/design_delta = length(cached_designs) - previous_design_count
 

--- a/modular_nova/modules/colony_fabricator/code/colony_fabricator.dm
+++ b/modular_nova/modules/colony_fabricator/code/colony_fabricator.dm
@@ -14,25 +14,25 @@
 	speedup_disabled = TRUE
 	/// The item we turn into when repacked
 	var/repacked_type = /obj/item/flatpacked_machine
-	/// The techweb we want to pull from. So we dont need to rewrite Inits a dozen times
-	var/intended_techweb = /datum/techweb/autounlocking/col_fab
 	/// The sound loop played while the fabricator is making something
 	var/datum/looping_sound/colony_fabricator_running/soundloop
 
 /obj/machinery/rnd/production/colony_lathe/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/repackable, repacked_type, 5 SECONDS)
+	handle_network()
 	give_manufacturer_examine()
-	// We don't get new designs but can't print stuff if something's not researched, so we use the web that has everything researched
-	if(!GLOB.autounlock_techwebs[intended_techweb])
-		GLOB.autounlock_techwebs[intended_techweb] = new intended_techweb
-	stored_research = GLOB.autounlock_techwebs[intended_techweb]
+	AddElement(/datum/element/repackable, repacked_type, 5 SECONDS)
 	soundloop = new(src, FALSE)
 	if(!mapload)
 		flick("colony_lathe_deploy", src) // Sick ass deployment animation
 
 /obj/machinery/rnd/production/colony_lathe/proc/give_manufacturer_examine() //remaking this is like 7x less annoying than remaking an entire init
 	AddElement(/datum/element/manufacturer_examine, COMPANY_FRONTIER)
+
+/obj/machinery/rnd/production/colony_lathe/proc/handle_network() //To handle the network in a modifiable way for subtypes down the way
+	if(!GLOB.autounlock_techwebs[/datum/techweb/autounlocking/col_fab])
+		GLOB.autounlock_techwebs[/datum/techweb/autounlocking/col_fab] = new /datum/techweb/autounlocking/col_fab
+	stored_research = GLOB.autounlock_techwebs[/datum/techweb/autounlocking/col_fab]
 
 /obj/machinery/rnd/production/colony_lathe/Destroy()
 	QDEL_NULL(soundloop)

--- a/modular_nova/modules/colony_fabricator/code/colony_fabricator.dm
+++ b/modular_nova/modules/colony_fabricator/code/colony_fabricator.dm
@@ -14,6 +14,8 @@
 	speedup_disabled = TRUE
 	/// The item we turn into when repacked
 	var/repacked_type = /obj/item/flatpacked_machine
+	/// The techweb we want to pull from so we dont need to rewrite Inits a dozen times
+	var/intended_techweb = /datum/techweb/autounlocking/col_fab
 	/// The sound loop played while the fabricator is making something
 	var/datum/looping_sound/colony_fabricator_running/soundloop
 
@@ -22,7 +24,9 @@
 	AddElement(/datum/element/repackable, repacked_type, 5 SECONDS)
 	AddElement(/datum/element/manufacturer_examine, COMPANY_FRONTIER)
 	// We don't get new designs but can't print stuff if something's not researched, so we use the web that has everything researched
-	stored_research = locate(/datum/techweb/admin) in SSresearch.techwebs
+	if(!GLOB.autounlock_techwebs[intended_techweb])
+		GLOB.autounlock_techwebs[intended_techweb] = new intended_techweb
+	stored_research = GLOB.autounlock_techwebs[intended_techweb]
 	soundloop = new(src, FALSE)
 	if(!mapload)
 		flick("colony_lathe_deploy", src) // Sick ass deployment animation

--- a/modular_nova/modules/colony_fabricator/code/colony_fabricator.dm
+++ b/modular_nova/modules/colony_fabricator/code/colony_fabricator.dm
@@ -14,7 +14,7 @@
 	speedup_disabled = TRUE
 	/// The item we turn into when repacked
 	var/repacked_type = /obj/item/flatpacked_machine
-	/// The techweb we want to pull from so we dont need to rewrite Inits a dozen times
+	/// The techweb we want to pull from. So we dont need to rewrite Inits a dozen times
 	var/intended_techweb = /datum/techweb/autounlocking/col_fab
 	/// The sound loop played while the fabricator is making something
 	var/datum/looping_sound/colony_fabricator_running/soundloop
@@ -22,7 +22,7 @@
 /obj/machinery/rnd/production/colony_lathe/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/repackable, repacked_type, 5 SECONDS)
-	AddElement(/datum/element/manufacturer_examine, COMPANY_FRONTIER)
+	give_manufacturer_examine()
 	// We don't get new designs but can't print stuff if something's not researched, so we use the web that has everything researched
 	if(!GLOB.autounlock_techwebs[intended_techweb])
 		GLOB.autounlock_techwebs[intended_techweb] = new intended_techweb
@@ -30,6 +30,9 @@
 	soundloop = new(src, FALSE)
 	if(!mapload)
 		flick("colony_lathe_deploy", src) // Sick ass deployment animation
+
+/obj/machinery/rnd/production/colony_lathe/proc/give_manufacturer_examine() //remaking this is like 7x less annoying than remaking an entire init
+	AddElement(/datum/element/manufacturer_examine, COMPANY_FRONTIER)
 
 /obj/machinery/rnd/production/colony_lathe/Destroy()
 	QDEL_NULL(soundloop)

--- a/modular_nova/modules/colony_fabricator/code/colony_fabricator.dm
+++ b/modular_nova/modules/colony_fabricator/code/colony_fabricator.dm
@@ -13,7 +13,7 @@
 	allowed_buildtypes = COLONY_FABRICATOR
 	speedup_disabled = TRUE
 	/// techweb we intend to use for unlocking stuff.
-	var/techweb_path = /datum/techweb/autounlocking/nova/col_fab
+	var/techweb_path = /datum/techweb/colony_fabricator
 	/// The item we turn into when repacked
 	var/repacked_type = /obj/item/flatpacked_machine
 	/// The sound loop played while the fabricator is making something
@@ -32,9 +32,8 @@
 	AddElement(/datum/element/manufacturer_examine, COMPANY_FRONTIER)
 
 /obj/machinery/rnd/production/colony_lathe/proc/handle_network() //To handle the network in a modifiable way for subtypes down the way
-	if(!GLOB.autounlock_techwebs[techweb_path])
-		GLOB.autounlock_techwebs[techweb_path] = new techweb_path
-	stored_research = GLOB.autounlock_techwebs[techweb_path]
+	if(isnull(stored_research))
+		stored_research = new techweb_path
 
 /obj/machinery/rnd/production/colony_lathe/Destroy()
 	QDEL_NULL(soundloop)

--- a/modular_nova/modules/colony_fabricator/code/design_datums/equipment.dm
+++ b/modular_nova/modules/colony_fabricator/code/design_datums/equipment.dm
@@ -12,8 +12,3 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SERVICE
 
-// Lets colony fabricators make soup pots, removes bluespace crystal requirement. It's just a pot...
-/datum/design/soup_pot/New()
-	build_type |= COLONY_FABRICATOR
-	materials -= /datum/material/bluespace
-	return ..()

--- a/modular_nova/modules/colony_fabricator/code/design_datums/fabricator_flag_additions/construction.dm
+++ b/modular_nova/modules/colony_fabricator/code/design_datums/fabricator_flag_additions/construction.dm
@@ -42,35 +42,7 @@
 
 // Wall frames
 
-/datum/design/camera_assembly/New()
-	. = ..()
-	build_type |= COLONY_FABRICATOR
-
-/datum/design/intercom_frame/New()
-	. = ..()
-	build_type |= COLONY_FABRICATOR
-
-/datum/design/light_switch_frame/New()
-	. = ..()
-	build_type |= COLONY_FABRICATOR
-
 /datum/design/ignition_control/New()
-	. = ..()
-	build_type |= COLONY_FABRICATOR
-
-/datum/design/sparker/New()
-	. = ..()
-	build_type |= COLONY_FABRICATOR
-
-/datum/design/newscaster_frame/New()
-	. = ..()
-	build_type |= COLONY_FABRICATOR
-
-/datum/design/status_display_frame/New()
-	. = ..()
-	build_type |= COLONY_FABRICATOR
-
-/datum/design/requests_console/New()
 	. = ..()
 	build_type |= COLONY_FABRICATOR
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7537,6 +7537,7 @@
 #include "modular_nova\master_files\code\modules\research\designs\weapon_designs.dm"
 #include "modular_nova\master_files\code\modules\research\machinery\_production.dm"
 #include "modular_nova\master_files\code\modules\research\techweb\all_nodes.dm"
+#include "modular_nova\master_files\code\modules\research\techweb\techweb_types.dm"
 #include "modular_nova\master_files\code\modules\shuttle\shuttle.dm"
 #include "modular_nova\master_files\code\modules\shuttle\shuttle_events\meteors.dm"
 #include "modular_nova\master_files\code\modules\sleep\code\datums\status_effects\_status_effect.dm"


### PR DESCRIPTION

## About The Pull Request

Moves the Colony Fabricator off of the admin techweb and onto a new autounlocking techweb, making it more modular to change along with the manufacturer text.

Mainly for future projects/work.

Also removes a handful of broken recipe paths. 

## How This Contributes To The Nova Sector Roleplay Experience

Not player facing (yet)

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="242" height="367" alt="image" src="https://github.com/user-attachments/assets/321d4cf1-d69e-42b1-a369-a1efed91163e" />

<img width="521" height="222" alt="image" src="https://github.com/user-attachments/assets/513b4702-271c-4f66-a8ec-822cfbd4607b" />

<img width="412" height="203" alt="image" src="https://github.com/user-attachments/assets/4383b8f6-d695-439b-99c3-645f58537006" />


</details>

## Changelog
:cl:
code: makes the colony fabricator easier to make subtypes of for future use.
/:cl:
