### PR TITLE
rechambers the NT20 to 9mm

### DIFF
--- a/modular_nova/modules/modular_weapons/code/autolathe_design.dm
+++ b/modular_nova/modules/modular_weapons/code/autolathe_design.dm
@@ -2,7 +2,7 @@
 	design_ids += list(
 		"kineticballs",
 		"pepperballs",
-		"mag_c20r",
+		"mag_nt20",
 		"mag_katyusha",
 	)
 	return ..()

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/submachinegun.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/submachinegun.dm
@@ -7,11 +7,11 @@ This is a Blueshield weapon. It's for the Blueshield. If this ends up in Cargo I
 /obj/item/gun/ballistic/automatic/nt20
 	name = "\improper NT20 Submachine Gun"
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/company_and_or_faction_based/nanotrasen_armories/ballistic.dmi'
-	desc = "A sleek, select-fire SMG chambered in the venerable .45 cartridge. The Blueshield's favorite toy."
+	desc = "A sleek, select-fire SMG chambered in the venerable 9mm cartridge. The Blueshield's favorite toy."
 	icon_state = "nt20"
 	inhand_icon_state = "c20r"
 	selector_switch_icon = TRUE
-	accepted_magazine_type = /obj/item/ammo_box/magazine/smgm45
+	accepted_magazine_type = /obj/item/ammo_box/magazine/smg_nt20
 	fire_delay = 1.5
 	burst_size = 2 // 30 damage a burst at 1.5s delay is about 3.5s
 	pin = /obj/item/firing_pin
@@ -23,9 +23,10 @@ This is a Blueshield weapon. It's for the Blueshield. If this ends up in Cargo I
 
 	lore_blurb = "The Nanotrasen Armories NT20 is a recent release from NT's esteemed private arms division, \
 		and it's received a warm welcome from the Shield teams and other NT armed forces who have been \
-		issued it in its ongoing rollout.<br><br>\
+		issued it in its ongoing rollout.<br>\
+		<br>\
 		Though certain rival manufacturers have dismissed the NT20 as a \"fake\" or a \"blatant bootleg,\" \
-		the venerable .45 round and a patent-pending multi-stage delayed blowback system \
+		the venerable 9mm round and a patent-pending multi-stage delayed blowback system \
 		make the NT20 powerful, reliable, accurate, and shockingly comfortable to fire."
 
 /obj/item/gun/ballistic/automatic/nt20/give_manufacturer_examine()
@@ -47,10 +48,24 @@ This is a Blueshield weapon. It's for the Blueshield. If this ends up in Cargo I
 	. = ..()
 	update_appearance()
 
+/obj/item/ammo_box/magazine/smg_nt20
+	name = "NT20 magazine (9mm)"
+	desc = "A long 9mm magazine, suitable for the NT20 SMG. Just geometrically different enough to not fit in other similar bullpup submachine guns."
+	icon_state = "c20r45"
+	base_icon_state = "c20r45"
+	ammo_band_icon = "+c20rab"
+	ammo_band_color = null
+	ammo_type = /obj/item/ammo_casing/c9mm
+	caliber = CALIBER_9MM
+	max_ammo = 24
+
+/obj/item/ammo_box/magazine/smg_nt20/empty
+	start_empty = TRUE
+
 /obj/item/storage/toolbox/guncase/nova/ntspecial/nt20
 	name = "\improper Nanotrasen Armories \"NT20\" gunset"
 	weapon_to_spawn = /obj/item/gun/ballistic/automatic/nt20
-	extra_to_spawn = /obj/item/ammo_box/magazine/smgm45
+	extra_to_spawn = /obj/item/ammo_box/magazine/smg_nt20
 
 /obj/item/storage/toolbox/guncase/nova/ntspecial/nt20/PopulateContents()
 	. = ..()

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/submachinegun.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/submachinegun.dm
@@ -49,12 +49,12 @@ This is a Blueshield weapon. It's for the Blueshield. If this ends up in Cargo I
 	update_appearance()
 
 /obj/item/ammo_box/magazine/smg_nt20
-	name = "NT20 magazine (9mm)"
+	name = "\improper NT20 magazine (9mm)"
 	desc = "A long 9mm magazine, suitable for the NT20 SMG. Just geometrically different enough to not fit in other similar bullpup submachine guns."
-	icon_state = "c20r45"
-	base_icon_state = "c20r45"
-	ammo_band_icon = "+c20rab"
-	ammo_band_color = null
+	icon_state = /obj/item/ammo_box/magazine/smgm45::icon_state
+	base_icon_state = /obj/item/ammo_box/magazine/smgm45::base_icon_state
+	ammo_band_icon = /obj/item/ammo_box/magazine/smgm45::ammo_band_icon
+	ammo_band_color = /obj/item/ammo_box/magazine/smgm45::ammo_band_color
 	ammo_type = /obj/item/ammo_casing/c9mm
 	caliber = CALIBER_9MM
 	max_ammo = 24

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/submachinegun.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/submachinegun.dm
@@ -59,6 +59,10 @@ This is a Blueshield weapon. It's for the Blueshield. If this ends up in Cargo I
 	caliber = CALIBER_9MM
 	max_ammo = 24
 
+/obj/item/ammo_box/magazine/smg_nt20/update_icon_state()
+	. = ..()
+	icon_state = "[base_icon_state]-[round(ammo_count(), 2)]"
+
 /obj/item/ammo_box/magazine/smg_nt20/empty
 	start_empty = TRUE
 

--- a/modular_nova/modules/security_designs/code/security_designs.dm
+++ b/modular_nova/modules/security_designs/code/security_designs.dm
@@ -4,13 +4,13 @@
 /datum/design/paperroll
 	departmental_flags = DEPARTMENT_BITFLAG_SERVICE | DEPARTMENT_BITFLAG_SECURITY
 
-/datum/design/mag_c20r // sec printable so that the blueshield can get more mags for the nt20, which takes the c20r mag
-	name = "Magazine (.45)"
-	desc = "A 24-round magazine designed to fit in submachine guns which fire .45."
-	id = "mag_c20r"
+/datum/design/mag_nt20 // sec printable so that the blueshield can get more mags for the nt20
+	name = "NT20 Magazine (9mm)"
+	desc = "A 24-round magazine designed to fit in submachine guns which fire 9mm, and definitely not for other guns that would fire, say, .45."
+	id = "mag_nt20"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2)
-	build_path = /obj/item/ammo_box/magazine/smgm45/empty
+	build_path = /obj/item/ammo_box/magazine/smg_nt20/empty
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO
@@ -19,7 +19,7 @@
 
 /datum/design/mag_katyusha // sec printable so that the blueshield can get more mags for the katyusha, which takes the katyusha drum mags
 	name = "Magazine (12 Gauge Shells)"
-	desc = "A 10-shell magazine designed to fit in the NT-Katyusha which fires 12 gauge"
+	desc = "A 10-shell magazine designed to fit in the NT-Katyusha, which fires 12 gauge."
 	id = "mag_katyusha"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2)


### PR DESCRIPTION
## About The Pull Request

Changes the NT20 to fire 9mm, which has basically the same damage profile as .45.

## How This Contributes To The Nova Sector Roleplay Experience

Separates the NT20 some more from the C-20r, and also stymies the recent trend of antags (marauders, primarily) using the roundstart research to print C-20r magazines and coming on-station with full belts of magazines. You *will* retain your magazines and you *will* double back for the ones you abandon mid-gunfight.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

<img width="539" height="386" alt="image" src="https://github.com/user-attachments/assets/c2d7b05d-5a37-4acb-bf35-c1c85b92814c" />
<img width="264" height="119" alt="2026-05-25_01-09-14-AM-Monday" src="https://github.com/user-attachments/assets/485181b1-ceee-457e-b110-a9aa6ade8934" />

</details>

## Changelog

:cl:
balance: Following the NT M-96's rechambering to 9mm, Nanotrasen Arms has decided to experiment with rechambering all currently in-service NT20s to 9mm, citing simplified logistics.
/:cl:
