### PR TITLE
fix cryopod hard deletes

### DIFF
--- a/modular_nova/modules/cryosleep/code/cryopod.dm
+++ b/modular_nova/modules/cryosleep/code/cryopod.dm
@@ -149,7 +149,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 /// Adds an item from the frozen items list.
 /// Use this or you will get hard deletes.
 /obj/machinery/computer/cryopod/proc/freeze_item(obj/item/item)
-	SIGNAL_HANDLER
+	if(QDELETED(item))
+		return
 	LAZYADD(frozen_items, item)
 	RegisterSignal(item, COMSIG_QDELETING, PROC_REF(unfreeze_item))
 
@@ -448,8 +449,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 					for(var/datum/computer_file/program/messenger/message_app in computer.stored_files)
 						message_app.invisible = TRUE
 				mob_occupant.transferItemToLoc(item_content, control_computer, force = TRUE, silent = TRUE)
-				if(QDELETED(item_content))
-					continue
 				control_computer.freeze_item(item_content)
 			else
 				mob_occupant.transferItemToLoc(item_content, drop_location(), force = TRUE, silent = TRUE)

--- a/modular_nova/modules/cryosleep/code/cryopod.dm
+++ b/modular_nova/modules/cryosleep/code/cryopod.dm
@@ -105,7 +105,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 			if(item in frozen_items)
 				item.forceMove(drop_location())
 				ui.user.put_in_hands(item)
-				LAZYREMOVE(frozen_items, item)
+				unfreeze_item(item)
 				visible_message("[src] dispenses \the [item].")
 				message_admins("[item] was retrieved by [ui.user] from cryostorage at [ADMIN_COORDJMP(src)]")
 			else
@@ -145,6 +145,21 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 					"PERSON" = user,
 					"RANK" = rank,
 				), src, list(announcement_channel), "Removing")
+
+/// Adds an item from the frozen items list.
+/// Use this or you will get hard deletes.
+/obj/machinery/computer/cryopod/proc/freeze_item(obj/item/item)
+	SIGNAL_HANDLER
+	LAZYADD(frozen_items, item)
+	RegisterSignal(item, COMSIG_QDELETING, PROC_REF(unfreeze_item))
+
+/// Removes an item from the frozen items list.
+/// Use this instead of directly removing it from the `frozen_items` list,
+/// as this also unregisters the qdel signal.
+/obj/machinery/computer/cryopod/proc/unfreeze_item(obj/item/item)
+	SIGNAL_HANDLER
+	UnregisterSignal(item, COMSIG_QDELETING)
+	LAZYREMOVE(frozen_items, item)
 
 // Cryopods themselves.
 /obj/machinery/cryopod
@@ -433,8 +448,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 					for(var/datum/computer_file/program/messenger/message_app in computer.stored_files)
 						message_app.invisible = TRUE
 				mob_occupant.transferItemToLoc(item_content, control_computer, force = TRUE, silent = TRUE)
-				item_content.dropped(mob_occupant)
-				LAZYADD(control_computer.frozen_items, item_content)
+				if(QDELETED(item_content))
+					continue
+				control_computer.freeze_item(item_content)
 			else
 				mob_occupant.transferItemToLoc(item_content, drop_location(), force = TRUE, silent = TRUE)
 


### PR DESCRIPTION

## About The Pull Request

When testing out the native refscanner downstream, there quite a few hard deletes related to items frozen in cryopods.
```
[2026-05-30 04:08:52.681] REFSCANNER: native refscan complete for /obj/item/modular_computer/pda/silicon/cyborg ([0x200571a]), took 1455 ms
 - === 2 finding(s)===
 - [list]       list #3451432 [index 1] (len=108, refs=1)
 - [list_owner] obj #59664 (/obj/machinery/computer/cryopod/directional/west).frozen_items -> list #3451432
[2026-05-30 04:09:37.736] REFSCANNER: native refscan complete for /obj/item/robot_model ([0x200571c]), took 1528 ms
 - === 2 finding(s)===
 - [list]       list #3451432 [index 2] (len=108, refs=1)
 - [list_owner] obj #59664 (/obj/machinery/computer/cryopod/directional/west).frozen_items -> list #3451432
[2026-05-30 04:10:26.671] REFSCANNER: native refscan complete for /obj/item/radio/borg ([0x2005720]), took 1481 ms
 - === 2 finding(s)===
 - [list]       list #3451432 [index 3] (len=108, refs=1)
 - [list_owner] obj #59664 (/obj/machinery/computer/cryopod/directional/west).frozen_items -> list #3451432
[2026-05-30 04:11:11.290] REFSCANNER: native refscan complete for /obj/item/camera/siliconcam/robot_camera ([0x2004368]), took 1467 ms
 - === 2 finding(s)===
 - [list]       list #3451432 [index 4] (len=108, refs=1)
 - [list_owner] obj #59664 (/obj/machinery/computer/cryopod/directional/west).frozen_items -> list #3451432
```

this makes it so adding/removing items to the cryopod computer's frozen items goes thru a helper instead - which will register `COMSIG_QDELETING` on the item, so it can be properly removed from the list if it's deleted after being frozen.

also removed a redundant `item.dropped()` call - `transferItemToLoc()` calls `doUnEquip()`, which calls `has_unequipped()`, which then calls `item.dropped()`

## How This Contributes To The Nova Sector Roleplay Experience

bugfix.

## Changelog
:cl:
fix: Fixed some hard deletes related to cryopod item storage.
/:cl:
