### PR TITLE
Makes nova star restrictions into a server config option

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -121,6 +121,7 @@
 	populate_interaction_instances()
 	remove_erp_things()
 	setup_gas_prices()
+	GLOB.nova_star_restrictions = CONFIG_GET(flag/enable_nova_star_restrictions)
 	// NOVA EDIT ADDITION END
 
 	loaded = TRUE

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -990,7 +990,7 @@ SUBSYSTEM_DEF(job)
 		job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_AGE)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
 		return JOB_UNAVAILABLE_AGE
 	//NOVA EDIT ADDITION BEGIN - CUSTOMIZATION
-	if(possible_job.nova_stars_only && !SSplayer_ranks.is_nova_star(player.client))
+	if(GLOB.nova_star_restrictions && possible_job.nova_stars_only && !SSplayer_ranks.is_nova_star(player.client))
 		job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_NOT_NOVA_STAR)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
 		return JOB_NOT_NOVA_STAR
 

--- a/code/modules/client/preferences/middleware/jobs.dm
+++ b/code/modules/client/preferences/middleware/jobs.dm
@@ -81,8 +81,8 @@
 		jobs[job.title] = list(
 			"description" = job.description,
 			"department" = department_name,
-			"nova_star" = job.nova_stars_only, // NOVA EDIT
-			"alt_titles" = job.alt_titles, // NOVA EDIT
+			"nova_star" = job.nova_stars_only, // NOVA EDIT ADDITION
+			"alt_titles" = job.alt_titles, // NOVA EDIT ADDITION
 		)
 
 	data["departments"] = departments
@@ -109,6 +109,7 @@
 	// NOVA EDIT
 	if(SSplayer_ranks.is_nova_star(user.client))
 		data["is_nova_star"] = TRUE
+	data["nova_star_restrictions"] = GLOB.nova_star_restrictions
 	// NOVA EDIT END
 	var/list/required_job_playtime = get_required_job_playtime(user)
 	if (!isnull(required_job_playtime))

--- a/code/modules/client/preferences/middleware/quirks.dm
+++ b/code/modules/client/preferences/middleware/quirks.dm
@@ -105,7 +105,7 @@
 	//NOVA EDIT ADDITION
 	var/list/quirks = SSquirks.get_quirks()
 	var/datum/quirk/quirk = quirks[quirk_name]
-	if(initial(quirk.nova_stars_only) && !SSplayer_ranks.is_nova_star(preferences?.parent))
+	if(GLOB.nova_star_restrictions && initial(quirk.nova_stars_only) && !SSplayer_ranks.is_nova_star(preferences?.parent))
 		return FALSE
 	//NOVA EDIT END
 
@@ -148,7 +148,7 @@
 		//NOVA EDIT ADDITION
 		var/list/quirks = SSquirks.get_quirks()
 		var/datum/quirk/quirk_datum = quirks[quirk]
-		if(initial(quirk_datum.nova_stars_only) && !SSplayer_ranks.is_nova_star(preferences?.parent))
+		if(GLOB.nova_star_restrictions && initial(quirk_datum.nova_stars_only) && !SSplayer_ranks.is_nova_star(preferences?.parent))
 			preferences.all_quirks -= quirk
 			continue
 		//NOVA EDIT END

--- a/code/modules/loadout/loadout_items.dm
+++ b/code/modules/loadout/loadout_items.dm
@@ -369,7 +369,7 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 		displayed_text[FA_ICON_SPAGHETTI_MONSTER_FLYING] = "Species Whitelist: [capitalize(jointext(species_whitelist, ", "))]"
 	if(species_blacklist)
 		displayed_text[FA_ICON_SHRIMP] = "Species Blacklist: [capitalize(jointext(species_blacklist, ", "))]"
-	if(nova_stars_only)
+	if(GLOB.nova_star_restrictions && nova_stars_only)
 		displayed_text[FA_ICON_HOURGLASS_HALF] = "Nova Star-Only"
 	if(donator_only || ckeywhitelist)
 		displayed_text[FA_ICON_COINS] = "Donator-Only"

--- a/code/modules/loadout/loadout_menu.dm
+++ b/code/modules/loadout/loadout_menu.dm
@@ -105,6 +105,8 @@
 	data["ckey"] = user.ckey
 	if(SSplayer_ranks.is_donator(user.client))
 		data["is_donator"] = TRUE
+	if(SSplayer_ranks.is_nova_star(user.client))
+		data["is_nova_star"] = TRUE
 	// NOVA EDIT END
 	return data
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -176,7 +176,7 @@
 		return JOB_UNAVAILABLE_LANGUAGE
 	if(job.has_banned_quirk(client.prefs))
 		return JOB_UNAVAILABLE_QUIRK
-	if(job.nova_stars_only && !SSplayer_ranks.is_nova_star(client))
+	if(GLOB.nova_star_restrictions && job.nova_stars_only && !SSplayer_ranks.is_nova_star(client))
 		return JOB_NOT_NOVA_STAR
 	if(job.has_banned_species(client.prefs))
 		return JOB_UNAVAILABLE_SPECIES

--- a/code/modules/modular_computers/file_system/programs/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/jobmanagement.dm
@@ -35,7 +35,10 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 	if(job.job_flags & JOB_CANNOT_OPEN_SLOTS)
 		return FALSE
 	// NOVA EDIT ADDITION START
-	if(job.nova_stars_only)
+	if(!GLOB.nova_star_restrictions)
+		if(istype(job, /datum/job/bridge_assistant)) // Bridge assistant is open
+			return TRUE
+	else if(job.nova_stars_only)
 		return FALSE
 	// NOVA EDIT ADDITION END
 	return TRUE

--- a/code/modules/modular_computers/file_system/programs/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/jobmanagement.dm
@@ -35,10 +35,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 	if(job.job_flags & JOB_CANNOT_OPEN_SLOTS)
 		return FALSE
 	// NOVA EDIT ADDITION START
-	if(!GLOB.nova_star_restrictions)
-		if(istype(job, /datum/job/bridge_assistant)) // Bridge assistant is open
-			return TRUE
-	else if(job.nova_stars_only)
+	if(GLOB.nova_star_restrictions && job.nova_stars_only)
 		return FALSE
 	// NOVA EDIT ADDITION END
 	return TRUE

--- a/config/nova/config_nova.txt
+++ b/config/nova/config_nova.txt
@@ -191,3 +191,6 @@ SAVEFILE_UPLOAD_LIMIT 2000
 #RELAY_OPTION Connect to Asia (Singapore),byond://asia.placeholder.com:1337
 #RELAY_OPTION Connect to South America (Brazil),byond://south-america.placeholder.com:1337
 #RELAY_OPTION Connect Directly (No Relay),byond://placeholder.com:1337
+
+## Comment to disable the Star rank restrictions
+ENABLE_NOVA_STAR_RESTRICTIONS

--- a/modular_nova/master_files/code/_globalvars/configuration.dm
+++ b/modular_nova/master_files/code/_globalvars/configuration.dm
@@ -1,6 +1,6 @@
-// LOOC Module
+/// LOOC Module
 GLOBAL_VAR_INIT(looc_allowed, TRUE)
-// Star restrictions enabled
+/// Star restrictions enabled
 GLOBAL_VAR(nova_star_restrictions)
 
 /datum/config_entry/number/rockplanet_budget

--- a/modular_nova/master_files/code/_globalvars/configuration.dm
+++ b/modular_nova/master_files/code/_globalvars/configuration.dm
@@ -1,5 +1,7 @@
 // LOOC Module
 GLOBAL_VAR_INIT(looc_allowed, TRUE)
+// Star restrictions enabled
+GLOBAL_VAR(nova_star_restrictions)
 
 /datum/config_entry/number/rockplanet_budget
 	config_entry_value = 60

--- a/modular_nova/master_files/code/controllers/configuration/entries/config_entries.dm
+++ b/modular_nova/master_files/code/controllers/configuration/entries/config_entries.dm
@@ -101,3 +101,6 @@
 ///The maximum file size allowed by savefile uploading, in kilobytes
 /datum/config_entry/number/savefile_upload_limit
 	default = 2000
+
+/datum/config_entry/flag/enable_nova_star_restrictions
+	default = TRUE

--- a/modular_nova/modules/loadouts/loadout_items/_loadout_datum.dm
+++ b/modular_nova/modules/loadouts/loadout_items/_loadout_datum.dm
@@ -141,7 +141,7 @@
 			message_client(client, target, "donator")
 		return FALSE
 
-	if(nova_stars_only && !SSplayer_ranks.is_nova_star(client))
+	if(GLOB.nova_star_restrictions && nova_stars_only && !SSplayer_ranks.is_nova_star(client))
 		if(!visuals_only)
 			message_client(client, target, "Nova star")
 		return FALSE

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/JobsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/JobsPage.tsx
@@ -232,7 +232,7 @@ function JobRow(props: JobRowProps) {
       </Stack>
     );
     // NOVA EDIT START
-  } else if (job.nova_star && !data.is_nova_star) {
+  } else if (data.nova_star_restrictions && job.nova_star && !data.is_nova_star) {
     rightSide = (
       <Stack align="center" height="100%" pr={1}>
         <Stack.Item grow textAlign="right">

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
@@ -378,7 +378,7 @@ function QuirkPage() {
       }
     }
     // NOVA EDIT START - Nova star quirks
-    if (quirk.nova_stars_only && !data.is_nova_star) {
+    if (data.nova_star_restrictions && quirk.nova_stars_only && !data.is_nova_star) {
       return 'You need to be a Nova star to select this quirk, apply today!';
     }
     // NOVA EDIT END

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/SpeciesPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/SpeciesPage.tsx
@@ -295,7 +295,7 @@ function SpeciesPageInner(props: SpeciesPageInnerProps) {
                   <Button
                     key={speciesKey}
                     onClick={() => {
-                      if (species.nova_stars_only && !data.is_nova_star) {
+                      if (data.nova_star_restrictions && species.nova_stars_only && !data.is_nova_star) {
                         return;
                       }
                       setSpecies(speciesKey);
@@ -316,7 +316,7 @@ function SpeciesPageInner(props: SpeciesPageInnerProps) {
                     />
                   </Button>
                 );
-                if (species.nova_stars_only && !data.is_nova_star) {
+                if (data.nova_star_restrictions && species.nova_stars_only && !data.is_nova_star) {
                   const tooltipContent =
                     species.name +
                     ' - You need to be a Nova star to select this race, apply today!';

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/loadout/ItemDisplay.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/loadout/ItemDisplay.tsx
@@ -174,7 +174,7 @@ type TabProps = {
 // NOVA EDIT ADDITION START - Expanded loadout framework
 const FilterItemList = (items: LoadoutItem[]) => {
   const { data } = useBackend<LoadoutManagerData>();
-  const { is_donator, is_nova_star, erp_pref } = data;
+  const { is_donator, is_nova_star, erp_pref, nova_star_restrictions } = data;
   const ckey = data.ckey;
 
   return items.filter((item: LoadoutItem) => {
@@ -184,7 +184,7 @@ const FilterItemList = (items: LoadoutItem[]) => {
     if (item.donator_only && !is_donator) {
       return false;
     }
-    if (item.nova_stars_only && !is_nova_star) {
+    if (nova_star_restrictions && item.nova_stars_only && !is_nova_star) {
       return false;
     }
     if (item.erp_item && !erp_pref) {


### PR DESCRIPTION
## About The Pull Request

This PR makes the 'Nova Star' restrictions on quirks, jobs, species, etc. into a config option that can be enabled/disabled easily

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
<img width="898" height="354" alt="dreamseeker_fG8PanjxsD" src="https://github.com/user-attachments/assets/1a47e628-39fe-4f2b-8ab4-5fc2084e9a4e" />

</details>

## Changelog

:cl:
config: adds a server config for nova star restrictions
/:cl: