### PR TITLE
Re-enables the turf emote for Naga taurs

### DIFF
--- a/modular_nova/modules/emotes/code/additionalemotes/turf_emote.dm
+++ b/modular_nova/modules/emotes/code/additionalemotes/turf_emote.dm
@@ -65,6 +65,7 @@
 		var/taur_mode = human_user.get_taur_mode()
 		if(taur_mode & STYLE_TAUR_SNAKE)
 			user.allowed_turfs -= list("pawprint", "hoofprint", "clawprint")
+			user.allowed_turfs += "coil"
 
 		//clothing
 		var/obj/item/shoes = user.get_item_by_slot(ITEM_SLOT_FEET)
@@ -112,13 +113,17 @@
 				user.owned_turf.color = human_user.dna.features[FEATURE_MUTANT_COLOR]
 
 
-		var/list/body_part = list("tails")
+		var/list/body_part = list("tails", "coil")
 		if(current_turf in body_part) //These turfs can be a body part and need color/size applied
 			var/key = null
 
 			var/list/tail_emotes = list("tails")
 			if(current_turf in tail_emotes)
 				key = "tail"
+
+			var/list/taur_emotes = list("coil")
+			if(current_turf in taur_emotes)
+				key = "taur"
 
 			//coloring
 			var/list/finished_list = list()

--- a/modular_nova/modules/emotes/code/additionalemotes/turf_list.dm
+++ b/modular_nova/modules/emotes/code/additionalemotes/turf_list.dm
@@ -121,6 +121,17 @@
 			src.add_overlay(overlay)
 			playsound(get_turf(src), 'sound/items/weapons/thudswoosh.ogg', 25, TRUE)
 
+		if("coil")
+			name = "tail"
+			desc = "It's a scaly tail."
+			icon = 'modular_nova/master_files/icons/effects/turf_effects_64.dmi'
+			icon_state = "naga"
+			pixel_x = -16
+			var/mutable_appearance/overlay = mutable_appearance('modular_nova/master_files/icons/effects/turf_effects_64.dmi', "naga_top", EXTRA_ABOVE_MOB_LAYER, src)
+			overlay.appearance_flags = TILE_BOUND|PIXEL_SCALE|KEEP_TOGETHER
+			src.add_overlay(overlay)
+			playsound(get_turf(src), 'modular_nova/modules/emotes/sound/emotes/hiss.ogg', 25, TRUE)
+
 		//prints
 		if("pawprint")
 			name = "pawprint"


### PR DESCRIPTION

## About The Pull Request

As titled. Reimpliments the code that was removed and made "obsolete" by #1953 and allows Naga to use the turf command once again.

Original code by Gandalf2k15 with defninition edit from "constrict" to "coil" avoid conflicts with new constrict
## How This Contributes To The Nova Sector Roleplay Experience

While I love the PR overall, I have to disagree with the statement "the old *turf emote but way more functional"
Mechanically, sure... but it destroyed alot of RP oppertunity in the process, leaving me and likely others unable to use it in the same way as before. It should not have been removed in the first place.

You cannot turf and curl your tail up at will and pretend you are "sitting" somewhere and letting you rotate the torso independantly of the tail without mechanically coiling someone. 
It also removed the "ability" to curl up into a ball by resting after turf (see testing), even IF you do constrict someone, it will break on resting.

(Yes, I'm aware the turf sprite is broken in general but that is a much bigger issue and exists with the current constrict sprites aswell, likely whatever broke skirts too and is therefore way out of scope and way beyond ability)
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="96" height="97" alt="NVIDIA_Overlay_4pO3RNMCBf" src="https://github.com/user-attachments/assets/2b1b8a4b-4e25-4599-9952-70f9cfe0c6b7" />

<img width="98" height="97" alt="NVIDIA_Overlay_WT8y8u9Cs8" src="https://github.com/user-attachments/assets/90dfb436-3c09-4539-a423-f971ff4d22b5" />

</details>

## Changelog
:cl: WhiteSnek, Gandalf2k15
add: Naga once again able to use their turf command
/:cl:
