### PR TITLE
Limits AEG recharge rate to captain's antique recharge rate

### DIFF
--- a/modular_nova/modules/modular_weapons/code/overrides/energy_self_charge.dm
+++ b/modular_nova/modules/modular_weapons/code/overrides/energy_self_charge.dm
@@ -57,8 +57,8 @@
 
 // Advanced Energy Gun
 /obj/item/gun/energy/e_gun/nuclear
-	charge_delay = 5 // compare/contrast tg's default delay of 8, tg's adv e-gun delay of 10, nova's egun self-charge delay of 15
-	self_charge_amount = STANDARD_ENERGY_GUN_SELF_CHARGE_RATE * 3 // recharges 15% of the internal cell per tick.
+	charge_delay = 8
+	self_charge_amount = STANDARD_ENERGY_GUN_SELF_CHARGE_RATE
 
 // Tesla Cannon
 /obj/item/gun/energy/tesla_cannon


### PR DESCRIPTION

## About The Pull Request

Balance patch to take into account AEG's are almost free with techwebs unlocked from the start and the fact materials to build it are usually available 20-30 minutes into the round. They still recharge twice as fast as the SC-2.
## How This Contributes To The Nova Sector Roleplay Experience

Prevents laser spam.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  <html>
<body>


Table with values.

Gun / Version | Values | Recharge Event | Shots Restored | Empty To Full | Rate vs SC-2
-- | -- | -- | -- | -- | --
SC-2 energy carbine | 15, base | 10% every ~16s | 2 shots | ~160s | 1x
Antique laser gun | 8, base | 10% every 8s | 2 shots | ~80s | 2x
AEG before | 5, * 3 | 30% every 6s | 6 shots | ~24s | 8x
AEG current | 8, base | 10% every 8s | 2 shots | ~80s | 2x


</body>
</html>
</details>

## Changelog
:cl:
balance: Advanced Energy Gun's recharge rate is set to the recharge rate of the captain's antique.

/:cl:
