### PR TITLE
Organizes Bunny stuff into Groups

### DIFF
--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_heads.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_heads.dm
@@ -307,7 +307,7 @@
 	group = "Costumes"
 
 /datum/loadout_item/head/rabbit_ears
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/synde
 	name = "Black Space-Helmet Replica"
@@ -749,251 +749,251 @@
 /datum/loadout_item/head/rabbit
 	name = "Playbunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunny
 	name = "CentCom Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/centcom
 	restricted_roles = list(ALL_JOBS_CC)
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnyusa
 	name = "American Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/usa
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnyussr
 	name = "Soviet Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/communist
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnybrit
 	name = "British Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/british
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnycap
 	name = "Captain Bunny Ears"
 	item_path = /obj/item/clothing/head/hats/caphat/bunnyears_captain
 	restricted_roles = list(JOB_CAPTAIN)
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnyqm
 	name = "Quartermaster Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/quartermaster
 	restricted_roles = list(JOB_QUARTERMASTER)
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnycargo
 	name = "Cargo Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/cargo
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnymail
 	name = "Courier Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/mailman
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnybitrun
 	name = "Gamer's Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/bitrunner
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnyengi
 	name = "Engineer's Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/engineer
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnyengiatmos
 	name = "Atmos Tech's Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/atmos_tech
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnyengice
 	name = "Chief Engineer's Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/ce
 	restricted_roles = list(JOB_CHIEF_ENGINEER)
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnymed
 	name = "Medical Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/doctor
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnymedpara
 	name = "Paramedical Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/paramedic
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnymedchem
 	name = "Chemical Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/chemist
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbit/playbunnymedviro
 	name = "Pathological Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/pathologist
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbit/playbunnymedcoroner
 	name = "Coroner Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/coroner
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbit/playbunnymedcmo
 	name = "Chief Medical Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/cmo
 	restricted_roles = list(JOB_CHIEF_MEDICAL_OFFICER)
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnyrnd
 	name = "Research Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/scientist
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnyrndrobo
 	name = "Robotic Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/roboticist
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnyrndgene
 	name = "Genetic Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/geneticist
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnyrndrd
 	name = "Director Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/rd
 	restricted_roles = list(JOB_RESEARCH_DIRECTOR)
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnysecdept
 	name = "Less Secure Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/security/assistant
 	restricted_roles = list(ALL_JOBS_SEC)
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnysec
 	name = "Secure Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/security
 	restricted_roles = list(ALL_JOBS_SEC)
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnysecwarden
 	name = "Secure Silver Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/warden
 	restricted_roles = list(JOB_WARDEN)
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnysechos
 	name = "Secure Gold Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/hos
 	restricted_roles = list(JOB_HEAD_OF_SECURITY)
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnysecmed
 	name = "Secure Medical Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/brig_phys
 	restricted_roles = list(ALL_JOBS_SEC)
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnysecdet
 	name = "Curious Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/detective
 	restricted_roles = list(JOB_DETECTIVE)
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnysecdetnoir
 	name = "Curious Noir Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/detective/noir
 	restricted_roles = list(JOB_DETECTIVE)
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnyprisoner
 	name = "Locked Up Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/prisoner
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnyhop
 	name = "Hopping Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/hop
 	restricted_roles = list(JOB_HEAD_OF_PERSONNEL)
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnybar
 	name = "Drunk Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/bartender
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnyjani
 	name = "Clean Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/janitor
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnychef
 	name = "Hungry Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/cook
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnyhydro
 	name = "Botanical Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/botanist
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnyclown
 	name = "Funny Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/clown
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnymime
 	name = "Quiet Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/mime
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnychaplain
 	name = "Holy Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/chaplain
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnycuratorred
 	name = "Nerdy Red Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/curator_red
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnycuratorgreen
 	name = "Nerdy Green Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/curator_green
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnycuratorteal
 	name = "Nerdy Green Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/curator_teal
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnylawyerblack
 	name = "Lawful Black Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/lawyer_black
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnylawyerblue
 	name = "Lawful Blue Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/lawyer_blue
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnylawyerred
 	name = "Lawful Red Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/lawyer_red
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnylawyergood
 	name = "Lawful Good Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/lawyer_good
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /datum/loadout_item/head/rabbitplaybunnypsych
 	name = "Shrink's Bunny Ears"
 	item_path = /obj/item/clothing/head/playbunnyears/psychologist
-	group = "Costumes"
+	group = "Playbunny Ears"
 
 /*
 *	erp_item

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_suit.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_suit.dm
@@ -752,153 +752,153 @@
 /datum/loadout_item/suit/tailcoat
 	name = "Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatbartender
 	name = "Bartender's Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/bartender
 	restricted_roles = list(JOB_BARTENDER)
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatwizard
 	name = "Magician's Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/magician
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatbrit
 	name = "Brit's Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/british
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatussr
 	name = "Soviet's Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/communist
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatusa
 	name = "Yank's Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/usa
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatcargo
 	name = "Cargo's Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/cargo
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatbitrunner
 	name = "Gamer's Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/bitrunner
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatmedical
 	name = "Doctor's Tailcoat"
 	item_path = /obj/item/clothing/suit/toggle/labcoat/doctor_tailcoat
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatmedicalpara
 	name = "Paramedic's Tailcoat"
 	item_path = /obj/item/clothing/suit/toggle/labcoat/paramedic/doctor_tailcoat
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatmedicalchem
 	name = "Chemist's Tailcoat"
 	item_path = /obj/item/clothing/suit/toggle/labcoat/chemist/doctor_tailcoat
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatmedicalviro
 	name = "Pathologist's Tailcoat"
 	item_path = /obj/item/clothing/suit/toggle/labcoat/virologist/doctor_tailcoat
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatmedicalcoroner
 	name = "Edgelord's Tailcoat"
 	item_path = /obj/item/clothing/suit/toggle/labcoat/coroner/doctor_tailcoat
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatrnd
 	name = "Scientist's Tailcoat"
 	item_path = /obj/item/clothing/suit/toggle/labcoat/science/doctor_tailcoat
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatrndrobo
 	name = "Roboticist's Tailcoat"
 	item_path = /obj/item/clothing/suit/toggle/labcoat/roboticist/doctor_tailcoat
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatrndgenetics
 	name = "Geneticist's Tailcoat"
 	item_path = /obj/item/clothing/suit/toggle/labcoat/genetics/doctor_tailcoat
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatjanitor
 	name = "Janitor's Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/janitor
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatcook
 	name = "Chef's Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/cook
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoathydro
 	name = "Botanist's Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/botanist
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatclown
 	name = "Clown's Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/clown
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatmime
 	name = "Mime's Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/mime
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatchaplain
 	name = "Priest's Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/chaplain
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatcuratorred
 	name = "Curator's Red Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/curator_red
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatcuratorgreen
 	name = "Curator's Green Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/curator_green
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatcuratorteal
 	name = "Curator's Teal Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/curator_teal
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatlawyerblack
 	name = "Lawyer's Black Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/lawyer_black
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatlawyerblue
 	name = "Lawyer's Blue Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/lawyer_blue
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatlawyerred
 	name = "Lawyer's Red Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/lawyer_red
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatlawyergood
 	name = "Lawyer's Good Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/lawyer_good
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/tailcoatshrink
 	name = "Psychologist's Tailcoat"
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/psychologist
-	group = "Costumes"
+	group = "Tailcoats"
 
 /datum/loadout_item/suit/jacket/long_robe
 	name = "Long Robe"

--- a/modular_nova/modules/loadouts/loadout_items/under/loadout_datum_under.dm
+++ b/modular_nova/modules/loadouts/loadout_items/under/loadout_datum_under.dm
@@ -382,148 +382,148 @@
 	name = "Bunny Suit (White)"
 	item_path = /obj/item/clothing/under/costume/bunnylewd/white
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 /datum/loadout_item/under/bunny/color
 	name = "Bunny Suit (Colorable)"
 	item_path = /obj/item/clothing/under/costume/playbunny/greyscale
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 /datum/loadout_item/under/bunny/wizard
 	name = "Bunny Suit (Magician)"
 	item_path = /obj/item/clothing/under/costume/playbunny/magician
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 /datum/loadout_item/under/bunny/centcom
 	name = "Bunny Suit (Centcom)"
 	item_path = /obj/item/clothing/under/costume/playbunny/centcom
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(ALL_JOBS_CC)
 
 /datum/loadout_item/under/bunny/brit
 	name = "Bunny Suit (British)"
 	item_path = /obj/item/clothing/under/costume/playbunny/british
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 /datum/loadout_item/under/bunny/ussr
 	name = "Bunny Suit (Communist)"
 	item_path = /obj/item/clothing/under/costume/playbunny/communist
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 /datum/loadout_item/under/bunny/usa
 	name = "Bunny Suit (USA)"
 	item_path = /obj/item/clothing/under/costume/playbunny/usa
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 /datum/loadout_item/under/bunny/tailor
 	name = "Bunny Suit (Tailormade)"
 	item_path = /obj/item/clothing/under/costume/playbunny/custom_playbunny
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 /datum/loadout_item/under/bunny/mailman
 	name = "Bunny Suit (Courier)"
 	item_path = /obj/item/clothing/under/rank/cargo/mailman_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 /datum/loadout_item/under/bunny/gamer
 	name = "Bunny Suit (Gamer)"
 	item_path = /obj/item/clothing/under/rank/cargo/bitrunner/bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 /datum/loadout_item/under/bunny/prisoner
 	name = "Bunny Suit (Prisoner)"
 	item_path = /obj/item/clothing/under/rank/security/prisoner_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 /datum/loadout_item/under/bunny/janitor
 	name = "Bunny Suit (Janitor)"
 	item_path = /obj/item/clothing/under/rank/civilian/janitor/bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 /datum/loadout_item/under/bunny/bartender
 	name = "Bunny Suit (Bartender)"
 	item_path = /obj/item/clothing/under/rank/civilian/bartender_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 /datum/loadout_item/under/bunny/chef
 	name = "Bunny Suit (Cook)"
 	item_path = /obj/item/clothing/under/rank/civilian/cook_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 /datum/loadout_item/under/bunny/hydro
 	name = "Bunny Suit (Botany)"
 	item_path = /obj/item/clothing/under/rank/civilian/hydroponics/bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 /datum/loadout_item/under/bunny/chaplain
 	name = "Bunny Suit (Chaplain)"
 	item_path = /obj/item/clothing/under/rank/civilian/chaplain_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 /datum/loadout_item/under/bunny/curatorred
 	name = "Bunny Suit (Curator, Red)"
 	item_path = /obj/item/clothing/under/rank/civilian/curator_bunnysuit_red
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 /datum/loadout_item/under/bunny/curatorgreen
 	name = "Bunny Suit (Curator, Green)"
 	item_path = /obj/item/clothing/under/rank/civilian/curator_bunnysuit_green
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 /datum/loadout_item/under/bunny/curatorteal
 	name = "Bunny Suit (Curator, Teal)"
 	item_path = /obj/item/clothing/under/rank/civilian/curator_bunnysuit_teal
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 /datum/loadout_item/under/bunny/lawyerblack
 	name = "Bunny Suit (Lawyer, Black)"
 	item_path = /obj/item/clothing/under/rank/civilian/lawyer_bunnysuit_black
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 /datum/loadout_item/under/bunny/lawyerblue
 	name = "Bunny Suit (Lawyer, Blue)"
 	item_path = /obj/item/clothing/under/rank/civilian/lawyer_bunnysuit_blue
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 
 /datum/loadout_item/under/bunny/lawyerred
 	name = "Bunny Suit (Lawyer, Red)"
 	item_path = /obj/item/clothing/under/rank/civilian/lawyer_bunnysuit_red
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 
 /datum/loadout_item/under/bunny/lawyergood
 	name = "Bunny Suit (Lawyer, Good)"
 	item_path = /obj/item/clothing/under/rank/civilian/lawyer_bunnysuit_good
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 /datum/loadout_item/under/bunny/psychologist
 	name = "Bunny Suit (Lawyer, Good)"
 	item_path = /obj/item/clothing/under/rank/civilian/psychologist_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 
 /datum/loadout_item/under/miscellaneous/latex_catsuit
 	name = "Latex Catsuit"

--- a/modular_nova/modules/loadouts/loadout_items/under/loadout_datum_under_job.dm
+++ b/modular_nova/modules/loadouts/loadout_items/under/loadout_datum_under_job.dm
@@ -215,7 +215,7 @@
 	name = "Bunny Suit (Captain)"
 	item_path = /obj/item/clothing/under/rank/captain/bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(JOB_CAPTAIN)
 
 //SERV
@@ -235,21 +235,21 @@
 	name = "Bunny Suit (HoP)"
 	item_path = /obj/item/clothing/under/rank/civilian/hop_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(JOB_HEAD_OF_PERSONNEL)
 
 /datum/loadout_item/under/bunny/clown
 	name = "Bunny Suit (Clown)"
 	item_path = /obj/item/clothing/under/rank/civilian/clown/clown_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(JOB_CLOWN)
 
 /datum/loadout_item/under/bunny/mime
 	name = "Bunny Suit (Mime)"
 	item_path = /obj/item/clothing/under/rank/civilian/mime_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(JOB_MIME)
 
 //MED
@@ -269,42 +269,42 @@
 	name = "Bunny Suit (Medical)"
 	item_path = /obj/item/clothing/under/rank/medical/doctor_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(ALL_JOBS_MED)
 
 /datum/loadout_item/under/bunny/medical/paramed
 	name = "Bunny Suit (Paramedic)"
 	item_path = /obj/item/clothing/under/rank/medical/paramedic_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(ALL_JOBS_MED)
 
 /datum/loadout_item/under/bunny/medical/chem
 	name = "Bunny Suit (Chemist)"
 	item_path = /obj/item/clothing/under/rank/medical/chemist/bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(ALL_JOBS_MED)
 
 /datum/loadout_item/under/bunny/medical/viro
 	name = "Bunny Suit (Virology)"
 	item_path = /obj/item/clothing/under/rank/medical/pathologist_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(ALL_JOBS_MED)
 
 /datum/loadout_item/under/bunny/medical/coroner
 	name = "Bunny Suit (Coroner)"
 	item_path = /obj/item/clothing/under/rank/medical/coroner_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(ALL_JOBS_MED)
 
 /datum/loadout_item/under/bunny/medical/coroner
 	name = "Bunny Suit (Chief Medical Officer)"
 	item_path = /obj/item/clothing/under/rank/medical/cmo_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(JOB_CHIEF_MEDICAL_OFFICER)
 
 
@@ -325,21 +325,21 @@
 	name = "Bunny Suit (Engineer)"
 	item_path = /obj/item/clothing/under/rank/engineering/engineer_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(ALL_JOBS_ENGI)
 
 /datum/loadout_item/under/bunny/engineer/atmos
 	name = "Bunny Suit (Atmos)"
 	item_path = /obj/item/clothing/under/rank/engineering/atmos_tech_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(ALL_JOBS_ENGI)
 
 /datum/loadout_item/under/bunny/engineer/ce
 	name = "Bunny Suit (Chief Engineer)"
 	item_path = /obj/item/clothing/under/rank/engineering/chief_engineer/bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(JOB_CHIEF_ENGINEER)
 
 //SCI
@@ -359,28 +359,28 @@
 	name = "Bunny Suit (Science)"
 	item_path = /obj/item/clothing/under/rank/rnd/scientist/bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(ALL_JOBS_SCI)
 
 /datum/loadout_item/under/bunny/rnd/robo
 	name = "Bunny Suit (Robotics)"
 	item_path = /obj/item/clothing/under/rank/rnd/scientist/roboticist_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(ALL_JOBS_SCI)
 
 /datum/loadout_item/under/bunny/rnd/gene
 	name = "Bunny Suit (Genetics)"
 	item_path = /obj/item/clothing/under/rank/rnd/geneticist/bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(ALL_JOBS_SCI)
 
 /datum/loadout_item/under/bunny/rnd/rd
 	name = "Bunny Suit (Research Director)"
 	item_path = /obj/item/clothing/under/rank/rnd/research_director/bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(ALL_JOBS_SCI)
 
 //CARGO
@@ -406,14 +406,14 @@
 	name = "Bunny Suit (Quartermaster)"
 	item_path = /obj/item/clothing/under/rank/cargo/quartermaster_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(JOB_QUARTERMASTER)
 
 /datum/loadout_item/under/bunny/cargo
 	name = "Bunny Suit (Cargo)"
 	item_path = /obj/item/clothing/under/rank/cargo/cargo_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 //restricted_roles = list(ALL_JOBS_CARGO)
 
 //SEC
@@ -511,47 +511,47 @@
 	name = "Bunny Suit (Security)"
 	item_path = /obj/item/clothing/under/rank/security/security_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(ALL_JOBS_SEC)
 
 /datum/loadout_item/under/bunny/sec/dept
 	name = "Bunny Suit (Deputy)"
 	item_path = /obj/item/clothing/under/rank/security/security_assistant_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(ALL_JOBS_SEC)
 
 /datum/loadout_item/under/bunny/sec/med
 	name = "Bunny Suit (SecMed)"
 	item_path = /obj/item/clothing/under/rank/security/brig_phys_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(ALL_JOBS_SEC)
 
 /datum/loadout_item/under/bunny/sec/warden
 	name = "Bunny Suit (Warden)"
 	item_path = /obj/item/clothing/under/rank/security/warden_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(JOB_WARDEN, JOB_HEAD_OF_SECURITY)
 
 /datum/loadout_item/under/bunny/sec/det
 	name = "Bunny Suit (Detective)"
 	item_path = /obj/item/clothing/under/rank/security/detective_bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(JOB_DETECTIVE)
 
 /datum/loadout_item/under/bunny/sec/det/noir
 	name = "Bunny Suit (Noir Detective)"
 	item_path = /obj/item/clothing/under/rank/security/detective_bunnysuit/noir
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(JOB_DETECTIVE)
 
 /datum/loadout_item/under/bunny/sec/hos
 	name = "Bunny Suit (Head of Security)"
 	item_path = /obj/item/clothing/under/rank/security/head_of_security/bunnysuit
 	erp_item = TRUE
-	group = "Bunny Suit"
+	group = "Bunny Suits"
 	restricted_roles = list(JOB_HEAD_OF_SECURITY)


### PR DESCRIPTION

## About The Pull Request
Title.

Organized better.

<img width="667" height="562" alt="image" src="https://github.com/user-attachments/assets/a72afefb-48e3-4da5-93fa-b99a04c4d33c" />
<img width="643" height="575" alt="image" src="https://github.com/user-attachments/assets/e657b815-d922-459e-9eab-d378a2c9824d" />

Ties were alright where they were.


## How This Contributes To The Nova Sector Roleplay Experience

Org good.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
qol: Tailcoats, bunny suits and bunny ears are now grouped.
/:cl:
