### PR TITLE
[NO GBP] fixes fastball grounders not having items (whoops)

### DIFF
--- a/modular_nova/modules/anomaly_grenades/code/grenade_kits.dm
+++ b/modular_nova/modules/anomaly_grenades/code/grenade_kits.dm
@@ -25,6 +25,7 @@
 	)
 	time = 5 SECONDS
 	category = CAT_WEAPON_RANGED
+	delete_contents = FALSE
 
 /// Grenade
 /datum/storage/lockbox/grenades
@@ -39,7 +40,7 @@
 	var/obj/item/grenade/starting_nade = /obj/item/grenade
 
 /obj/item/storage/lockbox/anomaly_grenades/PopulateContents()
-	for(var/i in 1 to 5)
+	for(var/i in 1 to 7)
 		new starting_nade(src)
 
 /obj/item/storage/lockbox/anomaly_grenades/anchor


### PR DESCRIPTION
## About The Pull Request

Flips a flag so anomaly grenade cases don't clear themselves when crafted.

## How This Contributes To The Nova Sector Roleplay Experience

If I craft a box of grenades I should probably have some grenades, huh.

## Proof of Testing

<img width="550" height="153" alt="image" src="https://github.com/user-attachments/assets/45372c85-436f-4d16-8aca-0f4c1132ef7e" />

## Changelog

:cl:
fix: Fastball bluespace grounders should actually have grenades when crafted, and now have enough to fill their case.
/:cl:
