### PR TITLE
Condenses Spinwarder and Pan-Slavic into one language

### DIFF
--- a/modular_nova/modules/bitrunning/code/virtual_domains/ancient_milsim/ghost_spawner.dm
+++ b/modular_nova/modules/bitrunning/code/virtual_domains/ancient_milsim/ghost_spawner.dm
@@ -18,7 +18,7 @@
 
 /obj/effect/mob_spawn/ghost_role/human/virtual_domain/ancient_milsim/special(mob/living/carbon/human/spawned_human, mob/mob_possessor, apply_prefs)
 	. = ..()
-	spawned_human.grant_language(/datum/language/panslavic, source = LANGUAGE_SPAWNER)
+	spawned_human.grant_language(/datum/language/spinwarder, source = LANGUAGE_SPAWNER)
 
 /obj/effect/mob_spawn/ghost_role/human/virtual_domain/ancient_milsim/post_transfer_prefs(mob/living/carbon/human/spawned_human)
 	. = ..()

--- a/modular_nova/modules/customization/modules/language/panslavic.dm
+++ b/modular_nova/modules/customization/modules/language/panslavic.dm
@@ -1,31 +1,41 @@
-/datum/language/panslavic
+/datum/language/spinwarder
 	name = "Pan-Slavic"
-	desc = "An elaborate mix of various Slavic languages with similar properties that has long since become the official language \
-		of the HC, with a steady amount of relevance in SolFed colonies with Slavic descendants and various types of trading posts and \
-		spaceports across Human space - it even managed to find a niche in communication with other species."
+	desc = "The primary language of the Heliostatic Coalition, Pan-Slavic evolved organically from the Eastern and Central European linguistic \
+	roots of the founding colonists who settled Vistula and its surrounding systems during the First Great Interstellar Migration. Isolated from \
+	Sol for centuries during the 'Quiet Century', the scattered colonies saw their inherited languages drift, merge, and simplify under the \
+	pressures of survival and limited communication between settlements. When the colonies re-established contact in the late 2390s and formalized \
+	the Heliostatic Compact in 2405, the artificially engineered Pan-Slavic emerged as the natural standard. Linguistically, Pan-Slavic retains \
+	the Slavic verbal aspect system and much of its foundational vocabulary: body parts, family, nature, and basic actions. However, centuries \
+	of separation and the mixing of settlers from different regional backgrounds simplified its noun morphology dramatically. Today, Pan-Slavic \
+	is spoken natively by the human majority of the CZD and as a second language by most other Coalition citizens. While Sol Common remains \
+	the language of interstellar communication, Pan-Slavic is the language of home, of the Chamber, and of the Long Arm. To an outsider, \
+	it sounds simultaneously familiar and alien - recognizably Slavic in its rhythm and structure, but punctuated by loanwords from the \
+	Turkic and Persian linguistic strata that survived the Quiet Century."
 	key = "P"
 	flags = TONGUELESS_SPEECH
-	syllables = list(
-		"do", "ber", "sve", "tel", "po", "ča", "sen", "jag", "nje", "sla", "do",
-		"led", "klo", "ba", "sa", "pa", "ra", "diž", "nik", "vol", "ko", "vi", "ži",
-		"ra", "fa", "zob", "na", "ščet", "ka", "zgo", "do", "vi", "na", "zah", "ra",
-		"da", "tam", "ten", "led", "nič", "ka", "zá", "pis", "ník", "krá", "va",
-		"ku", "ku", "ři", "ce", "ve", "přo", "vé", "ma", "so", "mo", "cný", "pi",
-		"kan", "tní", "o", "ran", "žo", "vý", "vlast", "nos", "ti", "hvi", "li", "na",
-		"mіs", "ce", "vij", "snі", "da", "nok", "kva", "so", "lja", "char", "ka", "mіs",
-		"jacj", "gar", "na", "ne", "pra", "vil", "niy", "min", "dal", "io", "lam", "pa",
-		"i", "zo", "bra", "ze", "ni", "e", "is", "kus", "stvo", "bi", "bli", "o", "te",
-		"ka", "bas", "se", "in", "fut", "bol", "o", "fis", "po", "che", "mu", "ru",
-		"bash", "ka", "kuh", "nia", "rech", "nik", "gor", "ko", "pi", "le", "ti", "na",
-		"ko", "ni", "spa", "va", "ha", "so", "ba", "sve", "ska", "nov", "cha", "nik",
-		"zem", "lya", "kan", "ce", "la", "ri", "јa", "snezh", "ne", "pa", "da", "vi", "ne"
-	)
-	space_chance = 5
-	sentence_chance = 0
+	space_chance = 35
+	sentence_chance = 5
 	between_word_sentence_chance = 10
-	between_word_space_chance = 25
+	between_word_space_chance = 60
 	additional_syllable_low = 0
-	additional_syllable_high = 0
+	additional_syllable_high = 2
+	syllables = list(
+		// Slavic stratum (core grammar, basic vocab)
+		"brat", "žen", "vod", "dom", "zvezd", "nog", "ruk", "syn", "mat", "otc", "serd", "neb", "ogn", "zem", "živ", "spa", "jed", "pij", "govor", "pis", "del", "vid", "slov", "hleb", "trud", "put", "dobr", "zly", "velik", "mal", "stary", "nov", "čorn", "zelen", "běl", "červen",
+		// Consonant clusters (common in Slavic)
+		"zd", "st", "sk", "zn", "zv", "tv", "dv", "kr", "tr", "pl", "bl", "gl", "chl", "kak", "tak", "čto", "kto", "gd", "vš", "čl", "čn", "str", "spr", "vz", "dr", "dl",
+		// Vowel-harmonized grammatical particles (Central Asian influence)
+		"da", "dä", "em", "bul", "mož", "ne", "je", "si", "či", "li", "že", "bo", "no", "aj", "ej", "uj", "ij", "yj", "in", "š", "aš",
+		// Cultural/administrative stratum leaking from Vistulan
+		"šäh", "nan", "pul", "dost", "čaj", "hükü", "met", "baš", "lyk", "hay", "qay", "ğu", "süy", "sanak", "učqu", "aläm", "bazar", "til", "jay", "hatun", "düšman", "rahmat", "salam", "kečir", "diqqat", "nešč", "ölke", "kilem", "čapan", "fan",
+		// Common phrases and grammaticalized forms
+		"prosim", "hair", "s-pis", "s-del", "poš", "zaš", "naš", "vaš", "moj", "tvoj", "onin", "onäin", "oniv",
+	)
 	icon_state = "panslavic"
 	icon = 'modular_nova/master_files/icons/misc/language.dmi'
 	default_priority = 95
+	mutual_understanding = list(
+		/datum/language/common = 25,
+		/datum/language/spacer = 30,
+		/datum/language/xerxian = 15,
+	)

--- a/modular_nova/modules/customization/modules/language/panslavic.dm
+++ b/modular_nova/modules/customization/modules/language/panslavic.dm
@@ -1,16 +1,16 @@
 /datum/language/spinwarder
 	name = "Pan-Slavic"
 	desc = "The primary language of the Heliostatic Coalition, Pan-Slavic evolved organically from the Eastern and Central European linguistic \
-	roots of the founding colonists who settled Vistula and its surrounding systems during the First Great Interstellar Migration. Isolated from \
-	Sol for centuries during the 'Quiet Century', the scattered colonies saw their inherited languages drift, merge, and simplify under the \
-	pressures of survival and limited communication between settlements. When the colonies re-established contact in the late 2390s and formalized \
-	the Heliostatic Compact in 2405, the artificially engineered Pan-Slavic emerged as the natural standard. Linguistically, Pan-Slavic retains \
-	the Slavic verbal aspect system and much of its foundational vocabulary: body parts, family, nature, and basic actions. However, centuries \
-	of separation and the mixing of settlers from different regional backgrounds simplified its noun morphology dramatically. Today, Pan-Slavic \
-	is spoken natively by the human majority of the CZD and as a second language by most other Coalition citizens. While Sol Common remains \
-	the language of interstellar communication, Pan-Slavic is the language of home, of the Chamber, and of the Long Arm. To an outsider, \
-	it sounds simultaneously familiar and alien - recognizably Slavic in its rhythm and structure, but punctuated by loanwords from the \
-	Turkic and Persian linguistic strata that survived the Quiet Century."
+		roots of the founding colonists who settled Vistula and its surrounding systems during the First Great Interstellar Migration. Isolated from \
+		Sol for centuries during the 'Quiet Century', the scattered colonies saw their inherited languages drift, merge, and simplify under the \
+		pressures of survival and limited communication between settlements. When the colonies re-established contact in the late 2390s and formalized \
+		the Heliostatic Compact in 2405, the artificially engineered Pan-Slavic emerged as the natural standard. Linguistically, Pan-Slavic retains \
+		the Slavic verbal aspect system and much of its foundational vocabulary: body parts, family, nature, and basic actions. However, centuries \
+		of separation and the mixing of settlers from different regional backgrounds simplified its noun morphology dramatically. Today, Pan-Slavic \
+		is spoken natively by the human majority of the CZD and as a second language by most other Coalition citizens. While Sol Common remains \
+		the language of interstellar communication, Pan-Slavic is the language of home, of the Chamber, and of the Long Arm. To an outsider, \
+		it sounds simultaneously familiar and alien - recognizably Slavic in its rhythm and structure, but punctuated by loanwords from the \
+		Turkic and Persian linguistic strata that survived the Quiet Century."
 	key = "P"
 	flags = TONGUELESS_SPEECH
 	space_chance = 35

--- a/modular_nova/modules/random_ship_event/random_ships/heliostatic_inspectors/code/antag_datum.dm
+++ b/modular_nova/modules/random_ship_event/random_ships/heliostatic_inspectors/code/antag_datum.dm
@@ -46,13 +46,13 @@
 	var/mob/living/owner_mob = mob_override || owner.current
 	var/datum/language_holder/holder = owner_mob.get_language_holder()
 	holder.grant_language(/datum/language/uncommon, TRUE, TRUE, LANGUAGE_PIRATE)
-	holder.grant_language(/datum/language/panslavic, TRUE, TRUE, LANGUAGE_PIRATE)
+	holder.grant_language(/datum/language/spinwarder, TRUE, TRUE, LANGUAGE_PIRATE)
 	holder.grant_language(/datum/language/yangyu, TRUE, TRUE, LANGUAGE_PIRATE)
 
 /datum/antagonist/cop/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/owner_mob = mob_override || owner.current
 	owner_mob.remove_language(/datum/language/uncommon, TRUE, TRUE, LANGUAGE_PIRATE)
-	owner_mob.remove_language(/datum/language/panslavic, TRUE, TRUE, LANGUAGE_PIRATE)
+	owner_mob.remove_language(/datum/language/spinwarder, TRUE, TRUE, LANGUAGE_PIRATE)
 	owner_mob.remove_language(/datum/language/yangyu, TRUE, TRUE, LANGUAGE_PIRATE)
 	return ..()
 

--- a/modular_nova/modules/random_ship_event/random_ships/heliostatic_inspectors/code/ghost_spawner.dm
+++ b/modular_nova/modules/random_ship_event/random_ships/heliostatic_inspectors/code/ghost_spawner.dm
@@ -27,7 +27,7 @@
 /obj/effect/mob_spawn/ghost_role/human/hc_officer/post_transfer_prefs(mob/living/spawned_mob)
 	. = ..()
 	spawned_mob.mind.add_antag_datum(/datum/antagonist/cop)
-	spawned_mob.grant_language(/datum/language/panslavic, source = LANGUAGE_SPAWNER)
+	spawned_mob.grant_language(/datum/language/spinwarder, source = LANGUAGE_SPAWNER)
 	spawned_mob.grant_language(/datum/language/uncommon, source = LANGUAGE_SPAWNER)
 	spawned_mob.grant_language(/datum/language/yangyu, source = LANGUAGE_SPAWNER)
 	spawned_mob.grant_language(/datum/language/akulan, source = LANGUAGE_SPAWNER)


### PR DESCRIPTION

## About The Pull Request
We don't exactly need two languages that do the exact same thing, unless there's some flavorful explanation to keep it that way. Alas, there is none, because thankfully, we don't use /tg/ lore and have our own in-house faction for any vaguely slavic representation.
Which is to say that Spinwarder is now dead, being replaced by Pan-Slavic; and Pan-Slavic itself gets its description rewritten and syllables redesigned to better fit with our lore. Two languages are turned into one.
## How This Contributes To The Nova Sector Roleplay Experience
This should make both our own slavic language more lore-compliant, meanwhile also making sure that we don't have two languages that do the exact same thing, by reusing Spinwarder as its base; and making sure there's one less mention of anything SSC- and TSSU-adjacent (which we do not have).
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="459" height="406" alt="изображение" src="https://github.com/user-attachments/assets/b09313dc-ccfc-45b1-9eb6-d9372743839a" />
<img width="487" height="262" alt="изображение" src="https://github.com/user-attachments/assets/0da9d781-dc2f-4c65-80e4-a3593f734d22" />
<img width="637" height="524" alt="изображение" src="https://github.com/user-attachments/assets/4c81c2f2-4b5b-463f-92b3-d5693b71923b" />
<img width="766" height="562" alt="изображение" src="https://github.com/user-attachments/assets/3591b45f-7201-4f6c-8551-8eaed8bacbd6" />

</details>

## Changelog
:cl: Stalkeros
add: Pan-slavic has been reflavored to comply with our lore.
del: Spinwarder is gone in its player-facing entirety.
/:cl:
