### PR TITLE
Disabled: Your ComputerID has already logged in. Jumpscare

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -453,6 +453,7 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 	// Edited - Only log this for admins, no need to spam their chat.
 	if(alert_mob_dupe_login && !holder)
 		if (alert_admin_multikey)
+			message_admins(span_danger("<B>MULTIKEYING: </B></span><span class='notice'>[key_name_admin(src)] has a matching CID+IP with another player."))
 			log_admin_private("MULTIKEYING: [key_name(src)] has a matching CID+IP with another player.")
 	// NOVA SECTOR - END
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -450,7 +450,7 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 			alert(mob, dupe_login_message) //players get banned if they don't see this message, do not convert to tgui_alert (or even tg_alert) please.
 			to_chat_immediate(mob, span_danger(dupe_login_message))
 	*/
-	// Edited - Only log this for admins, no need to spam their chat.
+	// Edited - Only log this for admins.
 	if(alert_mob_dupe_login && !holder)
 		if (alert_admin_multikey)
 			message_admins(span_danger("<B>MULTIKEYING: </B></span><span class='notice'>[key_name_admin(src)] has a matching CID+IP with another player."))

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -438,6 +438,8 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 
 	tgui_say.initialize()
 
+	// NOVA SECTOR - This is a false positive for multikeying that almost always triggers on innocent players, and can scare players who do not know to ignore this message.
+	/* Original
 	if(alert_mob_dupe_login && !holder)
 		var/dupe_login_message = "Your ComputerID has already logged in with another key this round, please log out of this one NOW or risk being banned!"
 		if (alert_admin_multikey)
@@ -447,6 +449,12 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 		spawn(0.5 SECONDS) //needs to run during world init, do not convert to add timer
 			alert(mob, dupe_login_message) //players get banned if they don't see this message, do not convert to tgui_alert (or even tg_alert) please.
 			to_chat_immediate(mob, span_danger(dupe_login_message))
+	*/
+	// Edited - Only log this for admins, no need to spam their chat.
+	if(alert_mob_dupe_login && !holder)
+		if (alert_admin_multikey)
+			log_admin_private("MULTIKEYING: [key_name(src)] has a matching CID+IP with another player.")
+	// NOVA SECTOR - END
 
 
 	connection_time = world.time


### PR DESCRIPTION

## About The Pull Request

This Pull Request disables from the **Players** the pop-up message which appears quite often.
`Your ComputerID has already logged in with another key this round, please log out of this one NOW or risk being banned!`

While changing the Admin Log/Message text to make it less of a major issue.
```json
			message_admins(span_danger("<B>MULTIKEYING: </B></span><span class='notice'>[key_name_admin(src)] has a matching CID+IP with another player."))
			log_admin_private("MULTIKEYING: [key_name(src)] has a matching CID+IP with another player.")
```

### This is a false-positive most of the time
And **Can** scare players.

## How This Contributes To The Nova Sector Roleplay Experience

No more **Five Nights at Byond Jumpscare**
(Picture is unrelated)

<img width="994" height="552" alt="image" src="https://github.com/user-attachments/assets/0fad4a3c-0a24-491d-aa98-b3355866fcd6" />



## Proof of Testing
I've tried to test this locally but I couldn't manage to get the Admin logs to show up when I launch two clients with the same CID, might need to **Test Merge** it.


## Changelog
:cl: Richard Blonski
del: Disabled the "Your ComputerID has already logged" pop-up message, it's a false positive most of the time.
admin: Multikeying message has been changed to be more of a warning due to how often it is a false positive.
/:cl:
