### PR TITLE
Adds some standard-pressure lavaland turfs

### DIFF
--- a/modular_nova/modules/mapping/code/planet_turfs.dm
+++ b/modular_nova/modules/mapping/code/planet_turfs.dm
@@ -132,7 +132,7 @@
 */
 /turf/closed/mineral/asteroid/has_more_air //this one is for if your checks are failing it might be because ya got dis rock, this can stay too as it will be convient for mappers in the future.
 	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
-	baseturfs = /turf/open/misc/asteroid/lowpressure
+	baseturfs = /turf/open/misc/asteroid
 
 /turf/open/chasm/sandy	//just a retexture of the other chasm. making this was nothing but painful.
 	icon = 'modular_nova/modules/mapping/icons/turf/open/sandychasm.dmi'

--- a/modular_nova/modules/mapping/code/planet_turfs.dm
+++ b/modular_nova/modules/mapping/code/planet_turfs.dm
@@ -125,12 +125,14 @@
 
 /turf/closed/mineral/asteroid/has_air
 	initial_gas_mix = OPENTURF_LOW_PRESSURE	//one that WONT screw with atmos if it's mapped somewhere
+	baseturfs = /turf/open/misc/asteroid/lowpressure
 
 /*
 *	HAZARD
 */
 /turf/closed/mineral/asteroid/has_more_air //this one is for if your checks are failing it might be because ya got dis rock, this can stay too as it will be convient for mappers in the future.
 	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
+	baseturfs = /turf/open/misc/asteroid/lowpressure
 
 /turf/open/chasm/sandy	//just a retexture of the other chasm. making this was nothing but painful.
 	icon = 'modular_nova/modules/mapping/icons/turf/open/sandychasm.dmi'
@@ -143,3 +145,18 @@
 	light_color = LIGHT_COLOR_TUNGSTEN
 
 	initial_gas_mix = OPENTURF_LOW_PRESSURE
+
+/turf/closed/mineral/random/volcanic/standard_air
+	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
+	baseturfs = /turf/open/misc/asteroid/basalt
+	turf_type = /turf/open/misc/asteroid/basalt
+
+/turf/closed/mineral/random/volcanic/red_rock/standard_air
+	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
+	baseturfs = /turf/open/misc/asteroid/basalt/smooth/siderite
+	turf_type = /turf/open/misc/asteroid/basalt/smooth/siderite
+
+/turf/closed/mineral/random/volcanic/shale/standard_air
+	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
+	baseturfs = /turf/open/misc/asteroid/basalt/smooth/shale
+	turf_type = /turf/open/misc/asteroid/basalt/smooth/shale

--- a/modular_nova/modules/mapping/code/planet_turfs.dm
+++ b/modular_nova/modules/mapping/code/planet_turfs.dm
@@ -146,17 +146,32 @@
 
 	initial_gas_mix = OPENTURF_LOW_PRESSURE
 
+/turf/open/misc/asteroid/basalt/standard_air
+	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
+	planetary_atmos = TRUE
+	baseturfs = /turf/open/misc/asteroid/basalt/standard_air
+
+/turf/open/misc/asteroid/basalt/smooth/shale/standard_air
+	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
+	planetary_atmos = TRUE
+	baseturfs = /turf/open/misc/asteroid/basalt/smooth/shale/standard_air
+	
+/turf/open/misc/asteroid/basalt/smooth/siderite/standard_air
+	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
+	planetary_atmos = TRUE
+	baseturfs = /turf/open/misc/asteroid/basalt/smooth/siderite/standard_air
+
 /turf/closed/mineral/random/volcanic/standard_air
 	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
-	baseturfs = /turf/open/misc/asteroid/basalt
-	turf_type = /turf/open/misc/asteroid/basalt
+	baseturfs = /turf/open/misc/asteroid/basalt/standard_air
+	turf_type = /turf/open/misc/asteroid/basalt/standard_air
 
 /turf/closed/mineral/random/volcanic/red_rock/standard_air
 	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
-	baseturfs = /turf/open/misc/asteroid/basalt/smooth/siderite
-	turf_type = /turf/open/misc/asteroid/basalt/smooth/siderite
+	baseturfs = /turf/open/misc/asteroid/basalt/smooth/siderite/standard_air
+	turf_type = /turf/open/misc/asteroid/basalt/smooth/siderite/standard_air
 
 /turf/closed/mineral/random/volcanic/shale/standard_air
 	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
-	baseturfs = /turf/open/misc/asteroid/basalt/smooth/shale
-	turf_type = /turf/open/misc/asteroid/basalt/smooth/shale
+	baseturfs = /turf/open/misc/asteroid/basalt/smooth/shale/standard_air
+	turf_type = /turf/open/misc/asteroid/basalt/smooth/shale/standard_air


### PR DESCRIPTION

## About The Pull Request
Request from darki for an event map, the variants of lavaland mineral walls but set up for standard pressure.
## How This Contributes To The Nova Sector ~~Roleplay~~ Mapping Experience
just some more tools for mappers
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="456" height="287" alt="image" src="https://github.com/user-attachments/assets/6e1e0ed1-7b7d-45ef-8771-60f3bc178918" />

scanned for air, default pressure
</details>

## Changelog
Not player facing
