### PR TITLE
unapologetic drone buff - more boxes, proper pocket drops on death

### DIFF
--- a/modular_nova/modules/drones/_drone.dm
+++ b/modular_nova/modules/drones/_drone.dm
@@ -113,22 +113,39 @@
 	// Sets our new storage
 	default_storage = /obj/item/storage/backpack/duffelbag/drone
 
+/mob/living/basic/drone/death(gibbed)
+	. = ..()
+	if(l_store)
+		dropItemToGround(l_store)
+	if(r_store)
+		dropItemToGround(r_store)
+
+/obj/item/storage/box/drone_tools/PopulateContents()
+	new /obj/item/screwdriver/omni_drill(src)
+	new /obj/item/multitool(src)
+	new /obj/item/crowbar(src)
+	new /obj/item/weldingtool(src)
+	new /obj/item/stack/cable_coil/thirty(src)
+	new /obj/item/analyzer(src)
+	new /obj/item/holosign_creator/atmos(src)// Drones handle atmos issues
+
+/obj/item/stack/sheet/mineral/wood/ten
+	amount = 10
+
+/obj/item/storage/box/drone_tools_misc/PopulateContents()
+	new /obj/item/lightreplacer(src)// Drones fix the station
+	new /obj/item/t_scanner(src)
+	new /obj/item/soap/nanotrasen(src)// Drones clean
+	new /obj/item/airlock_painter/decal(src) // for floor decals
+	new /obj/item/stack/sheet/mineral/wood/ten(src) // for fixing broken wood floors
+
 // Then populates the drone duffelbag with our extra items
 // Overwrites original proc because new tools means overwrites, also reorganization because :>
 /obj/item/storage/backpack/duffelbag/drone/PopulateContents()
-	new /obj/item/storage/box(src)// Reduce bag bloat
-	new /obj/item/crowbar(src)
-	new /obj/item/screwdriver/omni_drill(src)// Reduce bag bloat
-	new /obj/item/weldingtool(src)
-	new /obj/item/analyzer(src)
+	new /obj/item/storage/box/drone_tools(src)
+	new /obj/item/storage/box/drone_tools_misc(src)
 	new /obj/item/pipe_dispenser(src)
-	new /obj/item/lightreplacer(src)// Drones fix the station
 	new /obj/item/construction/rtd/loaded(src)// Drones fix the station
-	new /obj/item/holosign_creator/atmos(src)// Drones handle atmos issues
-	new /obj/item/multitool(src)
-	new /obj/item/t_scanner(src)
-	new /obj/item/stack/cable_coil(src)
-	new /obj/item/soap/nanotrasen(src)// Drones clean
 
 //
 // Babylon Drones

--- a/modular_nova/modules/drones/_drone.dm
+++ b/modular_nova/modules/drones/_drone.dm
@@ -129,9 +129,6 @@
 	new /obj/item/analyzer(src)
 	new /obj/item/holosign_creator/atmos(src)// Drones handle atmos issues
 
-/obj/item/stack/sheet/mineral/wood/ten
-	amount = 10
-
 /obj/item/storage/box/drone_tools_misc/PopulateContents()
 	new /obj/item/lightreplacer(src)// Drones fix the station
 	new /obj/item/t_scanner(src)

--- a/modular_nova/modules/modular_items/code/materials.dm
+++ b/modular_nova/modules/modular_items/code/materials.dm
@@ -1,2 +1,5 @@
+/obj/item/stack/sheet/mineral/wood/ten
+	amount = 10
+
 /obj/item/stack/sheet/mineral/wood/thirty
 	amount = 30


### PR DESCRIPTION
## About The Pull Request

Drones now drop their pocket slots properly when they die. Drones also have a slightly revised starting inventory in their duffel, with most tools shuffled into their box, and a second box with their other misc. small items/tools, which now also has a free decal painter and 10 planks of wood.

## How This Contributes To The Nova Sector Roleplay Experience

Inventory management *sucks*. Moving drone tools into boxes gives them slightly less inventory juggling downtime and more time to actually do things, like hunt down a cool hat to steal or stop the supermatter from exploding.

Fixing floors from the decay subsystem breaking floors randomly *sucks*. The RTD helps, but then fixing the decals takes some effort, too, if you can't find a matching pattern in adjacent tiles. The decal painter being free helps alleviate this, along with the wood planks being given so you could fix the occasional stray broken wood floor.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

<img width="336" height="203" alt="dreamseeker_2026-06-11_04-46-49-AM-Thursday" src="https://github.com/user-attachments/assets/2e3a54be-c21a-4f17-b1e0-ab42ab48b72a" />
<img width="288" height="213" alt="dreamseeker_2026-06-11_04-47-32-AM-Thursday" src="https://github.com/user-attachments/assets/3055cdb8-0ef4-4193-91ef-5e4bee85455a" />

</details>

## Changelog

:cl:
qol: Drone duffelbags now have a slightly more organized inventory. Drones drop their pocket contents properly on death.
/:cl:
