### PR TITLE
Fix randomly invisible stone griddles.

### DIFF
--- a/modular_nova/modules/primitive_cooking_additions/code/stone_griddle.dm
+++ b/modular_nova/modules/primitive_cooking_additions/code/stone_griddle.dm
@@ -13,11 +13,10 @@
 	variant = 1
 	custom_materials = list(/datum/material/stone = SHEET_MATERIAL_AMOUNT * 5)
 
-/obj/machinery/griddle/Initialize(mapload)
+/obj/machinery/griddle/stone/Initialize(mapload)
 	. = ..()
-	grill_loop = new(src, FALSE)
-	if(isnum(variant))
-		variant = 1
+	variant = 1
+	update_appearance()
 
 /obj/machinery/griddle/stone/examine(mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
The stone griddles inherited the variant code from their station counterpart due to a missing bit of code but do not have a variant sprite, so when they rolled variant 2 or 3, the sprite started invisible. This fixes it.
## How This Contributes To The Nova Sector Roleplay Experience
Bug fixing is always good, yes?
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="428" height="478" alt="image" src="https://github.com/user-attachments/assets/b1554d81-dd26-4823-98a9-e8a0dec15a84" />

</details>

## Changelog
:cl:
fix: Stone griddles do not have a chance to spawn invisible anymore.
/:cl:
