### PR TITLE
hybrid tool subtype blacklist, printable medical combitool

### DIFF
--- a/modular_nova/modules/alien_hybrid_tools/code/alien_hybrid_recipes.dm
+++ b/modular_nova/modules/alien_hybrid_tools/code/alien_hybrid_recipes.dm
@@ -10,6 +10,10 @@
 	time = 10 SECONDS
 	category = CAT_TOOLS
 
+/datum/crafting_recipe/hybrid_drill/New()
+	..()
+	LAZYOR(blacklist, subtypesof(/obj/item/screwdriver/power))
+
 /datum/crafting_recipe/hybrid_jaws
 	result = /obj/item/crowbar/power/alien
 	reqs = list(
@@ -20,6 +24,10 @@
 	)
 	time = 10 SECONDS
 	category = CAT_TOOLS
+
+/datum/crafting_recipe/hybrid_jaws/New()
+	..()
+	LAZYOR(blacklist, subtypesof(/obj/item/crowbar/power) - list(/obj/item/crowbar/power/syndicate))
 
 /datum/crafting_recipe/hybrid_scalpel
 	result = /obj/item/scalpel/advanced/alien
@@ -32,6 +40,10 @@
 	time = 10 SECONDS
 	category = CAT_TOOLS
 
+/datum/crafting_recipe/hybrid_scalpel/New()
+	..()
+	LAZYOR(blacklist, subtypesof(/obj/item/scalpel/advanced))
+
 /datum/crafting_recipe/hybrid_retractor
 	result = /obj/item/retractor/advanced/alien
 	reqs = list(
@@ -42,6 +54,10 @@
 	)
 	time = 10 SECONDS
 	category = CAT_TOOLS
+
+/datum/crafting_recipe/hybrid_retractor/New()
+	..()
+	LAZYOR(blacklist, subtypesof(/obj/item/retractor/advanced))
 
 /datum/crafting_recipe/hybrid_cautery
 	result = /obj/item/cautery/advanced/alien
@@ -54,6 +70,10 @@
 	time = 10 SECONDS
 	category = CAT_TOOLS
 
+/datum/crafting_recipe/hybrid_cautery/New()
+	..()
+	LAZYOR(blacklist, subtypesof(/obj/item/cautery/advanced))
+
 /datum/crafting_recipe/hybrid_med_combi
 	result = /obj/item/blood_filter/advanced/alien
 	reqs = list(
@@ -64,3 +84,7 @@
 	)
 	time = 10 SECONDS
 	category = CAT_TOOLS
+
+/datum/crafting_recipe/hybrid_med_combi/New()
+	..()
+	LAZYOR(blacklist, subtypesof(/obj/item/blood_filter/advanced))

--- a/modular_nova/modules/medical_combitool/code/medical_combitool.dm
+++ b/modular_nova/modules/medical_combitool/code/medical_combitool.dm
@@ -181,6 +181,7 @@
 	desc = "This tool can be either used as a blood filter or bonesetter."
 	id = "combitool"
 	build_path = /obj/item/blood_filter/advanced
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 6,
 					/datum/material/glass = SHEET_MATERIAL_AMOUNT * 2,
 					/datum/material/silver = SHEET_MATERIAL_AMOUNT * 2,


### PR DESCRIPTION
## About The Pull Request
Hybrid tool crafting recipes now require the _base_ tool and not any subtype (incl. science-specific subtypes and, funnily enough, their upgraded variants) (special case for allowing the Syndicate jaws for the hybrid jaws recipe).

Medical combitool now has build_type flags so it can actually be printed off techfabs/lathes.

## How This Contributes To The Nova Sector Roleplay Experience

The science tools being usable for this circumvents the entire purpose of encouraging departmental interaction, so that should probably get killed off. This also has the nice side effect of preventing you from accidentally using a hybrid tool for crafting a hybrid tool, wasting the other components. Also making the base medical combitool printable is probably good.

## Proof of Testing

<img width="500" height="177" alt="2026-04-26_03-54-29-AM-Sunday" src="https://github.com/user-attachments/assets/afcc3c2d-6cee-4f6e-9767-0d45658b9f33" />

## Changelog

:cl:
balance: Following an incident where several pieces of assimilative superalloy were wasted on repeatedly upgrading one specific set of tools, their pre-seeded intelligences were revised to only accept the most basic form of their power tool component. Unfortunately, this had the knock-on effect of preventing Science's equivalent tools from being usable for upgrading. Whoops.
fix: Medical combitools can now be printed, as they were missing the flags that allowed them to be printed off techfabs/lathes.
/:cl:

