### PR TITLE
Remove colossus vocal cords

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -103,7 +103,7 @@
 	var/list/choices = subtypesof(/obj/machinery/anomalous_crystal) - /obj/machinery/anomalous_crystal/theme_warp // NOVA EDIT CHANGE - Less griefing - ORIGINAL: var/list/choices = subtypesof(/obj/machinery/anomalous_crystal)
 	var/random_crystal = pick(choices)
 	new random_crystal(src)
-	new /obj/item/organ/vocal_cords/colossus(src)
+	// NOVA EDIT REMOVAL - Voice of God organ removed - ORIGINAL: new /obj/item/organ/vocal_cords/colossus(src)
 	new /obj/item/cain_and_abel(src)
 
 /obj/structure/closet/crate/necropolis/colossus/crusher


### PR DESCRIPTION

## About The Pull Request

This change removes the vocal cords from its only natural spawn, the colossus loot chest, making it officially unavailable outside adminbus. Simple inline edit.
## How This Contributes To The Nova Sector Roleplay Experience

VoG is grief incarnated, at best used as a meme, at worst ban bait for its user. The way it works doesn't work well in nova, hence its removal
## Proof of Testing

Q.E.D
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
del: Removes colossus vocal cords. 
/:cl:
