### PR TITLE
Adds more interactions (lite) 2

### DIFF
--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_arousal/climax.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_arousal/climax.dm
@@ -95,6 +95,7 @@
 			var/penis_climax_choice = tgui_alert(src, "Choose where to shoot your load.", "Load preference!", buttons)
 
 			var/create_cum_decal = FALSE
+			var/datum/reagents/target_reagents
 
 			if(isnull(penis_climax_choice) || penis_climax_choice == CLIMAX_ON_FLOOR)
 				create_cum_decal = TRUE
@@ -111,7 +112,7 @@
 					var/obj/item/reagent_containers/cup/target_open_container = interactable_inrange_open_containers[target_choice]
 					if(target_open_container.is_refillable() && target_open_container.is_drainable())
 						var/obj/item/organ/genital/testicles/src_testicles = src.get_organ_slot(ORGAN_SLOT_TESTICLES)
-						var/load_volume = src_testicles.genital_size * 10
+						var/load_volume = src_testicles.get_climax_fluid_amount()
 						playsound_if_pref(get_turf(src), SFX_DESECRATION, 50, TRUE, pref_to_check = /datum/preference/toggle/erp/sounds)
 						if(target_open_container.reagents.holder_full())
 							// reagent container is full
@@ -172,9 +173,16 @@
 						visible_message(span_userlove("[src] hilts [self_their] cock into [target_human]'s [climax_into_choice], shooting cum into [target_human_them]!"), \
 							span_userlove("You hilt your cock into [target_human]'s [climax_into_choice], shooting cum into [target_human_them]!"), pref_to_check = /datum/preference/toggle/erp)
 						to_chat(target_human, span_userlove("Your [climax_into_choice] fills with warm cum as [src] shoots [self_their] load into it."))
+						if(climax_into_choice == ORGAN_SLOT_VAGINA)
+							target_human.create_carbon_reagents()
+							target_reagents = target_human.reagents
+						else
+							var/obj/item/organ/stomach/target_stomach = target_human.get_organ_slot(ORGAN_SLOT_STOMACH)
+							target_reagents = target_stomach?.reagents
 
 			var/obj/item/organ/genital/testicles/testicles = get_organ_slot(ORGAN_SLOT_TESTICLES)
-			testicles.transfer_internal_fluid(null, testicles.internal_fluid_count * 0.6) // yep. we are sending semen to nullspace
+			var/load_volume = target_reagents ? testicles.prepare_targeted_climax_fluid() : testicles.get_climax_drain_amount()
+			testicles.transfer_internal_fluid(target_reagents, load_volume)
 			if(create_cum_decal)
 				add_cum_splatter_floor(get_turf(src))
 

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_chemistry/reagents/cum.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_chemistry/reagents/cum.dm
@@ -1,3 +1,5 @@
+#define CUM_STOMACH_PROTEIN_RATIO 0.1
+
 /datum/reagent/consumable/femcum
 	name = "femcum"
 	description = "Uhh... Someone had fun."
@@ -21,6 +23,19 @@
 	taste_description = "musky and salty"
 	color = "#ffffffff"
 
+/datum/reagent/consumable/cum/intercept_reagents_transfer(datum/reagents/target, amount, copy_only)
+	if(!istype(holder?.my_atom, /obj/item/organ/stomach) || !iscarbon(target?.my_atom))
+		return FALSE
+
+	var/protein_amount = amount * CUM_STOMACH_PROTEIN_RATIO
+	if(protein_amount > 0)
+		target.add_reagent(/datum/reagent/consumable/nutriment/protein, protein_amount, reagtemp = holder.chem_temp, added_purity = purity)
+
+	if(!copy_only)
+		volume -= amount
+		holder.update_total()
+	return TRUE
+
 /datum/glass_style/drinking_glass/cum
 	required_drink_type = /datum/reagent/consumable/cum
 	name = "glass of cum"
@@ -37,3 +52,5 @@
 	required_reagents = list(/datum/reagent/blood = 2, /datum/reagent/consumable/milk = 2, /datum/reagent/consumable/salt = 1) // Iiiinteresting...
 	mix_message = "The mixture turns into a gooey, musky white liquid..."
 	erp_reaction = TRUE
+
+#undef CUM_STOMACH_PROTEIN_RATIO

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_organs/_genital.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_organs/_genital.dm
@@ -47,8 +47,9 @@
 
 	attempt_amount = clamp(attempt_amount, 0, internal_fluid_count)
 	if(reagent_container)
-		reagent_container.add_reagent(internal_fluid_datum, attempt_amount)
+		attempt_amount = reagent_container.add_reagent(internal_fluid_datum, attempt_amount, added_purity = 1)
 	internal_fluid_count -= attempt_amount
+	return attempt_amount
 
 //This translates the float size into a sprite string
 /obj/item/organ/genital/proc/get_sprite_size_string()

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_organs/testicles.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_organs/testicles.dm
@@ -1,3 +1,7 @@
+#define TESTICLES_INTERNAL_FLUID_MULTIPLIER 20
+#define TESTICLES_CLIMAX_FLUID_MULTIPLIER 10
+#define TESTICLES_CLIMAX_DRAIN_RATIO 0.6
+
 /obj/item/organ/genital/testicles
 	name = "testicles"
 	desc = "A male reproductive organ."
@@ -50,7 +54,7 @@
 	if(DNA.features["balls_size"] > 0)
 		size = DNA.features["balls_size"]
 
-	internal_fluid_maximum = size * 20
+	internal_fluid_maximum = size * TESTICLES_INTERNAL_FLUID_MULTIPLIER
 
 	return ..()
 
@@ -83,3 +87,18 @@
 		if(GLOB.balls_size_translation[key] == cup)
 			return text2num(key)
 	return 0
+
+/obj/item/organ/genital/testicles/proc/get_climax_fluid_amount()
+	return genital_size * TESTICLES_CLIMAX_FLUID_MULTIPLIER
+
+/obj/item/organ/genital/testicles/proc/get_climax_drain_amount()
+	return internal_fluid_count * TESTICLES_CLIMAX_DRAIN_RATIO
+
+/obj/item/organ/genital/testicles/proc/prepare_targeted_climax_fluid()
+	var/fluid_amount = max(get_climax_drain_amount(), get_climax_fluid_amount())
+	adjust_internal_fluid(fluid_amount - internal_fluid_count)
+	return fluid_amount
+
+#undef TESTICLES_INTERNAL_FLUID_MULTIPLIER
+#undef TESTICLES_CLIMAX_FLUID_MULTIPLIER
+#undef TESTICLES_CLIMAX_DRAIN_RATIO

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_quirks.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_quirks.dm
@@ -200,7 +200,7 @@
 /datum/quirk/egg_production
 	name = "Oviparity"
 	desc = "Whether by genetics or some other factor, you can produce and lay eggs."
-	icon = FA_ICON_EGG
+	icon = FA_ICON_PERSON_PREGNANT
 	value = 0
 	gain_text = span_notice("You suddenly feel rather productive.")
 	lose_text = span_warning("You no longer feel productive.")

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_quirks.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_quirks.dm
@@ -184,6 +184,197 @@
 	/// Is this a quirk disabled by disabling the ERP config?
 	var/erp_quirk = FALSE
 
+/*
+*	OVIPARITY
+*/
+
+#define OVIPARITY_MAX_EGGS 10
+#define OVIPARITY_MAX_SLOWDOWN 5
+#define OVIPARITY_EGG_COUNT_LOW 2
+#define OVIPARITY_EGG_COUNT_MEDIUM 4
+#define OVIPARITY_EGG_COUNT_HIGH 6
+#define OVIPARITY_EGG_COUNT_SWOLLEN 8
+#define OVIPARITY_EGG_COUNT_FULL 10
+#define OVIPARITY_LAY_TIME (10 SECONDS)
+
+/datum/quirk/egg_production
+	name = "Oviparity"
+	desc = "Whether by genetics or some other factor, you can produce and lay eggs."
+	icon = FA_ICON_EGG
+	value = 0
+	gain_text = span_notice("You suddenly feel rather productive.")
+	lose_text = span_warning("You no longer feel productive.")
+	medical_record_text = "Patient is capable of producing eggs."
+	erp_quirk = TRUE
+
+/datum/quirk/egg_production/add(client/client_source)
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	var/datum/action/cooldown/mob_cooldown/egg_production/action = new(human_holder)
+	action.Grant(human_holder)
+
+/datum/quirk/egg_production/remove()
+	if(QDELETED(quirk_holder))
+		return ..()
+
+	var/datum/action/cooldown/mob_cooldown/egg_production/action = locate(/datum/action/cooldown/mob_cooldown/egg_production) in quirk_holder.actions
+	action?.Remove()
+
+	return ..()
+
+/datum/action/cooldown/mob_cooldown/egg_production
+	name = "Produce an Egg"
+	desc = "Lay one of your produced eggs."
+	button_icon = 'icons/obj/food/egg.dmi'
+	button_icon_state = "egg"
+	cooldown_time = 1 SECONDS
+	melee_cooldown_time = 0
+	shared_cooldown = NONE
+	click_to_activate = FALSE
+	/// Eggs currently ready to be laid.
+	var/eggs_stored = 0
+	/// Maximum eggs that can be stored at once.
+	var/maximum_eggs = OVIPARITY_MAX_EGGS
+	/// Prevents life ticks from producing more than one egg per catalyst cooldown.
+	var/can_produce = TRUE
+	var/static/list/possible_egg_thoughts = list(
+		"Your abdomen feels warm.",
+		"You feel something shift inside you.",
+		"A pleasant fullness builds in your abdomen.",
+		"You feel a little heavier."
+	)
+	/// Format: reagent typepath = list(required volume, production cooldown).
+	var/static/list/egg_production_reagents = list(
+		/datum/reagent/consumable/cum = list(20, 10 SECONDS),
+		/datum/reagent/drug/aphrodisiac/crocin = list(20, 30 SECONDS),
+		/datum/reagent/drug/aphrodisiac/crocin/hexacrocin = list(4, 30 SECONDS),
+	)
+
+/datum/action/cooldown/mob_cooldown/egg_production/Grant(mob/grant_to)
+	. = ..()
+	if(!owner)
+		return
+
+	RegisterSignal(owner, COMSIG_LIVING_LIFE, PROC_REF(on_life))
+
+/datum/action/cooldown/mob_cooldown/egg_production/Remove(mob/removed_from)
+	var/mob/action_owner = removed_from || owner
+	if(action_owner)
+		UnregisterSignal(action_owner, COMSIG_LIVING_LIFE)
+		action_owner.remove_movespeed_modifier(/datum/movespeed_modifier/oviparity)
+
+	return ..(action_owner)
+
+/datum/action/cooldown/mob_cooldown/egg_production/Activate(atom/target)
+	if(!owner)
+		return FALSE
+
+	if(eggs_stored <= 0)
+		owner.balloon_alert(owner, "no eggs to lay!")
+		return FALSE
+
+	to_chat(owner, span_purple("You start laying an egg..."))
+	if(!do_after(owner, OVIPARITY_LAY_TIME, target = owner, timed_action_flags = IGNORE_HELD_ITEM))
+		owner.balloon_alert(owner, "interrupted!")
+		return FALSE
+
+	update_egg_count(-1)
+	var/obj/item/food/oviparity_egg/egg = new(owner)
+	owner.put_in_hands(egg)
+	owner.visible_message(
+		span_purple("[owner] lays an egg!"),
+		span_purple("You lay an egg!"),
+		pref_to_check = /datum/preference/toggle/erp
+	)
+	StartCooldown()
+	return TRUE
+
+/datum/action/cooldown/mob_cooldown/egg_production/proc/on_life(mob/living/source, seconds_per_tick)
+	SIGNAL_HANDLER
+
+	if(source != owner || !can_produce || eggs_stored >= maximum_eggs)
+		return
+
+	try_produce_egg()
+
+/datum/action/cooldown/mob_cooldown/egg_production/proc/try_produce_egg()
+	if(!ishuman(owner))
+		return FALSE
+
+	var/mob/living/carbon/human/egg_holder = owner
+	if(!egg_holder.reagents)
+		return FALSE
+
+	for(var/datum/reagent/reagent_type as anything in egg_production_reagents)
+		var/list/reagent_values = egg_production_reagents[reagent_type]
+		var/required_volume = reagent_values[1]
+		if(!egg_holder.reagents.has_reagent(reagent_type, required_volume))
+			continue
+
+		egg_holder.reagents.remove_reagent(reagent_type, required_volume)
+		to_chat(owner, span_purple(pick(possible_egg_thoughts)))
+		update_egg_count(1)
+		can_produce = FALSE
+		addtimer(CALLBACK(src, PROC_REF(end_production_cooldown)), reagent_values[2])
+		return TRUE
+
+	return FALSE
+
+/datum/action/cooldown/mob_cooldown/egg_production/proc/end_production_cooldown()
+	can_produce = TRUE
+
+/datum/action/cooldown/mob_cooldown/egg_production/proc/update_egg_count(egg_delta)
+	eggs_stored = clamp(eggs_stored + egg_delta, 0, maximum_eggs)
+	desc = "[initial(desc)] You are carrying [eggs_stored] egg\s."
+
+	if(!owner)
+		return
+
+	if(eggs_stored <= 0)
+		owner.remove_movespeed_modifier(/datum/movespeed_modifier/oviparity)
+		return
+
+	var/egg_slowdown = CEILING(OVIPARITY_MAX_SLOWDOWN * (eggs_stored / maximum_eggs), 0.01)
+	owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/oviparity, multiplicative_slowdown = egg_slowdown)
+
+	var/is_laying = egg_delta < 0
+	switch(eggs_stored)
+		if(OVIPARITY_EGG_COUNT_LOW)
+			to_chat(owner, span_purple("You are beginning to feel [is_laying ? "a little less weighed down" : "rather heavy"]."))
+		if(OVIPARITY_EGG_COUNT_MEDIUM)
+			to_chat(owner, span_purple("Your abdomen feels [is_laying ? "less full, but still heavy" : "heavy and full"]."))
+		if(OVIPARITY_EGG_COUNT_HIGH)
+			to_chat(owner, span_purple("Moving around with so many eggs is [is_laying ? "becoming easier" : "getting difficult"]."))
+		if(OVIPARITY_EGG_COUNT_SWOLLEN)
+			to_chat(owner, span_purple("Your body feels [is_laying ? "less strained" : "swollen and strained"] from the eggs you are carrying."))
+		if(OVIPARITY_EGG_COUNT_FULL)
+			to_chat(owner, span_purple("You cannot hold any more eggs."))
+
+/datum/movespeed_modifier/oviparity
+	variable = TRUE
+	multiplicative_slowdown = OVIPARITY_MAX_SLOWDOWN
+
+/// Eggs laid by the Oviparity quirk. Deliberately not a subtype of /obj/item/food/egg.
+/obj/item/food/oviparity_egg
+	name = "laid egg"
+	desc = "A freshly laid egg. It is inert and too unusual to use in normal cooking."
+	icon = 'icons/obj/food/egg.dmi'
+	icon_state = "egg"
+	inhand_icon_state = "egg"
+	food_reagents = list(/datum/reagent/water = 6)
+	foodtypes = MEAT | RAW
+	w_class = WEIGHT_CLASS_TINY
+	ant_attracting = FALSE
+	preserved_food = TRUE
+
+#undef OVIPARITY_MAX_EGGS
+#undef OVIPARITY_MAX_SLOWDOWN
+#undef OVIPARITY_EGG_COUNT_LOW
+#undef OVIPARITY_EGG_COUNT_MEDIUM
+#undef OVIPARITY_EGG_COUNT_HIGH
+#undef OVIPARITY_EGG_COUNT_SWOLLEN
+#undef OVIPARITY_EGG_COUNT_FULL
+#undef OVIPARITY_LAY_TIME
+
 /datum/quirk/masochism
 	name = "Masochism"
 	desc = "Pain brings you indescribable pleasure."


### PR DESCRIPTION

## About The Pull Request

This is a subset of https://github.com/NovaSector/NovaSector/pull/7208. This PR in particular introduces the oviparity quirk + makes changes to calculations on how the life-bearing fluid is processed in the stomach (it turns into protein instead) vs when it's in the bloodstream directly. Climax also now injects said fluid into the bloodstream through a specific orifice, the other options place it on the stomach instead.
## How This Contributes To The Nova Sector Roleplay Experience

More options to RP in private quarters.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="427" height="85" alt="image" src="https://github.com/user-attachments/assets/8e01c3d4-9ea8-41ab-bf89-95c1edf6b353" />

</details>

## Changelog
:cl:
add: Adds the oviparity quirk. Several fluids can be used to achieve so.
/:cl:
