### PR TITLE
[FIX] Holosynths cannot move past broken electrified grilles

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -383,8 +383,6 @@
 /// Do some very specific checks to see if we *would* get shocked. Returns TRUE if it's shocked
 /obj/structure/grille/proc/is_shocked()
 	var/turf/turf = get_turf(src)
-	if(!anchored || broken)
-		return FALSE
 	var/obj/structure/cable/cable = turf.get_cable_node()
 	var/list/powernet_info = get_powernet_info_from_source(cable)
 

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -383,6 +383,8 @@
 /// Do some very specific checks to see if we *would* get shocked. Returns TRUE if it's shocked
 /obj/structure/grille/proc/is_shocked()
 	var/turf/turf = get_turf(src)
+	if(!anchored || broken)
+		return FALSE
 	var/obj/structure/cable/cable = turf.get_cable_node()
 	var/list/powernet_info = get_powernet_info_from_source(cable)
 

--- a/modular_nova/modules/holosynth/code/holopassthrough.dm
+++ b/modular_nova/modules/holosynth/code/holopassthrough.dm
@@ -30,6 +30,13 @@
 /datum/component/glass_passer/holosynth/Initialize(pass_time = HOLOSYNTH_GLASS_PASS_TIME, deform_glass = HOLOSYNTH_GLASS_DEFORM_TIME)
 	return ..()
 
+/datum/component/glass_passer/holosynth/on_cross_over(mob/passer, atom/crosser)
+	if(istype(crosser, /obj/structure/grille))
+		var/obj/structure/grille/grille = crosser
+		if(grille.broken)
+			return null
+	return ..()
+
 /datum/component/glass_passer/holosynth/phase_through_glass(mob/living/owner, atom/bumpee)
 	if(!auto_phase)
 		return
@@ -102,7 +109,7 @@
 			continue
 		if(istype(blocker, /obj/structure/grille))
 			var/obj/structure/grille/grille = blocker
-			if(grille.is_shocked())
+			if(!grille.broken && grille.is_shocked())
 				return TRUE
 			continue
 		if(istype(blocker, /obj/structure/window))

--- a/modular_nova/modules/holosynth/code/holopassthrough.dm
+++ b/modular_nova/modules/holosynth/code/holopassthrough.dm
@@ -31,7 +31,6 @@
 	return ..()
 
 /datum/component/glass_passer/holosynth/on_cross_over(mob/passer, atom/crosser)
-	SIGNAL_HANDLER
 	if(istype(crosser, /obj/structure/grille))
 		var/obj/structure/grille/grille = crosser
 		if(grille.broken)

--- a/modular_nova/modules/holosynth/code/holopassthrough.dm
+++ b/modular_nova/modules/holosynth/code/holopassthrough.dm
@@ -31,6 +31,7 @@
 	return ..()
 
 /datum/component/glass_passer/holosynth/on_cross_over(mob/passer, atom/crosser)
+	SIGNAL_HANDLER
 	if(istype(crosser, /obj/structure/grille))
 		var/obj/structure/grille/grille = crosser
 		if(grille.broken)


### PR DESCRIPTION

## About The Pull Request

fixes https://github.com/NovaSector/NovaSector/issues/7386

What it says on the title
## How This Contributes To The Nova Sector Roleplay Experience

Bugfix.
## Proof of Testing

Tested locally, holosynths can cross electrified grilles now
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: Holosynths can cross broken electrified grilles now.

/:cl:
