### PR TITLE
X-Ray Wit No X-Ray: reintroduces the X-ray laser but with a no-wallbang variant for crewside use

### DIFF
--- a/modular_nova/master_files/code/modules/research/designs/weapon_designs.dm
+++ b/modular_nova/master_files/code/modules/research/designs/weapon_designs.dm
@@ -55,8 +55,3 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
 	autolathe_exportable = FALSE
-
-// Disables xray design
-/datum/design/xray/New()
-	id = DESIGN_ID_IGNORE // Original: id = "xray_laser"
-	return ..()

--- a/modular_nova/master_files/code/modules/research/techweb/all_nodes.dm
+++ b/modular_nova/master_files/code/modules/research/techweb/all_nodes.dm
@@ -379,11 +379,3 @@
 	)
 	return ..()
 
-///////////////////////// Weapons /////////////////////////
-
-// Modularly removes x-ray
-/datum/techweb_node/beam_weapons/New()
-	design_ids -= list(
-		"xray_laser",
-	)
-	return ..()

--- a/modular_nova/modules/modular_weapons/code/overrides/energy.dm
+++ b/modular_nova/modules/modular_weapons/code/overrides/energy.dm
@@ -212,7 +212,7 @@
 		lore = "The NT Type 6 Heat Delivery System (sometimes referred to as the HDS6 in research notes) is a breakthrough in the \
 			development of directed energy weaponry, using modified Allstar SC-1s as a base.<br>\
 			<br>\
-			Very little is known about the Type 6, as it is a relatively new experimental weapon only accessible to Nanotrasen security forces.\
+			Very little is known about the Type 6, as it is a relatively new experimental weapon only accessible to Nanotrasen security forces. \
 			Somehow, Nanotrasen has found a means to 'slip' the energy beams produced by the Type 6 through unintended targets, only impacting \
 			once it has made contact with a pre-designated target by the weapon's user. It appears to be unable to slip past organic matter reliably, \
 			which hampers its potential for eliminating friendly-fire. However, inorganic targets are left unscathed unless the weapon is directed towards \
@@ -226,6 +226,22 @@
 			Whatever the truth may be, the weapon seems to function as advertised, and matches the energy efficiency of the SC-1. Nanotrasen \
 			expects full commercial rollout sometime in the next quarter." \
 	)
+
+// xray laser no wallbang variant
+/datum/crafting_recipe/laser/xraylaser
+	result = /obj/item/gun/energry/laser/xray/no_wallbang
+
+/obj/item/gun/energy/laser/xray/no_wallbang
+	name = "\improper Type 6/RP X-ray laser gun"
+	desc = "The Type 6 Heat Delivery System, Reduced Penetration variant, developed by Nanotrasen. \
+		Capable of expelling concentrated 'X-ray' blasts that pass through armor, but not denser structures."
+	ammo_type = list(/obj/item/ammo_casing/energy/xray/no_wallbang)
+
+/obj/item/ammo_casing/energy/xray/no_wallbang
+	projectile_type = /obj/projectile/beam/xray/no_wallbang
+
+/obj/projectile/beam/xray/no_wallbang
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 
 // Laser Carbine
 

--- a/modular_nova/modules/modular_weapons/code/overrides/energy.dm
+++ b/modular_nova/modules/modular_weapons/code/overrides/energy.dm
@@ -240,8 +240,9 @@
 /obj/item/ammo_casing/energy/xray/no_wallbang
 	projectile_type = /obj/projectile/beam/xray/no_wallbang
 
-/obj/projectile/beam/xray/no_wallbang
-	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
+/obj/projectile/beam/xray/no_wallbang/Initialize(mapload)
+	pass_flags &= ~(PASSCLOSEDTURF | PASSMACHINE | PASSSTRUCTURE | PASSDOORS)
+	return ..()
 
 // Laser Carbine
 

--- a/modular_nova/modules/modular_weapons/code/overrides/energy.dm
+++ b/modular_nova/modules/modular_weapons/code/overrides/energy.dm
@@ -229,7 +229,7 @@
 
 // xray laser no wallbang variant
 /datum/crafting_recipe/laser/xraylaser
-	result = /obj/item/gun/energry/laser/xray/no_wallbang
+	result = /obj/item/gun/energy/laser/xray/no_wallbang
 
 /obj/item/gun/energy/laser/xray/no_wallbang
 	name = "\improper Type 6/RP X-ray laser gun"


### PR DESCRIPTION
## About The Pull Request

Readds the X-ray laser with a "reduced penetration" variant that can't wallbang, but still has the 100 innate AP, for use against particularly troublesome armor/shields/etc.

The X-ray laser still requires you to convert a base laser gun, though, which isn't in most station armories at roundstart. Go, my spaceman. Shell out however-many-credits for the SC-1.

## How This Contributes To The Nova Sector Roleplay Experience

Vibe check! (The X-ray laser's niche of "piss-all damage but you kill the exosuit pilot" and/or "That guy's armor/block/etc. is really annoying let's just chip him to death" isn't really met by anything else in the TG weapon sandbox, and especially not by any other gunbloat weapon.)

## Proof of Testing

<img width="131" height="268" alt="dreamseeker_2026-05-30_10-55-44-PM-Saturday" src="https://github.com/user-attachments/assets/09bff623-3202-4a43-9132-112836566d5a" />

## Changelog

:cl:
balance: Reintroduces the X-ray laser by adding a "reduced penetration" variant that can't wallbang, but still has the 100 AP per shot. For dealing with particularly pesky exosuit pilots or big, bulky broadshields.
/:cl: