### PR TITLE
[Removal] Removes x-ray laser design

### DIFF
--- a/modular_nova/master_files/code/modules/research/designs/weapon_designs.dm
+++ b/modular_nova/master_files/code/modules/research/designs/weapon_designs.dm
@@ -43,3 +43,8 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
 	autolathe_exportable = FALSE
+
+// Disables xray design
+/datum/design/xray/New()
+	id = DESIGN_ID_IGNORE // Original: id = "xray_laser"
+	return ..()

--- a/modular_nova/master_files/code/modules/research/techweb/all_nodes.dm
+++ b/modular_nova/master_files/code/modules/research/techweb/all_nodes.dm
@@ -367,3 +367,12 @@
 		"mod_magnetic_deploy",
 	)
 	return ..()
+
+///////////////////////// Weapons /////////////////////////
+
+// Modularly removes x-ray
+/datum/techweb_node/beam_weapons/New()
+	design_ids -= list(
+		"xray_laser",
+	)
+	return ..()


### PR DESCRIPTION

## About The Pull Request
Just modularly removes the Xray design so that the component part to create it cannot be printed.

## How This Contributes To The Nova Sector Roleplay Experience
We had already removed it from Cargo when it we discovered it to shoot through walls. As it stands, its really hard to use with CI given people can hardly see through walls, it can hit other people without the user wanting, and even if its not used on PvP, its use on PvE is often to cheese otherwise difficult encounters by bypassing the entire encounter thanks to walls.

Opted to just remove the design so we can still enjoy it for deathmatch or other scenarios proposed by tg, and leaving the door open to other coders to tone it down or adapt it to nova.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="622" height="149" alt="image" src="https://github.com/user-attachments/assets/174e050a-cdac-470b-adca-9652d8e79f2e" />


</details>

## Changelog
:cl:
del: Removed the design for the X-Ray laser. Its still obtainable in bit running, deathmatch or admin interventions.
/:cl:
