### PR TITLE
[Spite] Adjust minor age for buying booze and cigarretes.

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -488,7 +488,7 @@
 #define AGE_MIN 18 //youngest a character can be
 #define AGE_MAX 100 //oldest a character can be //NOVA EDIT CHANGE - Increase max character age to 100 - ORIGINAL: #define AGE_MAX 85 //oldest a character can be
 #define AGE_CHRONO_MAX 400 //NOVA EDIT ADDITION - Chronological age
-#define AGE_MINOR 20 //legal age of space drinking and smoking
+#define AGE_MINOR 18 //NOVA EDIT CHANGE - We dont use these features, and its easier to just patch it from here. Original: AGE_MINOR 20 //legal age of space drinking and smoking
 #define WIZARD_AGE_MIN 30 //youngest a wizard can be
 #define APPRENTICE_AGE_MIN 29 //youngest an apprentice can be
 


### PR DESCRIPTION

## About The Pull Request
Adjust the minor age for drinking and buying cigarretes to the same of minimal age of the server, ie, 18.

## How This Contributes To The Nova Sector Roleplay Experience
Prevents some TG subsystems for being relevant, ends what was becoming a 3 different policy channels discussion, I wasted more time reading all the opinions than writting this code and documentation.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: Changed the minimum age of drinking and smoking to 18 instead of 21.
/:cl:
