### PR TITLE
Remove:  Heavy Medical Kit - Technician, from Cargo/Medical request consoles

### DIFF
--- a/modular_nova/master_files/code/modules/cargo/packs/companies/medical.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/medical.dm
@@ -39,10 +39,6 @@
 	contains = list(/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked)
 	cost = CARGO_CRATE_VALUE * 4.75
 
-/datum/supply_pack/companies/medical/first_aid_kit/technician_satchel
-	contains = list(/obj/item/storage/backpack/duffelbag/deforest_paramedic/stocked)
-	cost = CARGO_CRATE_VALUE * 8
-
 // Basic first aid supplies like gauze, sutures, mesh, so on
 /datum/supply_pack/companies/medical/first_aid
 

--- a/modular_nova/modules/deforest_medical_items/code/cargo_packs.dm
+++ b/modular_nova/modules/deforest_medical_items/code/cargo_packs.dm
@@ -29,16 +29,6 @@
 		/obj/item/storage/medkit/combat_surgeon/stocked = 3,
 	)
 
-/datum/supply_pack/medical/kit_technician
-	name = "Heavy Duty Medical Kit Crate - Technician"
-	crate_name = "technician kit crate"
-	desc = "Contains a pink medical technician kit."
-	access = ACCESS_MEDICAL
-	cost = CARGO_CRATE_VALUE * 5.5
-	contains = list(
-		/obj/item/storage/backpack/duffelbag/deforest_paramedic/stocked,
-	)
-
 /datum/supply_pack/medical/kit_surgical
 	name = "Heavy Duty Medical Kit Crate - Surgical"
 	crate_name = "surgical kit crate"


### PR DESCRIPTION

## About The Pull Request
This PR, disables/removes the Heavy Medical Kit (Technician) from the Medical Request Console, and the Cargo Request Console.

## How This Contributes To The Nova Sector Roleplay Experience
The Technician kit provides a simple and **easy** way for medical players to gain access to what I'd consider one of the most powerful kits they can get.

The Technician kit is this little container.
<img width="59" height="47" alt="Icon" src="https://github.com/user-attachments/assets/98561f45-43ba-4ce0-8ca5-ecbd087eeaf2" />
which contains the following items:
<img width="460" height="199" alt="What it has inside" src="https://github.com/user-attachments/assets/ff8cca20-6479-4f5b-8909-ee4b7ed6459c" />
The kits includes a hypospray, several basic vials to treat most common damage types (apart from airloss), advanced regen mesh/strutures, basic surgery tools, and an advanced health analyzer - as things of note.

This kit in short provides everything you need to be capable of treating most situations as a medical player.

### Why is this kit an issue?

I'm a **fairly new player** to Nova Sector, so you are free to take this PR with a huge grain of salt, but from my experience as mainly playing medical and eventually discovering the Technician kit, it just provides everything you'd need in a single package.

I feel at it's core it is likely taking away from the following two:
- Equipment already existant at the Medbay, this includes medkits and medical vendors which are placed in most if not all maps.
- Chemistry, as the kit provides you with pretty much all the vials you need to treat most common injury types.

### What do I hope could be achieved with this PR?

I hope with the removal of being able to order/request the Technician kit, medical players would be more inclined to use the various medkits already provided in the medbay, and the items included in the medical vendors, and chemistry.

### How could the removal of this kit effect the medical gameplay?

As I'd imagine with most things which remove quality of life features or ease of access this will affect gameplay ,and roleplay to some extent, as if you would like to gain access to the basic vials you'd need to use or have someone make those chemicals for you.

It could also potently slow down treatments as compared to medical player having access to those easy vials on hand they would have now to use the medkits or medical vendors in the department which could take more time.

## Proof of Testing
<details>
<summary>Screenshots before the PR</summary>
Cargo Console Before
<img width="789" height="739" alt="before cargo" src="https://github.com/user-attachments/assets/3d4f56e4-ee3b-4b76-bf1e-5a8985ec42f5" />

Medical Request Console Before
<img width="616" height="580" alt="Medic Cargo before" src="https://github.com/user-attachments/assets/658bbe23-9504-4de0-a733-ea5e93876422" />
</details>

<details>
<summary> Screenshots after the PR </summary>
Cargo Console After
<img width="791" height="753" alt="after cargo" src="https://github.com/user-attachments/assets/0e90aea1-6ee5-41fe-93de-b67ad8c9b5f8" />

Medical Request Console After
<img width="612" height="585" alt="medic cargo after" src="https://github.com/user-attachments/assets/9378460d-3d02-4486-8fea-37da6b289e69" />

Admin Spawn Menu still having the Technician kit, so it isn't fully removed from spawns.
<img width="741" height="559" alt="still is in spawn menu" src="https://github.com/user-attachments/assets/161aed96-b5b8-4db2-b47f-f88a7052cd4c" />
</details>

## Changelog
:cl: Richard Blonski
del: Removed The Heavy Medical Kit - Technician from Medical/Cargo request consoles.
/:cl:
