### PR TITLE
Adds lore factions (and clowns) to fax networks.

### DIFF
--- a/modular_nova/master_files/code/modules/paperwork/fax.dm
+++ b/modular_nova/master_files/code/modules/paperwork/fax.dm
@@ -4,6 +4,12 @@
 	special_networks += list(
 		tarkon = list(fax_name = "Tarkon Industries Corporate Command", fax_id = "tarkon", color = "brown", emag_needed = TRUE),
 		interdyne = list(fax_name = "Interdyne Legal Department", fax_id = "interdyne", color = "green", emag_needed = TRUE),
+		SolFed = list(fax_name = "Sol Federation Local Command Team", fax_id = "SolFed", color = "blue", emag_needed = FALSE),
+		Clowns = list(fax_name = "Clown Planet", fax_id = "Clowns", color = "pink", emag_needed = FALSE),
+		Mimes = list(fax_name = "La Pantomime Troupe", fax_id = "Mimes", color = "white", emag_needed = FALSE),
+		Union = list(fax_name = "Free Trade Union Local Office", fax_id = "Union", color = "brown", emag_needed = FALSE),
+		Void = list(fax_name = "Void Imperium", fax_id = "Void", color = "purple", emag_needed = FALSE),
+		HelioCoal = list(fax_name = "Heliostatic Coalition", fax_id = "HelioCoal", color = "red", emag_needed = FALSE),
 	)
 	return ..()
 

--- a/modular_nova/master_files/code/modules/paperwork/fax.dm
+++ b/modular_nova/master_files/code/modules/paperwork/fax.dm
@@ -4,12 +4,12 @@
 	special_networks += list(
 		tarkon = list(fax_name = "Tarkon Industries Corporate Command", fax_id = "tarkon", color = "brown", emag_needed = TRUE),
 		interdyne = list(fax_name = "Interdyne Legal Department", fax_id = "interdyne", color = "green", emag_needed = TRUE),
-		SolFed = list(fax_name = "Sol Federation Local Command Team", fax_id = "SolFed", color = "blue", emag_needed = FALSE),
-		Clowns = list(fax_name = "Clown Planet", fax_id = "Clowns", color = "pink", emag_needed = FALSE),
-		Mimes = list(fax_name = "La Pantomime Troupe", fax_id = "Mimes", color = "white", emag_needed = FALSE),
-		Union = list(fax_name = "Free Trade Union Local Office", fax_id = "Union", color = "brown", emag_needed = FALSE),
-		Void = list(fax_name = "Void Imperium", fax_id = "Void", color = "purple", emag_needed = FALSE),
-		HelioCoal = list(fax_name = "Heliostatic Coalition", fax_id = "HelioCoal", color = "red", emag_needed = FALSE),
+		sol_fed = list(fax_name = "Sol Federation Local Command Team", fax_id = "sol_fed", color = "blue", emag_needed = FALSE),
+		clowns = list(fax_name = "Clown Planet", fax_id = "clowns", color = "pink", emag_needed = FALSE),
+		mimes = list(fax_name = "La Pantomime Troupe", fax_id = "mimes", color = "white", emag_needed = FALSE),
+		trade_union = list(fax_name = "Free Trade Union Local Office", fax_id = "trade_union", color = "brown", emag_needed = FALSE),
+		void = list(fax_name = "Void Imperium", fax_id = "void", color = "purple", emag_needed = FALSE),
+		helio = list(fax_name = "Heliostatic Coalition", fax_id = "helio", color = "red", emag_needed = FALSE),
 	)
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request

<img width="333" height="367" alt="image" src="https://github.com/user-attachments/assets/4b1f9f74-64a6-4f68-ba2d-ab6ceb8ceddd" />
<img width="847" height="32" alt="image" src="https://github.com/user-attachments/assets/2646cc2b-c33d-4c55-b22c-c26f69eefbcd" />

## How This Contributes To The Nova Sector Roleplay Experience
It's a minor annoyance of mine wanting to fax someone but having to use NT HR as a forwarder.

This fixes that.

Other than Clown Planet and the Mime one, all of the names are sourced from the wiki.

## Proof of Testing
above

## Changelog
:cl:
add: Faxes have opened up. You may now fax the HC, FTU, IRA, IBS and a bunch of other two-three letter groups. Sadly the last two no longer own faxes. So we gave you Clowns and Mimes instead.
/:cl:
