### PR TITLE
Adds a clown megaphone and pie cannon to snowglobe.

### DIFF
--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -33423,6 +33423,7 @@
 	pixel_x = 4
 	},
 /obj/structure/sign/calendar/directional/south,
+/obj/item/pneumatic_cannon/pie,
 /turf/open/floor/carpet/donk,
 /area/station/service/greenroom)
 "iSR" = (

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -36811,6 +36811,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/item/megaphone/clown,
 /turf/open/floor/carpet/donk,
 /area/station/service/greenroom)
 "jMt" = (


### PR DESCRIPTION

## About The Pull Request

Does what it says on the tin. Doesn't have them currently. 

also 7500, :toot:

## Changelog

:cl:
map: Snowglobe's clown quarters now has a pie cannon and megaphone.
/:cl:

