### PR TITLE
Removing Blob Gacha Mechanics

### DIFF
--- a/code/__DEFINES/blob_defines.dm
+++ b/code/__DEFINES/blob_defines.dm
@@ -84,7 +84,7 @@
 #define BLOB_POWER_RELOCATE_COST 80 // Resource cost to move your core to a different node
 #define BLOB_POWER_REROLL_COST 40 // Strain reroll
 #define BLOB_POWER_REROLL_FREE_TIME (4 MINUTES) // Gain a free strain reroll every x minutes
-#define BLOB_POWER_REROLL_CHOICES 13 // Possibilities to choose from; keep in mind increasing this might fuck with the radial menu
+#define BLOB_POWER_REROLL_CHOICES 13 // NOVA EDIT CHANGE - increased reroll choices from 6 to 13 to make all strains available. You ARE already paying time/points for it already, afterall.
 
 
 // Mob defines

--- a/code/__DEFINES/blob_defines.dm
+++ b/code/__DEFINES/blob_defines.dm
@@ -84,7 +84,7 @@
 #define BLOB_POWER_RELOCATE_COST 80 // Resource cost to move your core to a different node
 #define BLOB_POWER_REROLL_COST 40 // Strain reroll
 #define BLOB_POWER_REROLL_FREE_TIME (4 MINUTES) // Gain a free strain reroll every x minutes
-#define BLOB_POWER_REROLL_CHOICES 6 // Possibilities to choose from; keep in mind increasing this might fuck with the radial menu
+#define BLOB_POWER_REROLL_CHOICES 13 // Possibilities to choose from; keep in mind increasing this might fuck with the radial menu
 
 
 // Mob defines


### PR DESCRIPTION

## About The Pull Request
Changes the Blob's re-roll choices from 6 to 13 to give the player all of the strains per re-roll.
## How This Contributes To The Nova Sector Roleplay Experience
I believe that since the player is paying for the new strain with time/points, that they should get whichever strain they want. It leaves the overall capabilities of of the blob less up to chance and more up to player skill and knowledge. I don't think they *need* a points sink, they're pressed for resources as it is. And because it is no longer a round ending threat, maybe we can tune them a little bit.
## Proof of Testing


https://github.com/user-attachments/assets/09f7427f-5332-43a0-9e71-73251aa9792b
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: Changes blob's reroll choices from 6 to 13: giving them all strains per re-roll.
/:cl:
