### PR TITLE
Update speedloaders.dm, or How I Made One Small Mistake

### DIFF
--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/speedloaders.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/speedloaders.dm
@@ -18,3 +18,4 @@
 	base_icon_state = "10_strip"
 	max_ammo = 10
 	caliber = CALIBER_10MM
+	w_class = WEIGHT_CLASS_SMALL


### PR DESCRIPTION

## About The Pull Request

So, as it turns out, the M-96 stripper clips are currently NORMAL weighted, meaning they're as big as the gun. This is a mistake, absolutely. 

## How This Contributes To The Nova Sector Roleplay Experience

This should've been small to start with, DAMN!

## Proof of Testing

One line hotfix, if it breaks the server, I'll delete my github account.

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: 10mm stripper clip no longer NORMAL, now SMALL
/:cl:
