### PR TITLE
Restores Per-Map Shuttles

### DIFF
--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -183,10 +183,6 @@
 		log_world("map_config shuttles is not a list!")
 		return
 
-	// NOVA ADD BEGIN - EMERGENCY SHUTTLE OVERRIDE
-	shuttles["emergency"] = "emergency_nova"
-	// NOVA ADD END
-
 	traits = json["traits"]
 	// "traits": [{"Linkage": "Cross"}, {"Space Ruins": true}]
 	if (islist(traits))


### PR DESCRIPTION

## About The Pull Request

Title.

## How This Contributes To The Nova Sector Roleplay Experience

TG maps typically have per-map shuttles which is very cool. Meaning that even if buying a shuttle slips the mind, you'd still have one different from the previous map.

I think having a uniform shuttle for every map is just boring. Some maps, namely Nova maps, will still have the Emergency_Nova.

## Proof of Testing

<img width="1919" height="1009" alt="image" src="https://github.com/user-attachments/assets/56e08318-4583-429d-9c59-ffd7322dffbb" />


## Changelog
:cl:
del: TG Maps have their unique shuttles back.
/:cl:
