### PR TITLE
QOL: 30s cooldown for AI requests per door/player

### DIFF
--- a/modular_nova/master_files/code/game/machinery/doors/door.dm
+++ b/modular_nova/master_files/code/game/machinery/doors/door.dm
@@ -13,12 +13,11 @@
 	var/static/list/requesters = list()
 
 /obj/machinery/door/airlock/attack_hand_secondary(mob/living/user, list/modifiers)
-
 	var/request_key = "[user.ckey]_[REF(src)]"
 	var/last_request = requesters[request_key]
 	if(last_request && world.time < last_request + DOOR_AI_REQUEST_COOLDOWN)
 		to_chat(user, span_warning("You've already asked the AI about this door recently."))
-		return
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 	// Lazy cleanup: prune any expired entries now so the list stays bounded across a shift.
 	var/cutoff = world.time - DOOR_AI_REQUEST_COOLDOWN
@@ -30,7 +29,7 @@
 
 	if(!hasPower())
 		to_chat(user, span_warning("This door isn't powered."))
-		return
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 	src.balloon_alert(user, "ai requested!")
 

--- a/modular_nova/master_files/code/game/machinery/doors/door.dm
+++ b/modular_nova/master_files/code/game/machinery/doors/door.dm
@@ -4,7 +4,7 @@
 #define LINK_SHOCK "<a href='byond://?_src_=usr;open_door=[REF(src)];user=[REF(user)];action=shock'> (Shock)</a>"
 
 /// How long the same player must wait between AI-open requests on the same door.
-#define DOOR_AI_REQUEST_COOLDOWN (5 MINUTES)
+#define DOOR_AI_REQUEST_COOLDOWN (30 SECONDS)
 
 /obj/machinery/door/airlock
 	//so the AI doesn't get spammed

--- a/modular_nova/master_files/code/game/machinery/doors/door.dm
+++ b/modular_nova/master_files/code/game/machinery/doors/door.dm
@@ -15,7 +15,8 @@
 /obj/machinery/door/airlock/attack_hand_secondary(mob/living/user, list/modifiers)
 
 	var/request_key = "[user.ckey]_[REF(src)]"
-	if(world.time < requesters[request_key] + DOOR_AI_REQUEST_COOLDOWN)
+	var/last_request = requesters[request_key]
+	if(last_request && world.time < last_request + DOOR_AI_REQUEST_COOLDOWN)
 		to_chat(user, span_warning("You've already asked the AI about this door recently."))
 		return
 

--- a/modular_nova/master_files/code/game/machinery/doors/door.dm
+++ b/modular_nova/master_files/code/game/machinery/doors/door.dm
@@ -3,16 +3,27 @@
 #define LINK_BOLT "<a href='byond://?_src_=usr;open_door=[REF(src)];user=[REF(user)];action=bolt'> (Bolt)</a>"
 #define LINK_SHOCK "<a href='byond://?_src_=usr;open_door=[REF(src)];user=[REF(user)];action=shock'> (Shock)</a>"
 
+/// How long the same player must wait between AI-open requests on the same door.
+#define DOOR_AI_REQUEST_COOLDOWN (5 MINUTES)
+
 /obj/machinery/door/airlock
 	//so the AI doesn't get spammed
 	COOLDOWN_DECLARE(answer_cd)
-	/// List of ai door requesters
+	/// Tracks per-(player, door) AI-open-request cooldowns. Keyed by "[ckey]_[REF(door)]".
 	var/static/list/requesters = list()
 
 /obj/machinery/door/airlock/attack_hand_secondary(mob/living/user, list/modifiers)
-	if(world.time < requesters[user.ckey] + 10 SECONDS)
-		to_chat(user, span_warning("Hold on, let the AI parse your request."))
+
+	var/request_key = "[user.ckey]_[REF(src)]"
+	if(world.time < requesters[request_key] + DOOR_AI_REQUEST_COOLDOWN)
+		to_chat(user, span_warning("You've already asked the AI about this door recently."))
 		return
+
+	// Lazy cleanup: prune any expired entries now so the list stays bounded across a shift.
+	var/cutoff = world.time - DOOR_AI_REQUEST_COOLDOWN
+	for(var/key in requesters)
+		if(requesters[key] < cutoff)
+			requesters -= key
 
 	. = ..()
 
@@ -35,9 +46,10 @@
 		if(!is_station_level(AI.registered_z))
 			continue
 		to_chat(AI, "<b><a href='byond://?src=[REF(AI)];track=[html_encode(user.name)]'>[user]</a></b> is requesting you to open the [src] [LINK_DENY][LINK_OPEN][LINK_BOLT][LINK_SHOCK].")
-	requesters[user.ckey] = world.time
+	requesters[request_key] = world.time
 
 #undef LINK_DENY
 #undef LINK_OPEN
 #undef LINK_BOLT
 #undef LINK_SHOCK
+#undef DOOR_AI_REQUEST_COOLDOWN

--- a/modular_nova/master_files/code/game/machinery/doors/door.dm
+++ b/modular_nova/master_files/code/game/machinery/doors/door.dm
@@ -19,12 +19,6 @@
 		to_chat(user, span_warning("You've already asked the AI about this door recently."))
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
-	// Lazy cleanup: prune any expired entries now so the list stays bounded across a shift.
-	var/cutoff = world.time - DOOR_AI_REQUEST_COOLDOWN
-	for(var/key in requesters)
-		if(requesters[key] < cutoff)
-			requesters -= key
-
 	. = ..()
 
 	if(!hasPower())
@@ -47,6 +41,14 @@
 			continue
 		to_chat(AI, "<b><a href='byond://?src=[REF(AI)];track=[html_encode(user.name)]'>[user]</a></b> is requesting you to open the [src] [LINK_DENY][LINK_OPEN][LINK_BOLT][LINK_SHOCK].")
 	requesters[request_key] = world.time
+	addtimer(CALLBACK(src, PROC_REF(clear_stale_requester), request_key, world.time), DOOR_AI_REQUEST_COOLDOWN)
+
+/// Clears a `requesters` entry only if its timestamp still matches `set_at`, so a renewed
+/// cooldown (same player re-requests the same door, or the sibling early-clear on open) isn't
+/// wiped by a stale timer.
+/obj/machinery/door/airlock/proc/clear_stale_requester(key, set_at)
+	if(requesters[key] == set_at)
+		requesters -= key
 
 #undef LINK_DENY
 #undef LINK_OPEN

--- a/modular_nova/modules/SiliconQoL/code/door_request.dm
+++ b/modular_nova/modules/SiliconQoL/code/door_request.dm
@@ -35,6 +35,8 @@
 			door.open()
 			playsound(door, 'sound/machines/ping.ogg', 50, FALSE, SILENCED_SOUND_EXTRARANGE, ignore_walls = FALSE)
 			to_chat(src, "<span class='notice'>You open the [door] for [requester].</span>")
+			// Clear the per-(player, door) AI-request cooldown since the ask succeeded — they may need to ask again later.
+			door.requesters -= "[requester.ckey]_[REF(door)]"
 		if("bolt")
 			if(!door.locked)
 				door.bolt()


### PR DESCRIPTION

## About The Pull Request

Forces a 30s cooldown for the same player to open the same door. They can still request a new door on a new 30s timer
## How This Contributes To The Nova Sector Roleplay Experience

Reduces AI's going malf by 16% because they get this spam

Officer AA has requested access
Officer AA has requested access
Officer AA has requested access
Officer AA has requested access
Officer AA has requested access
Officer AA has requested access
Officer AA has requested access
AI Where Antag
Officer AA has requested access
Officer AA has requested access
Officer AA has requested access
Officer AA has requested access
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/e416650c-4486-423d-a825-66f0419068b3


</details>

## Changelog
:cl:
qol: increase AI request cd to 5 mins, cd per door/player
/:cl:
