### PR TITLE
Adds Two Rechargers to Blueshift Because I Played Security There Once

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -31287,6 +31287,14 @@
 /obj/item/restraints/handcuffs,
 /obj/item/assembly/flash/handheld,
 /obj/effect/turf_decal/bot,
+/obj/machinery/recharger{
+	pixel_y = 2;
+	pixel_x = -6
+	},
+/obj/machinery/recharger{
+	pixel_y = 2;
+	pixel_x = 6
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What it says on the tin, adds two rechargers to Blueshift's security department, more precisely to the gear room.

## How This Contributes To The Nova Sector Roleplay Experience

The astute mappers amongst us might realize there are already rechargers in the Blueshift security department, but the issue arises in the fact that every single one of them is in the locked armory so John Security would need the same access to get a lethal weapon as to charge up his baton.

## Proof of Testing

Booted on my local, but not really a surprise considering the changes.

<details>
<summary>Screenshots/Videos</summary>
  
<img width="583" height="459" alt="image" src="https://github.com/user-attachments/assets/b6c38357-38a2-4272-9c3c-fd414fa19c80" />

</details>

## Changelog


:cl:
add: Two rechargers added to Blueshift's security department
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
