### PR TITLE
Renames the Command Drobe to Command Drobe for consistency

### DIFF
--- a/modular_nova/modules/command_vendor/code/vending.dm
+++ b/modular_nova/modules/command_vendor/code/vending.dm
@@ -1,5 +1,5 @@
 /obj/machinery/vending/access/command
-	name = "\improper Command Outfitting Station"
+	name = "\improper CommanDrobe"
 	desc = "A vending machine for specialised clothing for members of Command."
 	product_ads = "File paperwork in style!;It's red so you can't see the blood!;You have the right to be fashionable!;Now you can be the fashion police you always wanted to be!"
 	icon = 'modular_nova/modules/command_vendor/icons/vending.dmi'


### PR DESCRIPTION

## About The Pull Request
Title.

## How This Contributes To The Nova Sector Roleplay Experience

Nothing else is called an outfitting station.

## Proof of Testing

One line change.
## Changelog
:cl:
spellcheck: The Command Outfitting Station is now a drobe, same as every other clothing vendor.
/:cl:
