### PR TITLE
Fixes some (or even all) cases of direct references to procs inside CALLBACK macros for our modular folder

### DIFF
--- a/modular_nova/master_files/code/datums/traits/neutral.dm
+++ b/modular_nova/master_files/code/datums/traits/neutral.dm
@@ -96,8 +96,8 @@
 		if(user.stat == CONSCIOUS)
 			if(prob(20))
 				user.emote("laugh")
-				addtimer(CALLBACK(user, /mob/proc/emote, "laugh"), 5 SECONDS)
-				addtimer(CALLBACK(user, /mob/proc/emote, "laugh"), 10 SECONDS)
+				addtimer(CALLBACK(user, TYPE_PROC_REF(/mob, emote), "laugh"), 5 SECONDS)
+				addtimer(CALLBACK(user, TYPE_PROC_REF(/mob, emote), "laugh"), 10 SECONDS)
 
 /obj/item/paper/joker
 	name = "disability card"

--- a/modular_nova/modules/ashwalkers/code/buildings/railroad.dm
+++ b/modular_nova/modules/ashwalkers/code/buildings/railroad.dm
@@ -42,7 +42,7 @@
 		if(rail == src)
 			continue
 
-		addtimer(CALLBACK(rail, /atom/proc/update_appearance), 1 SECONDS)
+		addtimer(CALLBACK(rail, TYPE_PROC_REF(/atom, update_appearance)), 1 SECONDS)
 	return ..()
 
 /obj/structure/railroad/update_appearance(updates)

--- a/modular_nova/modules/hyposprays/code/hyposprays_II.dm
+++ b/modular_nova/modules/hyposprays/code/hyposprays_II.dm
@@ -324,7 +324,7 @@
 	else
 		selected_wait_time = (mode == HYPO_INJECT) ? inject_wait : spray_wait
 
-	if(!do_after(user, selected_wait_time, injectee, extra_checks = CALLBACK(injectee, /mob/living/proc/can_inject, user, user.zone_selected, penetrates)))
+	if(!do_after(user, selected_wait_time, injectee, extra_checks = CALLBACK(injectee, TYPE_PROC_REF(/mob/living, can_inject), user, user.zone_selected, penetrates)))
 		return ITEM_INTERACT_BLOCKING
 	if(!vial || !vial.reagents.total_volume)
 		return ITEM_INTERACT_BLOCKING

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_items/attachable_vibrator.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_items/attachable_vibrator.dm
@@ -190,7 +190,7 @@
 
 /obj/item/clothing/sextoy/eggvib/signalvib/click_alt(mob/user)
 	if(!color_changed)
-		var/choice = show_radial_menu(user, src, vib_designs, custom_check = CALLBACK(src, /obj/item/clothing/sextoy/proc/check_menu, user), radius = 36, require_near = TRUE)
+		var/choice = show_radial_menu(user, src, vib_designs, custom_check = CALLBACK(src, TYPE_PROC_REF(/obj/item/clothing/sextoy, check_menu), user), radius = 36, require_near = TRUE)
 		if(!choice)
 			return CLICK_ACTION_BLOCKING
 		current_color = choice

--- a/modular_nova/modules/mutants/code/mutant_component.dm
+++ b/modular_nova/modules/mutants/code/mutant_component.dm
@@ -71,7 +71,7 @@
 	host.mind?.remove_antag_datum(/datum/antagonist/mutant)
 	host.remove_filter("infection_glow")
 	host.update_appearance()
-	addtimer(CALLBACK(host, /mob/living/carbon/human/proc/remove_mutant_immunity), rand(IMMUNITY_LOWER, IMMUNITY_UPPER), TIMER_STOPPABLE)
+	addtimer(CALLBACK(host, TYPE_PROC_REF(/mob/living/carbon/human, remove_mutant_immunity)), rand(IMMUNITY_LOWER, IMMUNITY_UPPER), TIMER_STOPPABLE)
 
 /datum/component/mutant_infection/proc/extract_rna()
 	if(rna_extracted)

--- a/modular_nova/modules/solfed_mechs/code/equipment/swarm_rocket_pod.dm
+++ b/modular_nova/modules/solfed_mechs/code/equipment/swarm_rocket_pod.dm
@@ -241,4 +241,4 @@
 	tracker.target = target
 
 	var/drop_delay = 2 SECONDS
-	addtimer(CALLBACK(tracker, /obj/effect/swarm_rocket_tracker/proc/step_or_drop), drop_delay, TIMER_STOPPABLE | TIMER_DELETE_ME)
+	addtimer(CALLBACK(tracker, TYPE_PROC_REF(/obj/effect/swarm_rocket_tracker, step_or_drop)), drop_delay, TIMER_STOPPABLE | TIMER_DELETE_ME)


### PR DESCRIPTION

## About The Pull Request
Stumbled upon one by accident and decided to check if theres more. Honestly, i never bothered to learn how to use regex, so i just plopped `CALLBACK\(.+, \/.+\/proc\/.+,.+\)`. But it still found some more incorrectly used callbacks.
## How This Contributes To The Nova Sector Roleplay Experience
While not necessarily gamebreaking, its better if we catch those procs in case of their untimely demise right at compile rather than at runtime.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="246" height="56" alt="image" src="https://github.com/user-attachments/assets/f132af4d-6e37-47e7-b89d-2053f0b0d0c7" />
<img width="286" height="117" alt="image" src="https://github.com/user-attachments/assets/314ab8cb-e671-4b5d-b8b5-1889c94fd3d9" />

</details>

## Changelog
Nothing player facing (probably (most certainly) )
