### PR TITLE
Fixes Kobold Kubes spawning unbutcherable Kobolds

### DIFF
--- a/modular_nova/master_files/code/modules/mob/living/human/species_types/kobold.dm
+++ b/modular_nova/master_files/code/modules/mob/living/human/species_types/kobold.dm
@@ -1,5 +1,5 @@
 /datum/species/monkey/kobold
-	name = "\improper Kobold"
+	name = "\improper Primitive Kobold"
 	id = SPECIES_KOBOLD_PRIMITIVE
 	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID|MOB_REPTILE
 	mutant_organs = list()
@@ -132,6 +132,7 @@
 
 // Same as regular kobolds except they cannot be butchered, and are smart enough to use devices (debatable)
 /datum/species/monkey/kobold/roundstart
+	name = "\improper Kobold"
 	id = SPECIES_KOBOLD
 	examine_limb_id = SPECIES_KOBOLD
 	mutantbrain = /obj/item/organ/brain/lizard

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/human.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/human.dm
@@ -80,6 +80,9 @@
 	race = /datum/species/golem/weak
 
 /mob/living/carbon/human/species/monkey/kobold
+	race = /datum/species/monkey/kobold
+
+/mob/living/carbon/human/species/monkey/roundstartkobold
 	race = /datum/species/monkey/kobold/roundstart
 
 /mob/living/carbon/human/species/shadekin


### PR DESCRIPTION

## About The Pull Request
And also changes the species name a tiny bit so it's easier to tell which is primitive and which isn't

Closes https://github.com/NovaSector/NovaSector/issues/7300

## How This Contributes To The Nova Sector Roleplay Experience
Lets chefs get kobold meat again

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
Moth kobold is roundstart, synth kobold is primitive

<img width="324" height="286" alt="image" src="https://github.com/user-attachments/assets/3610d473-23c6-4839-a040-c608f95813e4" />


</details>

## Changelog
:cl: Hardly
fix: Fixes Kobold Kubes spawning unbutcherable Kobolds
code: Changed species name so it's easier to tell which Kobold is primitive and which isn't
/:cl:
