### PR TITLE
Xeno Hybrids No Longer Hear Hive Communications

### DIFF
--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/xeno.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/xeno.dm
@@ -20,7 +20,6 @@
 	mutant_organs = list(
 		/obj/item/organ/alien/plasmavessel/roundstart,
 		/obj/item/organ/alien/resinspinner/roundstart,
-		/obj/item/organ/alien/hivenode,
 		)
 	exotic_bloodtype = BLOOD_TYPE_XENO
 	heatmod = 2.5


### PR DESCRIPTION

## About The Pull Request
This PR removes the hivenode organ from xenohybrids, disallowing them from communicating or hearing the hive.
## How This Contributes To The Nova Sector Roleplay Experience
While allowing them to hear and speak to real xenos and other hybrids could be enriching, I've never seen it used in anything beyond an immediate cripple to xenomorphs as an antag. This is my solution to that.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="1222" height="246" alt="image" src="https://github.com/user-attachments/assets/cd7ed3ac-f55b-4da5-948d-ba1ede29cbe5" />

</details>

## Changelog
:cl: Macaroni
del: Xeno Hybrids can no longer communicate via the hive
/:cl:
