### PR TITLE
spaceship plates + spaceship glass lathe/smelter recipes

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -269,6 +269,10 @@
 					WD = new/obj/structure/window/reinforced/plasma/plastitanium(drop_location())
 				else if(istype(W, /obj/item/stack/sheet/bronze))
 					WD = new/obj/structure/window/bronze/fulltile(drop_location())
+				// NOVA EDIT ADDITION START
+				else if (istype(W, /obj/item/stack/sheet/spaceshipglass))
+					WD = new /obj/structure/window/reinforced/shuttle/spaceship(drop_location())
+				// NOVA EDIT ADDITION END
 				else
 					WD = new/obj/structure/window/fulltile(drop_location()) //normal window
 				WD.setDir(dir_to_set)

--- a/modular_nova/master_files/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/modular_nova/master_files/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -152,12 +152,22 @@ GLOBAL_LIST_INIT(nova_leather_belt_recipes, list(
 // Titanium
 
 GLOBAL_LIST_INIT(nova_titanium_recipes, list(
-	new/datum/stack_recipe("spaceship plating", /obj/item/stack/sheet/spaceship, 1, time = 5, category = CAT_MISC),
+	new/datum/stack_recipe("spaceship plating", /obj/item/stack/sheet/spaceship, 1, 1, max_res_amount = 50, category = CAT_MISC),
 ))
 
 /obj/item/stack/sheet/mineral/titanium/get_main_recipes()
 	. = ..()
 	. += GLOB.nova_titanium_recipes
+
+// Titanium Glass
+
+GLOBAL_LIST_INIT(nova_titaniumglass_recipes, list(
+	new/datum/stack_recipe("spaceship glass", /obj/item/stack/sheet/spaceshipglass, 1, 1, max_res_amount = 50, category = CAT_MISC),
+))
+
+/obj/item/stack/sheet/titaniumglass/get_main_recipes()
+	. = ..()
+	. += GLOB.nova_titaniumglass_recipes
 
 // Snow
 

--- a/modular_nova/master_files/code/modules/mining/equipment/survival_pod.dm
+++ b/modular_nova/master_files/code/modules/mining/equipment/survival_pod.dm
@@ -8,6 +8,7 @@
 	receive_ricochet_chance_mod = 1.2
 	rad_insulation = RAD_MEDIUM_INSULATION
 	glass_material_datum = /datum/material/alloy/titaniumglass
+	custom_materials = list(/datum/material/alloy/titaniumglass = SHEET_MATERIAL_AMOUNT)
 
 /obj/structure/window/reinforced/survival_pod/unanchored
 	anchored = FALSE

--- a/modular_nova/master_files/code/modules/mining/equipment/survival_pod.dm
+++ b/modular_nova/master_files/code/modules/mining/equipment/survival_pod.dm
@@ -1,0 +1,14 @@
+/obj/structure/window/reinforced/survival_pod
+	max_integrity = 75
+	reinf = FALSE // this actually only determines if it drops a rod when broken. neat!
+	armor_type = /datum/armor/reinforced_shuttle
+	explosion_block = 2
+	glass_type = /obj/item/stack/sheet/titaniumglass
+	glass_amount = 1
+	receive_ricochet_chance_mod = 1.2
+	rad_insulation = RAD_MEDIUM_INSULATION
+	glass_material_datum = /datum/material/alloy/titaniumglass
+
+/obj/structure/window/reinforced/survival_pod/unanchored
+	anchored = FALSE
+	state = WINDOW_OUT_OF_FRAME

--- a/modular_nova/master_files/code/modules/research/designs/smelting_designs.dm
+++ b/modular_nova/master_files/code/modules/research/designs/smelting_designs.dm
@@ -1,0 +1,23 @@
+// spaceship plates (titanium)
+/datum/design/spaceship_plates
+	name = "Spaceship Plates"
+	id = "spaceship_plates"
+	build_type = SMELTER | PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/titanium = SHEET_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sheet/spaceship
+	category = list(
+		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_MATERIALS
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_CARGO | DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING
+
+// spaceship glass (titanium glass)
+/datum/design/spaceship_glass
+	name = "Spaceship Glass"
+	id = "spaceship_glass"
+	build_type = SMELTER | PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/titanium = SHEET_MATERIAL_AMOUNT * 0.5, /datum/material/glass = SHEET_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sheet/spaceshipglass
+	category = list(
+		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_MATERIALS
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_CARGO | DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING

--- a/modular_nova/master_files/code/modules/research/techweb/all_nodes.dm
+++ b/modular_nova/master_files/code/modules/research/techweb/all_nodes.dm
@@ -107,6 +107,13 @@
 	)
 	return ..()
 
+/datum/techweb_node/material_processing/New()
+	design_ids += list(
+		"spaceship_plates",
+		"spaceship_glass",
+	)
+	return ..()
+
 /////////////////////////Biotech/////////////////////////
 
 /datum/techweb_node/medbay_equip_adv/New()
@@ -345,7 +352,7 @@
 	)
 	return ..()
 
-/////////////////////////Applied Bluespace /////////////////////////
+///////////////////////// Applied Bluespace /////////////////////////
 
 /datum/techweb_node/applied_bluespace/New()
 	design_ids += list(

--- a/modular_nova/modules/mapping/code/spaceship_items.dm
+++ b/modular_nova/modules/mapping/code/spaceship_items.dm
@@ -1,6 +1,6 @@
 /obj/item/stack/sheet/spaceship
 	name = "spaceship plating"
-	desc = "A metal sheet made out of a titanium alloy, rivited for use in spaceship walls."
+	desc = "A metal sheet made out of a titanium alloy, riveted for use in spaceship walls."
 	icon = 'modular_nova/modules/mapping/icons/unique/spaceships/shipstacks.dmi'
 	icon_state = "sheet-spaceship"
 	inhand_icon_state = "sheet-plastitaniumglass"
@@ -8,16 +8,17 @@
 	construction_path_type = "spaceship"
 	merge_type = /obj/item/stack/sheet/spaceship
 	walltype = /turf/closed/wall/mineral/titanium/spaceship
-	mats_per_unit = list(/datum/material/titanium = SHEET_MATERIAL_AMOUNT)
+	mats_per_unit = /obj/item/stack/sheet/mineral/titanium::mats_per_unit
 
 /obj/item/stack/sheet/spaceshipglass
 	name = "spaceship window plates"
-	desc = "A glass sheet made out of a titanium-silicate alloy, rivited for use in spaceship window frames."
+	desc = "A glass sheet made out of a titanium-silicate alloy, riveted for use in spaceship window frames."
 	icon = 'modular_nova/modules/mapping/icons/unique/spaceships/shipstacks.dmi'
 	icon_state = "sheet-spaceshipglass"
 	inhand_icon_state = "sheet-plastitaniumglass"
 	singular_name = "spaceship window plate"
 	merge_type = /obj/item/stack/sheet/spaceshipglass
+	mats_per_unit = /obj/item/stack/sheet/titaniumglass::mats_per_unit
 
 GLOBAL_LIST_INIT(spaceshipglass_recipes, list(
 	new/datum/stack_recipe("spaceship window", /obj/structure/window/reinforced/shuttle/spaceship/unanchored, 2, time = 4 SECONDS,  crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ON_SOLID_GROUND | CRAFT_IS_FULLTILE, category = CAT_WINDOWS), \

--- a/modular_nova/modules/mapping/code/spaceship_items.dm
+++ b/modular_nova/modules/mapping/code/spaceship_items.dm
@@ -21,7 +21,8 @@
 	mats_per_unit = /obj/item/stack/sheet/titaniumglass::mats_per_unit
 
 GLOBAL_LIST_INIT(spaceshipglass_recipes, list(
-	new/datum/stack_recipe("spaceship window", /obj/structure/window/reinforced/shuttle/spaceship/unanchored, 2, time = 4 SECONDS,  crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ON_SOLID_GROUND | CRAFT_IS_FULLTILE, category = CAT_WINDOWS), \
+	new /datum/stack_recipe("fulltile spaceship window", /obj/structure/window/reinforced/shuttle/spaceship/unanchored, 2, time = 2 SECONDS,  crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ON_SOLID_GROUND | CRAFT_IS_FULLTILE, category = CAT_WINDOWS), \
+	new /datum/stack_recipe("directional spaceship window", /obj/structure/window/reinforced/survival_pod/unanchored, 1, time = 0.5 SECONDS,  crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ON_SOLID_GROUND | CRAFT_IS_FULLTILE, category = CAT_WINDOWS), \
 	))
 
 /obj/item/stack/sheet/spaceshipglass/get_main_recipes()

--- a/modular_nova/modules/mapping/code/spaceship_turfs.dm
+++ b/modular_nova/modules/mapping/code/spaceship_turfs.dm
@@ -58,4 +58,4 @@
 
 /obj/structure/window/reinforced/shuttle/spaceship/unanchored
 	anchored = FALSE
-	custom_materials = null
+	state = WINDOW_OUT_OF_FRAME

--- a/modular_nova/modules/mapping/code/spaceship_turfs.dm
+++ b/modular_nova/modules/mapping/code/spaceship_turfs.dm
@@ -52,6 +52,7 @@
 	smoothing_groups = SMOOTH_GROUP_SHUTTLE_PARTS + SMOOTH_GROUP_WINDOW_FULLTILE_SHUTTLE + SMOOTH_GROUP_SHIPWALLS
 	canSmoothWith = SMOOTH_GROUP_WINDOW_FULLTILE_SHUTTLE
 	obj_flags = CAN_BE_HIT
+	custom_materials = list(/datum/material/alloy/titaniumglass = SHEET_MATERIAL_AMOUNT * 2)
 
 /obj/structure/window/reinforced/shuttle/spaceship/tinted
 	opacity = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7552,6 +7552,7 @@
 #include "modular_nova\master_files\code\modules\research\designs\medical_designs.dm"
 #include "modular_nova\master_files\code\modules\research\designs\mining_designs.dm"
 #include "modular_nova\master_files\code\modules\research\designs\misc_designs.dm"
+#include "modular_nova\master_files\code\modules\research\designs\smelting_designs.dm"
 #include "modular_nova\master_files\code\modules\research\designs\tool_designs.dm"
 #include "modular_nova\master_files\code\modules\research\designs\weapon_designs.dm"
 #include "modular_nova\master_files\code\modules\research\machinery\_production.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7409,6 +7409,7 @@
 #include "modular_nova\master_files\code\modules\mining\ash_flora\mushroom_leaf.dm"
 #include "modular_nova\master_files\code\modules\mining\boulder_processing\brm.dm"
 #include "modular_nova\master_files\code\modules\mining\equipment\explorer_gear.dm"
+#include "modular_nova\master_files\code\modules\mining\equipment\survival_pod.dm"
 #include "modular_nova\master_files\code\modules\mining\equipment\monster_organs\monster_organ.dm"
 #include "modular_nova\master_files\code\modules\mob\login.dm"
 #include "modular_nova\master_files\code\modules\mob\mob.dm"


### PR DESCRIPTION
## About The Pull Request
About what it says on the tin. Adds techfab/smelter recipes for spaceship plates and spaceship glass.

## How This Contributes To The Nova Sector Roleplay Experience

Player expression via material choices.

## Proof of Testing

<img width="668" height="166" alt="2026-04-14_11-26-46-AM-Tuesday" src="https://github.com/user-attachments/assets/ac9fbf23-01d8-4bcd-8b1d-bea7e9a6e287" />

## Changelog

:cl:
add: Spaceship plates and spaceship glass can now be smelted from the ore redemption machine or made at cargo/engi/science fabricators.
add: Pod windows are now buildable with spaceship glass. Pod windows have been rebalanced to account for them being titanium glass.
/:cl:
