### PR TITLE
Tones down whiteship_blueshift

### DIFF
--- a/_maps/shuttles/nova/whiteship_blueshift.dmm
+++ b/_maps/shuttles/nova/whiteship_blueshift.dmm
@@ -468,7 +468,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/alien/weeds,
-/mob/living/basic/alien/drone,
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/crew)
@@ -584,7 +583,6 @@
 "fH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/alien/weeds,
-/obj/structure/alien/egg,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "fM" = (
@@ -1058,18 +1056,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/crew)
-"kL" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/wooden{
-	desc = "Labeled as heavy ordnance crate, containing mech mounted weapons.";
-	name = "HO crate"
-	},
-/obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/cargo)
 "kP" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -1353,12 +1339,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/wooden{
-	desc = "Labeled as heavy ordnance crate, containing mech mounted weapons.";
-	name = "HO crate"
-	},
-/obj/item/mecha_ammo/lmg,
-/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/cargo)
 "mO" = (
@@ -1385,10 +1365,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/all_access,
-/obj/structure/closet/crate/secure/weapon,
-/obj/item/ammo_box/magazine/m12g/slug,
-/obj/item/ammo_box/magazine/m12g,
-/obj/item/gun/ballistic/shotgun/automatic/combat,
 /obj/structure/alien/weeds,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/cargo)
@@ -1689,15 +1665,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot_white,
 /obj/structure/guncase,
-/obj/item/ammo_box/speedloader/c357,
-/obj/item/ammo_box/speedloader/c357,
-/obj/item/gun/ballistic/revolver,
-/obj/item/ammo_box/magazine/wt550m9,
-/obj/item/ammo_box/magazine/wt550m9,
-/obj/item/ammo_box/magazine/wt550m9,
-/obj/item/ammo_box/magazine/wt550m9,
-/obj/item/gun/ballistic/automatic/wt550,
-/obj/item/gun/ballistic/automatic/wt550,
+/obj/item/gun/ballistic/automatic/pistol/m1911,
+/obj/item/gun/ballistic/automatic/pistol/m1911,
+/obj/item/ammo_box/magazine/m45,
+/obj/item/ammo_box/magazine/m45,
+/obj/item/ammo_box/magazine/m45,
+/obj/item/ammo_box/magazine/m45,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned)
 "pA" = (
@@ -1863,7 +1836,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/alien/weeds,
-/obj/structure/alien/egg,
 /obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned/crew)
@@ -1891,14 +1863,8 @@
 	},
 /obj/structure/closet/crate/secure/weapon,
 /obj/item/clothing/suit/armor/heavy,
-/obj/item/clothing/suit/armor/heavy,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/head/helmet/alt,
 /obj/item/clothing/head/helmet/alt,
 /obj/item/clothing/gloves/combat,
-/obj/item/clothing/gloves/combat,
-/obj/item/clothing/shoes/jackboots/fast,
 /obj/item/clothing/shoes/jackboots/fast,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/cargo)
@@ -2156,7 +2122,6 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/alien/weeds,
-/obj/structure/alien/egg/grown,
 /turf/open/floor/iron/white/side,
 /area/shuttle/abandoned/medbay)
 "tt" = (
@@ -2217,12 +2182,6 @@
 	dir = 8
 	},
 /area/shuttle/abandoned/crew)
-"ug" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/alien/weeds,
-/obj/structure/alien/egg,
-/turf/open/floor/iron/dark,
-/area/shuttle/abandoned/bar)
 "uk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot_white,
@@ -2271,7 +2230,6 @@
 "uV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/alien/weeds,
-/obj/structure/alien/egg,
 /obj/machinery/duct,
 /turf/open/floor/iron/dark/side{
 	dir = 1
@@ -2370,12 +2328,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/crew)
-"vQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/alien/weeds,
-/obj/structure/alien/egg,
-/turf/open/floor/iron/cafeteria,
-/area/shuttle/abandoned/crew)
 "vS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2413,7 +2365,6 @@
 	dir = 9
 	},
 /obj/structure/alien/weeds,
-/obj/structure/alien/egg,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/engine)
@@ -2695,7 +2646,6 @@
 	dir = 8
 	},
 /obj/structure/alien/weeds,
-/obj/structure/alien/egg,
 /obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
@@ -3058,9 +3008,9 @@
 /obj/effect/decal/cleanable/blood,
 /obj/structure/closet/crate/secure/weapon,
 /obj/item/gun/ballistic/rocketlauncher,
-/obj/item/ammo_casing/rocket,
-/obj/item/ammo_casing/rocket,
-/obj/item/ammo_casing/rocket,
+/obj/item/ammo_casing/rocket/weak,
+/obj/item/ammo_casing/rocket/weak,
+/obj/item/ammo_casing/rocket/weak,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/cargo)
 "CY" = (
@@ -3882,8 +3832,8 @@
 	desc = "A hefty wooden crate containing super heavy mech ordnance. You'll need a crowbar to get it open.";
 	name = "large HO crate"
 	},
-/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack,
 /obj/structure/alien/weeds,
+/obj/item/clothing/mask/facehugger,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/cargo)
 "Lw" = (
@@ -4472,11 +4422,9 @@
 "Rp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/secure/weapon,
-/obj/item/ammo_box/n762,
-/obj/item/gun/ballistic/rifle/boltaction,
-/obj/item/gun/ballistic/rifle/boltaction,
-/obj/item/gun/ballistic/rifle/boltaction,
 /obj/structure/alien/weeds,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/breaching,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/cargo)
 "Rv" = (
@@ -4627,7 +4575,6 @@
 	dir = 4
 	},
 /obj/structure/alien/weeds/node,
-/mob/living/basic/alien/drone,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden,
 /turf/open/floor/iron/dark,
@@ -4726,7 +4673,6 @@
 	dir = 8
 	},
 /obj/structure/alien/weeds,
-/obj/structure/alien/egg,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/crew)
@@ -4846,18 +4792,8 @@
 	dir = 1
 	},
 /obj/structure/alien/weeds,
-/obj/structure/alien/egg,
 /turf/open/floor/iron/white/side,
 /area/shuttle/abandoned/medbay)
-"UQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/structure/alien/weeds,
-/obj/structure/alien/egg,
-/turf/open/floor/iron,
-/area/shuttle/abandoned/bridge)
 "UT" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/bodybags{
@@ -5130,7 +5066,6 @@
 	dir = 4
 	},
 /obj/structure/alien/weeds,
-/mob/living/basic/alien/drone,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/engine)
 "WP" = (
@@ -5241,7 +5176,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/structure/alien/weeds,
-/obj/structure/alien/egg,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/medbay)
 "XC" = (
@@ -5957,7 +5891,7 @@ mP
 DS
 Gr
 Ho
-kL
+ZS
 IH
 KD
 GL
@@ -6143,7 +6077,7 @@ LQ
 Mx
 ty
 eK
-vQ
+XL
 xi
 Ud
 Tp
@@ -6336,7 +6270,7 @@ ph
 wD
 ha
 nY
-UQ
+Pm
 Pm
 Vj
 YO
@@ -6601,7 +6535,7 @@ GH
 GH
 cT
 EY
-ug
+gf
 fn
 Kd
 gf

--- a/_maps/shuttles/nova/whiteship_blueshift.dmm
+++ b/_maps/shuttles/nova/whiteship_blueshift.dmm
@@ -362,7 +362,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/blood,
 /obj/effect/mob_spawn/corpse/human/commander,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned)
@@ -473,10 +472,10 @@
 /area/shuttle/abandoned/crew)
 "fa" = (
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/rnd/production/protolathe/offstation,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/alien/weeds,
+/obj/machinery/autolathe,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/engine)
 "fj" = (
@@ -1028,7 +1027,6 @@
 /turf/open/floor/iron,
 /area/shuttle/abandoned/crew)
 "kE" = (
-/obj/machinery/rnd/production/circuit_imprinter/offstation,
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2161,7 +2159,6 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/crew)
 "ua" = (
-/obj/machinery/autolathe,
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/alien/weeds,
@@ -2750,13 +2747,6 @@
 /area/shuttle/abandoned)
 "Af" = (
 /obj/structure/table,
-/obj/item/construction/rcd{
-	pixel_y = 5
-	},
-/obj/item/rcd_upgrade/frames,
-/obj/item/rcd_upgrade/furnishing,
-/obj/item/rcd_upgrade/silo_link,
-/obj/item/rcd_upgrade/simple_circuits,
 /obj/item/mmi,
 /turf/open/floor/circuit,
 /area/shuttle/abandoned/engine)
@@ -3338,7 +3328,6 @@
 "GL" = (
 /obj/effect/turf_decal/box/white/corners,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/secure/tradership_cargo_valuable,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/cargo)
 "GM" = (
@@ -3638,7 +3627,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/secure/tradership_cargo_valuable,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/cargo)
 "Jq" = (
@@ -4273,9 +4261,6 @@
 "PG" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/box,
-/obj/machinery/computer/monitor{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 10
@@ -5144,7 +5129,6 @@
 /area/shuttle/abandoned/engine)
 "Xn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/secure/tradership_cargo_valuable,
 /obj/structure/alien/weeds,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -5288,7 +5272,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/obj/effect/mob_spawn/corpse/human/bridgeofficer,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/bridge)
 "YG" = (


### PR DESCRIPTION

## About The Pull Request

My only regret is that i never got to abuse this, because holy shit.

tbh idek if this spawns, supposedly it does.

Tones down a lot of the loot in this thing, but i still wish for this place to be a jackpot if you happen to roll it.

## How This Contributes To The Nova Sector Roleplay Experience

HE rocket shells.,,.
Pulse rifle mech weapon and SRM-8 missile rack(worse than the pulse rilfe) 
two sets of heavy armor and fastboots.,
357 in armory
the drum mags from the bulldog
removes some crates that can spawn some super overpowered stuff
and also removes the full rnd set up and an rcd and its upgrade stuff along with a centcom commander and centcom brig officer corpse

so on and so forth, begone- most of you.
so many facehuggers.,

The ship is still like the golden grail of space exploring but now just, less so.
As of right now the spawn chance of this thing is 1/13 chance (i think i dont know how whiteship spawn code works but the odds are probably lower because the white ship is not guaranteed to spawn at all)

## Proof of Testing

Tested in LH it works now.
<details>
<summary>Screenshots/Videos</summary>
  Tested in game and it works.
  
<img width="794" height="567" alt="image" src="https://github.com/user-attachments/assets/ae8acca8-899b-416e-adbf-d492590070bb" />

(note screenshot is taken post running around to make sure i didnt miss anything)
</details>

## Changelog
:cl:
balance: Toned down blueshift whiteship
/:cl:
