### PR TITLE
Fixes an overlay cap issue 

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1328,6 +1328,10 @@
 		. += image(icon_invisible, "invisible_[body_zone]", -BODYPARTS_LAYER, dir = image_dir)
 		SEND_SIGNAL(src, COMSIG_BODYPART_GET_LIMB_ICON, ., dropped)
 		return .
+	// NOVA EDIT ADDITION START - For invisible taur limbs, so we are not caching invalid keys and repeatedly adding the same overlay. I hate it here
+	if(is_actually_just_invisible)
+		return list()
+	// NOVA EDIT ADDITION END
 
 	// Normal non-husk handling
 	// This is the MEAT of limb icon code

--- a/modular_nova/modules/bodyparts/code/taur_bodyparts.dm
+++ b/modular_nova/modules/bodyparts/code/taur_bodyparts.dm
@@ -6,6 +6,7 @@
 	brute_modifier = 0.8
 	burn_modifier = 0.8
 	wound_resistance = 20
+	is_actually_just_invisible = TRUE
 
 /obj/item/bodypart/leg/right/taur/generate_icon_key()
 	RETURN_TYPE(/list)
@@ -20,6 +21,7 @@
 	brute_modifier = 0.8
 	burn_modifier = 0.8
 	wound_resistance = 20
+	is_actually_just_invisible = TRUE
 
 /obj/item/bodypart/leg/left/taur/generate_icon_key()
 	RETURN_TYPE(/list)

--- a/modular_nova/modules/customization/modules/surgery/bodyparts/_bodyparts.dm
+++ b/modular_nova/modules/customization/modules/surgery/bodyparts/_bodyparts.dm
@@ -3,6 +3,8 @@
 	/// The bodypart's currently applied style's name. Only necessary for bodyparts that come in multiple
 	/// variants, like prosthetics and cyborg bodyparts.
 	var/current_style = null
+	/// Used for taur limbs that do not get rendered at all
+	var/is_actually_just_invisible = FALSE
 
 /obj/item/bodypart/generate_icon_key()
 	RETURN_TYPE(/list)

--- a/modular_nova/modules/customization/modules/surgery/bodyparts/_bodyparts.dm
+++ b/modular_nova/modules/customization/modules/surgery/bodyparts/_bodyparts.dm
@@ -4,7 +4,7 @@
 	/// variants, like prosthetics and cyborg bodyparts.
 	var/current_style = null
 	/// Used for taur limbs that do not get rendered at all
-	VAR_PRIVATE/is_actually_just_invisible = FALSE
+	VAR_PROTECTED/is_actually_just_invisible = FALSE
 
 /obj/item/bodypart/generate_icon_key()
 	RETURN_TYPE(/list)

--- a/modular_nova/modules/customization/modules/surgery/bodyparts/_bodyparts.dm
+++ b/modular_nova/modules/customization/modules/surgery/bodyparts/_bodyparts.dm
@@ -4,7 +4,7 @@
 	/// variants, like prosthetics and cyborg bodyparts.
 	var/current_style = null
 	/// Used for taur limbs that do not get rendered at all
-	VAR_FINAL/is_actually_just_invisible = FALSE
+	VAR_PRIVATE/is_actually_just_invisible = FALSE
 
 /obj/item/bodypart/generate_icon_key()
 	RETURN_TYPE(/list)

--- a/modular_nova/modules/customization/modules/surgery/bodyparts/_bodyparts.dm
+++ b/modular_nova/modules/customization/modules/surgery/bodyparts/_bodyparts.dm
@@ -4,7 +4,7 @@
 	/// variants, like prosthetics and cyborg bodyparts.
 	var/current_style = null
 	/// Used for taur limbs that do not get rendered at all
-	var/is_actually_just_invisible = FALSE
+	VAR_FINAL/is_actually_just_invisible = FALSE
 
 /obj/item/bodypart/generate_icon_key()
 	RETURN_TYPE(/list)


### PR DESCRIPTION
## About The Pull Request

Testing to make sure this works, but this should hopefully fix an issue of endlessly stacking taur left leg overlays and causing people to hit the overlay cap. It is not the most elegant of solutions but it's probably the best I can come up with right now without doing some major work upstream.

## Proof of Testing

<details>
<summary>Seems to work fine, note absence of 'l_leg' overlays, and empty list in the cache</summary>
 
<img width="965" height="776" alt="image" src="https://github.com/user-attachments/assets/ec21057d-26dc-478b-b400-2c73da661b53" />

<img width="444" height="203" alt="image" src="https://github.com/user-attachments/assets/5cb806b3-b548-47b8-81fd-3b510bc82aba" />

</details>

## Changelog

:cl:
fix: fixes an issue that would cause taur legs to stack overlays on each rerender and eventually hit the overlay cap
/:cl: