### PR TITLE
Adds a cooldown to the access denied sound on airlocks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -680,8 +680,9 @@
 			use_energy(50 JOULES)
 			playsound(src, soundin = doorClose, vol = 30, vary = TRUE)
 		if(DOOR_DENY_ANIMATION)
-			if(feedback)
+			if(feedback && COOLDOWN_FINISHED(src, denied_sound_cd)) // NOVA EDIT CHANGE - ORIGINAL: if(feedback)
 				playsound(src, soundin = doorDeni, vol = 50, vary = FALSE, extrarange = 3)
+				COOLDOWN_START(src, denied_sound_cd, 4 SECONDS) // NOVA EDIT ADDITION - No spamming this sound, sorry
 			addtimer(CALLBACK(src, PROC_REF(handle_deny_end)), AIRLOCK_DENY_ANIMATION_TIME)
 
 /obj/machinery/door/airlock/proc/handle_deny_end()

--- a/modular_nova/master_files/code/game/machinery/doors/door.dm
+++ b/modular_nova/master_files/code/game/machinery/doors/door.dm
@@ -7,6 +7,8 @@
 #define DOOR_AI_REQUEST_COOLDOWN (30 SECONDS)
 
 /obj/machinery/door/airlock
+	/// Cooldown for the access denied sound being played
+	COOLDOWN_DECLARE(denied_sound_cd)
 	//so the AI doesn't get spammed
 	COOLDOWN_DECLARE(answer_cd)
 	/// Tracks per-(player, door) AI-open-request cooldowns. Keyed by "[ckey]_[REF(door)]".


### PR DESCRIPTION

## About The Pull Request
Adds a 4 second cooldown to the access denied sound playing on airlocks.
## How This Contributes To The Nova Sector Roleplay Experience
Being able to spam this sound for 3 business days until someone opens the airlock or stops you (mechanically or otherwise) doesn't contribute to the Nova Sector roleplay experience. Sorry.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/17635456-2b16-44c3-85f1-3b25c45377fb

</details>

## Changelog
:cl:
qol: Adds a cooldown to the access denied sound effect on airlocks.
/:cl:
