### PR TITLE
smol synth revival fix

### DIFF
--- a/modular_nova/modules/synths/code/surgery/operations/operation_revival.dm
+++ b/modular_nova/modules/synths/code/surgery/operations/operation_revival.dm
@@ -80,6 +80,9 @@
 		span_notice("[surgeon] sends a powerful shock to [patient]'s [brain_type] with [tool]..."),
 		span_notice("[surgeon] sends a powerful shock to [patient]'s [brain_type]..."),
 	)
+	if (patient.stat < DEAD)
+		patient.visible_message(span_notice("...[patient] is completely unaffected! Seems like they're already active!"))
+		return
 	patient.grab_ghost()
 	if(iscarbon(patient))
 		var/mob/living/carbon/carbon_patient = patient
@@ -92,23 +95,14 @@
 
 /// Call when successfully revived
 /datum/surgery_operation/basic/revive_synth/proc/on_revived(mob/living/surgeon, mob/living/patient)
-	if (patient.stat < DEAD)
-		patient.visible_message(span_notice("...[patient] is completely unaffected! Seems like they're already active!"))
-		return TRUE
-	patient.grab_ghost()
-	if(patient.revive())
-		patient.emote("chime")
-		patient.visible_message(span_notice("...[patient] reactivates, their chassis coming online!"))
-		if(HAS_MIND_TRAIT(surgeon, TRAIT_MORBID)) // Contrary to their typical hatred of resurrection, it wouldn't be very thematic if morbid people didn't love playing god
-			surgeon.add_mood_event("morbid_revival_success", /datum/mood_event/morbid_revival_success)
-		to_chat(patient, span_danger("[CONFIG_GET(string/blackoutpolicy)]"))
-	patient.adjust_organ_loss(ORGAN_SLOT_BRAIN, 15, 180)
+	patient.emote("chime")
+	patient.visible_message(span_notice("...[patient] reactivates, their chassis coming online!"))
+	to_chat(patient, span_danger("[CONFIG_GET(string/blackoutpolicy)]"))
 
 /// Called when revival fails
 /datum/surgery_operation/basic/revive_synth/proc/on_no_revive(mob/living/surgeon, mob/living/patient)
 	patient.emote("buzz")
 	patient.visible_message(span_warning("...[patient.p_they()] convulses, then goes offline."))
-	patient.adjust_organ_loss(ORGAN_SLOT_BRAIN, 50, 199) // MAD SCIENCE
 
 /// Flavor for failure
 /datum/surgery_operation/basic/revive_synth/on_failure(mob/living/patient, mob/living/surgeon, obj/item/tool, list/operation_args)


### PR DESCRIPTION

## About The Pull Request
apparently we tried to revive twice (on_revive called after succesful revival and once again calls for revival). while its not a game breaking it caused messages to mix together.

also removed brain damage from synth reviving process, because we already have penalties from other ways of resurrecting them
## How This Contributes To The Nova Sector Roleplay Experience
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="489" height="127" alt="image" src="https://github.com/user-attachments/assets/1af5d71b-32bf-44c7-ae60-9e29d4dadf0c" />

<img width="452" height="80" alt="image" src="https://github.com/user-attachments/assets/48657879-dfc6-4440-b683-ebb27c96b282" />


</details>

## Changelog
:cl:
fix: fixed double messaging during synth revival process
/:cl:
