### PR TITLE
Fixes issue where selecting 'No <limb>' in augments and then selecting 'None' immediately after would not update your preview

### DIFF
--- a/modular_nova/master_files/code/modules/client/preferences/middleware/limbs_and_markings.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/middleware/limbs_and_markings.dm
@@ -42,6 +42,7 @@
 		if(body_zone in visited_body_zones)
 			continue
 		var/obj/item/bodypart/target_bodypart = target.get_bodypart(body_zone, include_stumps = TRUE)
+		target_bodypart.bodypart_flags = initial(target_bodypart.bodypart_flags) // Reset bodypart flags so stumps can clear out when we select 'None'
 		if(should_greyscale_limbs)
 			target_bodypart?.change_appearance(icon = BODYPART_ICON_HUMANOID, id = SPECIES_HUMANOID, greyscale = TRUE)
 		else


### PR DESCRIPTION
## About The Pull Request

Tin, the resetting of the flags only occurs if you apply a new augment, but it should also happen in the code that clears your augments in the case of stumps

## How This Contributes To The Nova Sector Roleplay Experience

Bugfix

## Proof of Testing


<details>
<summary>Screenshots/Videos</summary>

<img width="482" height="254" alt="78YmWPyKjz" src="https://github.com/user-attachments/assets/09846ed0-42c1-4330-aa4a-8ac6ce5e9813" />

</details>

## Changelog


:cl:
fix: fixed an issue where selecting 'No left leg' etc in augments and then selecting 'None' immediately after would not give your leg back in the preview until you select another augment
/:cl: