### PR TITLE
[Moon] Removes Win Condition From Blob

### DIFF
--- a/modular_nova/modules/blob/overmind.dm
+++ b/modular_nova/modules/blob/overmind.dm
@@ -29,4 +29,5 @@
 		free_strain_rerolls = 1
 
 	if(!victory_in_progress && max_count < blobs_legit.len)
-		max_count = blobs_legit.len
+/mob/eye/blob/on_critical_mass()
+	return

--- a/modular_nova/modules/blob/overmind.dm
+++ b/modular_nova/modules/blob/overmind.dm
@@ -20,7 +20,7 @@
 
 			// Clear the biohazard emergency display when blob is defeated - async to avoid blocking
 			INVOKE_ASYNC(src, PROC_REF(clear_biohazard_display))
-//
+
 			qdel(src)
 	else if(!victory_in_progress && (blobs_legit.len >= blobwincount))
 		victory_in_progress = TRUE

--- a/modular_nova/modules/blob/overmind.dm
+++ b/modular_nova/modules/blob/overmind.dm
@@ -23,16 +23,7 @@
 
 			qdel(src)
 	else if(!victory_in_progress && (blobs_legit.len >= blobwincount))
-		victory_in_progress = TRUE
-		priority_announce("Biohazard has reached critical mass. Station loss is imminent.", "Biohazard Alert")
-		SSsecurity_level.set_level(SEC_LEVEL_DELTA)
-
-		// Set status displays to biohazard alert - critical level
-		send_status_display_biohazard_alert()
-
-/*		max_blob_points = INFINITY
-		blob_points = INFINITY
-		addtimer(CALLBACK(src, PROC_REF(victory)), 45 SECONDS)*/
+		on_critical_mass()
 	else if(!free_strain_rerolls && (last_reroll_time + BLOB_POWER_REROLL_FREE_TIME<world.time))
 		to_chat(src, span_boldnotice("You have gained another free strain re-roll."))
 		free_strain_rerolls = 1

--- a/modular_nova/modules/blob/overmind.dm
+++ b/modular_nova/modules/blob/overmind.dm
@@ -1,0 +1,41 @@
+/mob/eye/blob/victory()
+	var/datum/antagonist/blob/B = mind.has_antag_datum(/datum/antagonist/blob)
+	if(B)
+		var/datum/objective/blob_takeover/main_objective = locate() in B.objectives
+		if(main_objective)
+			main_objective.completed = TRUE
+
+/mob/eye/blob/process()
+	if(!blob_core)
+		if(!placed)
+			if(manualplace_min_time && world.time >= manualplace_min_time)
+				to_chat(src, span_boldnotice("You may now place your blob core."))
+				to_chat(src, span_bolddanger("You will automatically place your blob core in [DisplayTimeText(autoplace_max_time - world.time)]."))
+				manualplace_min_time = 0
+			if(autoplace_max_time && world.time >= autoplace_max_time)
+				place_blob_core(BLOB_RANDOM_PLACEMENT)
+		else
+			// If we get here, it means yes: the blob is kill
+			SSticker.news_report = BLOB_DESTROYED
+
+			// Clear the biohazard emergency display when blob is defeated - async to avoid blocking
+			INVOKE_ASYNC(src, PROC_REF(clear_biohazard_display))
+//
+			qdel(src)
+	else if(!victory_in_progress && (blobs_legit.len >= blobwincount))
+		victory_in_progress = TRUE
+		priority_announce("Biohazard has reached critical mass. Station loss is imminent.", "Biohazard Alert")
+		SSsecurity_level.set_level(SEC_LEVEL_DELTA)
+
+		// Set status displays to biohazard alert - critical level
+		send_status_display_biohazard_alert()
+
+/*		max_blob_points = INFINITY
+		blob_points = INFINITY
+		addtimer(CALLBACK(src, PROC_REF(victory)), 45 SECONDS)*/
+	else if(!free_strain_rerolls && (last_reroll_time + BLOB_POWER_REROLL_FREE_TIME<world.time))
+		to_chat(src, span_boldnotice("You have gained another free strain re-roll."))
+		free_strain_rerolls = 1
+
+	if(!victory_in_progress && max_count < blobs_legit.len)
+		max_count = blobs_legit.len

--- a/modular_nova/modules/blob/powers.dm
+++ b/modular_nova/modules/blob/powers.dm
@@ -1,9 +1,7 @@
-/mob/eye/blob/expand_blob(turf/tile)
-	if(world.time < last_attack)
-		return FALSE
-
+/mob/eye/blob/proc/can_expand(turf/tile)
+	. = ..()
+	if(!.)
+		return
 	if(blobs_legit.len >= 400)
 		to_chat(src, span_warning("You have reached your maximum size! You cannot expand any further."))
 		return FALSE
-
-	return ..()

--- a/modular_nova/modules/blob/powers.dm
+++ b/modular_nova/modules/blob/powers.dm
@@ -1,0 +1,12 @@
+/** Expands to nearby tiles */
+/mob/eye/blob/expand_blob(turf/tile)
+	if(world.time < last_attack)
+		return FALSE
+
+	// 1. Check the cap first
+	if(blobs_legit.len >= 400)
+		to_chat(src, span_warning("You have reached your maximum size! You cannot expand any further."))
+		return FALSE
+
+	// 2. If we are under 400, run the original expansion logic
+	return ..()

--- a/modular_nova/modules/blob/powers.dm
+++ b/modular_nova/modules/blob/powers.dm
@@ -1,12 +1,9 @@
-/** Expands to nearby tiles */
 /mob/eye/blob/expand_blob(turf/tile)
 	if(world.time < last_attack)
 		return FALSE
 
-	// 1. Check the cap first
 	if(blobs_legit.len >= 400)
 		to_chat(src, span_warning("You have reached your maximum size! You cannot expand any further."))
 		return FALSE
 
-	// 2. If we are under 400, run the original expansion logic
 	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7830,6 +7830,8 @@
 #include "modular_nova\modules\blastwave_outfits\code\clothing\blastwave_mask.dm"
 #include "modular_nova\modules\blastwave_outfits\code\clothing\blastwave_suit.dm"
 #include "modular_nova\modules\blastwave_outfits\code\clothing\blastwave_uniform.dm"
+#include "modular_nova\modules\blob\overmind.dm"
+#include "modular_nova\modules\blob\powers.dm"
 #include "modular_nova\modules\blooper\atoms_movable.dm"
 #include "modular_nova\modules\blooper\bark.dm"
 #include "modular_nova\modules\blooper\bark_list.dm"


### PR DESCRIPTION

## About The Pull Request
This PR removes the end condition for reaching critical mass and instead locks the blob from manually growing beyond 400 tiles.
## How This Contributes To The Nova Sector Roleplay Experience
I aim to make blobs more palatable to our community by giving the station an indefinite chance to defeat them. I'm doing this by limiting their expansion once they reach their peak instead of ending the round.
## Proof of Testing
<img width="1242" height="573" alt="image" src="https://github.com/user-attachments/assets/f79b1ab8-6960-4dbb-923e-4a1532e11438" />

## Changelog
:cl:  Macaroni
balance: The blob can no longer defeat the station
/:cl:
