### PR TITLE
Removes flashbang's knockdown and paralyze for Moon's proposals on combat changes.

### DIFF
--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -58,11 +58,9 @@
 	//Flash
 	var/attempt_flash = living_mob.flash_act(affect_silicon = 1)
 	if(attempt_flash == FLASH_COMPLETED)
-		if(distance <= sweetspot_range || issilicon(living_mob))
-			living_mob.Paralyze(max(20/max(1, distance), 5))
-			living_mob.Knockdown(max(200/max(1, distance), 60))
-		else
-			living_mob.adjust_dizzy_up_to(max(200/max(1, distance), 5), 20 SECONDS)
+		// NOVA MODULAR EDIT BEGIN
+		living_mob.adjust_dizzy_up_to(max(200/max(1, distance), 5), 20 SECONDS)
+		// NOVA MODULAR EDIT END
 		living_mob.dropItemToGround(living_mob.get_active_held_item())
 		living_mob.dropItemToGround(living_mob.get_inactive_held_item())
 
@@ -71,15 +69,15 @@
 		return
 
 	if(!distance)
-		living_mob.soundbang_act(SOUNDBANG_OVERWHELMING, 20 SECONDS, 10, 15)
+		living_mob.soundbang_act(SOUNDBANG_OVERWHELMING, 0, 10, 15) // NOVA MODULAR EDIT - Remove stuns from flashbangs - original living_mob.soundbang_act(SOUNDBANG_OVERWHELMING, 20 SECONDS, 10, 15)
 		return
 
 	if(distance <= 1) // Adds more stun as to not prime n' pull (#45381)
-		living_mob.soundbang_act(SOUNDBANG_STRONG, 3 SECONDS, 5)
+		living_mob.soundbang_act(SOUNDBANG_STRONG, 0, 5) // NOVA MODULAR EDIT - Remove stuns from flashbangs - original living_mob.soundbang_act(SOUNDBANG_STRONG, 3 SECONDS, 5)
 		return
 
 	if(distance <= sweetspot_range)
-		living_mob.soundbang_act(SOUNDBANG_NORMAL, max(20 SECONDS / max(1, distance), 60), rand(0, 5))
+		living_mob.soundbang_act(SOUNDBANG_NORMAL, 0, rand(0, 5)) // NOVA MODULAR EDIT - Remove stuns from flashbangs - original living_mob.soundbang_act(SOUNDBANG_NORMAL, max(20 SECONDS / max(1, distance), 60), rand(0, 5))
 		return
 
 	if(!living_mob.soundbang_act(SOUNDBANG_NORMAL, 0, rand(0, 2)))

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -75,7 +75,7 @@
 		return
 
 	if(!distance)
-		living_mob.soundbang_act(SOUNDBANG_OVERWHELMING, 0, 10, 15) // NOVA MODULAR EDIT - Remove stuns from flashbangs - original living_mob.soundbang_act(SOUNDBANG_OVERWHELMING, 20 SECONDS, 10, 15)
+		living_mob.soundbang_act(SOUNDBANG_OVERWHELMING, stun_pwr = 0 SECONDS, damage_pwr = 10, deafen_pwr = 15 SECONDS) // NOVA EDIT CHANGE - Remove stuns from flashbangs - ORIGINAL: living_mob.soundbang_act(SOUNDBANG_OVERWHELMING, 20 SECONDS, 10, 15)
 		return
 
 	if(distance <= 1) // Adds more stun as to not prime n' pull (#45381)

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -58,9 +58,15 @@
 	//Flash
 	var/attempt_flash = living_mob.flash_act(affect_silicon = 1)
 	if(attempt_flash == FLASH_COMPLETED)
-		// NOVA MODULAR EDIT BEGIN
+		/* // NOVA EDIT REMOVAL START
+		if(distance <= sweetspot_range || issilicon(living_mob))
+			living_mob.Paralyze(max(20/max(1, distance), 5))
+			living_mob.Knockdown(max(200/max(1, distance), 60))
+		else
+			living_mob.adjust_dizzy_up_to(max(200/max(1, distance), 5), 20 SECONDS)
 		living_mob.adjust_dizzy_up_to(max(200/max(1, distance), 5), 20 SECONDS)
-		// NOVA MODULAR EDIT END
+		*/ // NOVA EDIT REMOVAL END
+			living_mob.adjust_dizzy_up_to(max(200/max(1, distance), 5), 20 SECONDS) // NOVA EDIT ADDITION
 		living_mob.dropItemToGround(living_mob.get_active_held_item())
 		living_mob.dropItemToGround(living_mob.get_inactive_held_item())
 

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -79,11 +79,11 @@
 		return
 
 	if(distance <= 1) // Adds more stun as to not prime n' pull (#45381)
-		living_mob.soundbang_act(SOUNDBANG_STRONG, stun_pwr = 0, SECONDS, damage_pwr = 5) // NOVA EDIT CHANGE - Remove stuns from flashbangs - ORIGINAL: living_mob.soundbang_act(SOUNDBANG_STRONG, 3 SECONDS, 5)
+		living_mob.soundbang_act(SOUNDBANG_STRONG, stun_pwr = 0 SECONDS, damage_pwr = 5) // NOVA EDIT CHANGE - Remove stuns from flashbangs - ORIGINAL: living_mob.soundbang_act(SOUNDBANG_STRONG, 3 SECONDS, 5)
 		return
 
 	if(distance <= sweetspot_range)
-		living_mob.soundbang_act(SOUNDBANG_NORMAL, stun_pwr = 0, SECONDS, damage_pwr = rand(0, 5)) // NOVA EDIT CHANGE - Remove stuns from flashbangs - ORIGINAL: living_mob.soundbang_act(SOUNDBANG_NORMAL, max(20 SECONDS / max(1, distance), 60), rand(0, 5))
+		living_mob.soundbang_act(SOUNDBANG_NORMAL, stun_pwr = 0 SECONDS, damage_pwr = rand(0, 5)) // NOVA EDIT CHANGE - Remove stuns from flashbangs - ORIGINAL: living_mob.soundbang_act(SOUNDBANG_NORMAL, max(20 SECONDS / max(1, distance), 60), rand(0, 5))
 		return
 
 	if(!living_mob.soundbang_act(SOUNDBANG_NORMAL, 0, rand(0, 2)))

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -83,7 +83,7 @@
 		return
 
 	if(distance <= sweetspot_range)
-		living_mob.soundbang_act(SOUNDBANG_NORMAL, 0, rand(0, 5)) // NOVA MODULAR EDIT - Remove stuns from flashbangs - original living_mob.soundbang_act(SOUNDBANG_NORMAL, max(20 SECONDS / max(1, distance), 60), rand(0, 5))
+		living_mob.soundbang_act(SOUNDBANG_NORMAL, stun_pwr = 0 SECONDS, damage_pwr = rand(0, 5)) // NOVA EDIT CHANGE - Remove stuns from flashbangs - ORIGINAL: living_mob.soundbang_act(SOUNDBANG_NORMAL, max(20 SECONDS / max(1, distance), 60), rand(0, 5))
 		return
 
 	if(!living_mob.soundbang_act(SOUNDBANG_NORMAL, 0, rand(0, 2)))

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -79,7 +79,7 @@
 		return
 
 	if(distance <= 1) // Adds more stun as to not prime n' pull (#45381)
-		living_mob.soundbang_act(SOUNDBANG_STRONG, 0, 5) // NOVA MODULAR EDIT - Remove stuns from flashbangs - original living_mob.soundbang_act(SOUNDBANG_STRONG, 3 SECONDS, 5)
+		living_mob.soundbang_act(SOUNDBANG_STRONG, stun_pwr = 0 SECONDS, damage_pwr = 5) // NOVA EDIT CHANGE - Remove stuns from flashbangs - ORIGINAL: living_mob.soundbang_act(SOUNDBANG_STRONG, 3 SECONDS, 5)
 		return
 
 	if(distance <= sweetspot_range)

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -66,7 +66,7 @@
 			living_mob.adjust_dizzy_up_to(max(200/max(1, distance), 5), 20 SECONDS)
 		living_mob.adjust_dizzy_up_to(max(200/max(1, distance), 5), 20 SECONDS)
 		*/ // NOVA EDIT REMOVAL END
-			living_mob.adjust_dizzy_up_to(max(200/max(1, distance), 5), 20 SECONDS) // NOVA EDIT ADDITION
+		living_mob.adjust_dizzy_up_to(max(200/max(1, distance), 5), 20 SECONDS) // NOVA EDIT ADDITION
 		living_mob.dropItemToGround(living_mob.get_active_held_item())
 		living_mob.dropItemToGround(living_mob.get_inactive_held_item())
 

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -79,11 +79,11 @@
 		return
 
 	if(distance <= 1) // Adds more stun as to not prime n' pull (#45381)
-		living_mob.soundbang_act(SOUNDBANG_STRONG, stun_pwr = 0 SECONDS, damage_pwr = 5) // NOVA EDIT CHANGE - Remove stuns from flashbangs - ORIGINAL: living_mob.soundbang_act(SOUNDBANG_STRONG, 3 SECONDS, 5)
+		living_mob.soundbang_act(SOUNDBANG_STRONG, stun_pwr = 0, SECONDS, damage_pwr = 5) // NOVA EDIT CHANGE - Remove stuns from flashbangs - ORIGINAL: living_mob.soundbang_act(SOUNDBANG_STRONG, 3 SECONDS, 5)
 		return
 
 	if(distance <= sweetspot_range)
-		living_mob.soundbang_act(SOUNDBANG_NORMAL, stun_pwr = 0 SECONDS, damage_pwr = rand(0, 5)) // NOVA EDIT CHANGE - Remove stuns from flashbangs - ORIGINAL: living_mob.soundbang_act(SOUNDBANG_NORMAL, max(20 SECONDS / max(1, distance), 60), rand(0, 5))
+		living_mob.soundbang_act(SOUNDBANG_NORMAL, stun_pwr = 0, SECONDS, damage_pwr = rand(0, 5)) // NOVA EDIT CHANGE - Remove stuns from flashbangs - ORIGINAL: living_mob.soundbang_act(SOUNDBANG_NORMAL, max(20 SECONDS / max(1, distance), 60), rand(0, 5))
 		return
 
 	if(!living_mob.soundbang_act(SOUNDBANG_NORMAL, 0, rand(0, 2)))


### PR DESCRIPTION
## About The Pull Request

Removes flashbang's knockdown and paralyze for Moon's proposals on combat changes.

## How This Contributes To The Nova Sector Roleplay Experience

Moon's vision for the server's combat involves removing one-shot-win attacks. I think this is worth testing out, so I've made this PR.

## Proof of Testing

Just made some numbers adjustments and removed a bit of code calling force paralyzes.

## Changelog

:cl:
balance: Removes flashbang's knockdown and paralyze for Moon's proposals on combat changes.
/:cl: