### PR TITLE
Some augment related fixes

### DIFF
--- a/modular_nova/master_files/code/modules/client/preferences/middleware/limbs_and_markings.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/middleware/limbs_and_markings.dm
@@ -19,10 +19,9 @@
 	var/list/visited_body_zones = list()
 	for(var/key, augment_path in preferences.augments)
 		var/visited_body_zone
-		if(is_aug_valid_for_prefs(GLOB.augment_items[augment_path], target, preferences))
-			var/datum/augment_item/aug = new augment_path()
+		if(is_aug_valid_for_prefs(GLOB.augment_items[augment_path], key, target, preferences))
+			var/datum/augment_item/aug = GLOB.augment_items[augment_path]
 			visited_body_zone = aug.apply(target, visuals_only, prefs = preferences)
-			qdel(aug)
 		if(visited_body_zone)
 			visited_body_zones += visited_body_zone
 
@@ -251,7 +250,7 @@
 	return data
 
 /// Performs DM-side validation for anything we are reading from prefs
-/datum/preference_middleware/limbs_and_markings/proc/is_aug_valid_for_prefs(datum/augment_item/aug, mob/user, datum/preferences/prefs)
+/datum/preference_middleware/limbs_and_markings/proc/is_aug_valid_for_prefs(datum/augment_item/aug, augment_slot, mob/user, datum/preferences/prefs)
 	var/species_type = prefs.read_preference(/datum/preference/choiced/species)
 	var/datum/species/species = GLOB.species_prototypes[species_type]
 	if(aug.species_blacklist && aug.species_blacklist[species.id])
@@ -270,8 +269,9 @@
 		var/datum/augment_item/limb/limb_aug = astype(aug, /datum/augment_item/limb)
 		if(limb_aug?.slot_flag && (limb_aug.slot_flag & (LEG_LEFT|LEG_RIGHT)))
 			return FALSE
-	if(SSquirks.points_enabled && aug.cost > 0)
-		if((preferences.GetQuirkBalance() - aug.cost) < 0)
+	if(SSquirks.points_enabled)
+		var/datum/augment_item/replaced_augment = GLOB.augment_items[prefs.augments[augment_slot]]
+		if((preferences.GetQuirkBalance() + replaced_augment?.cost - aug.cost) < 0)
 			return FALSE
 	return TRUE
 
@@ -279,13 +279,15 @@
 /datum/preference_middleware/limbs_and_markings/proc/set_bodypart_aug(list/params, mob/user)
 	var/augment_path = text2path(params["augment_path"])
 	var/augment_slot = params["slot"]
+	var/datum/augment_item/old_augment = GLOB.augment_items[preferences.augments[augment_slot]]
 	if(!augment_path)
-		preferences.augments -= augment_slot
+		if(!SSquirks.points_enabled || preferences.GetQuirkBalance() + old_augment?.cost > 0)
+			preferences.augments -= augment_slot
 	else
 		var/datum/augment_item/aug = GLOB.augment_items[augment_path] // This augment path does not exist
 		if(!aug)
 			return
-		if(!is_aug_valid_for_prefs(GLOB.augment_items[augment_path], user, preferences))
+		if(!is_aug_valid_for_prefs(GLOB.augment_items[augment_path], augment_slot, user, preferences))
 			return
 		preferences.augments[augment_slot] = augment_path
 	filter_quirks_and_refresh(user)
@@ -308,13 +310,15 @@
 /datum/preference_middleware/limbs_and_markings/proc/set_internal_implant_aug(list/params, mob/user)
 	var/slot = params["internal_implant_slot"]
 	var/augment_path = text2path(params["augment_path"])
+	var/datum/augment_item/old_augment = GLOB.augment_items[preferences.augments[slot]]
 	if(!augment_path)
-		preferences.augments -= slot
+		if(!SSquirks.points_enabled || preferences.GetQuirkBalance() + old_augment?.cost > 0)
+			preferences.augments -= slot
 	else
 		var/datum/augment_item/aug = GLOB.augment_items[augment_path]
 		if(isnull(aug))
 			return
-		if(!is_aug_valid_for_prefs(GLOB.augment_items[augment_path], user, preferences))
+		if(!is_aug_valid_for_prefs(GLOB.augment_items[augment_path], slot, user, preferences))
 			return
 		preferences.augments[slot] = augment_path
 	filter_quirks_and_refresh(user)

--- a/modular_nova/modules/extra_vv/code/extra_vv.dm
+++ b/modular_nova/modules/extra_vv/code/extra_vv.dm
@@ -58,8 +58,8 @@
 
 	var/mob/living/carbon/human/human_mob = src
 	human_mob.dna.mutant_bodyparts = list()
-	client?.prefs?.apply_prefs_to(src, icon_updates = FALSE)
 	human_mob.dna.species.regenerate_organs(src, replace_current = TRUE)
+	client?.prefs?.apply_prefs_to(src, icon_updates = FALSE)
 	human_mob.dna.update_body_size()
 	human_mob.update_body(is_creating = TRUE)
 	if(quirks_prompt == "Yes")

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/LimbsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/LimbsPage.tsx
@@ -412,7 +412,7 @@ const BodypartAugmentSection = (props: { limb: BodypartData }) => {
                 if (option?.path === limb.selectedAug?.path) return;
                 if (
                   showCost &&
-                  (option?.cost ?? 0) > 0 &&
+                  (option?.cost ?? 0) != 0 &&
                   balance -
                     (limb.selectedAug?.cost ?? 0) +
                     (option?.cost ?? 0) >
@@ -550,7 +550,7 @@ const InternalImplantSection = (props: { internal_implant: AugmentData }) => {
             const option = aug_options.find((aug) => displayName(aug) === name);
             if (
               showCost &&
-              (option?.cost ?? 0) > 0 &&
+              (option?.cost ?? 0) != 0 &&
               balance -
                 (internal_implant.selectedAug?.cost ?? 0) +
                 (option?.cost ?? 0) >

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/LimbsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/LimbsPage.tsx
@@ -412,7 +412,6 @@ const BodypartAugmentSection = (props: { limb: BodypartData }) => {
                 if (option?.path === limb.selectedAug?.path) return;
                 if (
                   showCost &&
-                  (option?.cost ?? 0) != 0 &&
                   balance -
                     (limb.selectedAug?.cost ?? 0) +
                     (option?.cost ?? 0) >
@@ -479,7 +478,6 @@ const BodypartAugmentSection = (props: { limb: BodypartData }) => {
                   );
                   if (
                     showCost &&
-                    (option?.cost ?? 0) > 0 &&
                     balance -
                       (limb.selectedImplant?.cost ?? 0) +
                       (option?.cost ?? 0) >
@@ -550,7 +548,6 @@ const InternalImplantSection = (props: { internal_implant: AugmentData }) => {
             const option = aug_options.find((aug) => displayName(aug) === name);
             if (
               showCost &&
-              (option?.cost ?? 0) != 0 &&
               balance -
                 (internal_implant.selectedAug?.cost ?? 0) +
                 (option?.cost ?? 0) >

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
@@ -351,7 +351,7 @@ function QuirkPage() {
     }
   });
 
-  let balance = -data.quirks_balance;
+  const balance = -data.quirks_balance; // NOVA EDIT CHANGE - ORIGINAL: let balance = -data.default_quirk_balance;
   let positiveQuirks = 0;
 
   for (const selectedQuirkName of selectedQuirks) {
@@ -364,7 +364,7 @@ function QuirkPage() {
       positiveQuirks += 1;
     }
 
-    // balance += selectedQuirk.value; // NOVA EDIT REMOVAL - use DM data.quirks_balance instead
+    // balance += selectedQuirk.value; // NOVA EDIT REMOVAL - use DM data.quirks_balance
   }
 
   function getReasonToNotAdd(quirkName: string) {

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
@@ -351,7 +351,7 @@ function QuirkPage() {
     }
   });
 
-  let balance = -data.default_quirk_balance;
+  let balance = -data.quirks_balance;
   let positiveQuirks = 0;
 
   for (const selectedQuirkName of selectedQuirks) {
@@ -364,7 +364,7 @@ function QuirkPage() {
       positiveQuirks += 1;
     }
 
-    balance += selectedQuirk.value;
+    // balance += selectedQuirk.value; // NOVA EDIT REMOVAL - use DM data.quirks_balance instead
   }
 
   function getReasonToNotAdd(quirkName: string) {


### PR DESCRIPTION

## About The Pull Request
Fixes https://github.com/NovaSector/NovaSector/issues/7306
Fixes VV load prefs not loading augments by regenerating organs and *then* applying prefs/augments
Also fixes some weirdness that only happens with quirk points enabled, which isn't something that effects us, but downstreams exist.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  <img width="516" height="257" alt="image" src="https://github.com/user-attachments/assets/f8ee9df9-081a-4235-b0d5-8b6912ca8d59" />

</details>

## Changelog
:cl:
fix: Augments are applied when using vv apply prefs
fix: [Quirk points enabled] Fix needing extra points on top of your budget to spawn with augments
fix: [Quirk points enabled] Fix not being able to switch to augments that you would only have enough points to switch to after the old augment was removed
fix: [Quirk points enabled] Fix being able to go from a negative-point augment to none without validation (which would result in positive quirks being removed to maintain balance)
fix: [Quirk points enabled] Fix quirk screen balance not accounting for augment quirk balance
/:cl:
