### PR TITLE
[NON-MODULAR] Makes the Luxury Shuttle cost more to board on account of the crew being much richer by base here than on /tg/.

### DIFF
--- a/code/modules/shuttle/misc/special.dm
+++ b/code/modules/shuttle/misc/special.dm
@@ -218,7 +218,7 @@
 	use_power = NO_POWER_USE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	speech_span = SPAN_ROBOT
-	var/threshold = 500
+	var/threshold = 2000 // NOVA EDIT CHANGE - Accounts for the massively multiplied funds the crew has. Original - 500
 	var/static/list/approved_passengers = list()
 	var/static/list/check_times = list()
 	var/list/payees = list()

--- a/code/modules/shuttle/misc/special.dm
+++ b/code/modules/shuttle/misc/special.dm
@@ -218,7 +218,7 @@
 	use_power = NO_POWER_USE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	speech_span = SPAN_ROBOT
-	var/threshold = 2000 // NOVA EDIT CHANGE - Accounts for the massively multiplied funds the crew has. Original - 500
+	var/threshold = 2000 // NOVA EDIT CHANGE - Accounts for the massively multiplied funds the crew has. ORIGINAL: var/threshold = 500
 	var/static/list/approved_passengers = list()
 	var/static/list/check_times = list()
 	var/list/payees = list()

--- a/code/modules/shuttle/misc/special.dm
+++ b/code/modules/shuttle/misc/special.dm
@@ -218,7 +218,7 @@
 	use_power = NO_POWER_USE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	speech_span = SPAN_ROBOT
-	var/threshold = 2000 // NOVA EDIT CHANGE - Accounts for the massively multiplied funds the crew has. ORIGINAL: var/threshold = 500
+	var/threshold = 2000 // NOVA EDIT CHANGE - Accounts for the massively multiplied funds the crew has. - ORIGINAL: var/threshold = 500
 	var/static/list/approved_passengers = list()
 	var/static/list/check_times = list()
 	var/list/payees = list()


### PR DESCRIPTION
## About The Pull Request

Makes the Luxury Shuttle cost more on account of the crew being much richer by base here than on /tg/.

## How This Contributes To The Nova Sector Roleplay Experience

Numbers are set for the /tg/ economy, this is the nova economy where everyone is rich, so rich thresholds should be higher.

## Proof of Testing

numbers tweak, it'll be fine

## Changelog
:cl:
balance: Makes the Luxury Shuttle cost more on account of the crew being much richer by base here than on /tg/.
/:cl:
