### PR TITLE
[Moon] kills kittens and puppies from being used by players

### DIFF
--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -115,8 +115,8 @@
 		"mouse" = TRUE,
 		"rabbit" = TRUE,
 		"repairbot" = TRUE,
-		"kitten" = TRUE,
-		"puppy" = TRUE,
+		// "kitten" = TRUE, // NOVA EDIT REMOVAL
+		// "puppy" = TRUE, // NOVA EDIT REMOVAL
 		"spider" = TRUE,
 	)
 

--- a/modular_nova/master_files/code/modules/mob/living/basic/pet/pet.dm
+++ b/modular_nova/master_files/code/modules/mob/living/basic/pet/pet.dm
@@ -1,0 +1,5 @@
+/mob/living/basic/pet/cat/kitten
+	sentience_type = SENTIENCE_BOSS
+
+/mob/living/basic/pet/dog/corgi/puppy
+	sentience_type = SENTIENCE_BOSS

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7503,6 +7503,7 @@
 #include "modular_nova\master_files\code\modules\mob\living\basic\maintsroomdescent\houndoftindalos.dm"
 #include "modular_nova\master_files\code\modules\mob\living\basic\maintsroomdescent\maintsrooms_flags.dm"
 #include "modular_nova\master_files\code\modules\mob\living\basic\maintsroomdescent\shaggoth.dm"
+#include "modular_nova\master_files\code\modules\mob\living\basic\pet\pet.dm"
 #include "modular_nova\master_files\code\modules\mob\living\basic\trooper\syndicate.dm"
 #include "modular_nova\master_files\code\modules\mob\living\brain\brain_cybernetic.dm"
 #include "modular_nova\master_files\code\modules\mob\living\brain\brain_item.dm"


### PR DESCRIPTION

## About The Pull Request
Sets the sentience level of kittens and puppies to sentience_boss to make them unable to be mind swapped or given sentience.

Removes the kitten and puppy from the PAI chassis options

## How This Contributes To The Nova Sector Roleplay Experience
Makes it so we cannot have situations we rather the admins not have to handle, even if 99% of the time these would be used in good faith. 

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="212" height="208" alt="image" src="https://github.com/user-attachments/assets/1cc9a57b-500e-4229-b3e0-b45dd33090cf" />


<img width="382" height="331" alt="image" src="https://github.com/user-attachments/assets/a87427f1-a8ec-4472-b5c2-62b1201d1b0a" />

<img width="283" height="292" alt="image" src="https://github.com/user-attachments/assets/31542945-b43f-4694-8b4a-f2287977b7f1" />

<img width="278" height="292" alt="image" src="https://github.com/user-attachments/assets/fd6089de-5318-4fbb-8b40-dfbf4c0e8139" />


</details>

## Changelog
:cl:
del: Makes it impossible to mind swap or give sentience to kitten and puppies.
del: Removes the kitten and puppy chasis from the personal AI options.
/:cl:
