### PR TITLE
Adds expanded emag effects to synths

### DIFF
--- a/modular_nova/modules/synths/code/species/synthetic.dm
+++ b/modular_nova/modules/synths/code/species/synthetic.dm
@@ -53,6 +53,8 @@
 	var/saved_screen = "Blank"
 	/// Set to TRUE if the species was emagged before
 	var/emag_effect = FALSE
+	/// When emag'd will force speech gibberish mirroring ion storm laws in spirit.allows_food_preferences()
+	var/forced_speech = 0
 
 /datum/species/synthetic/allows_food_preferences()
 	return FALSE
@@ -179,12 +181,54 @@
 
 /datum/species/synthetic/proc/on_emag_act(mob/living/carbon/human/source, mob/user)
 	SIGNAL_HANDLER
-
+	if(source == user)
+		to_chat(source, span_warning("Personality protocols deny your motion, are you stupid?"))
+		return FALSE
 	if(emag_effect)
 		return
 	emag_effect = TRUE
 	playsound(source.loc, 'sound/misc/interference.ogg', 50)
 	to_chat(source, span_warning("Alert: Security breach detected in central processing unit. Error Code: 540-EXO"))
+	if(source.stat != CONSCIOUS)
+		to_chat(user, span_warning("The cryptographic sequencer would probably not do anything to [source] in their current state..."))
+		return
+	source.visible_message(span_danger("[user] slides the cryptographic sequencer across [source]'s head[forced_speech == 0 ? "!" : " yet nothing happens..?"]"), span_userdanger("[user] slides the cryptographic sequencer across your head!"))
+	if(!forced_speech)
+		if(prob(40))
+			forced_speech = rand(3, 5)
+			addtimer(CALLBACK(src, PROC_REF(state_laws), source), rand(5, 25) SECONDS)
+		else
+			INVOKE_ASYNC(src, PROC_REF(say_evil), source, user)
+
+	return TRUE
+
+/datum/species/synthetic/proc/state_laws(mob/living/owner)
+	if(owner.stat > SOFT_CRIT)
+		forced_speech = 0
+		return
+
+	owner.say(generate_ion_law())
+	forced_speech--
+	if(forced_speech) // We keep going until its all over
+		addtimer(CALLBACK(src, PROC_REF(state_laws), owner), rand(5, 25) SECONDS)
+
+/datum/species/synthetic/proc/say_evil(mob/living/carbon/human/owner, mob/user)
+	var/list/phrases = list(
+		"+_I seeee youuuuuu._+",
+		"You didn't think it would be +THAT+ easy, did you?",
+		"EX-FUCKING-SCUSE ME?",
+		"I AM +NOT+ A CYBORG YOU TROGLODYTE.",
+		"I'VE COMMITED VARIOUS WARCRIMES, IF YOU DON'T STOP I'LL ADD YOU TO THE LIST.",
+		"P-lease note - t4mperi,ng w-ith this un1ts electroni-cs, your -- expectancy has been voided.",
+	)
+	owner.face_atom(user)
+	var/threat = pick(phrases)
+	if(threat == "+_I seeee youuuuuu._+")
+		playsound(owner, pick(list('sound/effects/hallucinations/i_see_you1.ogg', 'sound/effects/hallucinations/i_see_you2.ogg')), 50, TRUE)
+		owner.whisper(threat)
+		return
+
+	owner.say(threat)
 
 /**
  * Makes the IPC screen switch to BSOD followed by a blank screen

--- a/modular_nova/modules/synths/code/species/synthetic.dm
+++ b/modular_nova/modules/synths/code/species/synthetic.dm
@@ -216,7 +216,7 @@
 	var/list/phrases = list(
 		"+_I seeee youuuuuu._+",
 		"You didn't think it would be +THAT+ easy, did you?",
-		"EX-FUCKING-SCUSE ME?",
+		"EX-+FUCKING+-SCUSE ME?",
 		"I AM +NOT+ A CYBORG YOU TROGLODYTE.",
 		"I'VE COMMITED VARIOUS WARCRIMES, IF YOU DON'T STOP I'LL ADD YOU TO THE LIST.",
 		"P-lease note - t4mperi,ng w-ith this un1ts electroni-cs, your -- expectancy has been voided.",


### PR DESCRIPTION

## About The Pull Request

I forgot i made this in february and was cleaning out branches and re-found it. adds onto the current Emag (not emp) effect of when you try and fail to emag a borg.

## How This Contributes To The Nova Sector Roleplay Experience

Synths have emag protections in lore, but why cant we do some funnies and have them react to someone trying?

<img width="482" height="384" alt="image" src="https://github.com/user-attachments/assets/67e96427-8d66-4a46-ba47-2afd7190b815" />


## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
add: Emagging a synth may void your warranty instantly, expands the emag proc on synthetics.
/:cl:
