### PR TITLE
[Crash] Fixes the cargo teleporters crashing the server.

### DIFF
--- a/modular_nova/modules/cargo_items/cargo_teleporter.dm
+++ b/modular_nova/modules/cargo_items/cargo_teleporter.dm
@@ -1,4 +1,6 @@
 GLOBAL_LIST_EMPTY(cargo_marks)
+#define MAX_CARGO_TELEPORTER_ITEMS 20 // same as the push broom.
+#define CARGO_TELEPORTER_COOLDOWN 8 SECONDS
 
 /obj/item/cargo_teleporter
 	name = "cargo teleporter"
@@ -75,7 +77,11 @@ GLOBAL_LIST_EMPTY(cargo_marks)
 
 	var/turf/moving_turf = get_turf(selected_mark)
 	var/turf/target_turf = get_turf(interacting_with)
+	var/teleported = 0
 	for(var/check_content in target_turf.contents)
+		if (teleported >= MAX_CARGO_TELEPORTER_ITEMS)
+			break
+
 		if(isobserver(check_content))
 			continue
 
@@ -92,10 +98,15 @@ GLOBAL_LIST_EMPTY(cargo_marks)
 		if(movable_content.anchored)
 			continue
 
-		do_teleport(movable_content, moving_turf, asoundout = 'sound/effects/magic/Disable_Tech.ogg')
+		do_teleport(movable_content, moving_turf, no_effects = TRUE)
+		teleported++
 
+	playsound(target_turf, 'sound/effects/magic/Disable_Tech.ogg', 50)
+	playsound(moving_turf, 'sound/effects/magic/Disable_Tech.ogg', 50)
+	do_sparks(2, FALSE, target_turf)
+	do_sparks(2, FALSE, moving_turf)
 	new /obj/effect/decal/cleanable/ash(target_turf)
-	COOLDOWN_START(src, use_cooldown, 8 SECONDS)
+	COOLDOWN_START(src, use_cooldown, CARGO_TELEPORTER_COOLDOWN)
 	return ITEM_INTERACT_SUCCESS
 
 /datum/design/cargo_teleporter


### PR DESCRIPTION

## About The Pull Request
Put a counter on the amount of items teleported at a time, removed the teleport sound and spark effects from the teleport action and moved it outside once the action is done. 

## How This Contributes To The Nova Sector Roleplay Experience
Game crashing is not cool.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="600" height="498" alt="image" src="https://github.com/user-attachments/assets/3f596462-e1d9-4364-8cb3-a78197727b33" />


</details>

## Changelog
:cl:
balance: Made Cargo teleporters to teleport stuff 20 a time, instead of all they have in a tile, to avoid crashes. Same amount as the push broom for the same reasons.
fix: Separates the sound effects and particle effects of cargo teleporters to be by teleporting chunks, instead of per atom.
/:cl:
