### PR TITLE
[Moon] Unrussians your revolver

### DIFF
--- a/modular_nova/master_files/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/modular_nova/master_files/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -3,7 +3,11 @@
 
 /obj/item/gun/ballistic/revolver/russian/Initialize(mapload)
 	. = ..()
-	if (src.type == /obj/item/gun/ballistic/revolver/russian/soul)
+	if(mapload)
+		new /obj/item/gun/ballistic/revolver/sol(get_turf(src))
+		return INITIALIZE_HINT_QDEL
+
+/obj/item/gun/ballistic/revolver/russian/soul/Initialize(mapload)
+	. = ..()
+	if (mapload)
 		new /obj/item/stack/spacecash/c1000{amount = 2}(get_turf(src)) //done for the relic since it can be sold for 4-5k
-	new /obj/item/gun/ballistic/revolver/sol(get_turf(src))
-	return INITIALIZE_HINT_QDEL

--- a/modular_nova/master_files/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/modular_nova/master_files/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -1,7 +1,9 @@
 /obj/item/gun/ballistic/revolver/c38
 	w_class = WEIGHT_CLASS_SMALL // concealed carry blickinator
 
-/obj/item/gun/ballistic/revolver/russian/shoot_self(mob/living/carbon/human/user, affecting = BODY_ZONE_HEAD)
+/obj/item/gun/ballistic/revolver/russian/Initialize(mapload)
 	. = ..()
-	user.set_suicide(TRUE)
-	user.final_checkout(src)
+	if (src.type == /obj/item/gun/ballistic/revolver/russian/soul)
+		new /obj/item/stack/spacecash/c1000{amount = 2}(get_turf(src)) //done for the relic since it can be sold for 4-5k
+	new /obj/item/gun/ballistic/revolver/sol(get_turf(src))
+	return INITIALIZE_HINT_QDEL

--- a/modular_nova/modules/modular_vending/code/games.dm
+++ b/modular_nova/modules/modular_vending/code/games.dm
@@ -34,3 +34,6 @@
 		/obj/item/storage/belt/utility/xenoarch/full = 3,
 	)
 
+/obj/machinery/vending/games/Initialize(mapload)
+	contraband -= /obj/item/gun/ballistic/revolver/russian
+	return ..()


### PR DESCRIPTION

## About The Pull Request
Makes the russian revolvers series be replaced by the renard revolver, and the soul version to come with 2k. This avoids the whole mapping issue otherwise.

## How This Contributes To The Nova Sector Roleplay Experience
This deals away with the turnsarounds people found with the russian revolvers, and makes it so it stops appearing in the staff tickets once and for all. 

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="723" height="573" alt="image" src="https://github.com/user-attachments/assets/d0acdf06-d609-4ea6-b5dd-db84d3bb100c" />


</details>

## Changelog
:cl:
balance: Removes russian revolvers and replaces it with Renard revolvers. Adds 2k to the Greed chappel.
/:cl:
