### PR TITLE
[Removal] Removes footprints on the ground

### DIFF
--- a/modular_nova/master_files/code/game/turfs/open/open.dm
+++ b/modular_nova/master_files/code/game/turfs/open/open.dm
@@ -1,0 +1,8 @@
+/turf/open/misc/beach
+	leave_footprints = FALSE
+
+/turf/open/misc/asteroid/snow
+	leave_footprints = FALSE
+
+/turf/open/misc/snow
+	leave_footprints = FALSE

--- a/modular_nova/master_files/code/game/turfs/open/open.dm
+++ b/modular_nova/master_files/code/game/turfs/open/open.dm
@@ -1,8 +1,14 @@
 /turf/open/misc/beach
 	leave_footprints = FALSE
 
-/turf/open/misc/asteroid/snow
-	leave_footprints = FALSE
+/turf/open/misc/asteroid/snow/Initialize(mapload)
+	// no footprints if the mapping level doesn't naturally have snowstorms
+	if(!SSmapping.level_trait(z, ZTRAIT_SNOWSTORM))
+		leave_footprints = FALSE
+	return ..()
 
-/turf/open/misc/snow
-	leave_footprints = FALSE
+/turf/open/misc/snow/Initialize(mapload)
+	// no footprints if the mapping level doesn't naturally have snowstorms
+	if(!SSmapping.level_trait(z, ZTRAIT_SNOWSTORM))
+		leave_footprints = FALSE
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7214,6 +7214,7 @@
 #include "modular_nova\master_files\code\game\turfs\closed\_closed.dm"
 #include "modular_nova\master_files\code\game\turfs\closed\minerals.dm"
 #include "modular_nova\master_files\code\game\turfs\closed\wall\mineral_walls.dm"
+#include "modular_nova\master_files\code\game\turfs\open\open.dm"
 #include "modular_nova\master_files\code\game\turfs\open\floor\fancy_floors.dm"
 #include "modular_nova\master_files\code\game\turfs\open\floor\floors.dm"
 #include "modular_nova\master_files\code\game\turfs\open\floor\iron_floor.dm"


### PR DESCRIPTION

## About The Pull Request
Toggles to false the flag of sand and snow turfs to leave footprints.

## How This Contributes To The Nova Sector Roleplay Experience
They look ugly, only clean on storms and can add up significantly on 3 hour rounds, not to mention concerns with performance. 

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
before:
<img width="555" height="395" alt="image" src="https://github.com/user-attachments/assets/0b3e011a-05c7-482c-8652-5beb100e4fc5" />

after:
<img width="773" height="701" alt="image" src="https://github.com/user-attachments/assets/0ec780da-e9c0-4048-bd2f-72375d6d07c8" />


</details>

## Changelog
:cl:
del: Removed footprints on snow (non snowstorm z levels) and sand.
/:cl:
