### PR TITLE
reshuffles the escape menu (opfor button fix)

### DIFF
--- a/code/modules/escape_menu/home_page.dm
+++ b/code/modules/escape_menu/home_page.dm
@@ -69,7 +69,7 @@
 			/* hud_owner = */ null,
 			/* escape_menu = */ src,
 			/* button_text = */ "Quit",
-			/* offset = */ list(-311, 30),
+			/* offset = */ list(-381, 30), // NOVA EDIT - original /* offset = */ list(-311, 30),
 			/* font_size = */ 24,
 			/* on_click_callback = */ CALLBACK(src, PROC_REF(quit_game_prompt)),
 		)

--- a/modular_nova/modules/escape_menu/code/escape_menu_nova.dm
+++ b/modular_nova/modules/escape_menu/code/escape_menu_nova.dm
@@ -13,7 +13,7 @@
 	)
 
 	page_holder.give_screen_object(
-		new /atom/movable/screen/escape_menu/text/clickable/leave_body/(
+		new /atom/movable/screen/escape_menu/text/clickable/leave_body(
 			null,
 			/* hud_owner = */ null,
 			/* hud_owner = */ src,
@@ -57,22 +57,11 @@
 	living_user?.opposing_force()
 	qdel(src)
 
-/atom/movable/screen/escape_menu/text/clickable/respawn
-
 /datum/escape_menu/proc/respawn()
 	PRIVATE_PROC(TRUE)
 
 	var/mob/living/client_mob = client?.mob
 	client_mob?.abandon_mob()
-
-/atom/movable/screen/escape_menu/text/clickable/respawn/Initialize(
-	mapload,
-	datum/escape_menu/escape_menu,
-	button_text,
-	offset,
-	on_click_callback,
-)
-	. = ..()
 
 /atom/movable/screen/escape_menu/text/clickable/respawn/enabled()
 	if (!..())
@@ -80,19 +69,18 @@
 
 	return !isliving(escape_menu.client?.mob)
 
-/atom/movable/screen/escape_menu/text/clickable/opfor
-
 /atom/movable/screen/escape_menu/text/clickable/opfor/Initialize(
 	mapload,
+	datum/hud/hud_owner,
 	datum/escape_menu/escape_menu,
 	button_text,
-	offset,
-	on_click_callback,
+	list/offset,
+	font_size = 24,
 )
 	. = ..()
-	src.maptext_width = max(round(length(button_text) * font_size * 0.75), font_size * 5) // slightly more generous maptext width scaling for the allcaps
+	src.maptext_width = max(round(length(button_text) * font_size * 0.75), font_size * 5) // more generous scaling so the all-caps fits. this sucks but it works
 
-/atom/movable/screen/escape_menu/text/clickable/clickable/opfor/enabled()
+/atom/movable/screen/escape_menu/text/clickable/opfor/enabled()
 	if (!..())
 		return FALSE
 

--- a/modular_nova/modules/escape_menu/code/escape_menu_nova.dm
+++ b/modular_nova/modules/escape_menu/code/escape_menu_nova.dm
@@ -1,7 +1,7 @@
 /datum/escape_menu/show_home_page()
 	. = ..()
 	page_holder.give_screen_object(
-		new /atom/movable/screen/escape_menu/text/clickable/home_button/opfor(
+		new /atom/movable/screen/escape_menu/text/clickable/opfor(
 			null,
 			/* hud_owner = */ null,
 			/* hud_owner = */ src,
@@ -25,7 +25,7 @@
 	)
 
 	page_holder.give_screen_object(
-		new /atom/movable/screen/escape_menu/text/clickable/home_button/respawn(
+		new /atom/movable/screen/escape_menu/text/clickable/respawn(
 			null,
 			/* hud_owner = */ null,
 			/* hud_owner = */ src,
@@ -57,7 +57,7 @@
 	living_user?.opposing_force()
 	qdel(src)
 
-/atom/movable/screen/escape_menu/text/clickable/home_button/respawn
+/atom/movable/screen/escape_menu/text/clickable/respawn
 
 /datum/escape_menu/proc/respawn()
 	PRIVATE_PROC(TRUE)
@@ -65,7 +65,7 @@
 	var/mob/living/client_mob = client?.mob
 	client_mob?.abandon_mob()
 
-/atom/movable/screen/escape_menu/text/clickable/home_button/respawn/Initialize(
+/atom/movable/screen/escape_menu/text/clickable/respawn/Initialize(
 	mapload,
 	datum/escape_menu/escape_menu,
 	button_text,
@@ -74,15 +74,15 @@
 )
 	. = ..()
 
-/atom/movable/screen/escape_menu/text/clickable/home_button/respawn/enabled()
+/atom/movable/screen/escape_menu/text/clickable/respawn/enabled()
 	if (!..())
 		return FALSE
 
 	return !isliving(escape_menu.client?.mob)
 
-/atom/movable/screen/escape_menu/text/clickable/home_button/opfor
+/atom/movable/screen/escape_menu/text/clickable/opfor
 
-/atom/movable/screen/escape_menu/text/clickable/home_button/opfor/Initialize(
+/atom/movable/screen/escape_menu/text/clickable/opfor/Initialize(
 	mapload,
 	datum/escape_menu/escape_menu,
 	button_text,
@@ -90,8 +90,9 @@
 	on_click_callback,
 )
 	. = ..()
+	src.maptext_width = max(round(length(button_text) * font_size * 0.75), font_size * 5) // slightly more generous maptext width scaling for the allcaps
 
-/atom/movable/screen/escape_menu/text/clickable/clickable/home_button/opfor/enabled()
+/atom/movable/screen/escape_menu/text/clickable/clickable/opfor/enabled()
 	if (!..())
 		return FALSE
 


### PR DESCRIPTION
## About The Pull Request

About what it says on the tin. Fixes some of the overlapping buttons on the escape menu and fixes the text on the OPFOR button.

## How This Contributes To The Nova Sector Roleplay Experience

Buttons should probably look usable.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

<img width="563" height="796" alt="dreamseeker_2026-06-11_10-21-23-AM-Thursday" src="https://github.com/user-attachments/assets/b80aa365-d921-4e46-a521-d3914352bd3f" />

</details>

## Changelog

:cl:
fix: The Nova-specific options on the escape menu should actually be usable/no longer squished (in the case of the OPFOR button).
/:cl: