### PR TITLE
renames a bunch of machine boards for consistency's sake

### DIFF
--- a/modular_nova/modules/multicellcharger/code/multi_cell_charger.dm
+++ b/modular_nova/modules/multicellcharger/code/multi_cell_charger.dm
@@ -200,7 +200,7 @@
 	return ..()
 
 /obj/item/circuitboard/machine/cell_charger_multi
-	name = "Multi-Cell Charger (Machine Board)"
+	name = "Multi-Cell Charger"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/cell_charger_multi
 	req_components = list(/datum/stock_part/capacitor = 6)

--- a/modular_nova/modules/multicellcharger/code/multi_cell_charger.dm
+++ b/modular_nova/modules/multicellcharger/code/multi_cell_charger.dm
@@ -208,7 +208,7 @@
 
 
 /datum/design/board/cell_charger_multi
-	name = "Machine Design (Multi-Cell Charger Board)"
+	name = "Multi-Cell Charger Board"
 	desc = "The circuit board for a multi-cell charger."
 	id = "multi_cell_charger"
 	build_path = /obj/item/circuitboard/machine/cell_charger_multi

--- a/modular_nova/modules/mutants/code/mutant_techweb.dm
+++ b/modular_nova/modules/mutants/code/mutant_techweb.dm
@@ -1,5 +1,5 @@
 /obj/item/circuitboard/machine/rna_recombinator
-	name = "RNA Recombinator (Machine Board)"
+	name = "RNA Recombinator"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/rnd/rna_recombinator
 	req_components = list(

--- a/modular_nova/modules/mutants/code/mutant_techweb.dm
+++ b/modular_nova/modules/mutants/code/mutant_techweb.dm
@@ -51,7 +51,7 @@
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_MEDICAL
 
 /datum/design/board/rna_recombinator
-	name = "Machine Design (RNA Recombinator)"
+	name = "RNA Recombinator Board"
 	desc = "The MRNA Recombinator is one of Nanotrasens most advanced technologies and allows the exact recombination of virus RNA."
 	id = "rna_recombinator"
 	build_path = /obj/item/circuitboard/machine/rna_recombinator

--- a/modular_nova/modules/powerator/powerator.dm
+++ b/modular_nova/modules/powerator/powerator.dm
@@ -24,7 +24,7 @@
 	crate_type = /obj/structure/closet/crate
 
 /datum/design/board/powerator
-	name = "Machine Design (Powerator)"
+	name = "Powerator Board"
 	desc = "Allows for the construction of circuit boards used to build a powerator."
 	id = "powerator"
 	build_path = /obj/item/circuitboard/machine/powerator

--- a/modular_nova/modules/rod-stopper/code/rodstopper.dm
+++ b/modular_nova/modules/rod-stopper/code/rodstopper.dm
@@ -1,5 +1,5 @@
 /obj/item/circuitboard/machine/rodstopper
-	name = "Rodstopper (Machine Board)"
+	name = "Rodstopper"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/rodstopper
 	req_components = list(

--- a/modular_nova/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_nova/modules/self_actualization_device/code/self_actualization_device.dm
@@ -18,7 +18,7 @@
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
 /obj/item/circuitboard/machine/self_actualization_device
-	name = "Self-Actualization Device (Machine Board)"
+	name = "Self-Actualization Device"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/self_actualization_device
 	req_components = list(/datum/stock_part/micro_laser = 1)

--- a/modular_nova/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_nova/modules/self_actualization_device/code/self_actualization_device.dm
@@ -10,7 +10,7 @@
 #define LASER_POWER_USAGE 7.2 MEGA WATTS
 
 /datum/design/board/self_actualization_device
-	name = "Machine Design (Self-Actualization Device)"
+	name = "Self-Actualization Device Board"
 	desc = "The circuit board for a Self-Actualization Device by Vey-Medical."
 	id = "self_actualization_device"
 	build_path = /obj/item/circuitboard/machine/self_actualization_device

--- a/modular_nova/modules/stasisrework/code/machine_circuitboards.dm
+++ b/modular_nova/modules/stasisrework/code/machine_circuitboards.dm
@@ -1,5 +1,5 @@
 /obj/item/circuitboard/machine/stasissleeper
-	name = "\improper Lifeform Stasis Unit (Machine Board)"
+	name = "Lifeform Stasis Unit"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/stasissleeper
 	req_components = list(

--- a/modular_nova/modules/trash_compactor/code/trash_compactor.dm
+++ b/modular_nova/modules/trash_compactor/code/trash_compactor.dm
@@ -241,7 +241,7 @@
 	return processed_count > 0
 
 /obj/item/circuitboard/machine/trash_compactor
-	name = "\improper DeForest trash reclamation terminal (Machine Board)"
+	name = "\improper DeForest trash reclamation terminal"
 	build_path = /obj/machinery/trash_compactor
 	req_components = list()
 

--- a/modular_nova/modules/trash_compactor/code/trash_compactor.dm
+++ b/modular_nova/modules/trash_compactor/code/trash_compactor.dm
@@ -241,7 +241,7 @@
 	return processed_count > 0
 
 /obj/item/circuitboard/machine/trash_compactor
-	name = "\improper DeForest trash reclamation terminal"
+	name = "DeForest Trash Reclamation Terminal"
 	build_path = /obj/machinery/trash_compactor
 	req_components = list()
 

--- a/modular_nova/modules/xenoarch/code/modules/research/xenoarch/designs_and_tech.dm
+++ b/modular_nova/modules/xenoarch/code/modules/research/xenoarch/designs_and_tech.dm
@@ -191,45 +191,45 @@
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
 /datum/design/board/xenoarch/researcher
-	name = "Machine Design (Xenoarch Researcher)"
+	name = "Xenoarch Researcher Board"
 	desc = "Allows for the construction of circuit boards used to build a new xenoarch researcher."
 	id = "xeno_researcher"
 	build_path = /obj/item/circuitboard/machine/xenoarch_machine/xenoarch_researcher
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO | DEPARTMENT_BITFLAG_SERVICE
 
 /datum/design/board/xenoarch/scanner
-	name = "Machine Design (Xenoarch Scanner)"
+	name = "Xenoarch Scanner Board"
 	desc = "Allows for the construction of circuit boards used to build a new xenoarch scanner."
 	id = "xeno_scanner"
 	build_path = /obj/item/circuitboard/machine/xenoarch_machine/xenoarch_scanner
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO | DEPARTMENT_BITFLAG_SERVICE
 
 /datum/design/board/xenoarch/artifact_analyzer
-	name = "Machine Design (Artifact Analyzer)"
+	name = "Artifact Analyzer Board"
 	desc = "Allows for the construction of circuit boards used to build a new xenoarch artifact analyzer."
 	id = "artifact_analyzer"
 	build_path = /obj/item/circuitboard/machine/artifact_analyser
 
 /datum/design/board/xenoarch/radiocarbon_spectrometer
-	name = "Machine Design (Radiocarbon spectrometer)"
+	name = "Radiocarbon spectrometer Board"
 	desc = "Allows for the construction of circuit boards used to build a new xenoarch radiocarbon spectrometer."
 	id = "radiocarbon spectrometer"
 	build_path = /obj/item/circuitboard/machine/radiocarbon_spectrometer
 
 /datum/design/board/xenoarch/artifact_harvester
-	name = "Machine Design (Exotic Particle Harvester)"
+	name = "Exotic Particle Harvester Board"
 	desc = "Allows for the construction of circuit boards used to build a new xenoarch exotic particle harvester."
 	id = "artifact_harvester"
 	build_path = /obj/item/circuitboard/machine/artifact_harvester
 
 /datum/design/board/xenoarch/artifact_scanpad
-	name = "Machine Design (Artifact Scanpad)"
+	name = "Artifact Scanpad Board"
 	desc = "Allows for the construction of circuit boards used to build a new xenoarch artifact scanpad."
 	id = "artifact_scanpad"
 	build_path = /obj/item/circuitboard/machine/artifact_scanpad
 
 /datum/design/board/xenoarch/digger
-	name = "Machine Design (Xenoarch Digger)"
+	name = "Xenoarch Digger Board"
 	desc = "Allows for the construction of circuit boards used to build a new xenoarch digger."
 	id = "xeno_digger"
 	build_path = /obj/item/circuitboard/machine/xenoarch_machine/xenoarch_digger

--- a/modular_nova/modules/xenoarch/code/modules/research/xenoarch/xenoarch_item.dm
+++ b/modular_nova/modules/xenoarch/code/modules/research/xenoarch/xenoarch_item.dm
@@ -101,15 +101,15 @@
 	needs_anchored = TRUE
 
 /obj/item/circuitboard/machine/xenoarch_machine/xenoarch_researcher
-	name = "Xenoarch Researcher (Machine Board)"
+	name = "Xenoarch Researcher"
 	build_path = /obj/machinery/xenoarch/researcher
 
 /obj/item/circuitboard/machine/xenoarch_machine/xenoarch_scanner
-	name = "Xenoarch Scanner (Machine Board)"
+	name = "Xenoarch Scanner"
 	build_path = /obj/machinery/xenoarch/scanner
 
 /obj/item/circuitboard/machine/xenoarch_machine/xenoarch_digger
-	name = "Xenoarch Digger (Machine Board)"
+	name = "Xenoarch Digger"
 	build_path = /obj/machinery/xenoarch/digger
 
 /obj/item/paper/fluff/xenoarch_guide
@@ -210,7 +210,7 @@
 	desc = "A set of items that contain chameleon technology allowing you to disguise as pretty much anything on the station, and more! \
 			This one seems to have some stuff missing, and clearly put in a box smaller than what it should be."
 
-/obj/item/storage/box/incomplete_chameleon/PopulateContents() 
+/obj/item/storage/box/incomplete_chameleon/PopulateContents()
 	new /obj/item/clothing/under/chameleon(src)
 	new /obj/item/clothing/suit/chameleon(src)
 	new /obj/item/clothing/gloves/chameleon(src)
@@ -225,7 +225,7 @@
 	name = "boxed voskhod replica space suit and helmet"
 	desc = "A sleek, sturdy box used to hold toy- wait, this has the real thing!"
 
-/obj/item/storage/box/fakesyndiesuit/voskhod/PopulateContents() 
+/obj/item/storage/box/fakesyndiesuit/voskhod/PopulateContents()
 	new /obj/item/clothing/suit/space/voskhod(src)
 	new /obj/item/clothing/head/helmet/space/voskhod(src)
 
@@ -257,7 +257,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = null
 
-/// A raptor egg that piggy backs on the watcher podometer and uses a spawn for 
+/// A raptor egg that piggy backs on the watcher podometer and uses a spawn for
 /obj/item/food/egg/watcher/raptor
 	name = "cold raptor egg"
 	desc = "A lonely egg still pulsing with life, somehow untouched by the corruption of the Necropolis."
@@ -288,7 +288,7 @@
 	desc = "An old shuttle construction kit, its contents worn but intact. Inside are faded blueprints and the circuitboards needed to \
 			assemble a basic shuttle. The instructions on the side of the box are unreadable though."
 
-/obj/item/storage/box/shuttle_construction_kit/PopulateContents() 
+/obj/item/storage/box/shuttle_construction_kit/PopulateContents()
 	new /obj/item/circuitboard/computer/shuttle/docker(src)
 	new	/obj/item/circuitboard/computer/shuttle/flight_control(src)
 	new	/obj/item/circuitboard/machine/engine/propulsion(src)
@@ -296,7 +296,7 @@
 	new	/obj/item/shuttle_blueprints(src)
 	new	/obj/item/stack/rods/shuttle/fifty(src)
 
-// This is just a cowboy hat (with minimal armor) that its sole function is to perfectly block a hit to the head and then flip out of the head of the user and away 3-5 tiles. It has a few seconds of cooldown from such, so even if players find a way to quickly reattach it, it wont be a sure protection. 
+// This is just a cowboy hat (with minimal armor) that its sole function is to perfectly block a hit to the head and then flip out of the head of the user and away 3-5 tiles. It has a few seconds of cooldown from such, so even if players find a way to quickly reattach it, it wont be a sure protection.
 /obj/item/clothing/head/cowboy/bounty/deadman
 	name = "dead man's brim"
 	desc = "A wide-brimmed black hat with a polished golden band. It sits just loose enough to be thrown clear at the first sign of trouble, taking the hit with it."


### PR DESCRIPTION
## About The Pull Request

About what it says on the tin. Renames the boards and the designs for printing the boards for xenoarch machines, rodstoppers, multi-cell chargers, etc. to be consistent with other TG machinery.

## How This Contributes To The Nova Sector Roleplay Experience

The inconsistency bugs me.

## Proof of Testing

<img width="1147" height="516" alt="image" src="https://github.com/user-attachments/assets/2d152d4e-b530-4c0e-9da2-2951e2425c86" />

## Changelog

:cl:
spellcheck: Various Nova machines (multi-cell chargers, xenoarch machines, etc.) have had their board names/design names adjusted for consistency with other TG machines.
/:cl: