### PR TITLE
Starfruit Jelly is a food.

### DIFF
--- a/modular_nova/modules/customization/modules/hydroponics/grown/starfruit.dm
+++ b/modular_nova/modules/customization/modules/hydroponics/grown/starfruit.dm
@@ -506,6 +506,7 @@
 		/obj/item/food/grown/starfruit = 10,
 		/datum/reagent/water = 25,
 	)
+	category = CAT_FOOD
 	result = /obj/item/reagent_containers/condiment/starfruitjelly
 
 /obj/item/food/cookie/macaron/starfruit


### PR DESCRIPTION

## About The Pull Request

Starfruit jelly currently shows up under the crafting menu. The non-food one. It's a food though. Or it should be.

## How This Contributes To The Nova Sector Roleplay Experience

Less confusion on crafting.


## Changelog

:cl:
qol: moves starfruit jelly from to food crafting menu.
/:cl:

