### PR TITLE
Gun purchases/special ammo types are tied to alert levels now + price increases + some gun rebalance

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -185,6 +185,13 @@ SUBSYSTEM_DEF(shuttle)
 		else if(pack.access_view)
 			pack.desc += " Requires [SSid_access.get_access_desc(pack.access_view)] access to purchase."
 
+		// NOVA EDIT ADDITION START - Append alert level requirement to description
+		if(pack.required_alert_level > SEC_LEVEL_GREEN)
+			var/static/list/alert_level_names = list("green", "blue", "violet", "orange", "amber", "red", "delta", "epsilon", "gamma", "federal")
+			var/alert_name = alert_level_names[pack.required_alert_level + 1] // +1 because SEC_LEVEL defines are 0-indexed
+			pack.desc += " Only available at [uppertext(alert_name)] alert or higher."
+		// NOVA EDIT ADDITION END
+
 		supply_packs[pack.id] = pack
 
 	for (var/obj/machinery/computer/cargo/express/console as anything in express_consoles)

--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -24,6 +24,8 @@
 	var/locked = TRUE
 	/// Is the console in beacon mode? Exists to let beacon know when a pod may come in
 	var/using_beacon = FALSE
+	/// NOVA EDIT ADDITION - If TRUE, this console bypasses alert level restrictions on supply packs.
+	var/bypass_alert_level = FALSE
 	/// Number of beacons printed. Used to determine beacon names.
 	var/static/printed_beacons = 0
 	/// Cooldown to prevent beacon spam
@@ -110,6 +112,17 @@
 	var/datum/bank_account/account = SSeconomy.get_dep_account(cargo_account)
 	if(account)
 		data["points"] = account.account_balance
+	// NOVA EDIT ADDITION START - Alert level data for express console UI
+	data["current_alert_level"] = SSsecurity_level.get_current_level_as_number()
+	var/has_armory_access = FALSE
+	if(isliving(user))
+		var/mob/living/living_user = user
+		var/obj/item/card/id/id_card = living_user.get_idcard(TRUE)
+		if(id_card)
+			var/list/access = id_card.GetAccess()
+			has_armory_access = (ACCESS_ARMORY in access)
+	data["has_armory_access"] = has_armory_access || bypass_alert_level
+	// NOVA EDIT ADDITION END
 	data["locked"] = locked//swipe an ID to unlock
 	data["siliconUser"] = HAS_SILICON_ACCESS(user)
 	data["beaconzone"] = beacon ? get_area(beacon) : ""//where is the beacon located? outputs in the tgui
@@ -177,6 +190,20 @@
 
 			if(!istype(pack))
 				CRASH("Unknown supply pack id given by express order console ui. ID: [params["id"]]")
+
+			// NOVA EDIT ADDITION START - Alert level gating for express console purchases
+			if(!bypass_alert_level && pack.required_alert_level > SEC_LEVEL_GREEN && SSsecurity_level.get_current_level_as_number() < pack.required_alert_level)
+				var/has_bypass = FALSE
+				if(isliving(user))
+					var/mob/living/living_user = user
+					var/obj/item/card/id/id_card = living_user.get_idcard(TRUE)
+					if(id_card)
+						var/list/buyer_access = id_card.GetAccess()
+						has_bypass = (ACCESS_ARMORY in buyer_access)
+				if(!has_bypass)
+					say("This item is only available at a higher alert level.")
+					return
+			// NOVA EDIT ADDITION END
 
 			/* NOVA EDIT REMOVAL BEGIN - We use the goody system for imports, so we remove this block in order to let cargo and ghost roles to get imports
 			if((pack.order_flags & ORDER_GOODY) && !self_paid && !(obj_flags & EMAGGED))

--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -120,7 +120,7 @@
 		var/obj/item/card/id/id_card = living_user.get_idcard(TRUE)
 		if(id_card)
 			var/list/access = id_card.GetAccess()
-			has_armory_access = (ACCESS_ARMORY in access)
+			has_armory_access = (ACCESS_BRIG in access)
 	data["has_armory_access"] = has_armory_access || bypass_alert_level || (obj_flags & EMAGGED)
 	// NOVA EDIT ADDITION END
 	data["locked"] = locked//swipe an ID to unlock
@@ -199,7 +199,7 @@
 					var/obj/item/card/id/id_card = living_user.get_idcard(TRUE)
 					if(id_card)
 						var/list/buyer_access = id_card.GetAccess()
-						has_bypass = (ACCESS_ARMORY in buyer_access)
+						has_bypass = (ACCESS_BRIG in buyer_access)
 				if(!has_bypass)
 					say("This item is only available at a higher alert level.")
 					return

--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -121,7 +121,7 @@
 		if(id_card)
 			var/list/access = id_card.GetAccess()
 			has_armory_access = (ACCESS_ARMORY in access)
-	data["has_armory_access"] = has_armory_access || bypass_alert_level
+	data["has_armory_access"] = has_armory_access || bypass_alert_level || (obj_flags & EMAGGED)
 	// NOVA EDIT ADDITION END
 	data["locked"] = locked//swipe an ID to unlock
 	data["siliconUser"] = HAS_SILICON_ACCESS(user)
@@ -192,7 +192,7 @@
 				CRASH("Unknown supply pack id given by express order console ui. ID: [params["id"]]")
 
 			// NOVA EDIT ADDITION START - Alert level gating for express console purchases
-			if(!bypass_alert_level && pack.required_alert_level > SEC_LEVEL_GREEN && SSsecurity_level.get_current_level_as_number() < pack.required_alert_level)
+			if(!bypass_alert_level && !(obj_flags & EMAGGED) && pack.required_alert_level > SEC_LEVEL_GREEN && SSsecurity_level.get_current_level_as_number() < pack.required_alert_level)
 				var/has_bypass = FALSE
 				if(isliving(user))
 					var/mob/living/living_user = user

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -259,10 +259,10 @@
 		if(istype(id_card, /obj/item/card/id/advanced/chameleon)) //We'll bypass access restrictions
 			bypass = TRUE
 
-		// NOVA EDIT ADDITION START - Alert level gating for supply packs, bypassed by armory access or emag
+		// NOVA EDIT ADDITION START - Alert level gating for supply packs, bypassed by security (brig access), emag, or chameleon ID
 		if(pack.required_alert_level > SEC_LEVEL_GREEN && SSsecurity_level.get_current_level_as_number() < pack.required_alert_level)
 			var/list/buyer_access = id_card?.GetAccess()
-			if(!bypass && !(obj_flags & EMAGGED) && !(ACCESS_ARMORY in buyer_access))
+			if(!bypass && !(obj_flags & EMAGGED) && !(ACCESS_BRIG in buyer_access))
 				say("This item is only available at a higher alert level.")
 				return
 		// NOVA EDIT ADDITION END

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -259,10 +259,10 @@
 		if(istype(id_card, /obj/item/card/id/advanced/chameleon)) //We'll bypass access restrictions
 			bypass = TRUE
 
-		// NOVA EDIT ADDITION START - Alert level gating for supply packs, bypassed by armory access
+		// NOVA EDIT ADDITION START - Alert level gating for supply packs, bypassed by armory access or emag
 		if(pack.required_alert_level > SEC_LEVEL_GREEN && SSsecurity_level.get_current_level_as_number() < pack.required_alert_level)
 			var/list/buyer_access = id_card?.GetAccess()
-			if(!bypass && !(ACCESS_ARMORY in buyer_access))
+			if(!bypass && !(obj_flags & EMAGGED) && !(ACCESS_ARMORY in buyer_access))
 				say("This item is only available at a higher alert level.")
 				return
 		// NOVA EDIT ADDITION END

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -193,6 +193,7 @@
 
 		if(!(pack.console_flag & console_flag))
 			continue
+
 		// NOVA EDIT ADDITION END
 		var/obj/item/first_item = length(pack.contains) > 0 ? pack.contains[1] : null
 		packs += list(list(
@@ -205,6 +206,7 @@
 			"goody" = (pack.order_flags & ORDER_GOODY),
 			"access" = pack.access,
 			"contraband" = (pack.order_flags & ORDER_CONTRABAND),
+			"required_alert_level" = pack.required_alert_level, // NOVA EDIT ADDITION
 			"contains" = pack.get_contents_ui_data(),
 		))
 
@@ -256,6 +258,14 @@
 		var/bypass = FALSE
 		if(istype(id_card, /obj/item/card/id/advanced/chameleon)) //We'll bypass access restrictions
 			bypass = TRUE
+
+		// NOVA EDIT ADDITION START - Alert level gating for supply packs, bypassed by armory access
+		if(pack.required_alert_level > SEC_LEVEL_GREEN && SSsecurity_level.get_current_level_as_number() < pack.required_alert_level)
+			var/list/buyer_access = id_card?.GetAccess()
+			if(!bypass && !(ACCESS_ARMORY in buyer_access))
+				say("This item is only available at a higher alert level.")
+				return
+		// NOVA EDIT ADDITION END
 
 		account = id_card?.registered_account // We can still assign an account for request department purposes.
 		if(self_paid)

--- a/code/modules/cargo/packs/_packs.dm
+++ b/code/modules/cargo/packs/_packs.dm
@@ -31,6 +31,8 @@
 	var/test_ignored = FALSE
 	/// Various properties for cargo order mostly used to determine which consoles can see it
 	var/order_flags = NONE
+	/// NOVA EDIT ADDITION - Minimum security alert level required to purchase this pack. Defaults to SEC_LEVEL_GREEN (no restriction).
+	var/required_alert_level = SEC_LEVEL_GREEN
 
 /datum/supply_pack/New()
 	id = type

--- a/modular_nova/master_files/code/modules/cargo/orderconsole.dm
+++ b/modular_nova/master_files/code/modules/cargo/orderconsole.dm
@@ -23,4 +23,4 @@
 		if(id_card)
 			var/list/access = id_card.GetAccess()
 			has_armory_access = (ACCESS_ARMORY in access)
-	.["has_armory_access"] = has_armory_access
+	.["has_armory_access"] = has_armory_access || (obj_flags & EMAGGED)

--- a/modular_nova/master_files/code/modules/cargo/orderconsole.dm
+++ b/modular_nova/master_files/code/modules/cargo/orderconsole.dm
@@ -3,3 +3,24 @@
 	var/console_flag = CARGO_CONSOLE_NT
 	///Flag to indicate that this console can bypass the express console block.
 	var/bypass_express_lock = FALSE
+
+/obj/machinery/computer/cargo/Initialize(mapload)
+	. = ..()
+	RegisterSignal(SSsecurity_level, COMSIG_SECURITY_LEVEL_CHANGED, PROC_REF(on_security_level_changed))
+
+/// Refresh the UI when the station alert level changes, since some packs are gated behind alert levels.
+/obj/machinery/computer/cargo/proc/on_security_level_changed(datum/source)
+	SIGNAL_HANDLER
+	SStgui.update_uis(src)
+
+/obj/machinery/computer/cargo/ui_data(mob/user)
+	. = ..()
+	.["current_alert_level"] = SSsecurity_level.get_current_level_as_number()
+	var/has_armory_access = FALSE
+	if(isliving(user))
+		var/mob/living/living_user = user
+		var/obj/item/card/id/id_card = living_user.get_idcard(TRUE)
+		if(id_card)
+			var/list/access = id_card.GetAccess()
+			has_armory_access = (ACCESS_ARMORY in access)
+	.["has_armory_access"] = has_armory_access

--- a/modular_nova/master_files/code/modules/cargo/orderconsole.dm
+++ b/modular_nova/master_files/code/modules/cargo/orderconsole.dm
@@ -22,5 +22,5 @@
 		var/obj/item/card/id/id_card = living_user.get_idcard(TRUE)
 		if(id_card)
 			var/list/access = id_card.GetAccess()
-			has_armory_access = (ACCESS_ARMORY in access)
+			has_armory_access = (ACCESS_BRIG in access)
 	.["has_armory_access"] = has_armory_access || (obj_flags & EMAGGED)

--- a/modular_nova/master_files/code/modules/cargo/packs/companies/ammo.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/ammo.dm
@@ -148,9 +148,11 @@
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/peacekeeper_hp
 	contains = list(/obj/item/ammo_box/c9mm/hp)
+	cost = CARGO_CRATE_VALUE * 0.5
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/peacekeeper_ap
 	contains = list(/obj/item/ammo_box/c9mm/ap)
+	cost = CARGO_CRATE_VALUE * 0.5
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/peacekeeper_rubber
 	contains = list(/obj/item/ammo_box/c9mm/rubber)
@@ -160,9 +162,11 @@
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/auto10mm_hp
 	contains = list(/obj/item/ammo_box/c10mm/hp)
+	cost = CARGO_CRATE_VALUE * 0.5
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/auto10mm_ap
 	contains = list(/obj/item/ammo_box/c10mm/ap)
+	cost = CARGO_CRATE_VALUE * 0.5
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/auto10mm_rubber
 	contains = list(/obj/item/ammo_box/c10mm/rubber)
@@ -181,6 +185,7 @@
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/strilka_ap
 	contains = list(/obj/item/ammo_box/c310_cargo_box/piercing)
+	cost = CARGO_CRATE_VALUE * 0.5
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/cesarzowa_lethal
 	contains = list(/obj/item/ammo_box/c27_54cesarzowa)
@@ -196,6 +201,7 @@
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/sol35_ripper
 	contains = list(/obj/item/ammo_box/c35sol/ripper)
+	cost = CARGO_CRATE_VALUE * 0.5
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/sol40
 	contains = list(/obj/item/ammo_box/c40sol)
@@ -205,9 +211,11 @@
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/sol40_flame
 	contains = list(/obj/item/ammo_box/c40sol/incendiary)
+	cost = CARGO_CRATE_VALUE * 0.5
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/sol40_pierce
 	contains = list(/obj/item/ammo_box/c40sol/pierce)
+	cost = CARGO_CRATE_VALUE * 0.5
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/trappiste585
 	contains = list(/obj/item/ammo_box/c585trappiste)
@@ -217,6 +225,7 @@
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/trappiste585_incendiary
 	contains = list(/obj/item/ammo_box/c585trappiste/incendiary)
+	cost = CARGO_CRATE_VALUE * 0.5
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/kineticballs
 	contains = list(/obj/item/ammo_box/advanced/kineticballs)
@@ -260,15 +269,18 @@
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/shot_shells/magnum_buckshot
 	contains = list(/obj/item/ammo_box/advanced/s12gauge/magnum)
+	cost = CARGO_CRATE_VALUE * 0.5
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/shot_shells/express_buckshot
 	contains = list(/obj/item/ammo_box/advanced/s12gauge/express)
+	cost = CARGO_CRATE_VALUE * 0.5
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/shot_shells/hunter_slug
 	contains = list(/obj/item/ammo_box/advanced/s12gauge/hunter)
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/shot_shells/flechettes
 	contains = list(/obj/item/ammo_box/advanced/s12gauge/flechette)
+	cost = CARGO_CRATE_VALUE * 0.5
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/shot_shells/hornet_nest
 	contains = list(/obj/item/ammo_box/advanced/s12gauge/beehive)

--- a/modular_nova/master_files/code/modules/cargo/packs/companies/ammo.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/ammo.dm
@@ -12,6 +12,7 @@
 	desc = "Contains one speedloader of .38 DumDum ammunition, good for embedding in soft targets."
 	contains = list(/obj/item/ammo_box/speedloader/c38/dumdum)
 	auto_name = FALSE
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/nt/match38
 	name = ".38 Match Grade Speedloader Single-Pack"
@@ -31,6 +32,7 @@
 	desc = "Contains one magazine of .38 DumDum ammunition, good for embedding in soft targets."
 	auto_name = FALSE
 	contains = list(/obj/item/ammo_box/magazine/m38/dumdum)
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/nt/match38br
 	name = ".38 Match Grade Magazine Single-Pack"
@@ -149,10 +151,12 @@
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/peacekeeper_hp
 	contains = list(/obj/item/ammo_box/c9mm/hp)
 	cost = CARGO_CRATE_VALUE * 0.5
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/peacekeeper_ap
 	contains = list(/obj/item/ammo_box/c9mm/ap)
 	cost = CARGO_CRATE_VALUE * 0.5
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/peacekeeper_rubber
 	contains = list(/obj/item/ammo_box/c9mm/rubber)
@@ -163,10 +167,12 @@
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/auto10mm_hp
 	contains = list(/obj/item/ammo_box/c10mm/hp)
 	cost = CARGO_CRATE_VALUE * 0.5
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/auto10mm_ap
 	contains = list(/obj/item/ammo_box/c10mm/ap)
 	cost = CARGO_CRATE_VALUE * 0.5
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/auto10mm_rubber
 	contains = list(/obj/item/ammo_box/c10mm/rubber)
@@ -186,6 +192,7 @@
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/strilka_ap
 	contains = list(/obj/item/ammo_box/c310_cargo_box/piercing)
 	cost = CARGO_CRATE_VALUE * 0.5
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/cesarzowa_lethal
 	contains = list(/obj/item/ammo_box/c27_54cesarzowa)
@@ -202,6 +209,7 @@
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/sol35_ripper
 	contains = list(/obj/item/ammo_box/c35sol/ripper)
 	cost = CARGO_CRATE_VALUE * 0.5
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/sol40
 	contains = list(/obj/item/ammo_box/c40sol)
@@ -212,10 +220,12 @@
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/sol40_flame
 	contains = list(/obj/item/ammo_box/c40sol/incendiary)
 	cost = CARGO_CRATE_VALUE * 0.5
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/sol40_pierce
 	contains = list(/obj/item/ammo_box/c40sol/pierce)
 	cost = CARGO_CRATE_VALUE * 0.5
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/trappiste585
 	contains = list(/obj/item/ammo_box/c585trappiste)
@@ -226,6 +236,7 @@
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/trappiste585_incendiary
 	contains = list(/obj/item/ammo_box/c585trappiste/incendiary)
 	cost = CARGO_CRATE_VALUE * 0.5
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/kineticballs
 	contains = list(/obj/item/ammo_box/advanced/kineticballs)
@@ -270,10 +281,12 @@
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/shot_shells/magnum_buckshot
 	contains = list(/obj/item/ammo_box/advanced/s12gauge/magnum)
 	cost = CARGO_CRATE_VALUE * 0.5
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/shot_shells/express_buckshot
 	contains = list(/obj/item/ammo_box/advanced/s12gauge/express)
 	cost = CARGO_CRATE_VALUE * 0.5
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/shot_shells/hunter_slug
 	contains = list(/obj/item/ammo_box/advanced/s12gauge/hunter)
@@ -281,6 +294,7 @@
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/shot_shells/flechettes
 	contains = list(/obj/item/ammo_box/advanced/s12gauge/flechette)
 	cost = CARGO_CRATE_VALUE * 0.5
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/shot_shells/hornet_nest
 	contains = list(/obj/item/ammo_box/advanced/s12gauge/beehive)

--- a/modular_nova/master_files/code/modules/cargo/packs/companies/ammo.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/ammo.dm
@@ -78,6 +78,7 @@
 /datum/supply_pack/companies/mags_and_ammo/sol_grenade_standard
 	contains = list(/obj/item/ammo_box/magazine/c980_grenade/starts_empty)
 	cost = CARGO_CRATE_VALUE
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/sol_grenade_drum
 	contains = list(/obj/item/ammo_box/magazine/c980_grenade/drum/starts_empty)
@@ -85,12 +86,14 @@
 	access_view = ACCESS_WEAPONS
 	express_lock = TRUE
 	order_flags = ORDER_GOODY
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/jager_shotgun_regular
 	contains = list(/obj/item/ammo_box/magazine/jager/empty)
 	access_view = ACCESS_WEAPONS
 	express_lock = TRUE
 	order_flags = ORDER_GOODY
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/jager_shotgun_Large
 	contains = list(/obj/item/ammo_box/magazine/jager/large/empty)
@@ -98,6 +101,7 @@
 	access_view = ACCESS_WEAPONS
 	express_lock = TRUE
 	order_flags = ORDER_GOODY
+	required_alert_level = SEC_LEVEL_AMBER
 
 // HC Mags
 
@@ -110,6 +114,7 @@
 /datum/supply_pack/companies/mags_and_ammo/hc_surplus/zaibas
 	contains = list(/obj/item/ammo_box/magazine/pulse/spawns_empty)
 	cost = CARGO_CRATE_VALUE * 0.5
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/hc_surplus/zashch
 	contains = list(/obj/item/ammo_box/magazine/zashch/spawns_empty)
@@ -119,16 +124,19 @@
 
 /datum/supply_pack/companies/mags_and_ammo/hc_surplus/napad
 	contains = list(/obj/item/ammo_box/magazine/napad/spawns_empty)
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/hc_surplus/sakhno
 	contains = list(/obj/item/ammo_box/speedloader/strilka310)
 
 /datum/supply_pack/companies/mags_and_ammo/hc_surplus/lanca
 	contains = list(/obj/item/ammo_box/magazine/lanca/spawns_empty)
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/hc_surplus/amr_magazine
 	contains = list(/obj/item/ammo_box/magazine/wylom)
 	cost = CARGO_CRATE_VALUE * 0.75
+	required_alert_level = SEC_LEVEL_AMBER
 
 // Vitezstv★ Boxes of non-shotgun ammo
 
@@ -163,6 +171,7 @@
 	contains = list(/obj/item/ammo_box/pulse_cargo_box)
 	//It's like, a lot of ammo compared to other packages; high-capacity universal ammo for all pulse plasma guns.
 	cost = CARGO_CRATE_VALUE
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/ammo_boxes/strilka_lethal
 	contains = list(/obj/item/ammo_box/c310_cargo_box)
@@ -289,18 +298,21 @@
 	access_view = ACCESS_WEAPONS
 	express_lock = TRUE
 	order_flags = ORDER_GOODY
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/grenade_shells/phosphor
 	contains = list(/obj/item/ammo_box/c980grenade/shrapnel/phosphor)
 	access_view = ACCESS_WEAPONS
 	express_lock = TRUE
 	order_flags = ORDER_GOODY
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/mags_and_ammo/vitezstvi/grenade_shells/concussion
 	contains = list(/obj/item/ammo_box/c980grenade/concussive)
 	access_view = ACCESS_WEAPONS
 	express_lock = TRUE
 	order_flags = ORDER_GOODY
+	required_alert_level = SEC_LEVEL_AMBER
 
 //Blacksteel Ammo
 

--- a/modular_nova/master_files/code/modules/cargo/packs/companies/ballistics.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/ballistics.dm
@@ -36,6 +36,7 @@
 /datum/supply_pack/companies/ballistics/nt/shotgun_automatic
 	cost = CARGO_CRATE_VALUE * 5
 	contains = list(/obj/item/gun/ballistic/shotgun/automatic/combat)
+	required_alert_level = SEC_LEVEL_BLUE
 
 /datum/supply_pack/companies/ballistics/nt/c38_super_kit
 	name = "NT/E \"Laevateinn\" Revolver Conversion Kit"
@@ -80,6 +81,7 @@
 
 /datum/supply_pack/companies/ballistics/sol_fed/longarm
 	cost = CARGO_CRATE_VALUE * 3
+	required_alert_level = SEC_LEVEL_BLUE
 
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/renoster_super_kit
 	name = "Archon Systems \"KOLBEN/NACHTREIHER\" M64 Shotgun Conversion Kit"
@@ -113,10 +115,12 @@
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/br38
 	contains = list(/obj/item/gun/ballistic/automatic/battle_rifle)
 	cost = CARGO_CRATE_VALUE * 4
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/elite
 	contains = list(/obj/item/gun/ballistic/automatic/sol_classic/marksman)
 	cost = CARGO_CRATE_VALUE * 6
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/bogseo
 	contains = list(/obj/item/gun/ballistic/automatic/xhihao_smg)
@@ -125,10 +129,12 @@
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/jager
 	contains = list(/obj/item/gun/ballistic/shotgun/katyusha/jager)
 	cost = CARGO_CRATE_VALUE * 8
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/infanterie
 	contains = list(/obj/item/gun/ballistic/automatic/sol_classic)
 	cost = CARGO_CRATE_VALUE * 7
+	required_alert_level = SEC_LEVEL_AMBER
 
 /* //
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/outomaties
@@ -139,11 +145,13 @@
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/kiboko
 	contains = list(/obj/item/gun/ballistic/automatic/sol_grenade_launcher)
 	cost = CARGO_CRATE_VALUE * 23
+	required_alert_level = SEC_LEVEL_AMBER
 
 // HC Surplus
 
 /datum/supply_pack/companies/ballistics/hc_surplus
 	cost = CARGO_CRATE_VALUE * 3
+	required_alert_level = SEC_LEVEL_BLUE
 
 /datum/supply_pack/companies/ballistics/hc_surplus/shotgun_revolver
 	contains = list(/obj/item/gun/ballistic/revolver/shotgun_revolver)
@@ -151,6 +159,7 @@
 	access_view = FALSE
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY
+	required_alert_level = SEC_LEVEL_GREEN
 
 /datum/supply_pack/companies/ballistics/hc_surplus/zashch
 	contains = list(/obj/item/gun/ballistic/automatic/pistol/zashch)
@@ -158,6 +167,7 @@
 	access_view = FALSE
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY
+	required_alert_level = SEC_LEVEL_GREEN
 
 /datum/supply_pack/companies/ballistics/hc_surplus/miecz
 	contains = list(/obj/item/gun/ballistic/automatic/miecz)
@@ -166,6 +176,7 @@
 /datum/supply_pack/companies/ballistics/hc_surplus/napad
 	contains = list(/obj/item/gun/ballistic/automatic/napad)
 	cost = CARGO_CRATE_VALUE * 6
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/ballistics/hc_surplus/sakhno_rifle
 	contains = list(/obj/item/gun/ballistic/rifle/boltaction)
@@ -174,10 +185,12 @@
 /datum/supply_pack/companies/ballistics/hc_surplus/lanca
 	contains = list(/obj/item/gun/ballistic/automatic/lanca)
 	cost = CARGO_CRATE_VALUE * 7
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/ballistics/hc_surplus/anti_materiel_rifle
 	contains = list(/obj/item/gun/ballistic/automatic/wylom)
 	cost = CARGO_CRATE_VALUE * 8
+	required_alert_level = SEC_LEVEL_AMBER
 
 // Donk
 

--- a/modular_nova/master_files/code/modules/cargo/packs/companies/ballistics.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/ballistics.dm
@@ -14,7 +14,7 @@
 /datum/supply_pack/companies/ballistics/nt/mars_single
 	name = "Colt Detective Special"
 	desc = "The HoS took your gun and your badge? No problem! Just pay the absurd taxation fee and you too can be reunited with the lethal power of a .38!"
-	cost = CARGO_CRATE_VALUE * 2.5
+	cost = CARGO_CRATE_VALUE * 4
 	auto_name = FALSE
 	access = FALSE
 	access_view = FALSE
@@ -25,7 +25,7 @@
 /datum/supply_pack/companies/ballistics/nt/double_barrel
 	name = "Double-Barreled Shotgun"
 	desc = "Lost your beloved bunny to a demonic invasion? Clown broke in and stole your beloved gun? No worries! Get a new gun as long as you can pay the absurd fees."
-	cost = CARGO_CRATE_VALUE * 2
+	cost = CARGO_CRATE_VALUE * 4
 	auto_name = FALSE
 	access = FALSE
 	access_view = FALSE
@@ -34,7 +34,7 @@
 	contains = list(/obj/item/gun/ballistic/shotgun/doublebarrel)
 
 /datum/supply_pack/companies/ballistics/nt/shotgun_automatic
-	cost = CARGO_CRATE_VALUE * 5
+	cost = CARGO_CRATE_VALUE * 7.5
 	contains = list(/obj/item/gun/ballistic/shotgun/automatic/combat)
 	required_alert_level = SEC_LEVEL_BLUE
 
@@ -56,7 +56,7 @@
 /datum/supply_pack/companies/ballistics/sol_fed
 
 /datum/supply_pack/companies/ballistics/sol_fed/sidearm
-	cost = CARGO_CRATE_VALUE * 2
+	cost = CARGO_CRATE_VALUE * 4
 	access = FALSE
 	access_view = FALSE
 	express_lock = FALSE
@@ -73,20 +73,20 @@
 
 /datum/supply_pack/companies/ballistics/sol_fed/sidearm/skild
 	contains = list(/obj/item/gun/ballistic/automatic/pistol/trappiste)
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 5
 
 /datum/supply_pack/companies/ballistics/sol_fed/sidearm/takbok
 	contains = list(/obj/item/gun/ballistic/revolver/takbok)
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 5
 
 /datum/supply_pack/companies/ballistics/sol_fed/longarm
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 6
 	required_alert_level = SEC_LEVEL_BLUE
 
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/renoster_super_kit
 	name = "Archon Systems \"KOLBEN/NACHTREIHER\" M64 Shotgun Conversion Kit"
 	desc = "A set of parts for converting an M64 shotgun into one of Archon Combat Systems's forays into improving the shotgun's end-user experience."
-	cost = CARGO_CRATE_VALUE * 3 // 600 cr at time of writing, 1200 cr total
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/crafting_conversion_kit/riot_sol_super)
 	auto_name = FALSE
 	access = FALSE
@@ -96,7 +96,7 @@
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/doublebarrel_super_kit
 	name = "Archon Systems \"LAMMERGEIER\" Double-Barrel Shotgun Conversion Kit"
 	desc = "A set of parts for converting a double-barrel shotgun into one of Archon Combat Systems's forays into improving the shotgun's end-user experience."
-	cost = CARGO_CRATE_VALUE * 3 // 600 cr at time of writing, 1000 cr total
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/crafting_conversion_kit/doublebarrel_super)
 	auto_name = FALSE
 	access = FALSE
@@ -111,29 +111,30 @@
 
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/type213
 	contains = list(/obj/item/gun/ballistic/automatic/type213)
+	cost = CARGO_CRATE_VALUE * 4
 
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/br38
 	contains = list(/obj/item/gun/ballistic/automatic/battle_rifle)
-	cost = CARGO_CRATE_VALUE * 4
+	cost = CARGO_CRATE_VALUE * 8
 	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/elite
 	contains = list(/obj/item/gun/ballistic/automatic/sol_classic/marksman)
-	cost = CARGO_CRATE_VALUE * 6
+	cost = CARGO_CRATE_VALUE * 12
 	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/bogseo
 	contains = list(/obj/item/gun/ballistic/automatic/xhihao_smg)
-	cost = CARGO_CRATE_VALUE * 5
+	cost = CARGO_CRATE_VALUE * 6.5
 
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/jager
 	contains = list(/obj/item/gun/ballistic/shotgun/katyusha/jager)
-	cost = CARGO_CRATE_VALUE * 8
+	cost = CARGO_CRATE_VALUE * 12.5
 	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/infanterie
 	contains = list(/obj/item/gun/ballistic/automatic/sol_classic)
-	cost = CARGO_CRATE_VALUE * 7
+	cost = CARGO_CRATE_VALUE * 11
 	required_alert_level = SEC_LEVEL_AMBER
 
 /* //
@@ -150,11 +151,12 @@
 // HC Surplus
 
 /datum/supply_pack/companies/ballistics/hc_surplus
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 6
 	required_alert_level = SEC_LEVEL_BLUE
 
 /datum/supply_pack/companies/ballistics/hc_surplus/shotgun_revolver
 	contains = list(/obj/item/gun/ballistic/revolver/shotgun_revolver)
+	cost = CARGO_CRATE_VALUE * 5
 	access = FALSE
 	access_view = FALSE
 	express_lock = FALSE
@@ -163,6 +165,7 @@
 
 /datum/supply_pack/companies/ballistics/hc_surplus/zashch
 	contains = list(/obj/item/gun/ballistic/automatic/pistol/zashch)
+	cost = CARGO_CRATE_VALUE * 5
 	access = FALSE
 	access_view = FALSE
 	express_lock = FALSE
@@ -171,11 +174,11 @@
 
 /datum/supply_pack/companies/ballistics/hc_surplus/miecz
 	contains = list(/obj/item/gun/ballistic/automatic/miecz)
-	cost = CARGO_CRATE_VALUE * 5
+	cost = CARGO_CRATE_VALUE * 6.5
 
 /datum/supply_pack/companies/ballistics/hc_surplus/napad
 	contains = list(/obj/item/gun/ballistic/automatic/napad)
-	cost = CARGO_CRATE_VALUE * 6
+	cost = CARGO_CRATE_VALUE * 10
 	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/ballistics/hc_surplus/sakhno_rifle
@@ -184,12 +187,12 @@
 
 /datum/supply_pack/companies/ballistics/hc_surplus/lanca
 	contains = list(/obj/item/gun/ballistic/automatic/lanca)
-	cost = CARGO_CRATE_VALUE * 7
+	cost = CARGO_CRATE_VALUE * 11
 	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/ballistics/hc_surplus/anti_materiel_rifle
 	contains = list(/obj/item/gun/ballistic/automatic/wylom)
-	cost = CARGO_CRATE_VALUE * 8
+	cost = CARGO_CRATE_VALUE * 12.5
 	required_alert_level = SEC_LEVEL_AMBER
 
 // Donk

--- a/modular_nova/master_files/code/modules/cargo/packs/companies/energy.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/energy.dm
@@ -10,7 +10,7 @@
 /datum/supply_pack/companies/energy/microstar
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_weapons
-	cost = CARGO_CRATE_VALUE * 1.25
+	cost = CARGO_CRATE_VALUE * 2.5
 	access = FALSE
 	access_view = FALSE
 	express_lock = FALSE
@@ -23,12 +23,12 @@
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_weapons/advtaser
 	contains = list(/obj/item/gun/energy/e_gun/advtaser)
-	cost = CARGO_CRATE_VALUE * 1.75
+	cost = CARGO_CRATE_VALUE * 2.5
 	required_alert_level = SEC_LEVEL_GREEN
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_weapons/disabler_smg
 	contains = list(/obj/item/gun/energy/disabler/smg)
-	cost = CARGO_CRATE_VALUE * 1.75
+	cost = CARGO_CRATE_VALUE * 3.5
 	access = ACCESS_WEAPONS
 	access_view = ACCESS_WEAPONS
 	express_lock = TRUE
@@ -44,14 +44,14 @@
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_weapons/energy_holster
 	contains = list(/obj/item/storage/belt/holster/energy/thermal)
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 6
 	required_alert_level = SEC_LEVEL_BLUE
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/laser
 	contains = list(/obj/item/gun/energy/laser)
-	cost = CARGO_CRATE_VALUE * 1.25
+	cost = CARGO_CRATE_VALUE * 4
 	access = FALSE
 	access_view = FALSE
 	express_lock = FALSE
@@ -63,17 +63,17 @@
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/laser_carbine
 	contains = list(/obj/item/gun/energy/laser/carbine)
-	cost = CARGO_CRATE_VALUE * 1.75
+	cost = CARGO_CRATE_VALUE * 3.5
 	required_alert_level = SEC_LEVEL_BLUE
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/laser_assault
 	contains = list(/obj/item/gun/energy/laser/assault)
-	cost = CARGO_CRATE_VALUE * 4
+	cost = CARGO_CRATE_VALUE * 8
 	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/egun
 	contains = list(/obj/item/gun/energy/e_gun)
-	cost = CARGO_CRATE_VALUE * 2
+	cost = CARGO_CRATE_VALUE * 4
 	access = FALSE
 	access_view = FALSE
 	express_lock = FALSE
@@ -82,7 +82,7 @@
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/mod_laser_small
 	contains = list(/obj/item/gun/energy/modular_laser_rifle/carbine)
-	cost = CARGO_CRATE_VALUE * 2.5
+	cost = CARGO_CRATE_VALUE * 5
 	access = FALSE
 	access_view = FALSE
 	express_lock = FALSE
@@ -91,11 +91,11 @@
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/mod_laser_large
 	contains = list(/obj/item/gun/energy/modular_laser_rifle)
-	cost = CARGO_CRATE_VALUE * 4
+	cost = CARGO_CRATE_VALUE * 6.5
 	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/energy/microstar/experimental_energy
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 8
 
 /datum/supply_pack/companies/energy/microstar/experimental_energy/ion_carbine
 	contains = list(/obj/item/gun/energy/ionrifle/carbine)
@@ -106,10 +106,12 @@
 
 /datum/supply_pack/companies/energy/hc_surplus/plasma_thrower
 	contains = list(/obj/item/gun/ballistic/automatic/pistol/plasma_thrower)
+	cost = CARGO_CRATE_VALUE * 4.25
 	required_alert_level = SEC_LEVEL_BLUE
 
 /datum/supply_pack/companies/energy/hc_surplus/plasma_marksman
 	contains = list(/obj/item/gun/ballistic/automatic/pistol/plasma_marksman)
+	cost = CARGO_CRATE_VALUE * 4.25
 	access = FALSE
 	access_view = FALSE
 	express_lock = FALSE
@@ -117,7 +119,7 @@
 
 /datum/supply_pack/companies/energy/hc_surplus/crank_taser
 	contains = list(/obj/item/gun/energy/taser/crank)
-	cost = CARGO_CRATE_VALUE * 2
+	cost = CARGO_CRATE_VALUE * 4
 	access = FALSE
 	access_view = FALSE
 	express_lock = FALSE
@@ -125,7 +127,7 @@
 
 /datum/supply_pack/companies/energy/hc_surplus/stun_gun //Not a gun but it's only fair to place similar items close to each other
 	contains = list(/obj/item/melee/baton/security/stun_gun/loaded)
-	cost = CARGO_CRATE_VALUE * 1.5 //Similarly live action roleplay'iy stun baton lite
+	cost = CARGO_CRATE_VALUE * 2.5 //Similarly live action roleplay'iy stun baton lite
 	access = FALSE
 	access_view = FALSE
 	express_lock = FALSE
@@ -133,10 +135,10 @@
 
 /datum/supply_pack/companies/energy/hc_surplus/zaibas
 	contains = list(/obj/item/gun/ballistic/automatic/pulse_rifle)
-	cost = CARGO_CRATE_VALUE * 6
+	cost = CARGO_CRATE_VALUE * 12
 	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/energy/hc_surplus/zaibas_a
 	contains = list(/obj/item/gun/ballistic/rifle/pulse_sniper)
-	cost = CARGO_CRATE_VALUE * 7
+	cost = CARGO_CRATE_VALUE * 11
 	required_alert_level = SEC_LEVEL_AMBER

--- a/modular_nova/master_files/code/modules/cargo/packs/companies/energy.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/energy.dm
@@ -15,13 +15,16 @@
 	access_view = FALSE
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY
+	required_alert_level = SEC_LEVEL_BLUE
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_weapons/disabler
 	contains = list(/obj/item/gun/energy/disabler)
+	required_alert_level = SEC_LEVEL_GREEN
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_weapons/advtaser
 	contains = list(/obj/item/gun/energy/e_gun/advtaser)
 	cost = CARGO_CRATE_VALUE * 1.75
+	required_alert_level = SEC_LEVEL_GREEN
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_weapons/disabler_smg
 	contains = list(/obj/item/gun/energy/disabler/smg)
@@ -33,13 +36,16 @@
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_weapons/mini_egun
 	contains = list(/obj/item/gun/energy/e_gun/mini)
+	required_alert_level = SEC_LEVEL_GREEN
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_weapons/laser_pistol
 	contains = list(/obj/item/gun/energy/laser/pistol)
+	required_alert_level = SEC_LEVEL_GREEN
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_weapons/energy_holster
 	contains = list(/obj/item/storage/belt/holster/energy/thermal)
 	cost = CARGO_CRATE_VALUE * 3
+	required_alert_level = SEC_LEVEL_BLUE
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons
 
@@ -50,6 +56,7 @@
 	access_view = FALSE
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY
+	required_alert_level = SEC_LEVEL_BLUE
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/laser/soul
 	contains = list(/obj/item/gun/energy/laser/soul)
@@ -57,10 +64,12 @@
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/laser_carbine
 	contains = list(/obj/item/gun/energy/laser/carbine)
 	cost = CARGO_CRATE_VALUE * 1.75
+	required_alert_level = SEC_LEVEL_BLUE
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/laser_assault
 	contains = list(/obj/item/gun/energy/laser/assault)
 	cost = CARGO_CRATE_VALUE * 4
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/egun
 	contains = list(/obj/item/gun/energy/e_gun)
@@ -69,6 +78,7 @@
 	access_view = FALSE
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY
+	required_alert_level = SEC_LEVEL_BLUE
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/mod_laser_small
 	contains = list(/obj/item/gun/energy/modular_laser_rifle/carbine)
@@ -77,22 +87,26 @@
 	access_view = FALSE
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY
+	required_alert_level = SEC_LEVEL_BLUE
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/mod_laser_large
 	contains = list(/obj/item/gun/energy/modular_laser_rifle)
 	cost = CARGO_CRATE_VALUE * 4
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/energy/microstar/experimental_energy
 	cost = CARGO_CRATE_VALUE * 3
 
 /datum/supply_pack/companies/energy/microstar/experimental_energy/ion_carbine
 	contains = list(/obj/item/gun/energy/ionrifle/carbine)
+	required_alert_level = SEC_LEVEL_AMBER
 
 // HC Weapons
 /datum/supply_pack/companies/energy/hc_surplus
 
 /datum/supply_pack/companies/energy/hc_surplus/plasma_thrower
 	contains = list(/obj/item/gun/ballistic/automatic/pistol/plasma_thrower)
+	required_alert_level = SEC_LEVEL_BLUE
 
 /datum/supply_pack/companies/energy/hc_surplus/plasma_marksman
 	contains = list(/obj/item/gun/ballistic/automatic/pistol/plasma_marksman)
@@ -120,7 +134,9 @@
 /datum/supply_pack/companies/energy/hc_surplus/zaibas
 	contains = list(/obj/item/gun/ballistic/automatic/pulse_rifle)
 	cost = CARGO_CRATE_VALUE * 6
+	required_alert_level = SEC_LEVEL_AMBER
 
 /datum/supply_pack/companies/energy/hc_surplus/zaibas_a
 	contains = list(/obj/item/gun/ballistic/rifle/pulse_sniper)
 	cost = CARGO_CRATE_VALUE * 7
+	required_alert_level = SEC_LEVEL_AMBER

--- a/modular_nova/modules/cargo/code/expressconsole.dm
+++ b/modular_nova/modules/cargo/code/expressconsole.dm
@@ -12,6 +12,7 @@
 	cargo_account = ACCOUNT_CIV /// Change this later to something else, as this is meant to prevent runtiming
 	contraband = TRUE
 	bypass_express_lock = TRUE
+	bypass_alert_level = TRUE
 	console_flag = CARGO_CONSOLE_PDA
 
 	pod_type = /obj/structure/closet/supplypod/bluespacepod

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/magazines.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/magazines.dm
@@ -128,13 +128,13 @@
 
 /obj/item/ammo_box/magazine/zashch
 	name = "\improper Zashch pistol magazine"
-	desc = "A large magazine for the Zashchitnik pistol. Holds 18 rounds of 10mm."
+	desc = "A magazine for the Zashchitnik pistol. Holds 10 rounds of 10mm."
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/company_and_or_faction_based/szot_dynamica/ammo.dmi'
 	icon_state = "zashch_mag"
 	base_icon_state = "zashch_mag"
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 	ammo_type = /obj/item/ammo_casing/c10mm
-	max_ammo = 18
+	max_ammo = 10
 	caliber = CALIBER_10MM
 
 /obj/item/ammo_box/magazine/zashch/spawns_empty

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/pistol.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/pistol.dm
@@ -123,7 +123,7 @@
 
 /obj/item/gun/ballistic/automatic/pistol/zashch
 	name = "\improper 'Zashch' Heavy Pistol"
-	desc = "A hulking, self-loading 10mm handgun, designated 'Zashchitnik'. Feeds from large 18 round box magazines."
+	desc = "A hulking, self-loading 10mm handgun, designated 'Zashchitnik'. Feeds from 10 round box magazines."
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/company_and_or_faction_based/szot_dynamica/guns_32.dmi'
 	icon_state = "zashch"
 	lefthand_file = 'modular_nova/modules/modular_weapons/icons/mob/company_and_or_faction_based/szot_dynamica/guns_lefthand.dmi'

--- a/modular_nova/modules/modular_weapons/code/overrides/energy.dm
+++ b/modular_nova/modules/modular_weapons/code/overrides/energy.dm
@@ -11,7 +11,7 @@
 	desc = "The Allstar Lasers Star Combat 1 Compact, or \"Allstar SC-1/C\", \
 		is a compact pistol variant of the venerable SC-1 designed with a focus on portability."
 	w_class = WEIGHT_CLASS_SMALL
-	projectile_damage_multiplier = 1
+	projectile_damage_multiplier = 0.8 // 25 * 0.8 = 20 damage, reduced for GREEN tier availability
 
 /obj/item/gun/energy/laser/assault
 	name = "laser assault rifle"
@@ -55,6 +55,9 @@
 
 /obj/item/gun/energy/laser/captain
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/hellfire/blueshield) // 20 hellfires up from 15
+
+/obj/item/gun/energy/e_gun/mini
+	projectile_damage_multiplier = 0.8 // 25 * 0.8 = 20 damage (laser), 30 * 0.8 = 24 damage (disabler), reduced for GREEN tier availability
 
 /obj/item/gun/energy/e_gun
 	name = "energy carbine"

--- a/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
@@ -181,12 +181,16 @@ type CatalogListProps = {
 
 function CatalogList(props: CatalogListProps) {
   const { act, data } = useBackend<CargoData>();
-  const { cart = [], max_order, self_paid, app_cost, displayed_currency_name } = data;
+  const { cart = [], max_order, self_paid, app_cost, displayed_currency_name, current_alert_level, has_armory_access } = data;
   const { packs = [], openContents } = props;
 
   return (
     <>
       {packs.map((pack) => {
+        const alertLocked = pack.required_alert_level > 0
+          && current_alert_level < pack.required_alert_level
+          && !has_armory_access;
+
         let color = '';
         const digits = Math.floor(Math.log10(pack.cost) + 1);
         if (self_paid) {
@@ -221,8 +225,9 @@ function CatalogList(props: CatalogListProps) {
             dmIcon={pack.first_item_icon}
             dmIconState={pack.first_item_icon_state}
             imageSize={32}
-            color={color}
-            disabled={amount >= max_order}
+            color={alertLocked ? 'transparent' : color}
+            disabled={amount >= max_order || alertLocked}
+            opacity={alertLocked ? 0.5 : 1}
             buttonsAlt={
               <Button
                 color="transparent"
@@ -240,7 +245,7 @@ function CatalogList(props: CatalogListProps) {
               <Stack.Item grow textAlign="left">
                 {pack.name}
               </Stack.Item>
-              {(!!pack.small_item || !!pack.access || !!pack.contraband) && (
+              {(!!pack.small_item || !!pack.access || !!pack.contraband || alertLocked) && (
                 <Stack.Item>
                   <Stack reverse>
                     {!!pack.small_item &&
@@ -249,6 +254,12 @@ function CatalogList(props: CatalogListProps) {
                       tooltipIcon('Restricted', 'lock', 'average')}
                     {!!pack.contraband &&
                       tooltipIcon('Contraband', 'pastafarianism', 'bad')}
+                    {alertLocked &&
+                      tooltipIcon(
+                        'Requires Higher Alert Level',
+                        'triangle-exclamation',
+                        pack.required_alert_level >= 4 ? 'yellow' : 'blue',
+                      )}
                   </Stack>
                 </Stack.Item>
               )}

--- a/tgui/packages/tgui/interfaces/Cargo/types.ts
+++ b/tgui/packages/tgui/interfaces/Cargo/types.ts
@@ -6,11 +6,13 @@ export type CargoData = {
   can_approve_requests: BooleanLike;
   can_send: BooleanLike;
   cart: CartEntry[];
+  current_alert_level: number;
   department: string;
   displayed_currency_full_name: string;
   displayed_currency_name: string;
   docked: BooleanLike;
   grocery: number;
+  has_armory_access: BooleanLike;
   loan_dispatched: BooleanLike;
   loan: BooleanLike;
   location: string;
@@ -30,6 +32,7 @@ export type SupplyCategory = {
 
 export type Supply = {
   access: BooleanLike;
+  required_alert_level: number;
   cost: number;
   desc: string;
   first_item_icon: string | null;


### PR DESCRIPTION

## About The Pull Request

Changes are made to cargo so certain guns are tied to alert levels before they can be purchased. List is provisional, this is right now just a proof of concept. I'll probably balance one or 2 guns along the way too. Prices have also been increased across the board. Brig access bypasses the alert requirement, this includes security officers, warden, HoS and captain (not detectives). Emag bypasses this.

## How This Contributes To The Nova Sector Roleplay Experience

Gargo has been a contentious topic for years at this point. It's brought up from time to time, most complaints coming in the form of guns being too cheap and/or the non-security crew being too armed beyond what would be considered reasonable. I aim to put a stop to that without outright destroying gargo because I still think it has a purpose and it's beneficial to the server, only not in its current form where anyone can buy almost whatever gun they want with 2-3 bounties and bother the captain/HoP for 2 minutes and 200-400 cr. People still deserve to earn the means to defend themselves, however I'm personally tired of seeing non-security members armed to the absolute teeth when the global situation doesn't warrant that level of escalation. It's detrimental for roleplay.

Avoids militarizing the station right at roundstart, It's jarring to see a janitor with an assault rifle for "self-defense" when nothing is happening and breaks the immersion a little. Small arms? sure, frontier is dangerous and a revolver or a pistol are totally reasonable; we don't want security to unilaterally hold all the strength. An AMR, even if you have a weapon permit? nah.

To be clear, if this doesn't go through in the end I still prefer gargo to remain as is rather than deleting it outright. People will want means to defend itself, if not through gargo via departmental shenanigans.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="1635" height="1110" alt="image" src="https://github.com/user-attachments/assets/6f7f7bbb-64a5-46ee-b43d-6a8986f70f77" />
Express console has the restrictions too
</details>

## Changelog
:cl:
balance: alert level restrict the purchase of certain items. Right now brig level access bypass this
balance: zasch magazines have 10 rounds now
balance: heavy price adjustment for cargo guns (all have gone up)
balance: mini egun and laser pistol damage reduced to 20 from 25
/:cl:
