### PR TITLE
Add Nova Star–Only Restriction for Prisoners

### DIFF
--- a/modular_nova/modules/star_only/code/job_types.dm
+++ b/modular_nova/modules/star_only/code/job_types.dm
@@ -3,3 +3,6 @@
 
 /datum/job/mime
 	nova_stars_only = TRUE
+
+/datum/job/prisoner
+	nova_stars_only = TRUE


### PR DESCRIPTION

## About The Pull Request

Nova Star Whitelist For Prisoner

## How This Contributes To The Nova Sector Roleplay Experience

Clown and Mime are explicitly held to higher standards due to the inherently disruptive nature of their roles and the tendency for them to fall into low-roleplay behavior below the standard we aim to maintain at Nova Sector.

The Prisoner role often produces the same type of disruption and can frequently become an even greater nuisance than the roles listed above. As such, it should be held to the same elevated expectations.

As part of this change, several restrictions surrounding the Prisoner role will be relaxed. The policy concerning “too many prisoners escaping or causing chaos without an OPFOR present” will be removed.

Since Prisoners will now be held to higher roleplay standards, they will also be given greater freedom in how they approach the role.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="299" height="30" alt="desktop" src="https://github.com/user-attachments/assets/950af407-0a09-4575-a20a-ca405aae58fd" />
</details>

## Changelog
:cl: Von Carstein

code: Prisoner Added To Nova Star Only

/:cl:
