### PR TITLE
Fixes custom tongue not applying on roundstart characters

### DIFF
--- a/modular_nova/modules/quirk_customtongue/customtongue.dm
+++ b/modular_nova/modules/quirk_customtongue/customtongue.dm
@@ -16,10 +16,10 @@
 	maximum_value_length = 64 // We may want to lower this for sanity.
 
 /datum/preference/text/custom_tongue/serialize(input)
-	var/regex/unwanted_characters = regex(@"[^a-z]") // Prevent people from inputting slop into my text fields. No, you CAN'T have an eggplant emoji for when you whisper.
+	var/regex/unwanted_characters = regex(@"[^a-zA-Z]") // Prevent people from inputting slop into my text fields. No, you CAN'T have an eggplant emoji for when you whisper.
 	if(unwanted_characters.Find(input))
 		return null // No fun allowed.
-	return htmlrendertext(input)
+	return LOWER_TEXT(htmlrendertext(input))
 
 /datum/preference/text/custom_tongue/is_accessible(datum/preferences/preferences)
 	if (!..())
@@ -62,31 +62,33 @@
 	var/client/client_source = quirk_holder.client
 
 	var/new_ask = client_source?.prefs.read_preference(/datum/preference/text/custom_tongue/ask)
-	if (new_ask)
-		quirk_holder.verb_ask = LOWER_TEXT(new_ask)
+	if(new_ask)
+		quirk_holder.verb_ask = new_ask
 
 	var/new_exclaim = client_source?.prefs.read_preference(/datum/preference/text/custom_tongue/exclaim)
-	if (new_exclaim)
-		quirk_holder.verb_exclaim = LOWER_TEXT(new_exclaim)
+	if(new_exclaim)
+		quirk_holder.verb_exclaim = new_exclaim
 
 	var/new_whisper = client_source?.prefs.read_preference(/datum/preference/text/custom_tongue/whisper)
-	if (new_whisper)
-		quirk_holder.verb_whisper = LOWER_TEXT(new_whisper)
+	if(new_whisper)
+		quirk_holder.verb_whisper = new_whisper
 
 	var/new_yell = client_source?.prefs.read_preference(/datum/preference/text/custom_tongue/yell)
-	if (new_yell)
-		quirk_holder.verb_yell = LOWER_TEXT(new_yell)
+	if(new_yell)
+		quirk_holder.verb_yell = new_yell
 
 	var/new_say = client_source?.prefs.read_preference(/datum/preference/text/custom_tongue/say)
-	if (new_say)
+	if(new_say)
 		var/obj/item/organ/tongue/tongue = quirk_holder.get_organ_slot(ORGAN_SLOT_TONGUE)
-		tongue.say_mod = LOWER_TEXT(new_say)
-
+		tongue?.say_mod = new_say
 	return TRUE
+
+/datum/quirk/custom_tongue/add(client/client_source)
+	. = ..()
+	RegisterSignal(quirk_holder, COMSIG_SET_SAY_MODIFIERS, PROC_REF(tongue_setup))
 
 /datum/quirk/custom_tongue/post_add()
 	. = ..()
-	RegisterSignal(quirk_holder, COMSIG_SET_SAY_MODIFIERS, PROC_REF(tongue_setup))
 	tongue_setup()
 
 /datum/quirk/custom_tongue/remove(client/client_source)

--- a/modular_nova/modules/quirk_customtongue/customtongue.dm
+++ b/modular_nova/modules/quirk_customtongue/customtongue.dm
@@ -84,7 +84,8 @@
 
 	return TRUE
 
-/datum/quirk/custom_tongue/add(client/client_source)
+/datum/quirk/custom_tongue/post_add()
+	. = ..()
 	RegisterSignal(quirk_holder, COMSIG_SET_SAY_MODIFIERS, PROC_REF(tongue_setup))
 	tongue_setup()
 


### PR DESCRIPTION

## About The Pull Request

``add()`` seems to struggle to add it to roundstart characters due to the characters not really having a client before the round truly starts, so we're moving ``tongue_handle()`` to ``post_add()`` which only procs it after the mob has a client.

I've done some changes to the serialization so it's a bit saner, capitalized letters can now go through but will still be changed to lower case, it's just there so the user doesn't get confused to why their "Asks" went blank with no input.
## How This Contributes To The Nova Sector Roleplay Experience
Lets people join roundstart without losing their custom tongue, and slightly saner code.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

For reference, "Blorbes" is my character's custom say mod
  
<img width="622" height="341" alt="image" src="https://github.com/user-attachments/assets/db9c3941-eb7b-4c82-a264-917d00e5cec9" />

<img width="607" height="66" alt="image" src="https://github.com/user-attachments/assets/db2bdc4d-c102-44e3-a3a7-fbde35a52912" />

<img width="606" height="67" alt="image" src="https://github.com/user-attachments/assets/ef0302c2-823f-4798-b732-73db883c99c6" />


https://github.com/user-attachments/assets/2d583f02-519d-4872-ac51-698aa95e11b9



</details>

## Changelog
:cl: Hardly
fix: Fixes custom tongue not working on characters that have joined at the start of the round
/:cl:
