### PR TITLE
Fixes Snowglobes Teleporter Network, Adds Custom Shuttle Kits to Ocean Pubby & Snowglobes Tech Storages

### DIFF
--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -1620,6 +1620,10 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/freezer,
 /area/station/commons/dorms/room3)
+"atu" = (
+/obj/item/beacon,
+/turf/open/floor/carpet/executive,
+/area/station/command/bridge)
 "atx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1886,6 +1890,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/beacon,
 /turf/open/floor/iron,
 /area/station/ai/satellite/foyer)
 "awQ" = (
@@ -4099,6 +4104,10 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/entry)
+"baz" = (
+/obj/item/beacon,
+/turf/open/floor/iron/dark,
+/area/station/science/explab)
 "baC" = (
 /obj/machinery/computer/message_monitor,
 /obj/effect/turf_decal/siding/yellow{
@@ -13973,7 +13982,8 @@
 /turf/open/floor/engine,
 /area/station/ai/satellite/chamber)
 "dLU" = (
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 9
 	},
@@ -15348,6 +15358,10 @@
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"edZ" = (
+/obj/item/beacon,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "eec" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "visitationbridgeshutters";
@@ -18728,6 +18742,10 @@
 /obj/structure/chair/sofa/bench/solo,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"eZV" = (
+/obj/item/beacon,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "eZW" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron,
@@ -20612,8 +20630,8 @@
 /area/station/service/kitchen/diner)
 "fBa" = (
 /obj/structure/chair/sofa/bench,
-/obj/effect/spawner/random/engineering/tracking_beacon,
 /obj/structure/window/reinforced/spawner/directional/north,
+/obj/item/beacon,
 /turf/open/floor/iron/white/small,
 /area/station/medical/medbay/lobby)
 "fBi" = (
@@ -21534,6 +21552,7 @@
 	},
 /area/station/service/chapel)
 "fMe" = (
+/obj/machinery/teleport/station,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -22589,6 +22608,8 @@
 	dir = 5
 	},
 /obj/machinery/status_display/evac/directional/north,
+/obj/effect/spawner/random/techstorage/custom_shuttle,
+/obj/structure/table,
 /turf/open/floor/iron/corner{
 	dir = 8
 	},
@@ -24878,7 +24899,6 @@
 /area/station/maintenance/solars/starboard/aft)
 "gGv" = (
 /obj/structure/cable,
-/obj/effect/spawner/random/engineering/tracking_beacon,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/dark_blue/full,
@@ -28896,7 +28916,6 @@
 	pixel_y = -24;
 	control_area = "/area/station/ai/satellite/chamber"
 	},
-/obj/machinery/teleport/hub,
 /turf/open/floor/circuit/green,
 /area/station/ai/satellite/hallway)
 "hKH" = (
@@ -31851,7 +31870,7 @@
 /area/station/hallway/secondary/recreation)
 "ixf" = (
 /obj/effect/landmark/event_spawn,
-/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/item/beacon,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/lobby)
 "ixu" = (
@@ -31875,6 +31894,7 @@
 "ixO" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/recharge_station,
+/obj/effect/landmark/start/cyborg,
 /turf/open/floor/circuit/green,
 /area/station/ai/satellite/hallway)
 "iyb" = (
@@ -33294,8 +33314,8 @@
 /turf/open/floor/plating,
 /area/station/service/hydroponics)
 "iRa" = (
-/obj/effect/spawner/random/engineering/tracking_beacon,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/item/beacon,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "iRo" = (
@@ -34507,6 +34527,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/edge,
 /area/station/engineering/lobby)
+"jhG" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 1
+	},
+/obj/item/beacon,
+/turf/open/floor/iron,
+/area/station/command/eva)
 "jhR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/dark,
@@ -35858,7 +35885,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/item/beacon,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "jBV" = (
@@ -39495,6 +39522,10 @@
 	dir = 1
 	},
 /area/station/medical/virology)
+"kwx" = (
+/obj/item/beacon,
+/turf/open/floor/iron/dark,
+/area/station/science/lab)
 "kwF" = (
 /obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/plating,
@@ -46394,7 +46425,6 @@
 	},
 /area/station/engineering/atmos/office)
 "mqy" = (
-/obj/structure/cable,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -53767,6 +53797,10 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
+"opU" = (
+/obj/item/beacon,
+/turf/open/floor/engine/xenobio,
+/area/station/science/xenobiology)
 "oqc" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 4
@@ -58383,6 +58417,7 @@
 /area/station/hallway/primary/port)
 "pCZ" = (
 /obj/machinery/light_switch/directional/east,
+/obj/machinery/teleport/hub,
 /turf/open/floor/iron/dark/side{
 	dir = 5
 	},
@@ -65421,7 +65456,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "rFD" = (
-/obj/machinery/light/floor,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -67412,7 +67446,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/item/beacon,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "sew" = (
@@ -68487,6 +68521,7 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/space_heater,
 /turf/open/floor/iron/dark/side{
 	dir = 6
 	},
@@ -75041,7 +75076,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/floor2)
 "ucm" = (
-/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/item/beacon,
 /turf/open/floor/plating/icemoon,
 /area/station/science/ordnance/bomb)
 "ucn" = (
@@ -76791,9 +76826,9 @@
 /turf/open/floor/iron/sepia,
 /area/station/service/kitchen/diner)
 "uBH" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/space_heater,
+/obj/machinery/computer/teleporter{
+	dir = 0
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 9
 	},
@@ -81362,7 +81397,7 @@
 	network = list("ss13","minisat")
 	},
 /obj/machinery/light_switch/directional/south,
-/obj/machinery/teleport/station,
+/obj/machinery/porta_turret/ai,
 /turf/open/floor/circuit/green,
 /area/station/ai/satellite/hallway)
 "vKO" = (
@@ -81621,9 +81656,6 @@
 /area/station/service/library)
 "vNL" = (
 /obj/machinery/light/directional/west,
-/obj/machinery/computer/teleporter{
-	dir = 4
-	},
 /turf/open/floor/circuit/green,
 /area/station/ai/satellite/hallway)
 "vNN" = (
@@ -88952,8 +88984,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/random/engineering/tracking_beacon,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/light/floor,
 /turf/open/floor/engine,
 /area/station/ai/satellite/hallway)
 "xHu" = (
@@ -210924,7 +210956,7 @@ vBO
 aYD
 eXN
 eXN
-eXN
+opU
 tZf
 eXN
 aYD
@@ -255316,7 +255348,7 @@ xFr
 xFr
 qGV
 cIU
-vgU
+jhG
 gvr
 fcw
 nRk
@@ -257863,7 +257895,7 @@ vMu
 vMu
 xcM
 iBj
-uTv
+atu
 dRS
 tNX
 ggl
@@ -265931,7 +265963,7 @@ nAK
 jkO
 xFd
 dQU
-xFd
+eZV
 xFd
 xFd
 xFd
@@ -266427,7 +266459,7 @@ wNV
 gEs
 umS
 wYm
-wYm
+kwx
 wYm
 wYm
 gRw
@@ -268427,7 +268459,7 @@ wnP
 wnP
 wnP
 wnP
-wnP
+edZ
 iBI
 ktX
 cns
@@ -268723,7 +268755,7 @@ cnS
 gHN
 rnB
 xiw
-xiw
+baz
 maY
 rWR
 nEt
@@ -277726,7 +277758,7 @@ jcZ
 jcZ
 keu
 keu
-mRH
+keu
 fMe
 nfE
 cly

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -1620,10 +1620,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/freezer,
 /area/station/commons/dorms/room3)
-"atu" = (
-/obj/item/beacon,
-/turf/open/floor/carpet/executive,
-/area/station/command/bridge)
 "atx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4104,10 +4100,6 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/entry)
-"baz" = (
-/obj/item/beacon,
-/turf/open/floor/iron/dark,
-/area/station/science/explab)
 "baC" = (
 /obj/machinery/computer/message_monitor,
 /obj/effect/turf_decal/siding/yellow{
@@ -7165,6 +7157,10 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark/textured_edge,
 /area/station/command/heads_quarters/hos)
+"bSO" = (
+/obj/item/beacon,
+/turf/open/floor/iron/dark,
+/area/station/science/explab)
 "bSS" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15358,10 +15354,6 @@
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
-"edZ" = (
-/obj/item/beacon,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "eec" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "visitationbridgeshutters";
@@ -15652,6 +15644,10 @@
 "eiq" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/hallway)
+"eiA" = (
+/obj/item/beacon,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "eiK" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron/grimy,
@@ -18742,10 +18738,6 @@
 /obj/structure/chair/sofa/bench/solo,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"eZV" = (
-/obj/item/beacon,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "eZW" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron,
@@ -27807,6 +27799,10 @@
 /obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"huT" = (
+/obj/item/beacon,
+/turf/open/floor/engine/xenobio,
+/area/station/science/xenobiology)
 "huU" = (
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored/graveyard)
@@ -34527,13 +34523,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/edge,
 /area/station/engineering/lobby)
-"jhG" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 1
-	},
-/obj/item/beacon,
-/turf/open/floor/iron,
-/area/station/command/eva)
 "jhR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/dark,
@@ -39522,10 +39511,6 @@
 	dir = 1
 	},
 /area/station/medical/virology)
-"kwx" = (
-/obj/item/beacon,
-/turf/open/floor/iron/dark,
-/area/station/science/lab)
 "kwF" = (
 /obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/plating,
@@ -42122,6 +42107,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"lgn" = (
+/obj/item/beacon,
+/turf/open/floor/iron/dark,
+/area/station/science/lab)
 "lgo" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
@@ -53797,10 +53786,6 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
-"opU" = (
-/obj/item/beacon,
-/turf/open/floor/engine/xenobio,
-/area/station/science/xenobiology)
 "oqc" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 4
@@ -63479,6 +63464,10 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"raM" = (
+/obj/item/beacon,
+/turf/open/floor/carpet/executive,
+/area/station/command/bridge)
 "raT" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
@@ -67440,15 +67429,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_wrestle)
 "set" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/beacon,
-/turf/open/floor/iron/dark,
-/area/station/science/research)
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "sew" = (
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/camera/autoname/directional/south,
@@ -89300,6 +89283,13 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/checker,
 /area/station/commons/fitness/recreation)
+"xLz" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 1
+	},
+/obj/item/beacon,
+/turf/open/floor/iron,
+/area/station/command/eva)
 "xLI" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -210956,7 +210946,7 @@ vBO
 aYD
 eXN
 eXN
-opU
+huT
 tZf
 eXN
 aYD
@@ -255348,7 +255338,7 @@ xFr
 xFr
 qGV
 cIU
-jhG
+xLz
 gvr
 fcw
 nRk
@@ -257895,7 +257885,7 @@ vMu
 vMu
 xcM
 iBj
-atu
+raM
 dRS
 tNX
 ggl
@@ -265963,7 +265953,7 @@ nAK
 jkO
 xFd
 dQU
-eZV
+eiA
 xFd
 xFd
 xFd
@@ -266459,7 +266449,7 @@ wNV
 gEs
 umS
 wYm
-kwx
+lgn
 wYm
 wYm
 gRw
@@ -268459,7 +268449,7 @@ wnP
 wnP
 wnP
 wnP
-edZ
+set
 iBI
 ktX
 cns
@@ -268755,7 +268745,7 @@ cnS
 gHN
 rnB
 xiw
-baz
+bSO
 maY
 rWR
 nEt
@@ -269797,7 +269787,7 @@ fkY
 fkY
 fkY
 fkY
-set
+npQ
 qyy
 qyy
 qyy

--- a/_maps/map_files/oceanpubby/oceanpubby.dmm
+++ b/_maps/map_files/oceanpubby/oceanpubby.dmm
@@ -13183,11 +13183,10 @@
 /obj/item/airlock_painter/decal,
 /obj/item/airlock_painter/decal,
 /obj/item/airlock_painter/decal,
-/obj/item/toner/infinite,
-/obj/item/toner/infinite,
-/obj/item/toner/infinite,
-/obj/item/toner/infinite,
-/obj/item/toner/infinite,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central/aft)
 "bgt" = (

--- a/_maps/map_files/oceanpubby/oceanpubby.dmm
+++ b/_maps/map_files/oceanpubby/oceanpubby.dmm
@@ -20389,12 +20389,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "bQz" = (
-/obj/effect/spawner/random/entertainment/arcade,
 /obj/machinery/requests_console/directional/north{
 	department = "Tech storage";
 	name = "Tech Storage RD"
 	},
 /obj/effect/turf_decal/tile/green/fourcorners,
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/custom_shuttle,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "bQA" = (
@@ -33748,6 +33749,9 @@
 /obj/structure/sign/warning/radiation/rad_area/directional/west,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
+	},
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)


### PR DESCRIPTION

## About The Pull Request
Snowglobe currently only has 2 functioning teleporter beacons because the incorrect spawner was used, I've replaced them all and alligned the beacon network with the rest of our maps. I've also added the custom shuttle kits to both Ocean Pubby and Snowglobe to remain consistent with all of our stations tech storages.

I've also cleaned up the teleporter in Snowglobes AI sat so we're not just landing in the middle of the turrets anymore.
## How This Contributes To The Nova Sector Roleplay Experience
It's frustrating only having two beacons on one of the selectable maps. It's also frustrating to want to go and build a custom shuttle only to scratch your head when only two of all the tech storages are missing the supplies you need to do it.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  Ocean Pubby Tech Storage
<img width="1482" height="612" alt="image" src="https://github.com/user-attachments/assets/71b11846-5173-4bb9-844c-38e91d86b506" />
Snowglobe Tech Storage

<img width="461" height="224" alt="Screenshot 2026-05-14 105120" src="https://github.com/user-attachments/assets/8b429744-e0cc-48e0-8030-664f03b06ede" />
Snowglobe AI Sat
<img width="809" height="667" alt="Screenshot 2026-05-14 105006" src="https://github.com/user-attachments/assets/51c7721f-9e68-45d2-ae31-cbe3f643c9e4" />

</details>

## Changelog
:cl: Macaroni
add: Added teleporter beacons to Snowglobes expirementor room, bridge, xenobiology, arrivals, departures, science bay, brig, and EVA storage
add: Added the custom shuttle building kit to Ocean Pubby and Snowglobes tech storage
fix: fixed Snowglobes teleporter beacon network
qol: Improved Snowglobes AI sat mapping
/:cl:
