### PR TITLE
[moon request] blobs: no longer end round or prevent shuttle departure by default

### DIFF
--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -231,6 +231,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 		priority_announce("Experimental, classified, and very expensive emergency countermeasures have been activated to prevent total station loss, \
 			but the initial failure to contain the viral biohazard will be noted on the station's performance report. Expect further penalties.", \
 			"Emergency Biohazard Countermeasure Alert")
+		SSsecurity_level.set_level(SEC_LEVEL_RED) // NOVA EDIT ADDITION
 
 /// Kill everyone who's still on the station area and not already part of the blob's faction, and cover every station area with blob icons. Everyone's soup now.
 /mob/eye/blob/proc/victory_sequence()

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -231,7 +231,6 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 		priority_announce("Experimental, classified, and very expensive emergency countermeasures have been activated to prevent total station loss, \
 			but the initial failure to contain the viral biohazard will be noted on the station's performance report. Expect further penalties.", \
 			"Emergency Biohazard Countermeasure Alert")
-		SSsecurity_level.set_level(SEC_LEVEL_RED) // NOVA EDIT ADDITION
 
 /// Kill everyone who's still on the station area and not already part of the blob's faction, and cover every station area with blob icons. Everyone's soup now.
 /mob/eye/blob/proc/victory_sequence()

--- a/modular_nova/master_files/code/modules/antagonists/blob/overmind.dm
+++ b/modular_nova/master_files/code/modules/antagonists/blob/overmind.dm
@@ -4,3 +4,7 @@
 /mob/eye/blob/Initialize(mapload, starting_points)
 	. = ..()
 	SSshuttle.clearHostileEnvironment(src)
+
+/mob/eye/blob/proc/victory()
+		. = ..()
+		SSsecurity_level.set_level(SEC_LEVEL_RED)

--- a/modular_nova/master_files/code/modules/antagonists/blob/overmind.dm
+++ b/modular_nova/master_files/code/modules/antagonists/blob/overmind.dm
@@ -5,6 +5,6 @@
 	. = ..()
 	SSshuttle.clearHostileEnvironment(src)
 
-/mob/eye/blob/proc/victory()
+/mob/eye/blob/victory()
 		. = ..()
 		SSsecurity_level.set_level(SEC_LEVEL_RED)

--- a/modular_nova/master_files/code/modules/antagonists/blob/overmind.dm
+++ b/modular_nova/master_files/code/modules/antagonists/blob/overmind.dm
@@ -1,0 +1,6 @@
+/mob/eye/blob
+	end_round_on_victory = FALSE
+
+/mob/eye/blob/Initialize(mapload, starting_points)
+	. = ..()
+	SSshuttle.clearHostileEnvironment(src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7253,6 +7253,7 @@
 #include "modular_nova\master_files\code\modules\admin\transform.dm"
 #include "modular_nova\master_files\code\modules\antagonists\_common\antag_datum.dm"
 #include "modular_nova\master_files\code\modules\antagonists\ashwalker\ashwalker.dm"
+#include "modular_nova\master_files\code\modules\antagonists\blob\overmind.dm"
 #include "modular_nova\master_files\code\modules\antagonists\changeling\changeling.dm"
 #include "modular_nova\master_files\code\modules\antagonists\changeling\powers\tiny_prick.dm"
 #include "modular_nova\master_files\code\modules\antagonists\cult\cult_armor.dm"


### PR DESCRIPTION
## About The Pull Request
Does about what it says on the tin. Closes NovaSector/NovaSector#7227. Basically leverages everything done in tgstation/tgstation#95878 by setting `end_round_on_victory` to `FALSE` by default, preventing blobs from ending the round prematurely and growing over 400 tiles. (If a blob *has* hit over 400 tiles, you're gonna be fighting like hell to take it down...)

## How This Contributes To The Nova Sector Roleplay Experience

...Someone asked, I think?

## Proof of Testing
<img width="1035" height="237" alt="image" src="https://github.com/user-attachments/assets/4b9dcb52-30ec-40a8-b126-4d884f5d88bc" />


## Changelog

:cl:
balance: Blobs no longer end the round by default nor count as a hostile environment. The IC repercussions for abandoning a blob-infested station, though, are... definitely someone else's problem.
/:cl:

