### PR TITLE
Removes the Ghost Cafe's Genetics Consoles

### DIFF
--- a/_maps/map_files/generic/CentCom_nova_z2.dmm
+++ b/_maps/map_files/generic/CentCom_nova_z2.dmm
@@ -5260,7 +5260,10 @@
 /area/centcom/holding/cafe)
 "cgA" = (
 /obj/effect/turf_decal/tile/dark_green/anticorner,
-/obj/machinery/dna_infuser,
+/obj/structure/showcase/machinery/cloning_pod{
+	desc = "An old prototype cloning pod, permanently decommissioned following the incident.";
+	name = "decommissioned cloner"
+	},
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 1
 	},
@@ -13273,7 +13276,11 @@
 /area/centcom/interlink)
 "nCr" = (
 /obj/effect/turf_decal/tile/dark_green/half,
-/obj/machinery/dna_scannernew,
+/obj/structure/showcase/machinery/cloning_pod{
+	desc = "An old decommissioned scanner, permanently scuttled.";
+	icon_state = "scanner";
+	name = "decommissioned cloning scanner"
+	},
 /turf/open/floor/iron/dark/smooth_edge,
 /area/centcom/holding/cafe)
 "nCz" = (
@@ -17729,10 +17736,10 @@
 /area/centcom/holding/cafedorms)
 "tad" = (
 /obj/effect/turf_decal/tile/dark_green/half,
-/obj/machinery/computer/dna_console{
+/obj/machinery/light/cold/directional/south,
+/obj/structure/showcase/fakeid{
 	dir = 1
 	},
-/obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/centcom/holding/cafe)
 "tag" = (


### PR DESCRIPTION

## About The Pull Request
 
Another small thing I've been meaning to squash. Ghost Cafe has a working genetics setup. This is neat, but it's also linked to the station's genetics experience so let's not do that. Just copying the exhibit from meta's abandoned medbay to here.

## How This Contributes To The Nova Sector Roleplay Experience

GC shouldn't be able to affect the round.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
map: Ghost Cafe's genetics has been removed with non-working displays.
/:cl:
