### PR TITLE
Fixes some indicators looking weird on multi-Z maps

### DIFF
--- a/modular_nova/master_files/code/modules/mob/living/emote_popup.dm
+++ b/modular_nova/master_files/code/modules/mob/living/emote_popup.dm
@@ -5,6 +5,7 @@
 	plane = GAME_PLANE
 	appearance_flags = APPEARANCE_UI_IGNORE_ALPHA | KEEP_APART
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	vis_flags = VIS_INHERIT_PLANE | VIS_INHERIT_ID
 
 /**
  * A proc type that, when called, causes a image/sprite to appear above whatever entity it is called on.

--- a/modular_nova/modules/indicators/code/_indicator.dm
+++ b/modular_nova/modules/indicators/code/_indicator.dm
@@ -3,3 +3,4 @@
 	layer = FLY_LAYER
 	appearance_flags = APPEARANCE_UI_IGNORE_ALPHA | KEEP_APART
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	vis_flags = VIS_INHERIT_PLANE | VIS_INHERIT_ID


### PR DESCRIPTION

## About The Pull Request

adds `vis_flags = VIS_INHERIT_PLANE | VIS_INHERIT_ID` to `/obj/effect/overlay/indicator` and `/obj/effect/overlay/emote_popup`, so that they render properly on multi-Z maps.

## How This Contributes To The Nova Sector Roleplay Experience

bugfix

## Proof of Testing

https://github.com/user-attachments/assets/a2487cb2-36e6-4d96-aeec-dea9efe3adfe

## Changelog
:cl:
fix: Some indicators (combat, ssd, temporary flavor text) will no longer be completely dark sometimes on multi-Z maps.
/:cl:
