### PR TITLE
Fix latejoin queue, shows real values now.

### DIFF
--- a/modular_nova/modules/title_screen/code/title_screen_subsystem.dm
+++ b/modular_nova/modules/title_screen/code/title_screen_subsystem.dm
@@ -66,13 +66,14 @@ SUBSYSTEM_DEF(title)
 	return SS_INIT_SUCCESS
 
 /**
- * Returns the length of the queued latejoin rulesets if we are past roundstart
+ * Returns the number of remaining latejoin antagonist slots if we are past roundstart,
+ * otherwise returns "PRE-ROUND".
  */
 /datum/controller/subsystem/title/proc/get_latejoin_queue_count()
-	if (SSticker.current_state <= GAME_STATE_SETTING_UP)
-		return 0
+	if (SSticker.current_state < GAME_STATE_PLAYING)
+		return "PRE-ROUND"
 
-	return length(SSdynamic.queued_rulesets)
+	return max(SSdynamic.rulesets_to_spawn[LATEJOIN], 0)
 
 /**
  * Make sure reference time is set up. If not, this is now time 0.


### PR DESCRIPTION

## About The Pull Request

What it says on the tin. It will show "PRE-ROUND" when the game hasn't started, after it started will show the number of latejoins available. If you stay in the lobby after the round restarts you have to observe/respawn or reconnect for the value to change.
## How This Contributes To The Nova Sector Roleplay Experience

Fixes something that wasn't working.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
  Tested it locally, can see the amount of latejoins at the moment of the refresh of the title screen.
  
</details>

## Changelog
:cl:
fix: Fix latejoin queue indicator on title screen so it shows the actual number of latejoin slots at the moment of the title screen refresh

/:cl:
