### PR TITLE
Buffs Praetorian and Queen Movement Speed

### DIFF
--- a/modular_nova/modules/xenomorph/mobs.dm
+++ b/modular_nova/modules/xenomorph/mobs.dm
@@ -1,0 +1,3 @@
+/datum/movespeed_modifier/tail_dragger/New()
+	..()
+	multiplicative_slowdown = 2

--- a/modular_nova/modules/xenomorph/praetorian.dm
+++ b/modular_nova/modules/xenomorph/praetorian.dm
@@ -1,0 +1,2 @@
+/mob/living/carbon/alien/adult/royal/praetorian
+	alien_speed = 0.4

--- a/modular_nova/modules/xenomorph/queen.dm
+++ b/modular_nova/modules/xenomorph/queen.dm
@@ -1,2 +1,2 @@
 /mob/living/carbon/alien/adult/royal/queen
-	alien_speed = 1
+	alien_speed = 0.4

--- a/modular_nova/modules/xenomorph/queen.dm
+++ b/modular_nova/modules/xenomorph/queen.dm
@@ -1,2 +1,2 @@
 /mob/living/carbon/alien/adult/royal/queen
-	alien_speed = 0.4
+	alien_speed = 0

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9764,5 +9764,6 @@
 #include "modular_nova\modules\xenoarchartifacts\obj\particle_battery.dm"
 #include "modular_nova\modules\xenoarchartifacts\obj\wave_scanner.dm"
 #include "modular_nova\modules\xenomorph\alien.dm"
+#include "modular_nova\modules\xenomorph\praetorian.dm"
 #include "modular_nova\modules\xenomorph\queen.dm"
 // END_INCLUDE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9764,6 +9764,7 @@
 #include "modular_nova\modules\xenoarchartifacts\obj\particle_battery.dm"
 #include "modular_nova\modules\xenoarchartifacts\obj\wave_scanner.dm"
 #include "modular_nova\modules\xenomorph\alien.dm"
+#include "modular_nova\modules\xenomorph\mobs.dm"
 #include "modular_nova\modules\xenomorph\praetorian.dm"
 #include "modular_nova\modules\xenomorph\queen.dm"
 // END_INCLUDE


### PR DESCRIPTION

## About The Pull Request
Drones or Sentinels should not be more threatening than Queens or Praetorians. The current movement debuffs enforce this backwards system. So once again, this time at the request of Moonridden, I am empowering the queen and praetorian to move faster.
## How This Contributes To The Nova Sector Roleplay Experience
The Xeno queens movement speed was indirectly debuffed by a TG PR when they enabled player characters to have the queens tail surgically implanted. It is never referenced if this was intentional let alone a known bug: https://github.com/tgstation/tgstation/pull/89618
For a more in depth exploration of why something like this is good within our community:
For a long time I have seen the xenomorph antag as a whole play out the same way for any new player: A role that offers no value if you do not have a meta understanding of how to play it. You will spawn in, but without knowing that you immediately need to evolve to drone and rush the nearest source of monkeys before an alarm calls upon your very existence, you will die. All of this can be remedied by empowering the queen and praetorian to be a defensible force which does not rely on the support of other xenos. In making both praetor and queen move only slightly slower than a standard player we stop them from being able to run people down, but empower them to flee fights. This is a necessary change to challenge the norm of being run down with lasers while hardly even having the means to strafe the shots.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/cbaab1d8-bbf4-494b-8af8-09de830a8630

https://github.com/user-attachments/assets/99dd5940-30c1-4e23-b537-8a9d668ee0bd

https://github.com/user-attachments/assets/01f4db04-3fdf-4dfc-ae3f-09ef20f0976e



</details>

## Changelog
:cl: Macaroni
balance: Reduces the taildragging debuff applied from the xeno queen's tail from 4 to 2
balance: Sets the queens alien_speed to 0 so as to entirely rely on the taildragging debuff
balance: The praetorian's movement debuff has been changed from 0.5 to 0.4
/:cl:
