### PR TITLE
The firing pin of the captain's antique gun is no longer removable

### DIFF
--- a/modular_nova/modules/modular_weapons/code/overrides/energy.dm
+++ b/modular_nova/modules/modular_weapons/code/overrides/energy.dm
@@ -56,6 +56,10 @@
 /obj/item/gun/energy/laser/captain
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/hellfire/blueshield) // 20 hellfires up from 15
 
+/obj/item/gun/energy/laser/captain/Initialize(mapload)
+	. = ..()
+	pin.pin_removable = FALSE
+
 /obj/item/gun/energy/e_gun
 	name = "energy carbine"
 	desc = "The Allstar Lasers Star Combat 2, or \"Allstar SC-2\", \


### PR DESCRIPTION

## About The Pull Request


sets pin_removable to FALSE in a modular file to prevent the antique from having its firing pin swapped
## How This Contributes To The Nova Sector Roleplay Experience

This gun is a legend, untameable. If you want to avoid it falling into evil hands protect it with your life, not using a mindshield firing pin. Makes it more palatable to people that have to steal it as an objective too.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="1469" height="255" alt="Captura de pantalla 2026-06-05 002719" src="https://github.com/user-attachments/assets/1c78b8ce-02f6-493b-8963-13bc801d343e" />

</details>

## Changelog
:cl:
balance: The captain's antique laser gun is so old it uses a fixed firing pin system, replacing it is impossible.

/:cl:
