### PR TITLE
Grand granted stamp fix

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
@@ -1172,7 +1172,7 @@
 	pixel_x = 4;
 	pixel_y = 3
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -7;
 	pixel_y = 6
 	},

--- a/_maps/RandomRuins/SpaceRuins/nova/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/spacehotel.dmm
@@ -580,7 +580,7 @@
 /area/ruin/space/has_grav/hotel/bar)
 "dY" = (
 /obj/structure/table/wood,
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = 7;
 	pixel_y = 9
 	},

--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -5234,7 +5234,7 @@
 	pixel_x = -4;
 	pixel_y = 3
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -3;
 	pixel_y = 9
 	},
@@ -18343,7 +18343,7 @@
 	pixel_x = -6;
 	pixel_y = 4
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -6
 	},
 /obj/structure/disposalpipe/segment,
@@ -24723,7 +24723,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/stamp,
+/obj/item/stamp/granted,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
@@ -54325,7 +54325,7 @@
 /obj/item/stamp/denied{
 	pixel_y = 5
 	},
-/obj/item/stamp,
+/obj/item/stamp/granted,
 /obj/item/reagent_containers/spray/pepper{
 	pixel_x = 14
 	},
@@ -83017,7 +83017,7 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/stamp,
+/obj/item/stamp/granted,
 /obj/effect/turf_decal/siding/brown{
 	dir = 9
 	},
@@ -90993,7 +90993,7 @@
 "srq" = (
 /obj/structure/table/reinforced,
 /obj/item/modular_computer/laptop,
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -7;
 	pixel_y = 14
 	},
@@ -95907,7 +95907,7 @@
 	pixel_x = 5;
 	pixel_y = 2
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -6
 	},
 /obj/structure/disposalpipe/segment{
@@ -97298,7 +97298,7 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/stamp,
+/obj/item/stamp/granted,
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "tCJ" = (
@@ -112776,7 +112776,7 @@
 	},
 /obj/item/folder/blue,
 /obj/item/stamp/denied,
-/obj/item/stamp,
+/obj/item/stamp/granted,
 /turf/open/floor/carpet/blue,
 /area/station/service/lawoffice)
 "wDa" = (

--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -7313,7 +7313,7 @@
 /obj/item/stamp/head/hop{
 	pixel_y = 12
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_y = 6;
 	pixel_x = 6
 	},
@@ -20651,7 +20651,7 @@
 /obj/item/stamp/head/qm{
 	pixel_y = 5
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = 5
 	},
 /obj/item/stamp/denied{
@@ -38091,7 +38091,7 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = 10;
 	pixel_y = 6
 	},
@@ -44762,7 +44762,7 @@
 	pixel_x = -7;
 	pixel_y = 9
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -7;
 	pixel_y = 1
 	},
@@ -67705,7 +67705,7 @@
 	pixel_x = 4;
 	pixel_y = 2
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -3
 	},
 /turf/open/floor/iron/dark,

--- a/_maps/map_files/SerenityStation/SerenityStation.dmm
+++ b/_maps/map_files/SerenityStation/SerenityStation.dmm
@@ -24082,7 +24082,7 @@
 	pixel_x = -6;
 	pixel_y = 4
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -6
 	},
 /obj/item/paper_bin{
@@ -28410,7 +28410,7 @@
 	pixel_x = -13;
 	pixel_y = 10
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -9;
 	pixel_y = 3
 	},
@@ -49072,7 +49072,7 @@
 	pixel_x = -7;
 	pixel_y = 9
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -7;
 	pixel_y = 1
 	},
@@ -63441,7 +63441,7 @@
 	pixel_x = -7;
 	pixel_y = 9
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -7;
 	pixel_y = 1
 	},

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -55874,7 +55874,7 @@
 	pixel_x = -2;
 	pixel_y = -4
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_y = 11;
 	pixel_x = 9
 	},
@@ -78114,6 +78114,13 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/stamp/denied{
+	pixel_y = 12
+	},
+/obj/item/stamp/granted{
+	pixel_y = 5;
+	pixel_x = 9
+	},
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/qm)
 "uUV" = (

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -1454,7 +1454,7 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -6
 	},
 /obj/structure/disposalpipe/segment,
@@ -14888,7 +14888,7 @@
 	pixel_x = -7;
 	pixel_y = 9
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -7;
 	pixel_y = 1
 	},
@@ -30108,7 +30108,7 @@
 	pixel_x = -7;
 	pixel_y = 9
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -7;
 	pixel_y = 1
 	},
@@ -43011,7 +43011,7 @@
 	pixel_x = -7;
 	pixel_y = 9
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -7;
 	pixel_y = 1
 	},
@@ -54485,7 +54485,7 @@
 	pixel_x = -7;
 	pixel_y = 9
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -7;
 	pixel_y = 1
 	},
@@ -62060,7 +62060,7 @@
 	pixel_x = -6;
 	pixel_y = 4
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -6
 	},
 /obj/item/coin/adamantine{

--- a/_maps/map_files/oceanpubby/oceanpubby.dmm
+++ b/_maps/map_files/oceanpubby/oceanpubby.dmm
@@ -34707,6 +34707,14 @@
 /obj/item/paper_bin/carbon,
 /obj/item/coin/silver,
 /obj/item/stamp/head/qm,
+/obj/item/stamp/denied{
+	pixel_y = 6;
+	pixel_x = -6
+	},
+/obj/item/stamp/granted{
+	pixel_y = 6;
+	pixel_x = 9
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "iBk" = (
@@ -47823,6 +47831,14 @@
 "rSR" = (
 /obj/item/universal_scanner,
 /obj/structure/table/reinforced,
+/obj/item/stamp/granted{
+	pixel_y = 5;
+	pixel_x = 9
+	},
+/obj/item/stamp/denied{
+	pixel_y = 6;
+	pixel_x = -5
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "rTb" = (

--- a/_maps/nova/automapper/templates/catwalkstation/catwalkstation_ntrep_office.dmm
+++ b/_maps/nova/automapper/templates/catwalkstation/catwalkstation_ntrep_office.dmm
@@ -158,7 +158,7 @@
 /area/station/hallway/primary/central)
 "Q" = (
 /obj/structure/table/wood,
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -2;
 	pixel_y = 6
 	},

--- a/_maps/nova/automapper/templates/deltastation/deltastation_ntrep_office.dmm
+++ b/_maps/nova/automapper/templates/deltastation/deltastation_ntrep_office.dmm
@@ -4,7 +4,7 @@
 /area/station/command/heads_quarters/nt_rep)
 "b" = (
 /obj/structure/table/wood,
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -6
 	},
 /obj/item/stamp/denied{

--- a/_maps/nova/automapper/templates/icebox/icebox_ntrep_office.dmm
+++ b/_maps/nova/automapper/templates/icebox/icebox_ntrep_office.dmm
@@ -9,7 +9,7 @@
 	pixel_x = -6;
 	pixel_y = 4
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -6
 	},
 /turf/open/floor/carpet/executive,

--- a/_maps/nova/automapper/templates/metastation/metastation_ntrep_office.dmm
+++ b/_maps/nova/automapper/templates/metastation/metastation_ntrep_office.dmm
@@ -207,7 +207,7 @@
 	pixel_x = 8;
 	pixel_y = 6
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -2;
 	pixel_y = 6
 	},

--- a/_maps/nova/automapper/templates/nebulastation/nebulastation_ntrep_office.dmm
+++ b/_maps/nova/automapper/templates/nebulastation/nebulastation_ntrep_office.dmm
@@ -93,7 +93,7 @@
 "n" = (
 /obj/structure/table/wood,
 /obj/structure/cable,
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -2;
 	pixel_y = 6
 	},

--- a/_maps/nova/automapper/templates/tramstation/tramstation_ntrep_office.dmm
+++ b/_maps/nova/automapper/templates/tramstation/tramstation_ntrep_office.dmm
@@ -18,7 +18,7 @@
 	pixel_x = -4;
 	pixel_y = 6
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = 8;
 	pixel_y = 8
 	},

--- a/_maps/nova/automapper/templates/wawastation/wawastation_ntrep_office.dmm
+++ b/_maps/nova/automapper/templates/wawastation/wawastation_ntrep_office.dmm
@@ -145,7 +145,7 @@
 	pixel_x = -4;
 	pixel_y = 6
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = 8;
 	pixel_y = 8
 	},


### PR DESCRIPTION

## About The Pull Request
Apparently since february every nova map and template lost their granted stamp, because no one ran UpdatePath on it. We were left with abstract `/obj/item/stamp` instead.

Also i added some redundant stamps for SnowGlobe and Pubby
## How This Contributes To The Nova Sector Roleplay Experience
Now we finally can approve cargo manifests
## Proof of Testing
I dont want to test every single map, sorry 😿
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: granted stamps are back on nova maps
/:cl:
