### PR TITLE
The roundend report for each player is saved to disk, even if they don't view it

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -409,7 +409,7 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 	fdel(roundend_file)
 	WRITE_FILE(roundend_file, content)
 
-/datum/controller/subsystem/ticker/proc/show_roundend_report(client/C, report_type = null)
+/datum/controller/subsystem/ticker/proc/show_roundend_report(client/C, report_type = null, save_to_disk_only = FALSE) // NOVA EDIT CHANGE - Allows only saving the report and not showing it - ORIGINAL: /datum/controller/subsystem/ticker/proc/show_roundend_report(client/C, report_type = null)
 	var/datum/browser/roundend_report = new(C, "roundend")
 	roundend_report.width = 800
 	roundend_report.height = 600
@@ -425,6 +425,7 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 		fdel(filename)
 		text2file(content, filename)
 
+	if (save_to_disk_only) { return } // NOVA EDIT ADDITION - This is ugly, but allows only saving the report and not showing it
 	roundend_report.set_content(content)
 	roundend_report.stylesheets = list()
 	roundend_report.add_stylesheet("roundend", 'html/browser/roundend.css')
@@ -463,14 +464,7 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 	GLOB.survivor_report = survivor_report(popcount)
 	log_roundend_report()
 	for(var/client/C in GLOB.clients)
-		//show_roundend_report(C) // NOVA EDIT REMOVAL - Disables automatically seeing the roundend report
-		// NOVA EDIT ADDITION START - Still saves the report to disk so it appears when you use the Your Last Round verb
-		// (if we don't do this, it'll show the last report they viewed using the action/chat link, which is non ideal)
-		var/list/report_parts = list(personal_report(C), GLOB.common_report)
-		var/filename = C.roundend_report_file()
-		fdel(filename)
-		text2file(report_parts.Join(), filename)
-		// NOVA EDIT ADDITION END
+		show_roundend_report(C, save_to_disk_only = TRUE) // NOVA EDIT CHANGE - Only saves the roundend report to the filesystem, doesn't show it to the player - ORIGINAL: show_roundend_report(C)
 		give_show_report_button(C)
 		CHECK_TICK
 

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -465,7 +465,7 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 	for(var/client/C in GLOB.clients)
 		//show_roundend_report(C) // NOVA EDIT REMOVAL - Disables automatically seeing the roundend report
 		// NOVA EDIT ADDITION START - Still saves the report to disk so it appears when you use the Your Last Round verb
-		// (if we don't do this, it'll show the last report when they pressed the report button, which is non ideal)
+		// (if we don't do this, it'll show the last report they viewed using the action/chat link, which is non ideal)
 		var/list/report_parts = list(personal_report(C), GLOB.common_report)
 		var/filename = C.roundend_report_file()
 		fdel(filename)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -463,7 +463,14 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 	GLOB.survivor_report = survivor_report(popcount)
 	log_roundend_report()
 	for(var/client/C in GLOB.clients)
-		//show_roundend_report(C) NOVA EDIT - Disables this from auto-showing at the end of round, maybe
+		//show_roundend_report(C) // NOVA EDIT REMOVAL - Disables automatically seeing the roundend report
+		// NOVA EDIT ADDITION START - Still saves the report to disk so it appears when you use the Your Last Round verb
+		// (if we don't do this, it'll show the last report when they pressed the report button, which is non ideal)
+		var/list/report_parts = list(personal_report(C), GLOB.common_report)
+		var/filename = C.roundend_report_file()
+		fdel(filename)
+		text2file(report_parts.Join(), filename)
+		// NOVA EDIT ADDITION END
 		give_show_report_button(C)
 		CHECK_TICK
 


### PR DESCRIPTION

## About The Pull Request
This adds a one line conditional to `show_roundend_report` to just not show the report and instead only generate content and save it to the filesystem if `report_type` is `null`. Strange but functional, and only adds two more non-modular edits.

Fixes https://github.com/NovaSector/NovaSector/issues/6581
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

Testing process: start the server, connect (with the `data/roundend_reports` directory deleted), end the round manually and specifically *not* open the roundend report, restart the server, Your Last Round verb is now present meaning it was saved to disk without having to open the roundend report. It shows the correct report:
<img width="799" height="233" alt="image" src="https://github.com/user-attachments/assets/3e55523d-47f8-4a86-842a-29eae7152899" />


</details>

## Changelog
:cl:
fix: [NOVA] The report shown by the Your Last Round verb will be updated if you're connected when the round ends, instead of only being updated if you manually viewed the roundend report. This is how it behaves on TG.
/:cl:
