### PR TITLE
Temp - Tones down DS2 until a rework has been set

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
@@ -3667,7 +3667,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
-/obj/machinery/suit_storage_unit/syndicate/deepspace,
+/obj/machinery/suit_storage_unit/syndicate/softsuit,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/nova/des_two/security/armory)
 "px" = (
@@ -7008,12 +7008,6 @@
 	pixel_y = 9
 	},
 /obj/item/melee/energy/sword/saber/red,
-/obj/item/melee/energy/sword/saber/red{
-	pixel_x = 13
-	},
-/obj/item/melee/energy/sword/saber/red{
-	pixel_x = 7
-	},
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/effect/turf_decal/siding/dark{

--- a/modular_nova/master_files/code/modules/mod/mod_theme.dm
+++ b/modular_nova/master_files/code/modules/mod/mod_theme.dm
@@ -17,6 +17,7 @@
 /datum/mod_theme/syndicate/deepspace
 	name = "deepspace"
 	default_skin = "deepspace"
+	armor_type = /datum/armor/mod_theme_security
 	ui_theme = "syndicate"
 	variants = list(
 		"deepspace" = list(
@@ -164,6 +165,7 @@
 /datum/mod_theme/elite/admiral
 	name = "admiral"
 	default_skin = "admiral"
+	armor_type = /datum/armor/mod_theme_safeguard
 	variants = list(
 		"admiral" = list(
 			MOD_ICON_OVERRIDE = 'modular_nova/master_files/icons/obj/clothing/modsuit/mod_clothing.dmi',

--- a/modular_nova/master_files/code/modules/mod/mod_types.dm
+++ b/modular_nova/master_files/code/modules/mod/mod_types.dm
@@ -25,14 +25,14 @@
 	starting_frequency = MODLINK_FREQ_SYNDICATE
 	applied_cell = /obj/item/stock_parts/power_store/cell/hyper
 	applied_modules = list(
-		/obj/item/mod/module/storage/syndicate,
+		/obj/item/mod/module/storage,
 		/obj/item/mod/module/emp_shield,
 		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/jetpack,
 		/obj/item/mod/module/chameleon,
 	)
 	default_pins = list(
-		/obj/item/mod/module/jetpack/advanced,
+		/obj/item/mod/module/jetpack,
 		/obj/item/mod/module/jump_jet,
 	)
 	theme = /datum/mod_theme/syndicate/deepspace
@@ -42,18 +42,16 @@
 	applied_cell = /obj/item/stock_parts/power_store/cell/hyper
 	applied_modules = list(
 		/obj/item/mod/module/storage/syndicate,
-		/obj/item/mod/module/shock_absorber,
 		/obj/item/mod/module/emp_shield,
 		/obj/item/mod/module/magnetic_harness,
-		/obj/item/mod/module/jetpack/advanced,
+		/obj/item/mod/module/jetpack,
 		/obj/item/mod/module/jump_jet,
 		/obj/item/mod/module/flashlight,
 		/obj/item/mod/module/dna_lock,
 		/obj/item/mod/module/hat_stabilizer/syndicate,
-		/obj/item/mod/module/quick_cuff,
 	)
 	default_pins = list(
-		/obj/item/mod/module/jetpack/advanced,
+		/obj/item/mod/module/jetpack,
 		/obj/item/mod/module/jump_jet,
 	)
 	theme = /datum/mod_theme/elite/admiral

--- a/modular_nova/modules/mapping/code/lockers/des_two/security.dm
+++ b/modular_nova/modules/mapping/code/lockers/des_two/security.dm
@@ -52,9 +52,9 @@
 /obj/structure/closet/secure_closet/des_two/armory_gear_locker/PopulateContents()
 	..()
 
-	new /obj/item/storage/belt/holster/nukie(src)
-	new /obj/item/storage/belt/holster/nukie(src)
-	new /obj/item/storage/belt/holster/nukie(src)
+	new /obj/item/storage/belt/holster(src)
+	new /obj/item/storage/belt/holster(src)
+	new /obj/item/storage/belt/holster(src)
 	new /obj/item/clothing/suit/armor/vest(src)
 	new /obj/item/clothing/suit/armor/vest(src)
 	new /obj/item/clothing/suit/armor/vest(src)

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/gunsets.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/gunsets.dm
@@ -101,8 +101,7 @@
 	generate_items_inside(list(
 		/obj/item/gun/ballistic/automatic/sol_grenade_launcher/evil/no_mag = 1,
 		/obj/item/ammo_box/magazine/c980_grenade/drum/starts_empty = 2,
-		/obj/item/ammo_box/c980grenade/shrapnel = 1,
-		/obj/item/ammo_box/c980grenade/shrapnel/phosphor = 1,
+		/obj/item/ammo_box/c980grenade = 2,
 		/obj/item/ammo_box/c980grenade/smoke = 1,
 		/obj/item/ammo_box/c980grenade/riot = 1,
 	), src)


### PR DESCRIPTION

## About The Pull Request

This pr mostly tunes down the gear found in DS2 to be more even with competing ghost roles to a degree, small changes may still be found and done later but this satisfies the initial pass.

## How This Contributes To The Nova Sector Roleplay Experience

Mostly this is for them to not be an impossible wall to come across inside of space, it grants them a fairly large advantage automatically when other roles/stationers have quite a lot to do before getting close to that.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: DS2 gear and armory has been toned down.
/:cl:
