### PR TITLE
Non-assistants now show on the manifest again with the visitor quirk

### DIFF
--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -112,7 +112,7 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 	if(!(person.mind?.assigned_role.job_flags & JOB_CREW_MANIFEST))
 		return
 	// NOVA EDIT ADDITION START - Visitor ID -> no manifest
-	if(person.has_quirk(/datum/quirk/visitor) & is_assistant_job(person))
+	if((person.has_quirk(/datum/quirk/visitor) || ("Visitor ID" in person_client?.prefs.all_quirks)) && is_assistant_job(person.mind?.assigned_role))
 		return inject_guest(person, person_client)
 	// NOVA EDIT ADDITION END
 

--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -112,7 +112,7 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 	if(!(person.mind?.assigned_role.job_flags & JOB_CREW_MANIFEST))
 		return
 	// NOVA EDIT ADDITION START - Visitor ID -> no manifest
-	if(person.has_quirk(/datum/quirk/visitor) || ("Visitor ID" in person_client?.prefs.all_quirks))
+	if(person.has_quirk(/datum/quirk/visitor) & is_assistant_job(person))
 		return inject_guest(person, person_client)
 	// NOVA EDIT ADDITION END
 


### PR DESCRIPTION

## About The Pull Request

Swaps the check to one that explicitly looks for the visitor job. 

Explicitly Tested:
Roundstart assistant w/ visitor quirk: Not on manifest.
Latejoin assistant w/ visitor quirk: Not on manifest.
Roundstart non-assistant w/ visitor quirk: On manifest.
Latejoin non-assistant w/ visitor quirk: On manifest.

I hate this quirk so much. Fixes #6919 
## How This Contributes To The Nova Sector Roleplay Experience
## Proof of Testing

<img width="618" height="325" alt="image" src="https://github.com/user-attachments/assets/42541e7a-bba0-46e9-b46c-5ed7b20f3f06" />


## Changelog
:cl:
fix: non-assistant visitors should properly show on manifest with records again.
/:cl:
