### PR TITLE
Touching the supermatter will now, before dusting your body, will respawn you as a definitely-not-an-illegal-clone who's late for work with a bad sense of deja vu.

### DIFF
--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -312,6 +312,10 @@
 				source = atom_source,
 				header = "Polytechnical Difficulties",
 			)
+		// NOVA EDIT ADDITION START - Supermatter clone replacement
+		if(ishuman(consumed_mob))
+			replace_with_clone(consumed_mob)
+		// NOVA EDIT ADDITION END
 		consumed_mob.dust(force = TRUE)
 		matter_increase += 100 * object_size * 2
 		if(is_clown_job(consumed_mob.mind?.assigned_role))
@@ -370,3 +374,43 @@
 /datum/component/supermatter_crystal/proc/consume_returns(matter_increase = 0, damage_increase = 0)
 	if(consume_callback)
 		consume_callback.Invoke(matter_increase, damage_increase)
+
+// NOVA EDIT ADDITION START - Replace crewmembers who get dusted with a fresh copy from the cloning vats at arrivals.
+/datum/component/supermatter_crystal/proc/replace_with_clone(mob/living/carbon/human/replaced_person)
+	if(!replaced_person || !replaced_person.mind || (replaced_person.mind && istype(replaced_person.mind.assigned_role, /datum/job/unassigned)))
+		return // NT don't give a shit about replacing this person, they're either not a player, not crew or not a player with a job
+	var/datum/mind/our_mind = replaced_person.mind
+	var/atom/destination = our_mind.assigned_role.get_latejoin_spawn_point()
+	// A lot of this is copied from new_player, but we need to run through a lot of this boiler-plate to "properly" make a "just late-joined" character.
+	if(!destination)
+		CRASH("Failed to find a latejoin spawn point.")
+	our_mind.active = FALSE
+	if(!replaced_person.client)
+		CRASH("Client disconnected before we could make the replacement mob.")
+	var/mob/living/carbon/human/spawning_mob = our_mind.assigned_role.get_spawn_mob(replaced_person.client, destination)
+	our_mind.transfer_to(spawning_mob)
+	// Notably we do NOT set original character here, because this is not their actual original character.
+	spawning_mob.PossessByPlayer(replaced_person.ckey)
+	to_chat(spawning_mob, span_userdanger("You have forgotten everything you did this shift. You are left with a horrible sense of Deja Vu."))
+	var/area/joined_area = get_area(spawning_mob.loc)
+	if(joined_area)
+		joined_area.on_joining_game(spawning_mob)
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CREWMEMBER_JOINED, spawning_mob, spawning_mob.mind.assigned_role.title)
+	SSjob.equip_rank(spawning_mob, our_mind.assigned_role, spawning_mob.client)
+	our_mind.assigned_role.after_latejoin_spawn(spawning_mob)
+	spawning_mob.increment_scar_slot()
+	spawning_mob.load_persistent_scars()
+	SSpersistence.load_modular_persistence(spawning_mob.get_organ_slot(ORGAN_SLOT_BRAIN))
+	if(GLOB.curse_of_madness_triggered)
+		give_madness(spawning_mob, GLOB.curse_of_madness_triggered)
+	if(our_mind.assigned_role.job_flags & JOB_ASSIGN_QUIRKS)
+		if(CONFIG_GET(flag/roundstart_traits))
+			SSquirks.AssignQuirks(spawning_mob, spawning_mob.client)
+	else
+		spawning_mob.clear_personalities()
+	var/list/loadout = spawning_mob.client?.get_loadout_datums()
+	for(var/datum/loadout_item/item as anything in loadout)
+		if (item.restricted_roles && length(item.restricted_roles) && !(our_mind.assigned_role.title in item.restricted_roles))
+			continue
+		item.post_equip_item(spawning_mob.client?.prefs, spawning_mob)
+// NOVA EDIT ADDITION END

--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -314,7 +314,8 @@
 			)
 		// NOVA EDIT ADDITION START - Supermatter clone replacement
 		if(ishuman(consumed_mob))
-			replace_with_clone(consumed_mob)
+			var/mob/living/carbon/human/consumed_human = consumed_mob
+			consumed_human.replace_with_clone()
 		// NOVA EDIT ADDITION END
 		consumed_mob.dust(force = TRUE)
 		matter_increase += 100 * object_size * 2
@@ -374,43 +375,3 @@
 /datum/component/supermatter_crystal/proc/consume_returns(matter_increase = 0, damage_increase = 0)
 	if(consume_callback)
 		consume_callback.Invoke(matter_increase, damage_increase)
-
-// NOVA EDIT ADDITION START - Replace crewmembers who get dusted with a fresh copy from the cloning vats at arrivals.
-/datum/component/supermatter_crystal/proc/replace_with_clone(mob/living/carbon/human/replaced_person)
-	if(!replaced_person || !replaced_person.mind || (replaced_person.mind && istype(replaced_person.mind.assigned_role, /datum/job/unassigned)))
-		return // NT don't give a shit about replacing this person, they're either not a player, not crew or not a player with a job
-	var/datum/mind/our_mind = replaced_person.mind
-	var/atom/destination = our_mind.assigned_role.get_latejoin_spawn_point()
-	// A lot of this is copied from new_player, but we need to run through a lot of this boiler-plate to "properly" make a "just late-joined" character.
-	if(!destination)
-		CRASH("Failed to find a latejoin spawn point.")
-	our_mind.active = FALSE
-	if(!replaced_person.client)
-		CRASH("Client disconnected before we could make the replacement mob.")
-	var/mob/living/carbon/human/spawning_mob = our_mind.assigned_role.get_spawn_mob(replaced_person.client, destination)
-	our_mind.transfer_to(spawning_mob)
-	// Notably we do NOT set original character here, because this is not their actual original character.
-	spawning_mob.PossessByPlayer(replaced_person.ckey)
-	to_chat(spawning_mob, span_userdanger("You have forgotten everything you did this shift. You are left with a horrible sense of Deja Vu."))
-	var/area/joined_area = get_area(spawning_mob.loc)
-	if(joined_area)
-		joined_area.on_joining_game(spawning_mob)
-	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CREWMEMBER_JOINED, spawning_mob, spawning_mob.mind.assigned_role.title)
-	SSjob.equip_rank(spawning_mob, our_mind.assigned_role, spawning_mob.client)
-	our_mind.assigned_role.after_latejoin_spawn(spawning_mob)
-	spawning_mob.increment_scar_slot()
-	spawning_mob.load_persistent_scars()
-	SSpersistence.load_modular_persistence(spawning_mob.get_organ_slot(ORGAN_SLOT_BRAIN))
-	if(GLOB.curse_of_madness_triggered)
-		give_madness(spawning_mob, GLOB.curse_of_madness_triggered)
-	if(our_mind.assigned_role.job_flags & JOB_ASSIGN_QUIRKS)
-		if(CONFIG_GET(flag/roundstart_traits))
-			SSquirks.AssignQuirks(spawning_mob, spawning_mob.client)
-	else
-		spawning_mob.clear_personalities()
-	var/list/loadout = spawning_mob.client?.get_loadout_datums()
-	for(var/datum/loadout_item/item as anything in loadout)
-		if (item.restricted_roles && length(item.restricted_roles) && !(our_mind.assigned_role.title in item.restricted_roles))
-			continue
-		item.post_equip_item(spawning_mob.client?.prefs, spawning_mob)
-// NOVA EDIT ADDITION END

--- a/code/modules/power/supermatter/supermatter_hit_procs.dm
+++ b/code/modules/power/supermatter/supermatter_hit_procs.dm
@@ -68,7 +68,12 @@
 	var/mob/living/carbon/jedi = user
 	to_chat(jedi, span_userdanger("That was a really dense idea."))
 	jedi.investigate_log("had [jedi.p_their()] brain dusted by touching [src] with telekinesis.", INVESTIGATE_DEATHS)
-	jedi.ghostize()
+	// NOVA EDIT ADDITION START - Supermatter replacement
+	if(ishuman(user))
+		replace_with_clone(user)
+	else
+		jedi.ghostize()
+	// NOVA EDIT ADDITION END
 	var/obj/item/organ/brain/rip_u = locate(/obj/item/organ/brain) in jedi.organs
 	if(rip_u)
 		rip_u.Remove(jedi)
@@ -123,6 +128,45 @@
 		return
 
 	return ..()
+// NOVA EDIT ADDITION START - Replace crewmembers who get dusted with a fresh copy from the cloning vats at arrivals.
+/obj/machinery/power/supermatter_crystal/proc/replace_with_clone(mob/living/carbon/human/replaced_person)
+	if(!replaced_person || !replaced_person.mind || (replaced_person.mind && istype(replaced_person.mind.assigned_role, /datum/job/unassigned)))
+		return // NT don't give a shit about replacing this person, they're either not a player, not crew or not a player with a job
+	var/datum/mind/our_mind = replaced_person.mind
+	var/atom/destination = our_mind.assigned_role.get_latejoin_spawn_point()
+	// A lot of this is copied from new_player, but we need to run through a lot of this boiler-plate to "properly" make a "just late-joined" character.
+	if(!destination)
+		CRASH("Failed to find a latejoin spawn point.")
+	our_mind.active = FALSE
+	if(!replaced_person.client)
+		CRASH("Client disconnected before we could make the replacement mob.")
+	var/mob/living/carbon/human/spawning_mob = our_mind.assigned_role.get_spawn_mob(replaced_person.client, destination)
+	our_mind.transfer_to(spawning_mob)
+	// Notably we do NOT set original character here, because this is not their actual original character.
+	spawning_mob.PossessByPlayer(replaced_person.ckey)
+	to_chat(spawning_mob, span_userdanger("You have forgotten everything you did this shift. You are left with a horrible sense of Deja Vu."))
+	var/area/joined_area = get_area(spawning_mob.loc)
+	if(joined_area)
+		joined_area.on_joining_game(spawning_mob)
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CREWMEMBER_JOINED, spawning_mob, spawning_mob.mind.assigned_role.title)
+	SSjob.equip_rank(spawning_mob, our_mind.assigned_role, spawning_mob.client)
+	our_mind.assigned_role.after_latejoin_spawn(spawning_mob)
+	spawning_mob.increment_scar_slot()
+	spawning_mob.load_persistent_scars()
+	SSpersistence.load_modular_persistence(spawning_mob.get_organ_slot(ORGAN_SLOT_BRAIN))
+	if(GLOB.curse_of_madness_triggered)
+		give_madness(spawning_mob, GLOB.curse_of_madness_triggered)
+	if(our_mind.assigned_role.job_flags & JOB_ASSIGN_QUIRKS)
+		if(CONFIG_GET(flag/roundstart_traits))
+			SSquirks.AssignQuirks(spawning_mob, spawning_mob.client)
+	else
+		spawning_mob.clear_personalities()
+	var/list/loadout = spawning_mob.client?.get_loadout_datums()
+	for(var/datum/loadout_item/item as anything in loadout)
+		if (item.restricted_roles && length(item.restricted_roles) && !(our_mind.assigned_role.title in item.restricted_roles))
+			continue
+		item.post_equip_item(spawning_mob.client?.prefs, spawning_mob)
+// NOVA EDIT ADDITION END
 
 //Do not blow up our internal radio
 /obj/machinery/power/supermatter_crystal/contents_explosion(severity, target)

--- a/code/modules/power/supermatter/supermatter_hit_procs.dm
+++ b/code/modules/power/supermatter/supermatter_hit_procs.dm
@@ -71,7 +71,8 @@
 	//jedi.ghostize() // NOVA EDIT REMOVAL
 	// NOVA EDIT ADDITION START - Supermatter replacement
 	if(ishuman(user))
-		replace_with_clone(user)
+		var/mob/living/carbon/human/jedi_human = user
+		jedi_human.replace_with_clone()
 	else
 		jedi.ghostize()
 	// NOVA EDIT ADDITION END
@@ -129,45 +130,6 @@
 		return
 
 	return ..()
-// NOVA EDIT ADDITION START - Replace crewmembers who get dusted with a fresh copy from the cloning vats at arrivals.
-/obj/machinery/power/supermatter_crystal/proc/replace_with_clone(mob/living/carbon/human/replaced_person)
-	if(!replaced_person || !replaced_person.mind || (replaced_person.mind && istype(replaced_person.mind.assigned_role, /datum/job/unassigned)))
-		return // NT don't give a shit about replacing this person, they're either not a player, not crew or not a player with a job
-	var/datum/mind/our_mind = replaced_person.mind
-	var/atom/destination = our_mind.assigned_role.get_latejoin_spawn_point()
-	// A lot of this is copied from new_player, but we need to run through a lot of this boiler-plate to "properly" make a "just late-joined" character.
-	if(!destination)
-		CRASH("Failed to find a latejoin spawn point.")
-	our_mind.active = FALSE
-	if(!replaced_person.client)
-		CRASH("Client disconnected before we could make the replacement mob.")
-	var/mob/living/carbon/human/spawning_mob = our_mind.assigned_role.get_spawn_mob(replaced_person.client, destination)
-	our_mind.transfer_to(spawning_mob)
-	// Notably we do NOT set original character here, because this is not their actual original character.
-	spawning_mob.PossessByPlayer(replaced_person.ckey)
-	to_chat(spawning_mob, span_userdanger("You have forgotten everything you did this shift. You are left with a horrible sense of Deja Vu."))
-	var/area/joined_area = get_area(spawning_mob.loc)
-	if(joined_area)
-		joined_area.on_joining_game(spawning_mob)
-	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CREWMEMBER_JOINED, spawning_mob, spawning_mob.mind.assigned_role.title)
-	SSjob.equip_rank(spawning_mob, our_mind.assigned_role, spawning_mob.client)
-	our_mind.assigned_role.after_latejoin_spawn(spawning_mob)
-	spawning_mob.increment_scar_slot()
-	spawning_mob.load_persistent_scars()
-	SSpersistence.load_modular_persistence(spawning_mob.get_organ_slot(ORGAN_SLOT_BRAIN))
-	if(GLOB.curse_of_madness_triggered)
-		give_madness(spawning_mob, GLOB.curse_of_madness_triggered)
-	if(our_mind.assigned_role.job_flags & JOB_ASSIGN_QUIRKS)
-		if(CONFIG_GET(flag/roundstart_traits))
-			SSquirks.AssignQuirks(spawning_mob, spawning_mob.client)
-	else
-		spawning_mob.clear_personalities()
-	var/list/loadout = spawning_mob.client?.get_loadout_datums()
-	for(var/datum/loadout_item/item as anything in loadout)
-		if (item.restricted_roles && length(item.restricted_roles) && !(our_mind.assigned_role.title in item.restricted_roles))
-			continue
-		item.post_equip_item(spawning_mob.client?.prefs, spawning_mob)
-// NOVA EDIT ADDITION END
 
 //Do not blow up our internal radio
 /obj/machinery/power/supermatter_crystal/contents_explosion(severity, target)

--- a/code/modules/power/supermatter/supermatter_hit_procs.dm
+++ b/code/modules/power/supermatter/supermatter_hit_procs.dm
@@ -70,10 +70,8 @@
 	jedi.investigate_log("had [jedi.p_their()] brain dusted by touching [src] with telekinesis.", INVESTIGATE_DEATHS)
 	//jedi.ghostize() // NOVA EDIT REMOVAL
 	// NOVA EDIT ADDITION START - Supermatter replacement
-	if(ishuman(user))
-		var/mob/living/carbon/human/jedi_human = user
-		jedi_human.replace_with_clone()
-	else
+	var/mob/living/carbon/human/jedi_human = user
+	if(!istype(jedi_human) || !jedi_human.replace_with_clone())
 		jedi.ghostize()
 	// NOVA EDIT ADDITION END
 	var/obj/item/organ/brain/rip_u = locate(/obj/item/organ/brain) in jedi.organs

--- a/code/modules/power/supermatter/supermatter_hit_procs.dm
+++ b/code/modules/power/supermatter/supermatter_hit_procs.dm
@@ -68,6 +68,7 @@
 	var/mob/living/carbon/jedi = user
 	to_chat(jedi, span_userdanger("That was a really dense idea."))
 	jedi.investigate_log("had [jedi.p_their()] brain dusted by touching [src] with telekinesis.", INVESTIGATE_DEATHS)
+	//jedi.ghostize() // NOVA EDIT REMOVAL
 	// NOVA EDIT ADDITION START - Supermatter replacement
 	if(ishuman(user))
 		replace_with_clone(user)

--- a/modular_nova/modules/delam_emergency_stop/code/supermatter_replacement.dm
+++ b/modular_nova/modules/delam_emergency_stop/code/supermatter_replacement.dm
@@ -42,3 +42,4 @@
 			continue
 		item.post_equip_item(spawning_mob.client?.prefs, spawning_mob)
 	return TRUE
+	return TRUE

--- a/modular_nova/modules/delam_emergency_stop/code/supermatter_replacement.dm
+++ b/modular_nova/modules/delam_emergency_stop/code/supermatter_replacement.dm
@@ -42,4 +42,3 @@
 			continue
 		item.post_equip_item(spawning_mob.client?.prefs, spawning_mob)
 	return TRUE
-	return TRUE

--- a/modular_nova/modules/delam_emergency_stop/code/supermatter_replacement.dm
+++ b/modular_nova/modules/delam_emergency_stop/code/supermatter_replacement.dm
@@ -1,3 +1,8 @@
+/**
+ * Replaces a crewmember who has been permanently removed from play (e.g. dusted by the
+ * supermatter) with a freshly spawned "clone" of their character, as if they had just
+ * late-joined the round.
+ */
 /mob/living/carbon/human/proc/replace_with_clone()
 	if(QDELETED(src) || !mind || istype(mind.assigned_role, /datum/job/unassigned))
 		return FALSE // NT don't give a shit about replacing this person, they're either not a player, not crew or not a player with a job

--- a/modular_nova/modules/delam_emergency_stop/code/supermatter_replacement.dm
+++ b/modular_nova/modules/delam_emergency_stop/code/supermatter_replacement.dm
@@ -1,17 +1,19 @@
 /mob/living/carbon/human/proc/replace_with_clone()
-	if(QDELETED(src) || !mind || (mind && istype(mind.assigned_role, /datum/job/unassigned)))
-		return // NT don't give a shit about replacing this person, they're either not a player, not crew or not a player with a job
+	if(QDELETED(src) || !mind || istype(mind.assigned_role, /datum/job/unassigned))
+		return FALSE // NT don't give a shit about replacing this person, they're either not a player, not crew or not a player with a job
 	var/atom/destination = mind.assigned_role.get_latejoin_spawn_point()
 	// A lot of this is copied from new_player, but we need to run through a lot of this boiler-plate to "properly" make a "just late-joined" character.
 	if(!destination)
 		CRASH("Failed to find a latejoin spawn point.")
-	mind.active = FALSE
 	if(!client)
 		CRASH("Client disconnected before we could make the replacement mob.")
+	mind.active = FALSE
 	var/mob/living/carbon/human/spawning_mob = mind.assigned_role.get_spawn_mob(client, destination)
 	mind.transfer_to(spawning_mob)
 	// Notably we do NOT set original character here, because this is not their actual original character.
 	spawning_mob.PossessByPlayer(ckey)
+	if(!spawning_mob.client)
+		CRASH("Client disconnected while we were making the replacement mob.")
 	to_chat(spawning_mob, span_userdanger("You have forgotten everything you did this shift. You are left with a horrible sense of Deja Vu."))
 	var/area/joined_area = get_area(spawning_mob.loc)
 	if(joined_area)
@@ -34,3 +36,4 @@
 		if (item.restricted_roles && length(item.restricted_roles) && !(spawning_mob.mind.assigned_role.title in item.restricted_roles))
 			continue
 		item.post_equip_item(spawning_mob.client?.prefs, spawning_mob)
+	return TRUE

--- a/modular_nova/modules/delam_emergency_stop/code/supermatter_replacement.dm
+++ b/modular_nova/modules/delam_emergency_stop/code/supermatter_replacement.dm
@@ -1,0 +1,36 @@
+/mob/living/carbon/human/proc/replace_with_clone()
+	if(QDELETED(src) || !mind || (mind && istype(mind.assigned_role, /datum/job/unassigned)))
+		return // NT don't give a shit about replacing this person, they're either not a player, not crew or not a player with a job
+	var/atom/destination = mind.assigned_role.get_latejoin_spawn_point()
+	// A lot of this is copied from new_player, but we need to run through a lot of this boiler-plate to "properly" make a "just late-joined" character.
+	if(!destination)
+		CRASH("Failed to find a latejoin spawn point.")
+	mind.active = FALSE
+	if(!client)
+		CRASH("Client disconnected before we could make the replacement mob.")
+	var/mob/living/carbon/human/spawning_mob = mind.assigned_role.get_spawn_mob(client, destination)
+	mind.transfer_to(spawning_mob)
+	// Notably we do NOT set original character here, because this is not their actual original character.
+	spawning_mob.PossessByPlayer(ckey)
+	to_chat(spawning_mob, span_userdanger("You have forgotten everything you did this shift. You are left with a horrible sense of Deja Vu."))
+	var/area/joined_area = get_area(spawning_mob.loc)
+	if(joined_area)
+		joined_area.on_joining_game(spawning_mob)
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CREWMEMBER_JOINED, spawning_mob, spawning_mob.mind.assigned_role.title)
+	SSjob.equip_rank(spawning_mob, spawning_mob.mind.assigned_role, spawning_mob.client)
+	spawning_mob.mind.assigned_role.after_latejoin_spawn(spawning_mob)
+	spawning_mob.increment_scar_slot()
+	spawning_mob.load_persistent_scars()
+	SSpersistence.load_modular_persistence(spawning_mob.get_organ_slot(ORGAN_SLOT_BRAIN))
+	if(GLOB.curse_of_madness_triggered)
+		give_madness(spawning_mob, GLOB.curse_of_madness_triggered)
+	if(spawning_mob.mind.assigned_role.job_flags & JOB_ASSIGN_QUIRKS)
+		if(CONFIG_GET(flag/roundstart_traits))
+			SSquirks.AssignQuirks(spawning_mob, spawning_mob.client)
+	else
+		spawning_mob.clear_personalities()
+	var/list/loadout = spawning_mob.client?.get_loadout_datums()
+	for(var/datum/loadout_item/item as anything in loadout)
+		if (item.restricted_roles && length(item.restricted_roles) && !(spawning_mob.mind.assigned_role.title in item.restricted_roles))
+			continue
+		item.post_equip_item(spawning_mob.client?.prefs, spawning_mob)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8368,6 +8368,7 @@
 #include "modular_nova\modules\delam_emergency_stop\code\admin_scram.dm"
 #include "modular_nova\modules\delam_emergency_stop\code\delam.dm"
 #include "modular_nova\modules\delam_emergency_stop\code\scram.dm"
+#include "modular_nova\modules\delam_emergency_stop\code\supermatter_replacement.dm"
 #include "modular_nova\modules\Department_Budgets\cards.dm"
 #include "modular_nova\modules\departmentization\cargo_technician.dm"
 #include "modular_nova\modules\departmentization\clothing_overrides.dm"


### PR DESCRIPTION
## About The Pull Request

Touching the supermatter will now, before dusting your body, will respawn you as a definitely-not-an-illegal-clone who's late for work with a bad sense of deja vu.

## How This Contributes To The Nova Sector Roleplay Experience

people touch the hyperdeath crystal by mistake and at /tg/, that's fine because the round ends in an hour and you get to roll for nuke ops, we account for this in the design for being dead 
the round ends in 2 to 3 hours at Nova and you don't get to roll for nuke ops, thereby mitigating a lot of the "being dead sucks actually" fixes we normally have 
thus, mechanics that are overly lethal based around that fun-ness of being dead are way rougher here for players

this is a way to both retain the supermatter's iconic dusting mechanics while maintaining the penalty for touching the supermatter, without it being a round-removal method

## Proof of Testing

https://github.com/user-attachments/assets/8b3a320a-efd7-4fde-b97d-56a3d63738ff

<img width="521" height="475" alt="dreamseeker_kKbVKnKAdy" src="https://github.com/user-attachments/assets/b0220abd-816a-4a59-9679-8319da0fc1e0" />

## Changelog
:cl:
balance: Touching the supermatter will now, before dusting your body, will respawn you as a definitely-not-an-illegal-clone who's late for work with a bad sense of deja vu.
/:cl: