### PR TITLE
Fixes topic limit spam in long form text boxes

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
@@ -268,7 +268,7 @@ export function FeatureShortTextInput(
   );
 }
 // NOVA EDIT ADDITION START - NOVA FEATURES DOWN HERE
-export const FeatureTextInput = (
+export const FeatureLongTextInput = (
   props: FeatureValueProps<string, string, FeatureShortTextData>,
 ) => {
   const { serverData, handleSetValue, value } = props;
@@ -281,10 +281,9 @@ export const FeatureTextInput = (
     <TextArea
       height="100px"
       fluid
-      expensive
       value={value}
       maxLength={serverData?.maximum_length}
-      onChange={(value) => handleSetValue(value)}
+      onBlur={(value) => handleSetValue(value)}
     />
   );
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/entombed.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/entombed.tsx
@@ -3,8 +3,8 @@ import {
   CheckboxInput,
   type Feature,
   type FeatureChoiced,
+  FeatureLongTextInput,
   FeatureShortTextInput,
-  FeatureTextInput,
   type FeatureToggle,
 } from '../../base';
 import { FeatureDropdownInput } from '../../dropdowns';
@@ -26,7 +26,7 @@ export const entombed_mod_name: Feature<string> = {
 
 export const entombed_mod_desc: Feature<string> = {
   name: 'MODsuit Control Unit Description',
-  component: FeatureTextInput,
+  component: FeatureLongTextInput,
 };
 
 export const entombed_mod_prefix: Feature<string> = {

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/pet_owner.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/pet_owner.tsx
@@ -2,8 +2,8 @@
 import {
   type Feature,
   type FeatureChoiced,
+  FeatureLongTextInput,
   FeatureShortTextInput,
-  FeatureTextInput,
 } from '../../base';
 import { FeatureDropdownInput } from '../../dropdowns';
 
@@ -27,5 +27,5 @@ export const pet_name: Feature<string> = {
 export const pet_desc: Feature<string> = {
   name: 'Pet Description',
   description: "If blank, will use the mob's default description.",
-  component: FeatureTextInput,
+  component: FeatureLongTextInput,
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/species_features.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/species_features.tsx
@@ -5,11 +5,11 @@ import {
   type FeatureChoiced,
   type FeatureChoicedServerData,
   FeatureColorInput,
+  FeatureLongTextInput,
   FeatureNumberInput,
   type FeatureNumeric,
   FeatureShortTextInput,
   FeatureSliderInput,
-  FeatureTextInput,
   type FeatureToggle,
   FeatureTriBoolInput,
   FeatureTriColorInput,
@@ -39,47 +39,47 @@ export const flavor_text: Feature<string> = {
   name: 'Flavor Text',
   description:
     "Appears when your character is examined (but only if they're identifiable - try a gas mask). Do not put sexual things in here—move those to Flavor Text (NSFW).",
-  component: FeatureTextInput,
+  component: FeatureLongTextInput,
 };
 
 export const flavor_text_nsfw: Feature<string> = {
   name: 'Flavor Text (NSFW)',
   description: 'Same as Flavor Text but requires you to click a tab to view.',
-  component: FeatureTextInput,
+  component: FeatureLongTextInput,
 };
 
 export const silicon_flavor_text: Feature<string> = {
   name: 'Flavor Text (Silicon)',
   description:
     "Only appears if you're playing as a borg/AI. Do not put sexual things in here—move those to Flavor Text (Silicon, NSFW).",
-  component: FeatureTextInput,
+  component: FeatureLongTextInput,
 };
 
 export const silicon_flavor_text_nsfw: Feature<string> = {
   name: 'Flavor Text (Silicon, NSFW)',
   description:
     'Same as Silicon Flavor Text but requires you to click a tab to view.',
-  component: FeatureTextInput,
+  component: FeatureLongTextInput,
 };
 
 export const ooc_notes: Feature<string> = {
   name: 'OOC Notes',
   description:
     'Anything you want other players to know about you goes here, such as antag information, OOC triggers, etc. Do not put sexual things in here—move those to OOC Notes (NSFW).',
-  component: FeatureTextInput,
+  component: FeatureLongTextInput,
 };
 
 export const ooc_notes_nsfw: Feature<string> = {
   name: 'OOC Notes (NSFW)',
   description: 'Same as OOC Notes but requires you to click a tab to view.',
-  component: FeatureTextInput,
+  component: FeatureLongTextInput,
 };
 
 export const character_ad: Feature<string> = {
   name: 'Character Advert',
   description:
     'An advertisement for your character. Give information on how to approach for those interested, for either regular and erotic roleplay.',
-  component: FeatureTextInput,
+  component: FeatureLongTextInput,
 };
 
 export const attraction: FeatureChoiced = {
@@ -106,14 +106,14 @@ export const custom_species: Feature<string> = {
 export const custom_species_lore: Feature<string> = {
   name: 'Custom Species Lore',
   description: "Won't show up if there's no custom species.",
-  component: FeatureTextInput,
+  component: FeatureLongTextInput,
 };
 export const general_record: Feature<string> = {
   name: 'Records - General',
   description:
     'Viewable with any records access. \
     For general viewing-things like employment, qualifications, etc.',
-  component: FeatureTextInput,
+  component: FeatureLongTextInput,
 };
 
 export const security_record: Feature<string> = {
@@ -121,7 +121,7 @@ export const security_record: Feature<string> = {
   description:
     'Viewable with security access. \
   For criminal records, arrest history, things like that.',
-  component: FeatureTextInput,
+  component: FeatureLongTextInput,
 };
 
 export const medical_record: Feature<string> = {
@@ -129,7 +129,7 @@ export const medical_record: Feature<string> = {
   description:
     'Viewable with medical access. \
   For things like medical history, prescriptions, DNR orders, etc.',
-  component: FeatureTextInput,
+  component: FeatureLongTextInput,
 };
 
 export const exploitable_info: Feature<string> = {
@@ -138,14 +138,14 @@ export const exploitable_info: Feature<string> = {
     'Can be IC or OOC. Viewable by certain antagonists/OPFOR users, as well as ghosts. Generally contains \
   things like weaknesses, strengths, important background, trigger words, etc. It ALSO may contain things like \
   antagonist preferences, e.g. if you want to be antagonized, by whom, with what, etc.',
-  component: FeatureTextInput,
+  component: FeatureLongTextInput,
 };
 
 export const background_info: Feature<string> = {
   name: 'Records - Background',
   description:
     'Only viewable by yourself and ghosts. You can have whatever you want in here - it may be valuable as a way to orient yourself to what your character is.',
-  component: FeatureTextInput,
+  component: FeatureLongTextInput,
 };
 
 export const pda_ringer: Feature<string> = {

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/underworld_connections.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/underworld_connections.tsx
@@ -2,8 +2,8 @@
 import {
   type Feature,
   type FeatureChoiced,
+  FeatureLongTextInput,
   FeatureShortTextInput,
-  FeatureTextInput,
 } from '../../base';
 import { FeatureDropdownInput } from '../../dropdowns';
 
@@ -19,5 +19,5 @@ export const underworld_uplink_name: Feature<string> = {
 
 export const underworld_uplink_desc: Feature<string> = {
   name: 'Uplink Description',
-  component: FeatureTextInput,
+  component: FeatureLongTextInput,
 };


### PR DESCRIPTION
## About The Pull Request
Fixes this when editing flavor text, OOC notes, etc:
<img width="459" height="68" alt="image" src="https://github.com/user-attachments/assets/1a615d6e-2ef6-4092-9cbd-cab2a889bfbb" />

For some reason, `FeatureTextInput` (the one for long form text, like flavor text) was using `onChange` for receiving input, making it send content to the server each time it was modified. This would make you hit the topic limit very quickly if you're a fast typer.

So... let's make it not do that by replacing `onChange` with `onBlur` to submit changes every time the input loses focus, or you hit enter, rather than every time the input is modified. This matches `FeatureShortTextInput`.

Also renames it to `FeatureLongTextInput` for clarity (plus I feel if someone at TG ever added a long form text input component for preferences, it'd be named that and create some kind of conflict when pulled here, which is good).
## How This Contributes To The Nova Sector Roleplay Experience
Using `onChange` for this is not a performance concern, but there's just no reason for a long form text box to send your changes to the server every time you modify it.

`expensive` is supposed to fix this but it's been broken since forever and was only fixed [on the 3rd of June 2026.](https://github.com/tgstation/tgui-core/commit/3714128a9362e03c33af493c9ed6ad459e347f71)
## Proof of Testing

It works and shouldn't be less reliable for most situations (I can only think of losing connection due to a client/server issue causing you to lose your changes). This can be test-merged until TGUI's core library gets an update on TG and it's pulled here.

## Changelog
:cl:
fix: [NOVA] Fixed long form text boxes (flavor text, OOC notes, etc.) causing players to hit the topic limit.
/:cl:
