### PR TITLE
Blueshield gets damaged tactical armor

### DIFF
--- a/modular_nova/modules/blueshield/code/closet.dm
+++ b/modular_nova/modules/blueshield/code/closet.dm
@@ -20,6 +20,8 @@
 	new /obj/item/clothing/under/rank/blueshield/russian(src)
 	new /obj/item/clothing/under/imperialvest/blueshield(src)
 	new /obj/item/clothing/under/imperialvest/blueshield(src)
+	new /obj/item/clothing/head/helmet/marine/sulaco(src)
+	new /obj/item/clothing/suit/armor/vest/marine/sulaco(src)
 
 /obj/structure/closet/secure_closet/blueshield
 	name = "blueshield's locker"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

somebody made a suggestion for it, and sure why not
gives the blueshield 2 pieces of mostly just cosmetic tactical armor

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

for their style

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

This should just work i dont see why it wouldnt.

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

:cl:
add: Blueshield now gets damaged tactical armor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
