### PR TITLE
Stasis Body Bag Differentiation

### DIFF
--- a/modular_nova/modules/stasisrework/code/bodybag.dm
+++ b/modular_nova/modules/stasisrework/code/bodybag.dm
@@ -1,5 +1,5 @@
 /obj/item/bodybag/stasis_longterm
-	name = "long-term stasis body bag"
+	name = "mortuary stasis body bag"
 	desc = "A folded long-term stasis body bag designed for the storage and stasis of cadavers."
 	icon = 'modular_nova/modules/stasisrework/icons/stasisbag.dmi'
 	icon_state = "greenbodybag_folded"

--- a/modular_nova/modules/stasisrework/code/bodybag.dm
+++ b/modular_nova/modules/stasisrework/code/bodybag.dm
@@ -1,9 +1,9 @@
-/obj/item/bodybag/stasis_longterm
+/obj/item/bodybag/stasis_mortuary
 	name = "mortuary stasis body bag"
 	desc = "A folded long-term stasis body bag designed for the storage and stasis of cadavers."
 	icon = 'modular_nova/modules/stasisrework/icons/stasisbag.dmi'
 	icon_state = "greenbodybag_folded"
-	unfoldedbag_path = /obj/structure/closet/body_bag/stasis_longterm
+	unfoldedbag_path = /obj/structure/closet/body_bag/stasis_mortuary
 	w_class = WEIGHT_CLASS_SMALL
 	item_flags = NO_MAT_REDEMPTION
 

--- a/modular_nova/modules/stasisrework/code/bodybag.dm
+++ b/modular_nova/modules/stasisrework/code/bodybag.dm
@@ -1,9 +1,9 @@
-/obj/item/bodybag/stasis
-	name = "stasis body bag"
-	desc = "A folded stasis body bag designed for the storage and stasis of cadavers."
+/obj/item/bodybag/stasis_longterm
+	name = "long-term stasis body bag"
+	desc = "A folded long-term stasis body bag designed for the storage and stasis of cadavers."
 	icon = 'modular_nova/modules/stasisrework/icons/stasisbag.dmi'
 	icon_state = "greenbodybag_folded"
-	unfoldedbag_path = /obj/structure/closet/body_bag/stasis
+	unfoldedbag_path = /obj/structure/closet/body_bag/stasis_longterm
 	w_class = WEIGHT_CLASS_SMALL
 	item_flags = NO_MAT_REDEMPTION
 

--- a/modular_nova/modules/stasisrework/code/bodybag_structure.dm
+++ b/modular_nova/modules/stasisrework/code/bodybag_structure.dm
@@ -1,5 +1,5 @@
 /obj/structure/closet/body_bag/stasis_longterm
-	name = "long-term stasis bodybag"
+	name = "mortuary stasis bodybag"
 	desc = "A body bag designed for the preservation of cadavers via integrated cryogenic technology and an insulative diamond mesh. \
 		Due to generator limitations, the stasis effect only works on dead bodies."
 	icon = 'modular_nova/modules/stasisrework/icons/stasisbag.dmi'

--- a/modular_nova/modules/stasisrework/code/bodybag_structure.dm
+++ b/modular_nova/modules/stasisrework/code/bodybag_structure.dm
@@ -1,9 +1,10 @@
-/obj/structure/closet/body_bag/stasis
-	name = "stasis body bag"
-	desc = "A body bag designed for the preservation of cadavers via integrated cryogenic technology and cryo-insulative mesh. Due to size limitations, it only works on dead bodies."
+/obj/structure/closet/body_bag/stasis_longterm
+	name = "long-term stasis bodybag"
+	desc = "A body bag designed for the preservation of cadavers via integrated cryogenic technology and an insulative diamond mesh. \
+		Due to generator limitations, the stasis effect only works on dead bodies."
 	icon = 'modular_nova/modules/stasisrework/icons/stasisbag.dmi'
 	icon_state = "greenbodybag"
-	foldedbag_path = /obj/item/bodybag/stasis
+	foldedbag_path = /obj/item/bodybag/stasis_longterm
 	mob_storage_capacity = 1
 	max_mob_size = MOB_SIZE_LARGE
 

--- a/modular_nova/modules/stasisrework/code/bodybag_structure.dm
+++ b/modular_nova/modules/stasisrework/code/bodybag_structure.dm
@@ -28,9 +28,7 @@
 	var/freq = rand(24750, 26550)
 	playsound(src, 'sound/effects/spray.ogg', 5, TRUE, 2, frequency = freq)
 	target.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_MACHINE_EFFECT)
-	ADD_TRAIT(target, TRAIT_TUMOR_SUPPRESSED, TRAIT_GENERIC)
 	target.extinguish_mob()
 
 /obj/structure/closet/body_bag/stasis/proc/thaw_them(mob/living/target)
 	target.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_MACHINE_EFFECT)
-	REMOVE_TRAIT(target, TRAIT_TUMOR_SUPPRESSED, TRAIT_GENERIC)

--- a/modular_nova/modules/stasisrework/code/bodybag_structure.dm
+++ b/modular_nova/modules/stasisrework/code/bodybag_structure.dm
@@ -1,10 +1,10 @@
-/obj/structure/closet/body_bag/stasis_longterm
+/obj/structure/closet/body_bag/stasis_mortuary
 	name = "mortuary stasis bodybag"
 	desc = "A body bag designed for the preservation of cadavers via integrated cryogenic technology and an insulative diamond mesh. \
 		Due to generator limitations, the stasis effect only works on dead bodies."
 	icon = 'modular_nova/modules/stasisrework/icons/stasisbag.dmi'
 	icon_state = "greenbodybag"
-	foldedbag_path = /obj/item/bodybag/stasis_longterm
+	foldedbag_path = /obj/item/bodybag/stasis_mortuary
 	mob_storage_capacity = 1
 	max_mob_size = MOB_SIZE_LARGE
 

--- a/modular_nova/modules/stasisrework/code/medical_designs.dm
+++ b/modular_nova/modules/stasisrework/code/medical_designs.dm
@@ -1,10 +1,10 @@
-/datum/design/stasisbag_longterm
+/datum/design/stasisbag_mortuary
 	name = "Mortuary Stasis Bodybag"
 	desc = "A long-term cadaver stasis body bag, powered by integrated stasis technology. It can hold only one body, but it prevents decay. \
 		The reinforced materials and improved stasis generator prevent it from falling apart easily."
 	id = "stasisbag"
 	build_type = PROTOLATHE | AWAY_LATHE
-	build_path = /obj/item/bodybag/stasis_longterm
+	build_path = /obj/item/bodybag/stasis_mortuary
 	materials = list(
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2,
 		/datum/material/plasma = SHEET_MATERIAL_AMOUNT,

--- a/modular_nova/modules/stasisrework/code/medical_designs.dm
+++ b/modular_nova/modules/stasisrework/code/medical_designs.dm
@@ -1,7 +1,7 @@
 /datum/design/stasisbag_longterm
-	name = "Long-Term Stasis Bodybag"
-	desc = "A long-term stasis body bag, powered by integrated stasis technology. It can hold only one body, but it prevents decay. \
-		The reinforced materials and improved stasis generator prevents it from falling apart easily."
+	name = "Mortuary Stasis Bodybag"
+	desc = "A long-term cadaver stasis body bag, powered by integrated stasis technology. It can hold only one body, but it prevents decay. \
+		The reinforced materials and improved stasis generator prevent it from falling apart easily."
 	id = "stasisbag"
 	build_type = PROTOLATHE | AWAY_LATHE
 	build_path = /obj/item/bodybag/stasis_longterm

--- a/modular_nova/modules/stasisrework/code/medical_designs.dm
+++ b/modular_nova/modules/stasisrework/code/medical_designs.dm
@@ -1,9 +1,10 @@
-/datum/design/stasisbag
-	name = "Stasis Body Bag"
-	desc = "A stasis body bag, powered by cryogenic stasis technology. It can hold only one body, but it prevents decay."
+/datum/design/stasisbag_longterm
+	name = "Long-Term Stasis Bodybag"
+	desc = "A long-term stasis body bag, powered by integrated stasis technology. It can hold only one body, but it prevents decay. \
+		The reinforced materials and improved stasis generator prevents it from falling apart easily."
 	id = "stasisbag"
 	build_type = PROTOLATHE | AWAY_LATHE
-	build_path = /obj/item/bodybag/stasis
+	build_path = /obj/item/bodybag/stasis_longterm
 	materials = list(
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2,
 		/datum/material/plasma = SHEET_MATERIAL_AMOUNT,


### PR DESCRIPTION
## About The Pull Request

Differentiates the two different kinds of stasis body bags some more after upstream added their own.

Green ones are the Nova ones that only work on dead people, blue ones are the TG ones that degrade during active use but work on living people. To clarify the difference, the Nova bags have been renamed to "long-term stasis bodybags", and have had some description tweaks.

Also fixes both bodybag print recipes printing the same Nova bodybag. I think.

## How This Contributes To The Nova Sector Roleplay Experience

Probably good that these have tangible differences, actually.

## Proof of Testing

<img width="77" height="140" alt="image" src="https://github.com/user-attachments/assets/57a55046-95d3-4559-907a-a8fdd2c6623c" />


## Changelog

:cl:
spellcheck: Adjusts the naming of Nova-specific stasis bodybags to "long-term stasis bodybags", as they don't fall apart but only work on dead people.
fix: Nova-specific stasis bodybags now print their own (green) bodybags, TG stasis bodybags (blue) restored.
/:cl:
