### PR TITLE
Fixes Some Oversights in VoidRaptors Perma

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -804,6 +804,29 @@
 	dir = 1
 	},
 /area/station/science/genetics)
+"aks" = (
+/obj/item/plant_analyzer,
+/obj/item/plant_analyzer,
+/obj/item/storage/bag/plants,
+/obj/item/secateurs,
+/obj/item/storage/bag/plants,
+/obj/item/secateurs,
+/obj/item/cultivator,
+/obj/item/reagent_containers/cup/bucket,
+/obj/item/wirecutters,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/reagent_containers/cup/bucket{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/cup/bucket{
+	pixel_x = 4
+	},
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark/small,
+/area/station/security/prison/garden)
 "akv" = (
 /obj/structure/bodycontainer/morgue,
 /obj/effect/turf_decal/bot_red,
@@ -3274,6 +3297,10 @@
 /obj/structure/trash_pile,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/aft/greater)
+"aVe" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/wood,
+/area/station/security/prison/garden)
 "aVg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -4604,6 +4631,7 @@
 	dir = 4
 	},
 /obj/machinery/newscaster/directional/west,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood,
 /area/station/security/prison/garden)
 "bpz" = (
@@ -5225,6 +5253,7 @@
 "bzh" = (
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/small,
 /area/station/security/prison/garden)
 "bzn" = (
@@ -6206,11 +6235,12 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "bPI" = (
-/obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/item/kirbyplants/random,
+/obj/machinery/newscaster/directional/north,
+/obj/structure/table,
+/obj/item/toy/figure/prisoner,
 /turf/open/floor/iron/dark,
 /area/station/security/corrections_officer)
 "bPZ" = (
@@ -10453,6 +10483,9 @@
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison)
 "deg" = (
@@ -12164,14 +12197,6 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/command)
-"dDl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 8
-	},
-/area/station/security/prison)
 "dDp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12551,6 +12576,7 @@
 	name = "Jerry's bed"
 	},
 /mob/living/basic/pet/cat/jerry,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/security/prison/garden)
 "dIf" = (
@@ -15044,10 +15070,10 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/lobby)
 "eon" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sink/directional/east,
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/small,
 /area/station/security/prison/garden)
 "eoq" = (
@@ -17098,6 +17124,10 @@
 /turf/open/floor/pod/dark,
 /area/station/service/chapel)
 "eTa" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/wood,
 /area/station/security/prison/garden)
 "eTo" = (
@@ -19468,7 +19498,6 @@
 	},
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/security/prison)
 "fDA" = (
@@ -22226,6 +22255,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/security/prison)
 "gug" = (
@@ -23191,30 +23221,6 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/atmos)
-"gIB" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/cup/bucket{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/cup/bucket{
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/cup/bucket,
-/obj/item/wirecutters,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/obj/item/secateurs,
-/obj/item/secateurs,
-/obj/item/plant_analyzer,
-/obj/item/plant_analyzer,
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark/small,
-/area/station/security/prison/garden)
 "gIJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -23586,6 +23592,14 @@
 	},
 /turf/open/floor/pod/dark,
 /area/station/service/chapel/funeral)
+"gNl" = (
+/obj/machinery/button/flasher{
+	id = "isolation";
+	pixel_y = 24;
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/execution/transfer)
 "gNo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
@@ -25304,11 +25318,11 @@
 /turf/open/floor/noslip,
 /area/station/service/janitor)
 "hlF" = (
-/obj/machinery/requests_console/auto_name/directional/west,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
-/obj/machinery/newscaster/directional/north,
+/obj/item/kirbyplants/random,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/corrections_officer)
 "hlZ" = (
@@ -27534,6 +27548,7 @@
 /area/station/service/theater)
 "hSW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "hSX" = (
@@ -30296,6 +30311,7 @@
 /obj/structure/cable,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/security/prison/garden)
 "iFZ" = (
@@ -40101,6 +40117,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/security/prison)
 "lnl" = (
@@ -43575,6 +43592,9 @@
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison)
 "miR" = (
@@ -43953,10 +43973,12 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/execution/transfer)
 "mnI" = (
-/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
+/obj/machinery/requests_console/auto_name/directional/north,
+/obj/structure/table,
+/obj/item/restraints/handcuffs,
 /turf/open/floor/iron/dark,
 /area/station/security/corrections_officer)
 "mnM" = (
@@ -51935,6 +51957,7 @@
 	},
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/machinery/camera/directional/south,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/corrections_officer)
 "oyg" = (
@@ -55883,6 +55906,9 @@
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison)
 "pzS" = (
@@ -58831,7 +58857,7 @@
 /area/station/ai/satellite/chamber)
 "qmI" = (
 /obj/machinery/flasher/directional/south{
-	id = "Cell 6"
+	id = "isolation"
 	},
 /obj/machinery/light/small/broken/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -64211,6 +64237,17 @@
 "rOQ" = (
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/engine/atmos)
+"rPc" = (
+/obj/machinery/door/airlock/security{
+	glass = 1;
+	name = "Garden"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/prison/garden)
 "rPp" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white/smooth_large,
@@ -68425,15 +68462,11 @@
 /turf/open/floor/carpet/purple,
 /area/station/common/night_club)
 "sVg" = (
-/obj/machinery/door/airlock/security{
-	glass = 1;
-	name = "Garden"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/bush/flowers_pp,
+/obj/structure/window/fulltile,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/grass,
 /area/station/security/prison/garden)
 "sVi" = (
 /obj/structure/cable,
@@ -68800,7 +68833,9 @@
 /turf/open/floor/circuit,
 /area/station/ai/satellite/atmos)
 "sZZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/prison/garden)
 "tac" = (
@@ -71607,6 +71642,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
+/obj/structure/sign/poster/contraband/random/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "tLN" = (
@@ -77752,9 +77788,9 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/commons/vacant_room)
 "vwz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/small,
 /area/station/security/prison/garden)
 "vwJ" = (
@@ -77937,7 +77973,6 @@
 	color = "#596479";
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood,
 /area/station/security/prison/garden)
 "vzV" = (
@@ -80124,8 +80159,6 @@
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "wev" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
@@ -81957,7 +81990,6 @@
 /area/station/service/kitchen/abandoned)
 "wDz" = (
 /obj/effect/spawner/liquids_spawner,
-/obj/structure/sign/poster/contraband/random/directional/east,
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/pool,
 /area/station/security/prison)
@@ -86009,7 +86041,6 @@
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck,
 /obj/machinery/light/warm/directional/south,
-/obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
 /area/station/security/prison/garden)
 "xNg" = (
@@ -86911,10 +86942,6 @@
 "yaj" = (
 /turf/closed/wall,
 /area/station/cargo/miningoffice)
-"yak" = (
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/security/prison/garden)
 "yaE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/fueltank,
@@ -131200,7 +131227,7 @@ pbe
 uNy
 qmI
 cDj
-xRQ
+gNl
 rPq
 rPq
 acV
@@ -133510,7 +133537,7 @@ ttw
 ttw
 arU
 cst
-yak
+dIg
 noj
 xNf
 agC
@@ -134024,9 +134051,9 @@ ttw
 arU
 aaA
 sZZ
-dIg
-wev
 uEu
+wev
+aVe
 agC
 iru
 gPQ
@@ -134280,7 +134307,7 @@ ttw
 ttw
 arU
 iNL
-eTa
+sZZ
 wfJ
 cJv
 htS
@@ -134295,7 +134322,7 @@ ghu
 qpM
 eDY
 wOx
-nZW
+iID
 sPK
 cNE
 spn
@@ -134797,7 +134824,7 @@ xoG
 gPc
 oGP
 eon
-dmJ
+aks
 sVg
 ehD
 nqI
@@ -135054,8 +135081,8 @@ bzh
 cig
 bGJ
 vwz
-gIB
-agC
+dmJ
+rPc
 fDz
 eNb
 qLM
@@ -135311,7 +135338,7 @@ qZA
 qht
 jhn
 qZA
-qht
+sVg
 agC
 pSm
 kWf
@@ -136353,9 +136380,9 @@ vmm
 uUL
 pLj
 lne
-dDl
-dDl
-dDl
+dKU
+dKU
+dKU
 dKU
 oOX
 qyE


### PR DESCRIPTION

## About The Pull Request
I missed a couple of details in https://github.com/NovaSector/NovaSector/pull/7345
## How This Contributes To The Nova Sector Roleplay Experience
The flasher in isolation does something again, the floor paint in perma lines up with doors now. All vents are properly piped as well.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl: Macaroni
fix: fixed niche mapping discrepancies in VoidRaptors Perma
/:cl:
