### PR TITLE
VV load prefs will no longer transfer incomplete prefs

### DIFF
--- a/modular_nova/modules/extra_vv/code/extra_vv.dm
+++ b/modular_nova/modules/extra_vv/code/extra_vv.dm
@@ -54,6 +54,7 @@
 	var/notice = tgui_alert(usr, "Are you sure you want to load the clients current prefs onto their mob?", "Load Preferences", list("Yes", "No"))
 	if(notice != "Yes")
 		return
+	var/quirks_prompt = tgui_alert(usr, "Reload their quirks too? This will clear any existing quirks on the mob.", "Load Quirks", list("Yes", "No"))
 
 	var/mob/living/carbon/human/human_mob = src
 	human_mob.dna.mutant_bodyparts = list()
@@ -61,8 +62,7 @@
 	human_mob.dna.species.regenerate_organs(src, replace_current = TRUE)
 	human_mob.dna.update_body_size()
 	human_mob.update_body(is_creating = TRUE)
-	var/prompt = tgui_alert(usr, "Reload their quirks too? This will also remove existing quirks on the mob.", "Load Quirks", list("Yes", "No"))
-	if(prompt == "Yes")
+	if(quirks_prompt == "Yes")
 		human_mob.cleanse_quirk_datums()
 		SSquirks.AssignQuirks(src, client)
 	var/msg = span_notice("[key_name_admin(usr)] has loaded [key_name(src)]'s preferences onto their current mob [ADMIN_VERBOSEJMP(src)].")

--- a/modular_nova/modules/extra_vv/code/extra_vv.dm
+++ b/modular_nova/modules/extra_vv/code/extra_vv.dm
@@ -55,7 +55,14 @@
 	if(notice != "Yes")
 		return
 
-	client?.prefs?.apply_prefs_to(src)
+	var/mob/living/carbon/human/human_mob = src
+	human_mob.dna.mutant_bodyparts = list()
+	human_mob.cleanse_quirk_datums()
+	client?.prefs?.apply_prefs_to(src, icon_updates = FALSE)
+	SSquirks.AssignQuirks(src, client)
+	human_mob.dna.species.regenerate_organs(src, replace_current = TRUE)
+	human_mob.dna.update_body_size()
+	human_mob.update_body(is_creating = TRUE)
 	var/msg = span_notice("[key_name_admin(usr)] has loaded [key_name(src)]'s preferences onto their current mob [ADMIN_VERBOSEJMP(src)].")
 	message_admins(msg)
 	admin_ticket_log(src, msg)

--- a/modular_nova/modules/extra_vv/code/extra_vv.dm
+++ b/modular_nova/modules/extra_vv/code/extra_vv.dm
@@ -57,12 +57,14 @@
 
 	var/mob/living/carbon/human/human_mob = src
 	human_mob.dna.mutant_bodyparts = list()
-	human_mob.cleanse_quirk_datums()
 	client?.prefs?.apply_prefs_to(src, icon_updates = FALSE)
-	SSquirks.AssignQuirks(src, client)
 	human_mob.dna.species.regenerate_organs(src, replace_current = TRUE)
 	human_mob.dna.update_body_size()
 	human_mob.update_body(is_creating = TRUE)
+	var/prompt = tgui_alert(usr, "Refresh quirks too?", "Load Quirks", list("Yes", "No"))
+	if(prompt == "Yes")
+		human_mob.cleanse_quirk_datums()
+		SSquirks.AssignQuirks(src, client)
 	var/msg = span_notice("[key_name_admin(usr)] has loaded [key_name(src)]'s preferences onto their current mob [ADMIN_VERBOSEJMP(src)].")
 	message_admins(msg)
 	admin_ticket_log(src, msg)

--- a/modular_nova/modules/extra_vv/code/extra_vv.dm
+++ b/modular_nova/modules/extra_vv/code/extra_vv.dm
@@ -61,7 +61,7 @@
 	human_mob.dna.species.regenerate_organs(src, replace_current = TRUE)
 	human_mob.dna.update_body_size()
 	human_mob.update_body(is_creating = TRUE)
-	var/prompt = tgui_alert(usr, "Refresh quirks too?", "Load Quirks", list("Yes", "No"))
+	var/prompt = tgui_alert(usr, "Reload their quirks too? This will also remove existing quirks on the mob.", "Load Quirks", list("Yes", "No"))
 	if(prompt == "Yes")
 		human_mob.cleanse_quirk_datums()
 		SSquirks.AssignQuirks(src, client)


### PR DESCRIPTION
## About The Pull Request

The 'load prefs onto mob' vv menu option will now actually remove all the existing parts and replace them with the ones from the prefs you are loading. So you shouldn't need to spawn a fresh featureless base body anymore.

## How This Contributes To The Nova Sector Roleplay Experience

Admins deserve tools that actually work

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
<img width="728" height="427" alt="dreamseeker_atNUsgSxXh" src="https://github.com/user-attachments/assets/632d9c74-ca4a-4816-aa0e-ee4c4be2eaa7" />

</details>

## Changelog

:cl:
fix: 'load prefs onto mob' will now fully reset and apply the client's current slot prefs to the mob, including quirks and size
/:cl: