### PR TITLE
Fix digi socks/underwear

### DIFF
--- a/code/datums/sprite_accessories.dm
+++ b/code/datums/sprite_accessories.dm
@@ -1300,7 +1300,7 @@ GLOBAL_LIST_EMPTY(blended_hair_icons_cache)
 		result = mutable_appearance(created)
 
 	else // no caching necessary
-		result = mutable_appearance(icon, icon_state)
+		result = mutable_appearance(icon, icon_state_to_use) // NOVA EDIT CHANGE - ORIGINAL - result = mutable_appearance(icon, icon_state)
 
 	result.layer = -layer
 	result.color = use_static ? null : color


### PR DESCRIPTION

## About The Pull Request

d4c79c745f65 made some changes to how underwear is rendered. Due to how tg's and nova's underwear clothing handle digi states, a new catchall state was making sprites default to the non-digi part. This fix uses the computed icon state on the fallback too.
## How This Contributes To The Nova Sector Roleplay Experience

fix
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: digi socks/underwear should render correctly again.
/:cl:
