### PR TITLE
Spaceship plates make proper plated walls now

### DIFF
--- a/code/_globalvars/lists/girder_wall_recipes.dm
+++ b/code/_globalvars/lists/girder_wall_recipes.dm
@@ -27,6 +27,7 @@ GLOBAL_LIST_INIT(material_girder_wall_recipes, init_material_girder_wall_recipes
 			/turf/closed/wall/mineral/cult,
 			/turf/closed/wall/mineral/bronze,
 			/turf/closed/wall/material,
+			/turf/closed/wall/mineral/titanium/spaceship, // NOVA EDIT ADDITION
 		),
 		falsewall_types = list(
 			/obj/structure/falsewall,


### PR DESCRIPTION
## About The Pull Request

Adds spaceship walls to the girder wall recipes so that spaceship plates properly make spaceship walls on girders.

## How This Contributes To The Nova Sector Roleplay Experience

Puts the spaceship walls back into circulation/usability.

## Proof of Testing

https://github.com/user-attachments/assets/70742382-aaac-475a-b00a-d697dd5b1cea

## Changelog

:cl:
fix: Spaceship plating now makes spaceship walls and not titanium material walls.
/:cl:
