### PR TITLE
fix temporary flavor text examine not using pronouns

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -328,9 +328,9 @@
 	//Temporary flavor text addition:
 	if(temporary_flavor_text)
 		if(length_char(temporary_flavor_text) < TEMPORARY_FLAVOR_PREVIEW_LIMIT)
-			. += span_revennotice("<br>They look different than usual: [temporary_flavor_text]")
+			. += span_revennotice("<br>[t_He] look[p_s()] different than usual: [temporary_flavor_text]")
 		else
-			. += span_revennotice("<br>They look different than usual: [copytext_char(temporary_flavor_text, 1, TEMPORARY_FLAVOR_PREVIEW_LIMIT)]... <a href='byond://?src=[REF(src)];temporary_flavor=1'>More...</a>")
+			. += span_revennotice("<br>[t_He] look[p_s()] look different than usual: [copytext_char(temporary_flavor_text, 1, TEMPORARY_FLAVOR_PREVIEW_LIMIT)]... <a href='byond://?src=[REF(src)];temporary_flavor=1'>More...</a>")
 
 	. += EXAMINE_SECTION_BREAK
 

--- a/modular_nova/modules/customization/modules/mob/living/living_verbs.dm
+++ b/modular_nova/modules/customization/modules/mob/living/living_verbs.dm
@@ -13,8 +13,8 @@ GLOBAL_DATUM_INIT(temporary_flavor_text_vis, /obj/effect/overlay/indicator/tempo
 		to_chat(usr, span_warning("You can't set your temporary flavor text now..."))
 		return
 
-	var/msg = tgui_input_text(usr, "Set the temporary flavor text in your 'examine' verb. This is for describing what people can tell by looking at your character.", "Temporary Flavor Text", temporary_flavor_text, max_length = MAX_FLAVOR_LEN, multiline = TRUE)
-	if(msg == null)
+	var/msg = tgui_input_text(usr, "Set the temporary flavor text in your 'examine' verb. This is for describing what people can tell by looking at your character.", "Temporary Flavor Text", html_decode(temporary_flavor_text), max_length = MAX_FLAVOR_LEN, multiline = TRUE)
+	if(isnull(msg))
 		return
 
 	// Turn empty input into no flavor text

--- a/modular_nova/modules/customization/modules/mob/living/silicon/examine.dm
+++ b/modular_nova/modules/customization/modules/mob/living/silicon/examine.dm
@@ -14,7 +14,7 @@
 		. += flavor_text_link
 
 	if (client?.prefs.read_preference(/datum/preference/text/character_ad))
-		. += span_notice("They have an ad in the character directory... <a href='byond://?src=[REF(src)];lookup_info=open_character_ad'>\[Open directory?\]</a>")
+		. += span_notice("[p_They()] [p_have()] an ad in the character directory... <a href='byond://?src=[REF(src)];lookup_info=open_character_ad'>\[Open directory?\]</a>")
 
 	if(client)
 		var/erp_status_pref = client.prefs.read_preference(/datum/preference/choiced/erp_status)
@@ -29,6 +29,6 @@
 
 	if(temporary_flavor_text)
 		if(length_char(temporary_flavor_text) <= 40)
-			. += span_notice("<b>They look different than usual:</b> [temporary_flavor_text]")
+			. += span_notice("<b>[p_They()] look[p_s()] different than usual:</b> [temporary_flavor_text]")
 		else
-			. += span_notice("<b>They look different than usual:</b> [copytext_char(temporary_flavor_text, 1, 37)]... <a href='byond://?src=[REF(src)];temporary_flavor=1'>More...</a>")
+			. += span_notice("<b>[p_They()] look[p_s()] different than usual:</b> [copytext_char(temporary_flavor_text, 1, 37)]... <a href='byond://?src=[REF(src)];temporary_flavor=1'>More...</a>")


### PR DESCRIPTION

## About The Pull Request

This make so the temporary flavor text examine will also use the examinee's pronouns instead of always being "they" - like the rest of examine text.

Also, whenever changing your temporary flavor text, if it had html encoded characters before, they'll be properly decoded when being used as the "default" in the text input popup.

## How This Contributes To The Nova Sector Roleplay Experience

Consistency is nice.

## Proof of Testing

<img width="1046" height="172" alt="image" src="https://github.com/user-attachments/assets/892dd349-0997-463d-b8e5-6875aa62637d" />

## Changelog
:cl:
fix: The examine line indicating temporary flavor text now actually uses the examinee's pronouns, instead of always using "they".
/:cl:
