### PR TITLE
Minor Pubby Fixes

### DIFF
--- a/_maps/map_files/oceanpubby/oceanpubby.dmm
+++ b/_maps/map_files/oceanpubby/oceanpubby.dmm
@@ -175,7 +175,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/photocopier/prebuilt,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "aaY" = (
@@ -6701,6 +6700,10 @@
 	pixel_y = 2
 	},
 /obj/machinery/computer/security/telescreen/vault/directional/north,
+/obj/item/stamp/head/hop{
+	pixel_x = -4;
+	pixel_y = 4
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "aBB" = (
@@ -20603,7 +20606,6 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/engine_equipment,
-/obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "bRI" = (
@@ -26957,15 +26959,9 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "cYk" = (
-/obj/structure/table/wood,
-/obj/item/stamp/head/hop{
-	pixel_x = -4;
-	pixel_y = 4
-	},
 /obj/machinery/button/ticket_machine{
 	pixel_x = 28
 	},
-/obj/item/paper_bin/carbon,
 /obj/machinery/button/door/directional/south{
 	id = "hop";
 	name = "Privacy Shutters Control";
@@ -26983,6 +26979,9 @@
 /obj/machinery/button/photobooth{
 	pixel_x = 27;
 	pixel_y = -10
+	},
+/obj/machinery/computer/accounting{
+	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)


### PR DESCRIPTION

## About The Pull Request

removes the extra copier from the hop office
adds the account lookup console.
removes an abandoned airlock helper to fix a flaky ci.

## Changelog

:cl:
fix: pubby's hop office now has the account console, loses the extra photocopier.
/:cl:

