### PR TITLE
Makes twitch not cook synths alive on first overdose

### DIFF
--- a/modular_nova/modules/deforest_medical_items/code/chemicals/twitch.dm
+++ b/modular_nova/modules/deforest_medical_items/code/chemicals/twitch.dm
@@ -38,7 +38,7 @@
 	/// What type of span class do we change heard speech to?
 	var/speech_effect_span
 	/// How much the mob heating is multiplied by, if the target is a robot or has muscled veins
-	var/mob_heating_muliplier = 2
+	var/mob_heating_muliplier = 2.25
 
 
 /datum/reagent/drug/twitch/on_mob_metabolize(mob/living/our_guy)

--- a/modular_nova/modules/deforest_medical_items/code/chemicals/twitch.dm
+++ b/modular_nova/modules/deforest_medical_items/code/chemicals/twitch.dm
@@ -38,7 +38,7 @@
 	/// What type of span class do we change heard speech to?
 	var/speech_effect_span
 	/// How much the mob heating is multiplied by, if the target is a robot or has muscled veins
-	var/mob_heating_muliplier = 2.25
+	var/mob_heating_muliplier = 2.30
 
 
 /datum/reagent/drug/twitch/on_mob_metabolize(mob/living/our_guy)

--- a/modular_nova/modules/deforest_medical_items/code/chemicals/twitch.dm
+++ b/modular_nova/modules/deforest_medical_items/code/chemicals/twitch.dm
@@ -38,7 +38,7 @@
 	/// What type of span class do we change heard speech to?
 	var/speech_effect_span
 	/// How much the mob heating is multiplied by, if the target is a robot or has muscled veins
-	var/mob_heating_muliplier = 3.8
+	var/mob_heating_muliplier = 1.25
 
 
 /datum/reagent/drug/twitch/on_mob_metabolize(mob/living/our_guy)

--- a/modular_nova/modules/deforest_medical_items/code/chemicals/twitch.dm
+++ b/modular_nova/modules/deforest_medical_items/code/chemicals/twitch.dm
@@ -38,7 +38,7 @@
 	/// What type of span class do we change heard speech to?
 	var/speech_effect_span
 	/// How much the mob heating is multiplied by, if the target is a robot or has muscled veins
-	var/mob_heating_muliplier = 1.25
+	var/mob_heating_muliplier = 2
 
 
 /datum/reagent/drug/twitch/on_mob_metabolize(mob/living/our_guy)


### PR DESCRIPTION

## About The Pull Request

Tin. Current value for heating is too aggressive, even with liberal application of chilled hercuri you die on the first overdose very fast.
## How This Contributes To The Nova Sector Roleplay Experience

It's a balance.
## Proof of Testing

Simple number change.
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: Reduces heat damage from using synth twitch.
/:cl:
