### PR TITLE
Fixes some stray errors with the Rabbit clothes

### DIFF
--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_suit.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_suit.dm
@@ -1,4 +1,4 @@
-// LOADOUT ITEM DATUMS FOR THE SHOE SLOT
+// LOADOUT ITEM DATUMS FOR THE SUIT SLOT
 /datum/loadout_item/suit/pre_equip_item(datum/outfit/outfit, datum/outfit/outfit_important_for_life, mob/living/carbon/human/equipper, visuals_only = FALSE) // don't bother storing in backpack, can't fit
 	if(initial(outfit_important_for_life.suit))
 		return TRUE
@@ -753,6 +753,7 @@
 /datum/loadout_item/suit/tailcoatbartender
 	name = "Bartender's Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/bartender
+	restricted_roles = list(JOB_BARTENDER)
 	group = "Costumes"
 
 /datum/loadout_item/suit/tailcoatwizard

--- a/modular_nova/modules/modular_vending/code/autodrobe.dm
+++ b/modular_nova/modules/modular_vending/code/autodrobe.dm
@@ -45,7 +45,7 @@
 				/obj/item/clothing/shoes/clown_shoes/pink/heels = 5,
 				/obj/item/clothing/gloves/pink_clown = 5,
 				/obj/item/clothing/head/playbunnyears/clown = 3,
-				/obj/item/clothing/head/playbunnyears/mime = 3,,
+				/obj/item/clothing/head/playbunnyears/mime = 3,
 				/obj/item/clothing/neck/tie/clown = 3,
 				/obj/item/clothing/shoes/clown_shoes/heeled = 3,
 				/obj/item/clothing/suit/jacket/tailcoat/clown = 3,


### PR DESCRIPTION

## About The Pull Request
Fixed the Bluescreen in the Autodrobe.
Fixed everyone being able to get roundstart armor via the Bartender tailcoat in the loadout.
## How This Contributes To The Nova Sector Roleplay Experience

things work good

## Proof of Testing

<img width="1305" height="696" alt="image" src="https://github.com/user-attachments/assets/d8af80c3-67ab-49dd-ae3b-e1369e5d42c5" />


## Changelog
:cl:
fix: Fixed the Bluescreen in the Autodrobe. 
fix: Fixed everyone being able to get roundstart armor via the Bartender tailcoat in the loadout.
/:cl:
