### PR TITLE
[No GBP] [Fix] forgot to add the t3 clothing objects to xenoarch

### DIFF
--- a/modular_nova/modules/xenoarch/code/modules/research/xenoarch/xenoarch_reward.dm
+++ b/modular_nova/modules/xenoarch/code/modules/research/xenoarch/xenoarch_reward.dm
@@ -31,6 +31,7 @@
 		/obj/item/xenoarch/broken_item/weapon/t3 = 3,
 		/obj/item/xenoarch/broken_item/illegal/t3 = 3,
 		/obj/item/xenoarch/broken_item/alien/t3 = 3,
+		/obj/item/xenoarch/broken_item/clothing/t3 = 3,
 	)
 
 /obj/effect/spawner/random/xenoarch/plant


### PR DESCRIPTION

## About The Pull Request
Adds the tier 3 clothing objects to xenoarch t3 loot pool.

## How This Contributes To The Nova Sector Roleplay Experience
I had prepared some strange items, that are quite rare, which had not been appearing as of late, turns out, an errant return to saved object had fooled me out of it. In any case, these items while unique and proper t3 items are generally of low impact or one/few uses to be significant on the long run, while being interesting to find.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: Xenoarch t3 clothing objects were readded to the rewards pool.
/:cl:
