### PR TITLE
Contractor QoL

### DIFF
--- a/modular_nova/modules/contractor/code/items/boxes.dm
+++ b/modular_nova/modules/contractor/code/items/boxes.dm
@@ -24,22 +24,10 @@
 	new /obj/item/fulton_core(src)
 
 /obj/item/storage/box/syndicate/contract_kit/midround/PopulateContents()
-	var/static/list/item_list = list(
-		/obj/item/storage/box/syndie_kit/throwing_weapons,
-		/obj/item/pen/edagger,
-		/obj/item/pen/sleepy,
-		/obj/item/flashlight/emp,
-		/obj/item/reagent_containers/hypospray/medipen/stimulants,
-		/obj/item/storage/box/syndie_kit/imp_freedom,
-		/obj/item/crowbar/power/syndicate,
-		/obj/item/storage/box/syndie_kit/emp,
-		/obj/item/shield/energy,
-		/obj/item/healthanalyzer/rad_laser,
-	)
-	// All about 4 TC or less - some nukeops only items, but fit nicely to the theme.
-	for(var/iteration in 1 to SMALL_ITEM_AMOUNT)
-		var/obj/item/small_item = pick_n_take(item_list)
-		new small_item(src)
+	new	/obj/item/crowbar/power/syndicate(src)
+	new	/obj/item/storage/box/syndie_kit/emp(src)
+	new	/obj/item/shield/energy(src)
+
 	// finally. a real gun
 	new /obj/item/storage/toolbox/guncase/traitor/contractor_fisher(src)
 

--- a/modular_nova/modules/contractor/code/items/modsuit/modsuit.dm
+++ b/modular_nova/modules/contractor/code/items/modsuit/modsuit.dm
@@ -47,6 +47,7 @@
 		/obj/item/mod/module/shock_absorber,
 		/obj/item/mod/module/quick_cuff,
 		/obj/item/mod/module/jetpack,
+		/obj/item/mod/module/rad_protection,
 		/obj/item/mod/module/scorpion_hook,
 		/obj/item/mod/module/springlock/contractor/no_complexity,
 		/obj/item/mod/module/storage/syndicate,


### PR DESCRIPTION

## About The Pull Request

Contractor has become near and dear to my heart as an antag, one that you can do all the objectives for without killing anyone while being loud. What's not to like? But there's a couple issues here- namely that of the RNG system that can make or break one's run, this PR addresses that and gives them a rad shield due to the space radiation divergency.

Now you'll get jaws of death, an EMP kit and an energy shield by default, so you can get on into that station and cause some trouble, you magnificent bastard.





Also Moon said I could unjank contractor.

## How This Contributes To The Nova Sector Roleplay Experience
For one, this prevents contractor from being fried by the radiation divergency. For the other, having antags that don't rely on RNG for when you get the quite rare chance to play them, I can only say is a plus. 

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="527" height="187" alt="image" src="https://github.com/user-attachments/assets/cf2e209a-b149-40ae-b131-a5a81b70495c" />

</details>

## Changelog
:cl:
balance: Contractor now spawns with a gear set instead of RNG taking the wheel on it
fix: Contractor now spawns with radiation projection (radioactive nebula would just kill them before)
/:cl:
