### PR TITLE
Removes pepper-spray's knockdown for Moon's proposals on combat changes.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -478,7 +478,7 @@
 			victim.set_eye_blur_if_lower(10 SECONDS)
 			victim.set_temp_blindness_if_lower(6 SECONDS)
 			victim.set_confusion_if_lower(5 SECONDS)
-			//victim.Knockdown(3 SECONDS) - MODULAR NOVA EDIT - Disables pepper-spray knockdowns
+			//victim.Knockdown(3 SECONDS) // NOVA EDIT REMOVAL - Disables pepper-spray knockdowns
 			victim.add_movespeed_modifier(/datum/movespeed_modifier/reagent/pepperspray)
 			addtimer(CALLBACK(victim, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/reagent/pepperspray), 10 SECONDS)
 			ADD_TRAIT(victim, TRAIT_ANOSMIA, type)

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -478,7 +478,7 @@
 			victim.set_eye_blur_if_lower(10 SECONDS)
 			victim.set_temp_blindness_if_lower(6 SECONDS)
 			victim.set_confusion_if_lower(5 SECONDS)
-			victim.Knockdown(3 SECONDS)
+			//victim.Knockdown(3 SECONDS) - MODULAR NOVA EDIT - Disables pepper-spray knockdowns
 			victim.add_movespeed_modifier(/datum/movespeed_modifier/reagent/pepperspray)
 			addtimer(CALLBACK(victim, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/reagent/pepperspray), 10 SECONDS)
 			ADD_TRAIT(victim, TRAIT_ANOSMIA, type)


### PR DESCRIPTION
## About The Pull Request

Removes pepper-spray's knockdown for Moon's proposals on combat changes.

## How This Contributes To The Nova Sector Roleplay Experience

Moon's vision for the server's combat involves removing one-shot-win attacks. I think this is worth testing out, so I've made this PR.

## Proof of Testing

Just commented out a knockdown call.

## Changelog

:cl:
balance: Removes pepper-spray's knockdown for Moon's proposals on combat changes.
/:cl: