### PR TITLE
properly sets CHAP intrinsic materials (by removing its materials)

### DIFF
--- a/code/game/objects/items/food/martian.dm
+++ b/code/game/objects/items/food/martian.dm
@@ -247,7 +247,6 @@
 	foodtypes = MEAT | GRAIN | VEGETABLES | FRUIT | PINEAPPLE
 	w_class = WEIGHT_CLASS_SMALL
 	crafting_complexity = FOOD_COMPLEXITY_3
-	custom_materials = list(/datum/material/meat = MEATDISH_MATERIAL_AMOUNT * 1.2, /datum/material/iron = MEATDISH_MATERIAL_AMOUNT * 0.15) // NOVA EDIT ADDITION
 
 /obj/item/food/salad/ketchup_fried_rice
 	name = "ketchup fried rice"
@@ -437,7 +436,6 @@
 	foodtypes =  MEAT|GRAIN|DAIRY|FRIED
 	w_class = WEIGHT_CLASS_SMALL
 	crafting_complexity = FOOD_COMPLEXITY_3
-	custom_materials = list(/datum/material/meat = MEATDISH_MATERIAL_AMOUNT * 2.4, /datum/material/iron = MEATDISH_MATERIAL_AMOUNT * 0.3) // NOVA EDIT ADDITION
 
 /obj/item/food/king_katsu_sandwich
 	name = "\improper King Katsu sandwich"
@@ -822,7 +820,6 @@
 	foodtypes = MEAT|GRAIN|FRIED|BREAKFAST|VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
 	crafting_complexity = FOOD_COMPLEXITY_3
-	custom_materials = list(/datum/material/meat = MEATDISH_MATERIAL_AMOUNT * 2.4, /datum/material/iron = MEATDISH_MATERIAL_AMOUNT * 0.3) // NOVA EDIT ADDITION
 
 /obj/item/food/chap_hash
 	name = "chap hash"
@@ -838,7 +835,6 @@
 	foodtypes = MEAT | VEGETABLES | BREAKFAST
 	w_class = WEIGHT_CLASS_SMALL
 	crafting_complexity = FOOD_COMPLEXITY_3
-	custom_materials = list(/datum/material/meat = MEATDISH_MATERIAL_AMOUNT * 2.4, /datum/material/iron = MEATDISH_MATERIAL_AMOUNT * 0.3) // NOVA EDIT ADDITION
 
 /obj/item/food/salad/agedashi_tofu
 	name = "agedashi tofu"

--- a/code/game/objects/items/food/packaged.dm
+++ b/code/game/objects/items/food/packaged.dm
@@ -197,7 +197,6 @@
 	tastes = list("meat" = 1)
 	foodtypes = MEAT
 	w_class = WEIGHT_CLASS_SMALL
-	custom_materials = list(/datum/material/meat = MEATDISH_MATERIAL_AMOUNT * 1.2, /datum/material/iron = MEATDISH_MATERIAL_AMOUNT * 0.15) // NOVA EDIT ADDITION - no idea why this is needed here and not upstream.
 
 /obj/item/food/chapslice/make_grillable()
 	AddComponent(/datum/component/grillable, /obj/item/food/grilled_chapslice, rand(20 SECONDS, 40 SECONDS), TRUE, TRUE)
@@ -213,7 +212,6 @@
 	tastes = list("meat" = 1)
 	foodtypes = MEAT
 	w_class = WEIGHT_CLASS_SMALL
-	custom_materials = list(/datum/material/meat = MEATDISH_MATERIAL_AMOUNT * 1.2, /datum/material/iron = MEATDISH_MATERIAL_AMOUNT * 0.15) // NOVA EDIT ADDITION - no idea why this is needed here and not upstream.
 
 // DONK DINNER: THE INNOVATIVE WAY TO GET YOUR DAILY RECOMMENDED ALLOWANCE OF SALT... AND THEN SOME!
 /obj/item/food/ready_donk

--- a/modular_nova/master_files/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/modular_nova/master_files/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -4,8 +4,5 @@
 /obj/item/food/pizza/arnold // Account for our low iron diet, 6x AMMO_MATS_BASIC
 	custom_materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 16, /datum/material/meat = MEATSLAB_MATERIAL_AMOUNT)
 
-/obj/item/food/canned/chap
-	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT * 2, /datum/material/iron = SHEET_MATERIAL_AMOUNT)
-
 /obj/item/food/canned/tuna
 	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT)

--- a/modular_nova/modules/cook_console_recipes/recipes.dm
+++ b/modular_nova/modules/cook_console_recipes/recipes.dm
@@ -139,13 +139,9 @@
 // intrinsic fixes
 /obj/item/food/canned/chap
 	intrinsic_food_materials = list(/datum/material/meat, /datum/material/iron)
-	// as per the recipe being 1 meat 1 iron,
-	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT)
 
 /obj/item/food/chapslice
 	intrinsic_food_materials = list(/datum/material/meat)
-	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT / 5)
 
 /obj/item/food/grilled_chapslice
 	intrinsic_food_materials = list(/datum/material/meat)
-	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT / 5)

--- a/modular_nova/modules/cook_console_recipes/recipes.dm
+++ b/modular_nova/modules/cook_console_recipes/recipes.dm
@@ -91,7 +91,7 @@
 	time = 40
 	reqs = list(
 		/obj/item/stack/sheet/iron = 1,
-		/obj/item/food/meat/slab = 2,
+		/obj/item/food/meat/slab = 1,
 	)
 	result = /obj/item/food/canned/chap
 	category = CAT_MEAT
@@ -132,9 +132,13 @@
 // intrinsic fixes
 /obj/item/food/canned/chap
 	intrinsic_food_materials = list(/datum/material/meat, /datum/material/iron)
+	// as per the recipe being 1 meat 1 iron,
+	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT, /datum/material/iron = SHEET_MATERIAL_AMOUNT)
 
 /obj/item/food/chapslice
 	intrinsic_food_materials = list(/datum/material/meat, /datum/material/iron)
+	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT / 5)
 
 /obj/item/food/grilled_chapslice
 	intrinsic_food_materials = list(/datum/material/meat, /datum/material/iron)
+	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT / 5)

--- a/modular_nova/modules/cook_console_recipes/recipes.dm
+++ b/modular_nova/modules/cook_console_recipes/recipes.dm
@@ -90,11 +90,8 @@
 	name = "Can of CHAP"
 	time = 1 SECONDS
 	requirements_mats_blacklist = list(
-		/obj/item/reagent_containers/cup/bowl,
-		/obj/item/popsicle_stick,
-		/obj/item/stack/rods,
-		/obj/item/reagent_containers/cup/glass/sillycup,
 		/obj/item/stack/sheet/iron,
+		/obj/item/food/meat/slab,
 	)
 	reqs = list(
 		/obj/item/stack/sheet/iron = 1,

--- a/modular_nova/modules/cook_console_recipes/recipes.dm
+++ b/modular_nova/modules/cook_console_recipes/recipes.dm
@@ -88,7 +88,14 @@
 
 /datum/crafting_recipe/food/can_of_chap
 	name = "Can of CHAP"
-	time = 40
+	time = 10
+	requirements_mats_blacklist = list(
+		/obj/item/reagent_containers/cup/bowl,
+		/obj/item/popsicle_stick,
+		/obj/item/stack/rods,
+		/obj/item/reagent_containers/cup/glass/sillycup,
+		/obj/item/stack/sheet/iron,
+	)
 	reqs = list(
 		/obj/item/stack/sheet/iron = 1,
 		/obj/item/food/meat/slab = 1,

--- a/modular_nova/modules/cook_console_recipes/recipes.dm
+++ b/modular_nova/modules/cook_console_recipes/recipes.dm
@@ -128,3 +128,13 @@
 	reqs = list(/obj/item/food/grown/herbs = 1)
 	result = /obj/item/food/dried_herbs
 	category = CAT_MARTIAN
+
+// intrinsic fixes
+/obj/item/food/canned/chap
+	intrinsic_food_materials = list(/datum/material/meat, /datum/material/iron)
+
+/obj/item/food/chapslice
+	intrinsic_food_materials = list(/datum/material/meat, /datum/material/iron)
+
+/obj/item/food/grilled_chapslice
+	intrinsic_food_materials = list(/datum/material/meat, /datum/material/iron)

--- a/modular_nova/modules/cook_console_recipes/recipes.dm
+++ b/modular_nova/modules/cook_console_recipes/recipes.dm
@@ -133,12 +133,12 @@
 /obj/item/food/canned/chap
 	intrinsic_food_materials = list(/datum/material/meat, /datum/material/iron)
 	// as per the recipe being 1 meat 1 iron,
-	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT, /datum/material/iron = SHEET_MATERIAL_AMOUNT)
+//	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT, /datum/material/iron = SHEET_MATERIAL_AMOUNT)
 
 /obj/item/food/chapslice
-	intrinsic_food_materials = list(/datum/material/meat, /datum/material/iron)
-	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT / 5)
+	intrinsic_food_materials = list(/datum/material/meat)
+//	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT / 5)
 
 /obj/item/food/grilled_chapslice
-	intrinsic_food_materials = list(/datum/material/meat, /datum/material/iron)
-	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT / 5)
+	intrinsic_food_materials = list(/datum/material/meat)
+//	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT / 5)

--- a/modular_nova/modules/cook_console_recipes/recipes.dm
+++ b/modular_nova/modules/cook_console_recipes/recipes.dm
@@ -88,7 +88,7 @@
 
 /datum/crafting_recipe/food/can_of_chap
 	name = "Can of CHAP"
-	time = 10
+	time = 1 SECONDS
 	requirements_mats_blacklist = list(
 		/obj/item/reagent_containers/cup/bowl,
 		/obj/item/popsicle_stick,
@@ -140,12 +140,12 @@
 /obj/item/food/canned/chap
 	intrinsic_food_materials = list(/datum/material/meat, /datum/material/iron)
 	// as per the recipe being 1 meat 1 iron,
-//	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT, /datum/material/iron = SHEET_MATERIAL_AMOUNT)
+	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT)
 
 /obj/item/food/chapslice
 	intrinsic_food_materials = list(/datum/material/meat)
-//	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT / 5)
+	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT / 5)
 
 /obj/item/food/grilled_chapslice
 	intrinsic_food_materials = list(/datum/material/meat)
-//	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT / 5)
+	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT / 5)


### PR DESCRIPTION
## About The Pull Request

About what it says on the tin. ~~Sets CHAP's intrinsic materials so it stops turning weird and pink regardless of if you ordered it through the order console or canned it yourself.~~ Removes the custom materials from CHAP and its associated products so it stops turning weird and metallic-meaty.

## How This Contributes To The Nova Sector Roleplay Experience

it'd be really cool if i could make food without it becoming evil translucent pink thanks

## Changelog

:cl:
fix: Following complaints from approximately two people with a one person margin of error, cans of CHAP and associated products (sliced CHAP, grilled sliced CHAP) should no longer become "meat-iron" and squishy/grey/translucent/etc.
/:cl:
