### PR TITLE
[SPITE] Stop plasma rivers from melting players into bone‑fungus creatures

### DIFF
--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -424,6 +424,7 @@
 	if(need_mob_update)
 		burn_living.updatehealth()
 
+/* //NOVA EDIT REMOVAL START - PLASMAMAN TRANSFORMATION - (It's practically a RR most of the time.)
 	if(QDELETED(burn_living) \
 		|| !ishuman(burn_living) \
 		|| HAS_TRAIT(burn_living, TRAIT_NODISMEMBER) \
@@ -476,6 +477,8 @@
 	burn_human.set_species(/datum/species/plasmaman)
 	burn_human.visible_message(span_warning("[burn_human] bursts into flame as the last of [burn_human.p_their()] body is coated in fungus!"), \
 		span_userdanger("Your senses numb as what remains of your flesh sloughs off, revealing the plasma-encrusted bone beneath!"))
+
+*/ // NOVA EDIT REMOVAL END
 
 //mafia specific tame happy plasma (normal atmos, no slowdown)
 /turf/open/lava/plasma/mafia

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -479,7 +479,6 @@
 		span_userdanger("Your senses numb as what remains of your flesh sloughs off, revealing the plasma-encrusted bone beneath!"))
 
 */ // NOVA EDIT REMOVAL END
-
 //mafia specific tame happy plasma (normal atmos, no slowdown)
 /turf/open/lava/plasma/mafia
 	initial_gas_mix = OPENTURF_DEFAULT_ATMOS


### PR DESCRIPTION

## About The Pull Request

This PR removes the plasma‑river plasmaman transformation mechanic.
## How This Contributes To The Nova Sector Roleplay Experience

Plasmaman transformation often means a very long stay in medbay, for the roles that actually have a medbay, and a round removal for ghost roles that lack advanced medical options like hermit, tribals or interdyne when solo. This is made worse by Byond lags that can make you go a few tiles further than where you wanted to go.

With this change, plasma rivers are still deadly, they will still _kill_ and _husk_ you like lava does, even more so as they have toxin damage added to the burns but they won't raceswap you to something that can't live without specific gear.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
 
<img width="145" height="177" alt="dead in plasma" src="https://github.com/user-attachments/assets/54688f98-fe69-4d23-a970-c133861547f1" />

<img width="432" height="273" alt="still human" src="https://github.com/user-attachments/assets/a93a54ad-3c0d-41f2-89f1-4bf9b055319d" />

<img width="407" height="49" alt="husked" src="https://github.com/user-attachments/assets/54d5e42e-ea58-4118-ba54-160604b7107f" />

</details>

## Changelog
:cl:
del: Removed the plasma river plasmaman transformation mechanic.
/:cl:
