### PR TITLE
Added empty Medkits to medical techfab

### DIFF
--- a/modular_nova/master_files/code/modules/research/techweb/all_nodes.dm
+++ b/modular_nova/master_files/code/modules/research/techweb/all_nodes.dm
@@ -106,6 +106,7 @@
 		"smartdartgun",
 		"cone_of_shame",
 		"defibrillator",
+		"medkit",
 	)
 	return ..()
 

--- a/modular_nova/modules/medical_designs/medical_designs.dm
+++ b/modular_nova/modules/medical_designs/medical_designs.dm
@@ -16,7 +16,7 @@
 	id = "medkit"
 	build_type = PROTOLATHE
 	materials = list(
-		/datum/material/plastic =  HALF_SHEET_MATERIAL_AMOUNT,
+		/datum/material/plastic =  SHEET_MATERIAL_AMOUNT * 2,
 	)
 	build_path = /obj/item/storage/medkit
 	category = list(

--- a/modular_nova/modules/medical_designs/medical_designs.dm
+++ b/modular_nova/modules/medical_designs/medical_designs.dm
@@ -10,3 +10,16 @@
 		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_MEDICAL,
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SCIENCE
+
+/datum/design/medkit
+	name = "Medkit"
+	id = "medkit"
+	build_type = PROTOLATHE
+	materials = list(
+		/datum/material/plastic =  HALF_SHEET_MATERIAL_AMOUNT,
+	)
+	build_path = /obj/item/storage/medkit
+	category = list(
+		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_MEDICAL,
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL


### PR DESCRIPTION

## About The Pull Request

I've always thought it was possible to print empty plastic medkits from the medical techfab, but you apparently can't.
Until now!, now you can print as many medical medkits you want for the low price of **2 plastic sheets**.

## How This Contributes To The Nova Sector Roleplay Experience
### The Good
You can now print empty medkits from the medical techfab, as it **just makes sense**,
In addition, it could allow medical in theory to make medkits to hand to other departments (as some people in the community have discussed wanting medical to give equipment to other departments to be a thing).

### The Bad
The Medkit is stackable in the backpack, it means that you could technically **be a walking ambulance** of medical equipment.
<img width="468" height="126" alt="image" src="https://github.com/user-attachments/assets/ac7e8c82-519a-4398-88ba-714bd7d5a1e7" />
 

## Proof of Testing
<img width="677" height="607" alt="Screenshot_20260511_173736" src="https://github.com/user-attachments/assets/34edfe0e-cdbf-4c8e-ad93-662cbe8d5080" />


https://github.com/user-attachments/assets/7ceb47ee-1149-4684-a0a8-bc7dc6038095


## Changelog
:cl: Richard Blonski
add: The Medkit is now printable from the Medical Techfab.
/:cl:
