### PR TITLE
The Prisoner Bunny Suit is Now in Prisoner Lockers Instead of the Sec Vendor

### DIFF
--- a/modular_nova/modules/goofsec/code/lockers.dm
+++ b/modular_nova/modules/goofsec/code/lockers.dm
@@ -58,3 +58,13 @@
 	new /obj/item/restraints/handcuffs/cable/green(src)
 	new /obj/item/assembly/flash/handheld(src)
 	new /obj/item/storage/bag/garment/service_guard(src)
+
+//Prisoner Lockers
+
+/obj/structure/closet/secure_closet/brig/PopulateContents()
+	..()
+
+	new /obj/item/clothing/head/playbunnyears/prisoner(src)
+	new /obj/item/clothing/under/rank/security/prisoner_bunnysuit(src)
+	new /obj/item/clothing/neck/tie/bunnytie/prisoner(src)
+

--- a/modular_nova/modules/sec_haul/code/misc/vending.dm
+++ b/modular_nova/modules/sec_haul/code/misc/vending.dm
@@ -76,9 +76,6 @@
 				/obj/item/clothing/under/rank/security/security_assistant_bunnysuit = 6,
 				/obj/item/clothing/suit/armor/security_tailcoat/assistant = 6,
 				/obj/item/clothing/neck/tie/bunnytie/security_assistant = 6,
-				/obj/item/clothing/head/playbunnyears/prisoner = 6,
-				/obj/item/clothing/under/rank/security/prisoner_bunnysuit = 6,
-				/obj/item/clothing/neck/tie/bunnytie/prisoner = 6,
 			),
 		),
 


### PR DESCRIPTION

## About The Pull Request
The prisoner bunny suit can no longer be bought from the sec vendor and instead now spawns in all prisoner lockers.
## How This Contributes To The Nova Sector Roleplay Experience
Prisoner clothing doesn't belong in a vendor.
## Proof of Testing
I tested it I forgot to take a picture 😭 
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl: Macaroni
fix: The prisoner bunny suit has been moved to all prisoner lockers.
/:cl:
