### PR TITLE
Sec_Vouchers_Tweaked

### DIFF
--- a/modular_nova/modules/security_vouchers/code/sec_vouchers_vendor.dm
+++ b/modular_nova/modules/security_vouchers/code/sec_vouchers_vendor.dm
@@ -38,16 +38,14 @@
 		/obj/item/storage/belt/holster/energy/disabler,
 	)
 
-/datum/voucher_set/security/primary/e_carbine
-	name = "Energy Carbine"
-	description = "A standard model Energy Carbine manufacture by Nano-Trasen. Nothing fancy, just old reliable."
-	icon = 'icons/obj/weapons/guns/energy.dmi'
-	icon_state = "energy"
+/datum/voucher_set/security/primary/hybrid_taser
+	name = "Hybrid Taser"
+	description = "A dual-mode taser designed to fire both short-range high-power electrodes and long-range disabler beams."
 	set_items = list(
-		/obj/item/gun/energy/e_gun,
+		/obj/item/gun/energy/e_gun/advtaser,
 	)
 
-/datum/voucher_set/security/primary/disabler_smg
+/datum/voucher_set/security/primary/pepperball
 	name = "Pepperball AGH"
 	description = "A slower firing handgun that fires 'pepperballs', which easily drop targets to the floor."
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/pepperball/pepperball.dmi'
@@ -60,8 +58,6 @@
 /datum/voucher_set/security/primary/strobe_shield
 	name = "Strobe Shield"
 	description = "A shield with a built in, high intensity light capable of blinding and disorienting suspects. Takes regular handheld flashes as bulbs."
-	icon = 'icons/obj/weapons/shields.dmi'
-	icon_state = "flashshield"
 	set_items = list(
 		/obj/item/shield/riot/flash,
 	)


### PR DESCRIPTION
## About The Pull Request
As it stands, Security Primary Vouchers don't really give you a choice, they give you the illusion of choice. There's no reason not to pick the E-Carbine, it's literally a free AEG since techwebs have been removed.
## How This Contributes To The Nova Sector Roleplay Experience
I believe this is some perfidious power creep, as the original PR was claimed to be a port from Bubber, but the 4th option on the voucher from Bubber was *also* just a taser.
## Proof of Testing
<img width="391" height="354" alt="image" src="https://github.com/user-attachments/assets/7cc2b35d-29ff-4da6-8d17-c3fa716408d1" />
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: Changes the E-carbine from the Primary Security Voucher into a Hybrid Taser, as was originally intended.
/:cl:
