### PR TITLE
Adds tennis balls to the games vendor

### DIFF
--- a/modular_nova/modules/modular_vending/code/games.dm
+++ b/modular_nova/modules/modular_vending/code/games.dm
@@ -11,7 +11,7 @@
 				/obj/item/toy/tennis/yellow = 2,
 				/obj/item/toy/tennis/green = 2,
 				/obj/item/toy/tennis/cyan = 2,
-				/obj/item/toy/tennis/purple = 2,
+				/obj/item/toy/tennis/blue = 2,
 				/obj/item/toy/tennis/purple = 2,
 			),
 		),

--- a/modular_nova/modules/modular_vending/code/games.dm
+++ b/modular_nova/modules/modular_vending/code/games.dm
@@ -6,6 +6,13 @@
 			"products" = list(
 				/obj/item/storage/briefcase/secure/white/wargame_kit = 3,
 				/obj/item/laser_pointer/limited = 3,
+				/obj/item/toy/tennis = 2,
+				/obj/item/toy/tennis/red = 2,
+				/obj/item/toy/tennis/yellow = 2,
+				/obj/item/toy/tennis/green = 2,
+				/obj/item/toy/tennis/cyan = 2,
+				/obj/item/toy/tennis/purple = 2,
+				/obj/item/toy/tennis/purple = 2,
 			),
 		),
 		list(


### PR DESCRIPTION

## About The Pull Request

Tennis balls are currently only available if they're mapped in or part of the loadout. This is discriminatory against dogboys and doggirls everywhere, who just want to play fetch. This PR adds tennis balls to the toy vendor, two of each colour.

## How This Contributes To The Nova Sector Roleplay Experience

puppy dog city's real. it's a city full of puppy dogs, a place i'll belong & fit in, it's home. i saw it

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="423" height="628" alt="image" src="https://github.com/user-attachments/assets/d80accd8-e675-4cab-8822-530d5fc96b21" />

</details>

## Changelog
:cl:
add: In a win for puppies dogs everywhere, tennis balls are now available at Good Clean Fun vendors
/:cl:
