### PR TITLE
Fixes Two Mapping Discrepancies Between Centcom and Ocean Pubby

### DIFF
--- a/_maps/map_files/oceanpubby/oceanpubby.dmm
+++ b/_maps/map_files/oceanpubby/oceanpubby.dmm
@@ -32307,6 +32307,9 @@
 	pixel_y = 7
 	},
 /obj/item/radio/intercom/directional/north,
+/obj/item/stamp/centcom{
+	pixel_x = 6
+	},
 /turf/open/floor/carpet/green,
 /area/station/command/heads_quarters/nt_rep)
 "gHR" = (

--- a/_maps/nova/automapper/templates/centcom/centcom_ferry_dock.dmm
+++ b/_maps/nova/automapper/templates/centcom/centcom_ferry_dock.dmm
@@ -473,9 +473,11 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/stamp,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/stamp/granted{
+	pixel_x = 5
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
 "Yy" = (


### PR DESCRIPTION

## About The Pull Request
Alligns Ocean Pubby with the rest of our stations by adding the NT Stamp to the reps office.
Fixes the granted stamp missing from the CentCom dock.

Fixes https://github.com/NovaSector/NovaSector/issues/7244
Fixes https://github.com/NovaSector/NovaSector/issues/7161

Frankly unplayable in the games current state.
## How This Contributes To The Nova Sector Roleplay Experience
Unplayable oversight I'm so sorry.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="428" height="493" alt="image" src="https://github.com/user-attachments/assets/e7a91e2b-8c2b-4b2f-91a8-2e20596a0488" />
<img width="826" height="706" alt="image" src="https://github.com/user-attachments/assets/26b03439-d7a4-46b8-8ceb-79b195449736" />

</details>

## Changelog
:cl: Macaroni
fix: The NT Rep now has their stamp on Ocean Pubby
fix: The CentCom ferry bay now has a granted stamp again
/:cl:
