### PR TITLE
[S] [Fix] Fixes Hunter slugs behaving weirdly

### DIFF
--- a/modular_nova/modules/shotgunrebalance/code/shotgun.dm
+++ b/modular_nova/modules/shotgunrebalance/code/shotgun.dm
@@ -352,10 +352,6 @@
 		damage *= biotype_damage_multiplier
 	return ..()
 
-/obj/projectile/bullet/shotgun_slug/hunter/Initialize(mapload)
-	. = ..()
-	AddElement(/datum/element/bane, mob_biotypes = MOB_BEAST, damage_multiplier = 5)
-
 /obj/item/ammo_casing/shotgun/honkshot
 	name = "confetti shell"
 	desc = "A 12 gauge buckshot shell thats been filled to the brim with confetti. Yippie!"


### PR DESCRIPTION

## About The Pull Request
Removes the Bane element from hunter slugs, it already has snowflake code to do the same.

## How This Contributes To The Nova Sector Roleplay Experience
The bane element was interfering with the snowflake code of the hunter slugs and causing conditions  where it would re add their multiplier on top of their current one, which was less than ideal for the gameplay.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="1328" height="544" alt="image" src="https://github.com/user-attachments/assets/17fe9b3c-d84d-4797-a011-6dcecdae7c45" />


</details>

## Changelog
:cl:
fix: Fixed an exploit with hunter slugs which caused them to do 5 times more damage than they should be doing
/:cl:
