### PR TITLE
[FIX] Blacklist hemophages from changing the tumour in the augments tab

### DIFF
--- a/modular_nova/modules/customization/modules/client/augment/organs.dm
+++ b/modular_nova/modules/customization/modules/client/augment/organs.dm
@@ -73,6 +73,7 @@
 	abstract_type = /datum/augment_item/organ/heart
 	slot = AUGMENT_SLOT_HEART
 	icon = "tg-znova-heart-organ"
+	species_blacklist = list(SPECIES_HEMOPHAGE = 1)
 
 /datum/augment_item/organ/heart/normal
 	name = "Organic heart"


### PR DESCRIPTION

## About The Pull Request

Tin.
## How This Contributes To The Nova Sector Roleplay Experience

Prevents hemophages from purging their tumour and their obligations as an hemophage while keeping all the actions. You will pay for these in blood (literally)
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="914" height="646" alt="image" src="https://github.com/user-attachments/assets/8165854b-03b7-44d7-9a13-b11424e3d184" />

</details>

## Changelog
:cl:
fix: Hemophages cannot select different heart organs in the augments tab
/:cl:
