### PR TITLE
Adds a nanite 8-ball to the NIF toy summoner

### DIFF
--- a/modular_nova/modules/modular_implants/code/nifsofts/prop_summoner.dm
+++ b/modular_nova/modules/modular_implants/code/nifsofts/prop_summoner.dm
@@ -36,6 +36,7 @@
 		/obj/item/cane/white/nanite,
 		/obj/item/lighter/nanite,
 		/obj/item/holocigarette/nanite,
+		/obj/item/toy/eightball/nanite,
 	)
 
 	///The objects currently summoned by the NIFSoft
@@ -207,6 +208,9 @@
 
 /datum/nifsoft/summoner/combat
 	mutually_exclusive_programs = list(/datum/nifsoft/summoner/combat) //One combat grimoire per person
+
+/obj/item/toy/eightball/nanite
+	desc = "A black ball with a number eight etched on the side. It's full of a liquid-like nanite slurry.\nThe instructions state that you should ask your question aloud, and then shake. "
 
 #undef SUMMONED_ITEM_ALPHA
 #undef SUMMONED_ITEM_LIGHT

--- a/modular_nova/modules/modular_implants/code/nifsofts/prop_summoner.dm
+++ b/modular_nova/modules/modular_implants/code/nifsofts/prop_summoner.dm
@@ -210,7 +210,7 @@
 	mutually_exclusive_programs = list(/datum/nifsoft/summoner/combat) //One combat grimoire per person
 
 /obj/item/toy/eightball/nanite
-	desc = "A black ball with a number eight etched on the side. It's full of a liquid-like nanite slurry.\nThe instructions state that you should ask your question aloud, and then shake. "
+	special_desc = "A staple of adolescent sleepovers and drunken revelry for centuries, the humble eightball has seen a resurgence in popularity with it's inclusion in the Grimoire. A simple nanite shell filled with a colloidal suspension of nanites programmed for pure diviniation: a chaos engine rendered into a toy. It's a topic of hot debate on whether or not there's an actual pseudorandom number generator embedded in it, or if it truly does just let it's answer die slosh around inside like the original would."
 
 #undef SUMMONED_ITEM_ALPHA
 #undef SUMMONED_ITEM_LIGHT

--- a/modular_nova/modules/modular_implants/code/nifsofts/prop_summoner.dm
+++ b/modular_nova/modules/modular_implants/code/nifsofts/prop_summoner.dm
@@ -210,7 +210,10 @@
 	mutually_exclusive_programs = list(/datum/nifsoft/summoner/combat) //One combat grimoire per person
 
 /obj/item/toy/eightball/nanite
-	special_desc = "A staple of adolescent sleepovers and drunken revelry for centuries, the humble eightball has seen a resurgence in popularity with it's inclusion in the Grimoire. A simple nanite shell filled with a colloidal suspension of nanites programmed for pure diviniation: a chaos engine rendered into a toy. It's a topic of hot debate on whether or not there's an actual pseudorandom number generator embedded in it, or if it truly does just let it's answer die slosh around inside like the original would."
+	special_desc = "A staple of adolescent sleepovers and drunken revelry for centuries, the humble eightball has seen a resurgence in popularity with its inclusion in the Grimoire. \
+		A simple nanite shell filled with a colloidal suspension of nanites programmed for pure divination: a chaos engine rendered into a toy. \
+		It's a topic of hot debate on whether or not there's an actual pseudorandom number generator embedded in it, or if it truly does just \
+		let its answer slosh around inside like the original would."
 
 #undef SUMMONED_ITEM_ALPHA
 #undef SUMMONED_ITEM_LIGHT


### PR DESCRIPTION

## About The Pull Request

Does what it says on the tin.

## How This Contributes To The Nova Sector Roleplay Experience

Why not? It's just as woo-woo goofy magic as the tarot deck.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
<img width="422" height="387" alt="image" src="https://github.com/user-attachments/assets/a345350c-a557-4261-b2da-f15d89e7fb96" />

<img width="384" height="50" alt="image" src="https://github.com/user-attachments/assets/7684e5d0-704f-46ca-b5db-e02d5c6ad371" />


</details>

## Changelog

:cl:
add: the grimoire caeruleam can now summon a magic(ish) 8 ball
/:cl:

