### PR TITLE
Fix for synth brain repair surgery

### DIFF
--- a/modular_nova/modules/synths/code/surgery/operations/operation_organ_repair.dm
+++ b/modular_nova/modules/synths/code/surgery/operations/operation_organ_repair.dm
@@ -275,7 +275,7 @@
 	success_sound = 'sound/items/taperecorder/taperecorder_close.ogg'
 	required_organ_flag = ORGAN_ROBOTIC & ORGAN_SYNTHETIC_FROM_SPECIES
 	blocked_organ_flag = NONE
-	heal_to_percent = 0
+	heal_to_percent = 0.1 // Silly variable. It works completely differently here than in other organ repair surgeries
 	failure_damage_percent = 0.2
 	repeatable = TRUE
 	time = 12 SECONDS //long and complicated
@@ -312,15 +312,15 @@
 		span_notice("[surgeon] completes the surgery on [FORMAT_ORGAN_OWNER(organ)]'s [brain_type]."),
 	)
 	display_pain(organ.owner, "The fragmentation errors start clearing.")
-		// Remove all neuroware
+	// Remove all neuroware
 	if(!isnull(organ.owner.has_status_effect(/datum/status_effect/neuroware)))
 		organ.owner.balloon_alert_to_viewers("neuroware reset")
 		for(var/datum/reagent/reagent as anything in organ.owner.reagents.reagent_list)
 			if(reagent.chemical_flags & REAGENT_NEUROWARE)
 				organ.owner.reagents.del_reagent(reagent.type)
-	if (organ.owner)
+	if(organ.owner)
 		organ.owner.mind?.remove_antag_datum(/datum/antagonist/brainwashed)
-	else if (organ.brainmob)
+	else if(organ.brainmob)
 		organ.brainmob.mind?.remove_antag_datum(/datum/antagonist/brainwashed)
 	organ.cure_all_traumas(TRAUMA_RESILIENCE_SURGERY)
 	if(organ.damage > organ.maxHealth * 0.1)


### PR DESCRIPTION

## About The Pull Request

Weh! 🦎 
Just a fix for synth brain repair surgery. Previously, it did not heal brain damage at all

This was because healing was calculated here: `organ.apply_organ_damage(-organ.maxHealth * heal_to_percent)`
However, `heal_to_percent` was set to 0, as the description of this variable is slightly misleading

<img width="451" height="65" alt="изображение" src="https://github.com/user-attachments/assets/6991320d-99d9-4ebe-9356-4f8cb1c7cd9f" />

Because of this, healing was always 0 😄 

Now, after each surgical "cycle" the brain will be healed by 10% (always 20 hp, since the brain’s max health is 200)
## How This Contributes To The Nova Sector Roleplay Experience

It is a fix
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="499" height="628" alt="изображение" src="https://github.com/user-attachments/assets/7a1d2e1f-79b9-4f0c-8bd9-a4a4cc9f668e" />

</details>

## Changelog
:cl:
fix: synth brain repair surgery now works
/:cl:
