### PR TITLE
Adds wheelchairs to loadout

### DIFF
--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_inhands.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_inhands.dm
@@ -119,6 +119,10 @@
 	name = "Saddlebags"
 	item_path = /obj/item/storage/backpack/saddlebags
 
+/datum/loadout_item/inhand/wheelchair
+	name = "Folded Wheelchair"
+	item_path = /obj/item/wheelchair
+
 /datum/loadout_item/inhand/pet
 	abstract_type = /datum/loadout_item/inhand/pet
 


### PR DESCRIPTION

## About The Pull Request

Simply adds the wheelchair item to the loadout, so people can have a folded up wheelchair in hand.
## How This Contributes To The Nova Sector Roleplay Experience

It allows our cast to have a roundstart wheelchair without necessarily being paraplegic. Perfect world paraplegic might have a choice in ride, but that's out of scope.

There is a tiny Gamer Balance concern by people like, carrying around something to handcuff people to or something, but rolling chairs (and wheelchairs in general) are accessible enough that I don't think it'll be an issue.
## Proof of Testing
Throwing up a test server was giving _unrelated_ errors that I don't have the gumption to fix for a line change. I cross referenced other place's loadouts and the entry worked fine, so I am confident without it.

## Changelog
:cl:
add: Manual, foldable wheelchairs added to loadout.
/:cl:
