### PR TITLE
fix `SPLINT_OVERLAY` not actually being a valid bitshift

### DIFF
--- a/code/__DEFINES/~nova_defines/wounds.dm
+++ b/code/__DEFINES/~nova_defines/wounds.dm
@@ -1,2 +1,2 @@
 /// If this wound, when bandaged, will cause a splint overlay to generate rather than a bandage overlay.
-#define SPLINT_OVERLAY (1<<200) // we use a big number since tg realistically wouldnt go to it
+#define SPLINT_OVERLAY (1 << 23) // we use a big number since tg realistically wouldnt go to it


### PR DESCRIPTION

## About The Pull Request

This changes `SPLINT_OVERLAY` to be `1 << 23` (the highest proper bitflag) instead of the invalid `1 << 200`, fixing these sdmm errors:
<img width="523" height="465" alt="image" src="https://github.com/user-attachments/assets/7ccd60af-0a79-4f58-b65f-dd27b8dd4ba3" />

funny thing: `1 << 200` actually ends up being 256, which is equivalent to `1 << 8` - which I doubt is the intent of it being a "big number" ([dm playground link](https://play.dm-lang.org/#1:eF5TUk5JTcvMS1Vw8QwO8HGMjHfyDAn28HQL0ShLzClN1VQozy_KSdHLyU9XsLFRiFHSMATR0WDJWE0FW4VosACEH6NkHZMXk6dfUJSfrJ-bmJmnoRmTp4BptDl2YQvswkZGOMSNcYib4BA3MABKKAEAHM1FyA)):
```
(1 << 7) = 128
(1 << 8) = 256
(1 << 22) = 4194304
(1 << 23) = 8388608
(1 << 24) = 0
(1 << 200) = 256
```

## How This Contributes To The Nova Sector Roleplay Experience

seeing these stupid warnings in vscode constantly is driving me mad

## Proof of Testing

<img width="387" height="90" alt="2026-06-05 (1780673369) ~ Code" src="https://github.com/user-attachments/assets/afdb715f-992b-4530-9736-704f97ad9534" />

<img width="353" height="33" alt="2026-06-05 (1780673373)" src="https://github.com/user-attachments/assets/3f7c6966-17f2-4c8b-9e9a-4a5914bf9ffa" />
