### PR TITLE
Removed the Appendix from Slime people.

### DIFF
--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -14,6 +14,7 @@
 	mutantstomach = /obj/item/organ/stomach/slime
 	mutantbrain = /obj/item/organ/brain/slime
 	mutantears = /obj/item/organ/ears/jelly
+	mutantappendix = null // Slimes have no Appendix
 	inherent_traits = list(
 		TRAIT_MUTANT_COLORS,
 		TRAIT_TOXINLOVER,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR Fixes #7488

This Pull request removes the **Appendix** from being created/spawned inside Slime people.
Having an appendix can cause #7488 as when a player has an appendix it has a chance to get inflamed, and slimes well... have no humanoid digestive organs.

## How This Contributes To The Nova Sector Roleplay Experience

Slimes do not have traditional human-like digestive systems, slimes instead consume food and break it down using their gelatinous body, by such they should not have an appendix.

## Proof of Testing

<img width="1193" height="845" alt="image" src="https://github.com/user-attachments/assets/d196c4ec-31b4-4148-9518-ed0c26b84b9b" />


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Richard Blonski
del:  Slime People/Xenobiological Hybrids, will now spawn without an Appendix.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
