### PR TITLE
Update alt_job_titles.dm

### DIFF
--- a/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -117,6 +117,8 @@
 		"Bouncer",
 		"Service Guard",
 		"Doorman",
+		"Civil Protection Officer",
+		"Public Peacekeeper",
 	)
 
 /datum/job/corrections_officer
@@ -248,6 +250,8 @@
 	alt_titles = list(
 		"Customs Agent",
 		"Supply Guard",
+		"Deck Defense Officer",
+		"Delivery Escort",
 	)
 
 /datum/job/cyborg
@@ -284,6 +288,11 @@
 	)
 
 /datum/job/engineering_guard //see orderly
+	alt_titles = list(
+		"Tide Deterrent",
+		"Power Plant Guard",
+		"Construction Guard",
+	)
 
 /datum/job/geneticist
 	alt_titles = list(
@@ -366,6 +375,7 @@
 	alt_titles = list(
 		"Orderly",
 		"Medical Guard",
+		"Medical Escort",
 	) //other dept guards' alt-titles should be kept to [department] guard to avoid confusion, unless the department gets a re-do.
 
 /datum/job/paramedic
@@ -430,6 +440,11 @@
 	)
 
 /datum/job/science_guard //See orderly
+	alt_titles = list(
+		"Hazardous Experiment Overwatch",
+		"Xenobiological Recontainment Officer",
+		"Expedition Protection Agent",
+	)
 
 /datum/job/scientist
 	alt_titles = list(


### PR DESCRIPTION

## About The Pull Request

Baby's first PR!
Adds extra alt titles to the department guard roles. The new names are as follows:

### Science Guard
Hazardous Experiment Overwatch
Xenobiological Recontainment Officer
Expedition Protection Agent

### Engineering Guard
Tide Deterrent
Power Plant Guard
Construction Guard

### Service Guard
Civil Protection Officer
Public Peacekeeper

### Cargo Guard
Deck Defense Officer
Delivery Escort

### Medical Guard
Medical Escort


## How This Contributes To The Nova Sector Roleplay Experience

Giving more options to players for job titles makes things generally more realistic, seeing how many different titles there are in the real world. These extra names are also meant to say, "Hey! I'll focus more on doing [x]!"
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="200" height="143" alt="image" src="https://github.com/user-attachments/assets/8ad9ba29-5c03-4138-b8c3-f72ee3031a07" />
<img width="186" height="110" alt="image" src="https://github.com/user-attachments/assets/43a5ad1b-d7ca-4169-a86d-c5ba8fae400d" />
<img width="326" height="154" alt="image" src="https://github.com/user-attachments/assets/53de7bb4-1f8c-43c2-9e52-28f68c555caa" />
<img width="332" height="137" alt="image" src="https://github.com/user-attachments/assets/44aa3eab-837b-4d43-9a8c-2afa20c81b64" />
<img width="147" height="137" alt="image" src="https://github.com/user-attachments/assets/7ccbc3c0-966f-473a-89dd-340fb925147a" />
<img width="1528" height="602" alt="image" src="https://github.com/user-attachments/assets/f211cdd4-6eae-4be8-8244-499e37ad8637" />
<img width="987" height="764" alt="image" src="https://github.com/user-attachments/assets/b5dd2125-f4cd-43ba-83ad-1d52aa2b0ba5" />

</details>

## Changelog
:cl:
add: Gave Science and Engineering Guards 3 new alt titles.
add: Gave Service and Cargo Guards 2 new alt titles.
add: Gave Medical Guards 1 new alt title.
/:cl:
