### PR TITLE
Slime People Revive Fixes

### DIFF
--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -381,10 +381,6 @@
 	to_chat(owner, span_purple("Your torso fully forms out of your core, yet to form the rest."))
 	return TRUE
 
-	// CORE DESTROY SECTION
-	// Ensure to
-
-
 // HEALING SECTION
 // Handles passive healing and water damage for slimes and water-breathing variants.
 /datum/species/jelly/proc/on_life(mob/living/carbon/human/slime, seconds_per_tick)

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -185,8 +185,14 @@
 	throw_range = 9 //Oh! That's a baseball!
 	throw_speed = 0.5
 	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | LAVA_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
+	/**
+	* Death/Revival Cache
+	* This is used to cache a new body in nullspace for storing the slime's quirks and preferences, so that when they are revived, they can be restored without issues.
+	*/
 	/// Quirks Cache upon death.
 	var/list/cached_quirks
+	/// The new body to regenerate into
+	var/mob/living/carbon/human/new_body
 
 /obj/item/organ/brain/slime/Initialize(mapload, mob/living/carbon/organ_owner, list/examine_list)
 	. = ..()
@@ -265,11 +271,11 @@
 	core_ejected = TRUE
 	victim.visible_message(span_warning("[victim]'s body completely dissolves, collapsing outwards!"), span_notice("Your body completely dissolves, collapsing outwards!"), span_notice("You hear liquid splattering."))
 	var/atom/death_loc = victim.drop_location()
-	victim.unequip_everything()
 
-	// Cache quirks
-	if(victim.quirks && victim.quirks.len)
-		src.cached_quirks = victim.quirks.Copy()
+	// Create a new body in nullspace, and transfer their prefrences and quirks into it.
+	new_body = new(null)
+	victim.client?.prefs.safe_transfer_prefs_to(new_body)
+	victim.transfer_quirk_datums(new_body)
 
 	// Drop the Brain/Core, and implants to the floor.
 	for(var/obj/item/organ/organs in victim)
@@ -344,13 +350,8 @@
 		gps_active = FALSE
 		qdel(GetComponent(/datum/component/gps))
 
-	// Make a new body for them to put the brain in, and move the brain into it, effectively reviving them.
-	// This uses a basic human as a base
-	var/mob/living/carbon/human/new_body = new /mob/living/carbon/human(src.loc)
-
-	// Transfer player prefrences to the new body
-	if(brainmob.client)
-		brainmob.client.prefs.safe_transfer_prefs_to(new_body)
+	// Retreive the new body we created from nullspace.
+	new_body.forceMove(src.drop_location())
 
 	// Ensure they appear fully nude when revived, since slimes don't regrow clothes.
 	new_body.underwear = "Nude"
@@ -360,12 +361,6 @@
 
 	// Handle Blood
 	new_body.set_blood_volume(BLOOD_VOLUME_SAFE + 60)
-
-	// Handle Quirks
-	if(src.cached_quirks)
-		brainmob.quirks = src.cached_quirks
-		brainmob.transfer_quirk_datums(new_body)
-		src.cached_quirks = null
 
 	// Remove non-chest limbs.
 	for(var/obj/item/bodypart/part in new_body.bodyparts)
@@ -379,6 +374,7 @@
 	// Notify the player that their body has been rebuilt
 	new_body.visible_message(span_warning("[new_body]'s torso \"forms\" from [new_body.p_their()] core, yet to form the rest."))
 	to_chat(owner, span_purple("Your torso fully forms out of your core, yet to form the rest."))
+	new_body = null // Clear the new_body variable to avoid dangling references
 	return TRUE
 
 // HEALING SECTION

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -301,24 +301,24 @@
 	brainmob?.notify_revival("You are being revived!", sound = null, source = src) // no sound since it's a whopping 60 second wait time after this
 	if(!do_after(user, 60 SECONDS, src))
 		to_chat(user, span_warning("You failed to pour the contents of [item] onto [src]!"))
-		return TRUE
+		return FALSE
 
 	user.visible_message(
 		span_notice("[user] pours the contents of [item] onto [src], causing it to form a proper cytoplasm and outer membrane."),
 		span_notice("You pour the contents of [item] onto [src], causing it to form a proper cytoplasm and outer membrane.")
 	)
-	item.reagents.clear_reagents() //removes the whole shit
 	if(isnull(brainmob))
 		user.balloon_alert(user, "brain is not a viable candidate for repair!")
-		return TRUE
-
+		return FALSE
 	brainmob.grab_ghost()
 	if(isnull(brainmob.stored_dna))
 		user.balloon_alert(user, "brain does not contain any dna!")
-		return TRUE
+		return FALSE
 	if(isnull(brainmob.client))
 		user.balloon_alert(user, "brain does not contain a mind!")
-		return TRUE
+		return FALSE
+
+	item.reagents.clear_reagents() // Consume the Plasma.
 	regenerate()
 	return TRUE
 
@@ -343,10 +343,15 @@
 	new_body.undershirt = "Nude"
 	new_body.socks = "Nude"
 
-	// Handle Blood and Quriks
+	// Handle Blood and Quriks.
 	new_body.set_blood_volume(BLOOD_VOLUME_SAFE + 60)
 	SSquirks.AssignQuirks(new_body, brainmob.client)
-	// TODO: Handle removing quirk items spawning
+
+ 	// Remove any quirk items that spawn.
+	for(var/obj/item/contents in new_body.get_contents())
+		if(contents == src || istype(contents, /obj/item/organ) || istype(contents, /obj/item/bodypart)) // Only remove quirk items
+			continue
+		qdel(contents)
 
 	// Move the brain/core into the new body
 	src.replace_into(new_body)
@@ -358,8 +363,6 @@
 			to_remove += bodypart
 
 	for(var/obj/item/bodypart/rem in to_remove)
-		rem.moveToNullspace()
-		STOP_PROCESSING(SSobj, rem)
 		qdel(rem)
 
 	// Notify the player that their body has been rebuilt

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -347,7 +347,7 @@
 	new_body.set_blood_volume(BLOOD_VOLUME_SAFE + 60)
 	SSquirks.AssignQuirks(new_body, brainmob.client)
 
- 	// Remove any quirk items that spawn.
+	// Remove any quirk items that spawn.
 	for(var/obj/item/contents in new_body.get_contents())
 		if(contents == src || istype(contents, /obj/item/organ) || istype(contents, /obj/item/bodypart)) // Only remove quirk items
 			continue

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -264,10 +264,18 @@
 	victim.visible_message(span_warning("[victim]'s body completely dissolves, collapsing outwards!"), span_notice("Your body completely dissolves, collapsing outwards!"), span_notice("You hear liquid splattering."))
 	var/atom/death_loc = victim.drop_location()
 	victim.unequip_everything()
-	if(victim.get_organ_slot(ORGAN_SLOT_BRAIN) == src)
-		Remove(victim)
+	// Drop the Brain/Core, and implants to the floor.
+	for(var/obj/item/organ/organs in victim)
+		if(istype(organs, /obj/item/organ/brain) || istype(organs, /obj/item/implant))
+			Remove(organs)
 	if(death_loc)
 		forceMove(death_loc)
+		// Cleans up spilled organs - When a mob is attacked, it has a chance to spill all its organs on the ground upon death, for slime people we do not need their organs as they regain them when they get revived.
+		for(var/obj/item/organ/spilled_organ in death_loc)
+			if(istype(spilled_organ, /obj/item/organ/brain) || istype(spilled_organ, /obj/item/implant))
+				continue
+			else
+				qdel(spilled_organ)
 	src.wash(CLEAN_WASH)
 	new death_melt_type(death_loc, victim.dir)
 
@@ -277,7 +285,7 @@
 	if(gps_active) // adding the gps signal if they have activated the ability
 		AddComponent(/datum/component/gps, "[victim]'s Core")
 
-	qdel(victim)
+	qdel(victim) // Remove the body.
 	UnregisterSignal(victim, COMSIG_LIVING_DEATH)
 
 /**
@@ -347,23 +355,14 @@
 	new_body.set_blood_volume(BLOOD_VOLUME_SAFE + 60)
 	SSquirks.AssignQuirks(new_body, brainmob.client)
 
-	// Remove any quirk items that spawn.
+	// Remove non-chest limbs, and quirk spawned items
 	for(var/obj/item/contents in new_body.get_contents())
-		if(contents == src || istype(contents, /obj/item/organ) || istype(contents, /obj/item/bodypart)) // Only remove quirk items
+		if(contents == src || istype(contents, /obj/item/organ) || istype(contents, /obj/item/bodypart/chest))
 			continue
 		qdel(contents)
 
 	// Move the brain/core into the new body
 	src.replace_into(new_body)
-
-	// Remove non-chest body parts
-	var/list/to_remove = list()
-	for(var/obj/item/bodypart/bodypart in new_body.bodyparts)
-		if(!istype(bodypart, /obj/item/bodypart/chest))
-			to_remove += bodypart
-
-	for(var/obj/item/bodypart/rem in to_remove)
-		qdel(rem)
 
 	// Notify the player that their body has been rebuilt
 	new_body.visible_message(span_warning("[new_body]'s torso \"forms\" from [new_body.p_their()] core, yet to form the rest."))

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -329,28 +329,40 @@
 		gps_active = FALSE
 		qdel(GetComponent(/datum/component/gps))
 
+	// Make a new body for them to put the brain in, and move the brain into it, effectively reviving them.
+	// This uses a basic human as a base
 	var/mob/living/carbon/human/new_body = new /mob/living/carbon/human(src.loc)
 
-	brainmob.client?.prefs?.safe_transfer_prefs_to(new_body)
+	// Transfer player prefrences to the new body
+	if(brainmob.client)
+		brainmob.client.prefs.apply_prefs_to(new_body)
+
+	// Ensure they appear fully nude when revived, since slimes don't regrow clothes.
 	new_body.underwear = "Nude"
 	new_body.bra = "Nude"
-	new_body.undershirt = "Nude" //Which undershirt the player wants
-	new_body.socks = "Nude" //Which socks the player wants
-	brainmob.stored_dna.copy_dna(new_body.dna, transfer_flags = COPY_DNA_SE|COPY_DNA_SPECIES)
-	new_body.dna.features[FEATURE_MUTANT_COLOR] = new_body.dna.features[FEATURE_MUTANT_COLOR]
-	new_body.dna.update_uf_block(FEATURE_MUTANT_COLOR)
-	new_body.real_name = new_body.dna.real_name
-	new_body.name = new_body.dna.real_name
-	new_body.updateappearance(mutcolor_update=1)
-	new_body.domutcheck()
-	new_body.forceMove(get_turf(src))
+	new_body.undershirt = "Nude"
+	new_body.socks = "Nude"
+
+	// Handle Blood and Quriks
 	new_body.set_blood_volume(BLOOD_VOLUME_SAFE + 60)
 	SSquirks.AssignQuirks(new_body, brainmob.client)
+	// TODO: Handle removing quirk items spawning
+
+	// Move the brain/core into the new body
 	src.replace_into(new_body)
-	for(var/obj/item/bodypart/bodypart as anything in new_body.bodyparts)
+
+	// Remove non-chest body parts
+	var/list/to_remove = list()
+	for(var/obj/item/bodypart/bodypart in new_body.bodyparts)
 		if(!istype(bodypart, /obj/item/bodypart/chest))
-			bodypart.drop_limb()
-			continue
+			to_remove += bodypart
+
+	for(var/obj/item/bodypart/rem in to_remove)
+		rem.moveToNullspace()
+		STOP_PROCESSING(SSobj, rem)
+		qdel(rem)
+
+	// Notify the player that their body has been rebuilt
 	new_body.visible_message(span_warning("[new_body]'s torso \"forms\" from [new_body.p_their()] core, yet to form the rest."))
 	to_chat(owner, span_purple("Your torso fully forms out of your core, yet to form the rest."))
 	return TRUE

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -267,7 +267,7 @@
 	// Drop the Brain/Core, and implants to the floor.
 	for(var/obj/item/organ/organs in victim)
 		if(istype(organs, /obj/item/organ/brain) || istype(organs, /obj/item/implant))
-			Remove(organs)
+			Remove(organs, special = TRUE)
 	if(death_loc)
 		forceMove(death_loc)
 		// Cleans up spilled organs - When a mob is attacked, it has a chance to spill all its organs on the ground upon death, for slime people we do not need their organs as they regain them when they get revived.
@@ -343,7 +343,7 @@
 
 	// Transfer player prefrences to the new body
 	if(brainmob.client)
-		brainmob.client.prefs.apply_prefs_to(new_body)
+		brainmob.client.prefs.safe_transfer_prefs_to(new_body)
 
 	// Ensure they appear fully nude when revived, since slimes don't regrow clothes.
 	new_body.underwear = "Nude"
@@ -355,11 +355,15 @@
 	new_body.set_blood_volume(BLOOD_VOLUME_SAFE + 60)
 	SSquirks.AssignQuirks(new_body, brainmob.client)
 
-	// Remove non-chest limbs, and quirk spawned items
-	for(var/obj/item/contents in new_body.get_contents())
-		if(contents == src || istype(contents, /obj/item/organ) || istype(contents, /obj/item/bodypart/chest))
+	// Remove Quirk items.
+	for(var/obj/item/items in new_body.get_equipped_items(INCLUDE_POCKETS | INCLUDE_ACCESSORIES))
+		qdel(items)
+
+	// Remove non-chest limbs.
+	for(var/obj/item/bodypart/part in new_body.bodyparts)
+		if(part.body_zone == BODY_ZONE_CHEST)
 			continue
-		qdel(contents)
+		part.drop_limb(TRUE)
 
 	// Move the brain/core into the new body
 	src.replace_into(new_body)

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -185,13 +185,7 @@
 	throw_range = 9 //Oh! That's a baseball!
 	throw_speed = 0.5
 	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | LAVA_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
-	/**
-	* Death/Revival Cache
-	* This is used to cache a new body in nullspace for storing the slime's quirks and preferences, so that when they are revived, they can be restored without issues.
-	*/
-	/// Quirks Cache upon death.
-	var/list/cached_quirks
-	/// The new body to regenerate into
+	/// This tracks a new body that is created when a slime core is killed, and is used to safely trasnfer quirks and prefrences to this body and than summon it upon revival.
 	var/mob/living/carbon/human/new_body
 
 /obj/item/organ/brain/slime/Initialize(mapload, mob/living/carbon/organ_owner, list/examine_list)

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -185,6 +185,8 @@
 	throw_range = 9 //Oh! That's a baseball!
 	throw_speed = 0.5
 	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | LAVA_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
+	/// Quirks Cache upon death.
+	var/list/cached_quirks
 
 /obj/item/organ/brain/slime/Initialize(mapload, mob/living/carbon/organ_owner, list/examine_list)
 	. = ..()
@@ -264,6 +266,11 @@
 	victim.visible_message(span_warning("[victim]'s body completely dissolves, collapsing outwards!"), span_notice("Your body completely dissolves, collapsing outwards!"), span_notice("You hear liquid splattering."))
 	var/atom/death_loc = victim.drop_location()
 	victim.unequip_everything()
+
+	// Cache quirks
+	if(victim.quirks && victim.quirks.len)
+		src.cached_quirks = victim.quirks.Copy()
+
 	// Drop the Brain/Core, and implants to the floor.
 	for(var/obj/item/organ/organs in victim)
 		if(istype(organs, /obj/item/organ/brain) || istype(organs, /obj/item/implant))
@@ -351,13 +358,14 @@
 	new_body.undershirt = "Nude"
 	new_body.socks = "Nude"
 
-	// Handle Blood and Quriks.
+	// Handle Blood
 	new_body.set_blood_volume(BLOOD_VOLUME_SAFE + 60)
-	SSquirks.AssignQuirks(new_body, brainmob.client)
 
-	// Remove Quirk items.
-	for(var/obj/item/items in new_body.get_equipped_items(INCLUDE_POCKETS | INCLUDE_ACCESSORIES))
-		qdel(items)
+	// Handle Quirks
+	if(src.cached_quirks)
+		brainmob.quirks = src.cached_quirks
+		brainmob.transfer_quirk_datums(new_body)
+		src.cached_quirks = null
 
 	// Remove non-chest limbs.
 	for(var/obj/item/bodypart/part in new_body.bodyparts)
@@ -372,6 +380,10 @@
 	new_body.visible_message(span_warning("[new_body]'s torso \"forms\" from [new_body.p_their()] core, yet to form the rest."))
 	to_chat(owner, span_purple("Your torso fully forms out of your core, yet to form the rest."))
 	return TRUE
+
+	// CORE DESTROY SECTION
+	// Ensure to
+
 
 // HEALING SECTION
 // Handles passive healing and water damage for slimes and water-breathing variants.

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -193,6 +193,12 @@
 	AddComponent(/datum/component/bubble_icon_override, "slime", BUBBLE_ICON_PRIORITY_ORGAN)
 	colorize()
 
+// Handle the slime core being destroyed, and if it has a new body, delete it as well.
+/obj/item/organ/brain/slime/Destroy(force)
+	if(new_body)
+		QDEL_NULL(new_body)
+	return ..()
+
 /obj/item/organ/brain/slime/examine()
 	. = ..()
 	if(gps_active)


### PR DESCRIPTION

## About The Pull Request

This pull request addresses some bugs related to Slime People/Hybrids upon revival or death.
- [x] Fix #7413 , Slime people turning into Human when revived and dropping human limbs.
- [x] Fix Slime people/hybrids getting quirk items when revived (such as gloves, blindfolds, canes, etc..)
- [x] Fix Plasma being consumed if the revival fails for whatever reason.
- [x] Ensure if Slime people have implants they get dropped as well.
- [x] Fix Slime people sometimes spawning slime organs when dying. (Slime Organs are not needed when they die, because when they get revived they get those organs back).

This PR compliments #7508

### As this PR effects slime people, and does some workarounds such as the organ spilling part, test-merging would be wise to ensure no new issues come with it.


## How This Contributes To The Nova Sector Roleplay Experience

Most of those are bugs,
As for the organ spilling part, slime players when dead have no use to their organs as with the current implantation of slime players, upon revival they will get a new body with new organs.

## Proof of Testing
For the Video, we are using two clients, one is the slime the other is the attacker.
- The slime has the blind perk which spawns a blindfold.
- For Testing purposes we did `new_body.set_blood_volume(BLOOD_VOLUME_SAFE + 600)`
- and `if(!do_after(user, 1 SECONDS, src))` for the revival time with plasma.
- in the last revival we DNR as our slime character and try to revive them to showcase the plasma was not consumed.


https://github.com/user-attachments/assets/22bccabd-569a-434c-aa6c-0ff2320198e1



## Changelog
:cl: Richard Blonski
add: Player Slimes now will drop their implants upon death.
fix: Player Slimes now get revived with their character preferences/as actual slimes.
fix: Player Slimes dropping human limbs upon revival.
fix: Player Slimes revival consuming plasma when it fails. 
fix: Player Slimes dropping organs upon death.
/:cl:
