### PR TITLE
Allows Clown Slots to Be Opened

### DIFF
--- a/modular_nova/master_files/code/modules/jobs/job_types/clown.dm
+++ b/modular_nova/master_files/code/modules/jobs/job_types/clown.dm
@@ -1,6 +1,5 @@
 /datum/job/clown
 	vox_outfit = /datum/outfit/vox/clown
-	job_flags = STATION_JOB_FLAGS | JOB_CANNOT_OPEN_SLOTS
 
 /datum/outfit/job/clown
 	messenger = /obj/item/storage/backpack/messenger/clown


### PR DESCRIPTION

## About The Pull Request

Title.

## How This Contributes To The Nova Sector Roleplay Experience
Mime slots can be opened, this seemed to be an oversight with Trusted being removed.

## Proof of Testing

Compiles

## Changelog
:cl:
add: Clown Slots can be opened once more.
/:cl:
