### PR TITLE
roundstart decay subsystem no longer blows up floors

### DIFF
--- a/config/nova/config_nova.txt
+++ b/config/nova/config_nova.txt
@@ -71,6 +71,30 @@ SSDECAY_DISABLED
 ## If SSDECAY_DISABLED is uncommented, then it does not matter if this is commented out since this config requires SSDecay to be enabled first.
 SSDECAY_DISABLE_NESTS
 
+## Percent chance that a floor will be randomly dirty, scaled with SSDecay severity.
+SSDECAY_FLOOR_DIRT_PERCENT_CHANCE 15
+
+## Percent chance that a floor will be randomly bloody, scaled with SSDecay severity.
+SSDECAY_FLOOR_BLOOD_PERCENT_CHANCE 1
+
+## Percent chance that a floor will be randomly vomit-covered, scaled with SSDecay severity.
+SSDECAY_FLOOR_VOMIT_PERCENT_CHANCE 1
+
+## Percent chance that a floor will be randomly oily, scaled with SSDecay severity.
+SSDECAY_FLOOR_OIL_PERCENT_CHANCE 5
+
+## Percent chance that a floor will be randomly stripped down to damaged plating, scaled with SSDecay severity.
+SSDECAY_FLOOR_TILE_MISSING_PERCENT_CHANCE 0
+
+## Percent chance that a floor will have cobwebs, scaled with SSDecay severity.
+SSDECAY_FLOOR_COBWEB_PERCENT_CHANCE 1
+
+## Percent chance that (if not previously disabled via SSDECAY_DISABLE_NESTS) a nest will spawn, scaled with SSDecay severity.
+SSDECAY_NEST_PERCENT_CHANCE 1
+
+## Percent chance that a light will be flickery, used with SSDecay.
+SSDECAY_LIGHT_FLICKER_PERCENT_CHANCE 10
+
 ## Disables any ERP preferences for codebases that don't want it.
 #DISABLE_ERP_PREFERENCES
 #DISABLE_LEWD_ITEMS

--- a/modular_nova/master_files/code/controllers/configuration/entries/config_entries.dm
+++ b/modular_nova/master_files/code/controllers/configuration/entries/config_entries.dm
@@ -23,17 +23,17 @@
 
 // SSDecay - Percent chance that a floor will be bloody, scaled with SSDecay severity.
 /datum/config_entry/number/ssdecay_floor_blood_percent_chance
-	default = 15
+	default = 1
 	min_val = 0
 
 // SSDecay - Percent chance that a floor will be vomit-covered, scaled with SSDecay severity.
 /datum/config_entry/number/ssdecay_floor_vomit_percent_chance
-	default = 15
+	default = 1
 	min_val = 0
 
 // SSDecay - Percent chance that a floor will be oily, scaled with SSDecay severity.
 /datum/config_entry/number/ssdecay_floor_oil_percent_chance
-	default = 15
+	default = 5
 	min_val = 0
 
 // SSDecay - Percent chance that a floor will be randomly stripped down to damaged plating, scaled with SSDecay severity.
@@ -43,12 +43,12 @@
 
 // SSDecay - Percent chance that a floor will have cobwebs, scaled with SSDecay severity.
 /datum/config_entry/number/ssdecay_floor_cobweb_percent_chance
-	default = 0
+	default = 1
 	min_val = 0
 
 // SSDecay - Percent chance that (if not previously disabled via SSDECAY_DISABLE_NESTS) a nest will spawn, scaled with SSDecay severity.
 /datum/config_entry/number/ssdecay_nest_percent_chance
-	default = 0
+	default = 1
 	min_val = 0
 
 // SSDecay - Percent chance that a light will be flickery.

--- a/modular_nova/master_files/code/controllers/configuration/entries/config_entries.dm
+++ b/modular_nova/master_files/code/controllers/configuration/entries/config_entries.dm
@@ -38,7 +38,7 @@
 
 // SSDecay - Percent chance that a floor will be randomly stripped down to damaged plating, scaled with SSDecay severity.
 /datum/config_entry/number/ssdecay_floor_tile_missing_percent_chance
-	default = 0
+	default = 1
 	min_val = 0
 
 // SSDecay - Percent chance that a floor will have cobwebs, scaled with SSDecay severity.

--- a/modular_nova/master_files/code/controllers/configuration/entries/config_entries.dm
+++ b/modular_nova/master_files/code/controllers/configuration/entries/config_entries.dm
@@ -16,6 +16,46 @@
 // To turn off SSDecay nests based on a config. If SSDecay is disabled, this won't matter.
 /datum/config_entry/flag/ssdecay_disable_nests
 
+// SSDecay - Percent chance that a floor will be dirty, scaled with SSDecay severity.
+/datum/config_entry/number/ssdecay_floor_dirt_percent_chance
+	default = 15
+	min_val = 0
+
+// SSDecay - Percent chance that a floor will be bloody, scaled with SSDecay severity.
+/datum/config_entry/number/ssdecay_floor_blood_percent_chance
+	default = 15
+	min_val = 0
+
+// SSDecay - Percent chance that a floor will be vomit-covered, scaled with SSDecay severity.
+/datum/config_entry/number/ssdecay_floor_vomit_percent_chance
+	default = 15
+	min_val = 0
+
+// SSDecay - Percent chance that a floor will be oily, scaled with SSDecay severity.
+/datum/config_entry/number/ssdecay_floor_oil_percent_chance
+	default = 15
+	min_val = 0
+
+// SSDecay - Percent chance that a floor will be randomly stripped down to damaged plating, scaled with SSDecay severity.
+/datum/config_entry/number/ssdecay_floor_tile_missing_percent_chance
+	default = 0
+	min_val = 0
+
+// SSDecay - Percent chance that a floor will have cobwebs, scaled with SSDecay severity.
+/datum/config_entry/number/ssdecay_floor_cobweb_percent_chance
+	default = 0
+	min_val = 0
+
+// SSDecay - Percent chance that (if not previously disabled via SSDECAY_DISABLE_NESTS) a nest will spawn, scaled with SSDecay severity.
+/datum/config_entry/number/ssdecay_nest_percent_chance
+	default = 0
+	min_val = 0
+
+// SSDecay - Percent chance that a light will be flickery.
+/datum/config_entry/number/ssdecay_light_flicker_percent_chance
+	default = 10
+	min_val = 0
+
 // Turn on/off guncargo permit-locked firing pins
 /datum/config_entry/flag/permit_pins
 

--- a/modular_nova/modules/decay_subsystem/code/decaySS.dm
+++ b/modular_nova/modules/decay_subsystem/code/decaySS.dm
@@ -1,18 +1,8 @@
 /*
 This is the decay subsystem that is run once at startup.
 These procs are incredibly expensive and should only really be run once. That's why the only run once.
+Now with chances controlled via configs!
 */
-
-#define FLOOR_DIRT_PERCENT_CHANCE 15
-#define FLOOR_BLOOD_PERCENT_CHANCE 1
-#define FLOOR_VOMIT_PERCENT_CHANCE 1
-#define FLOOR_OIL_PERCENT_CHANCE 5
-#define FLOOR_TILE_MISSING_PERCENT_CHANCE 0
-#define FLOOR_COBWEB_PERCENT_CHANCE 1
-
-#define NEST_PERCENT_CHANCE 1
-
-#define LIGHT_FLICKER_PERCENT_CHANCE 10
 
 SUBSYSTEM_DEF(decay)
 	name = "Decay System"
@@ -24,6 +14,16 @@ SUBSYSTEM_DEF(decay)
 	var/list/possible_turfs = list()
 	var/list/possible_areas = list()
 	var/severity_modifier = 1
+
+	// variable holders for pulling from config
+	var/floor_dirt_percent_chance
+	var/floor_blood_percent_chance
+	var/floor_vomit_percent_chance
+	var/floor_oil_percent_chance
+	var/floor_tile_missing_percent_chance
+	var/floor_cobweb_percent_chance
+	var/nest_percent_chance
+	var/light_flicker_percent_chance
 
 	var/list/possible_nests = list(
 		/obj/structure/mob_spawner/spiders,
@@ -48,6 +48,16 @@ SUBSYSTEM_DEF(decay)
 		message_admins("SSDecay will not interact with this round.")
 		log_world("SSDecay will not interact with this round.")
 		return SS_INIT_NO_NEED
+
+	// The part where we get everything from configs in one go (this is that part)
+	floor_dirt_percent_chance = CONFIG_GET(number/ssdecay_floor_dirt_percent_chance)
+	floor_blood_percent_chance = CONFIG_GET(number/ssdecay_floor_blood_percent_chance)
+	floor_vomit_percent_chance = CONFIG_GET(number/ssdecay_floor_vomit_percent_chance)
+	floor_oil_percent_chance = CONFIG_GET(number/ssdecay_floor_oil_percent_chance)
+	floor_tile_missing_percent_chance = CONFIG_GET(number/ssdecay_floor_tile_missing_percent_chance)
+	floor_cobweb_percent_chance = CONFIG_GET(number/ssdecay_floor_cobweb_percent_chance)
+	nest_percent_chance = CONFIG_GET(number/ssdecay_nest_percent_chance)
+	light_flicker_percent_chance = CONFIG_GET(number/ssdecay_light_flicker_percent_chance)
 
 	for(var/area/iterating_area as anything in GLOB.areas)
 		if(!is_station_level(iterating_area.z))
@@ -82,49 +92,49 @@ SUBSYSTEM_DEF(decay)
 /datum/controller/subsystem/decay/proc/do_common()
 	for(var/turf/open/floor/iterating_floor in possible_turfs)
 		if(iterating_floor.turf_flags & CAN_DECAY_BREAK_1)
-			if(prob(FLOOR_TILE_MISSING_PERCENT_CHANCE * severity_modifier) && prob(60))
+			if(prob(floor_tile_missing_percent_chance * severity_modifier) && prob(60))
 				iterating_floor.break_tile_to_plating()
 
-		if(prob(FLOOR_DIRT_PERCENT_CHANCE * severity_modifier))
+		if(prob(floor_dirt_percent_chance * severity_modifier))
 			new /obj/effect/decal/cleanable/dirt(iterating_floor)
 
-		if(prob(FLOOR_DIRT_PERCENT_CHANCE * severity_modifier))
+		if(prob(floor_dirt_percent_chance * severity_modifier))
 			new /obj/effect/decal/cleanable/dirt(iterating_floor)
 
 /datum/controller/subsystem/decay/proc/do_maintenance()
 	for(var/area/station/maintenance/iterating_maintenance in possible_areas)
 		for(var/turf/open/iterating_floor in iterating_maintenance)
-			if(prob(FLOOR_BLOOD_PERCENT_CHANCE * severity_modifier))
+			if(prob(floor_blood_percent_chance * severity_modifier))
 				var/obj/effect/decal/cleanable/blood/spawned_blood = new (iterating_floor)
 				spawned_blood.dry()
 				if(!iterating_floor.Enter(spawned_blood))
 					qdel(spawned_blood) //No blood under windows.
 
-			if(prob(FLOOR_COBWEB_PERCENT_CHANCE * severity_modifier))
+			if(prob(floor_cobweb_percent_chance * severity_modifier))
 				var/obj/structure/spider/stickyweb/spawned_web = new (iterating_floor)
 				if(!iterating_floor.Enter(spawned_web))
 					qdel(spawned_web)
 
-			if(!CONFIG_GET(flag/ssdecay_disable_nests) && prob(NEST_PERCENT_CHANCE * severity_modifier) && prob(50))
+			if(!CONFIG_GET(flag/ssdecay_disable_nests) && prob(nest_percent_chance * severity_modifier) && prob(50))
 				var/spawner_to_spawn = pick(possible_nests)
 				var/obj/structure/mob_spawner/spawned_spawner = new spawner_to_spawn(iterating_floor)
 				if(!iterating_floor.Enter(spawned_spawner))
 					qdel(spawned_spawner)
 
 		for(var/obj/machinery/light/iterating_light in iterating_maintenance)
-			if(prob(LIGHT_FLICKER_PERCENT_CHANCE))
+			if(prob(light_flicker_percent_chance))
 				iterating_light.start_flickering()
 
 /datum/controller/subsystem/decay/proc/do_engineering()
 	for(var/area/station/engineering/iterating_engineering in possible_areas)
 		for(var/turf/open/iterating_floor in iterating_engineering)
-			if(prob(FLOOR_BLOOD_PERCENT_CHANCE * severity_modifier))
+			if(prob(floor_blood_percent_chance * severity_modifier))
 				var/obj/effect/decal/cleanable/blood/spawned_blood = new (iterating_floor)
 				spawned_blood.dry()
 				if(!iterating_floor.Enter(spawned_blood))
 					qdel(spawned_blood)
 
-			if(prob(FLOOR_OIL_PERCENT_CHANCE * severity_modifier))
+			if(prob(floor_oil_percent_chance * severity_modifier))
 				var/obj/effect/decal/cleanable/blood/oil/spawned_oil = new (iterating_floor)
 				if(!iterating_floor.Enter(spawned_oil))
 					qdel(spawned_oil)
@@ -132,27 +142,18 @@ SUBSYSTEM_DEF(decay)
 /datum/controller/subsystem/decay/proc/do_medical()
 	for(var/area/station/medical/iterating_medical in possible_areas)
 		for(var/turf/open/iterating_floor in iterating_medical)
-			if(prob(FLOOR_BLOOD_PERCENT_CHANCE * severity_modifier))
+			if(prob(floor_blood_percent_chance * severity_modifier))
 				var/obj/effect/decal/cleanable/blood/spawned_blood = new (iterating_floor)
 				spawned_blood.dry()
 				if(!iterating_floor.Enter(spawned_blood))
 					qdel(spawned_blood)
 
-			if(prob(FLOOR_VOMIT_PERCENT_CHANCE * severity_modifier))
+			if(prob(floor_vomit_percent_chance * severity_modifier))
 				var/obj/effect/decal/cleanable/vomit/spawned_vomit = new (iterating_floor)
 				if(!iterating_floor.Enter(spawned_vomit))
 					qdel(spawned_vomit)
 
 		if(is_type_in_list(iterating_medical, list(/area/station/medical/coldroom, /area/station/medical/morgue, /area/station/medical/psychology)))
 			for(var/obj/machinery/light/iterating_light in iterating_medical)
-				if(prob(LIGHT_FLICKER_PERCENT_CHANCE))
+				if(prob(light_flicker_percent_chance))
 					iterating_light.start_flickering()
-
-#undef FLOOR_DIRT_PERCENT_CHANCE
-#undef FLOOR_BLOOD_PERCENT_CHANCE
-#undef FLOOR_VOMIT_PERCENT_CHANCE
-#undef FLOOR_OIL_PERCENT_CHANCE
-#undef FLOOR_TILE_MISSING_PERCENT_CHANCE
-#undef FLOOR_COBWEB_PERCENT_CHANCE
-#undef NEST_PERCENT_CHANCE
-#undef LIGHT_FLICKER_PERCENT_CHANCE

--- a/modular_nova/modules/decay_subsystem/code/decaySS.dm
+++ b/modular_nova/modules/decay_subsystem/code/decaySS.dm
@@ -15,16 +15,6 @@ SUBSYSTEM_DEF(decay)
 	var/list/possible_areas = list()
 	var/severity_modifier = 1
 
-	// variable holders for pulling from config
-	var/floor_dirt_percent_chance
-	var/floor_blood_percent_chance
-	var/floor_vomit_percent_chance
-	var/floor_oil_percent_chance
-	var/floor_tile_missing_percent_chance
-	var/floor_cobweb_percent_chance
-	var/nest_percent_chance
-	var/light_flicker_percent_chance
-
 	var/list/possible_nests = list(
 		/obj/structure/mob_spawner/spiders,
 		/obj/structure/mob_spawner/bush,
@@ -48,16 +38,6 @@ SUBSYSTEM_DEF(decay)
 		message_admins("SSDecay will not interact with this round.")
 		log_world("SSDecay will not interact with this round.")
 		return SS_INIT_NO_NEED
-
-	// The part where we get everything from configs in one go (this is that part)
-	floor_dirt_percent_chance = CONFIG_GET(number/ssdecay_floor_dirt_percent_chance)
-	floor_blood_percent_chance = CONFIG_GET(number/ssdecay_floor_blood_percent_chance)
-	floor_vomit_percent_chance = CONFIG_GET(number/ssdecay_floor_vomit_percent_chance)
-	floor_oil_percent_chance = CONFIG_GET(number/ssdecay_floor_oil_percent_chance)
-	floor_tile_missing_percent_chance = CONFIG_GET(number/ssdecay_floor_tile_missing_percent_chance)
-	floor_cobweb_percent_chance = CONFIG_GET(number/ssdecay_floor_cobweb_percent_chance)
-	nest_percent_chance = CONFIG_GET(number/ssdecay_nest_percent_chance)
-	light_flicker_percent_chance = CONFIG_GET(number/ssdecay_light_flicker_percent_chance)
 
 	for(var/area/iterating_area as anything in GLOB.areas)
 		if(!is_station_level(iterating_area.z))
@@ -90,6 +70,9 @@ SUBSYSTEM_DEF(decay)
 	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/decay/proc/do_common()
+	var/floor_dirt_percent_chance = CONFIG_GET(number/ssdecay_floor_dirt_percent_chance)
+	var/floor_tile_missing_percent_chance = CONFIG_GET(number/ssdecay_floor_tile_missing_percent_chance)
+
 	for(var/turf/open/floor/iterating_floor in possible_turfs)
 		if(iterating_floor.turf_flags & CAN_DECAY_BREAK_1)
 			if(prob(floor_tile_missing_percent_chance * severity_modifier) && prob(60))
@@ -98,10 +81,11 @@ SUBSYSTEM_DEF(decay)
 		if(prob(floor_dirt_percent_chance * severity_modifier))
 			new /obj/effect/decal/cleanable/dirt(iterating_floor)
 
-		if(prob(floor_dirt_percent_chance * severity_modifier))
-			new /obj/effect/decal/cleanable/dirt(iterating_floor)
-
 /datum/controller/subsystem/decay/proc/do_maintenance()
+	var/floor_blood_percent_chance = CONFIG_GET(number/ssdecay_floor_blood_percent_chance)
+	var/floor_cobweb_percent_chance = CONFIG_GET(number/ssdecay_floor_cobweb_percent_chance)
+	var/nest_percent_chance = CONFIG_GET(number/ssdecay_nest_percent_chance)
+	var/light_flicker_percent_chance = CONFIG_GET(number/ssdecay_light_flicker_percent_chance)
 	for(var/area/station/maintenance/iterating_maintenance in possible_areas)
 		for(var/turf/open/iterating_floor in iterating_maintenance)
 			if(prob(floor_blood_percent_chance * severity_modifier))
@@ -115,7 +99,7 @@ SUBSYSTEM_DEF(decay)
 				if(!iterating_floor.Enter(spawned_web))
 					qdel(spawned_web)
 
-			if(!CONFIG_GET(flag/ssdecay_disable_nests) && prob(nest_percent_chance * severity_modifier) && prob(50))
+			if(!CONFIG_GET(flag/ssdecay_disable_nests) && prob(nest_percent_chance * severity_modifier))
 				var/spawner_to_spawn = pick(possible_nests)
 				var/obj/structure/mob_spawner/spawned_spawner = new spawner_to_spawn(iterating_floor)
 				if(!iterating_floor.Enter(spawned_spawner))
@@ -126,6 +110,8 @@ SUBSYSTEM_DEF(decay)
 				iterating_light.start_flickering()
 
 /datum/controller/subsystem/decay/proc/do_engineering()
+	var/floor_blood_percent_chance = CONFIG_GET(number/ssdecay_floor_blood_percent_chance)
+	var/floor_oil_percent_chance = CONFIG_GET(number/ssdecay_floor_oil_percent_chance)
 	for(var/area/station/engineering/iterating_engineering in possible_areas)
 		for(var/turf/open/iterating_floor in iterating_engineering)
 			if(prob(floor_blood_percent_chance * severity_modifier))
@@ -140,6 +126,9 @@ SUBSYSTEM_DEF(decay)
 					qdel(spawned_oil)
 
 /datum/controller/subsystem/decay/proc/do_medical()
+	var/floor_blood_percent_chance = CONFIG_GET(number/ssdecay_floor_blood_percent_chance)
+	var/floor_vomit_percent_chance = CONFIG_GET(number/ssdecay_floor_vomit_percent_chance)
+	var/light_flicker_percent_chance = CONFIG_GET(number/ssdecay_light_flicker_percent_chance)
 	for(var/area/station/medical/iterating_medical in possible_areas)
 		for(var/turf/open/iterating_floor in iterating_medical)
 			if(prob(floor_blood_percent_chance * severity_modifier))

--- a/modular_nova/modules/decay_subsystem/code/decaySS.dm
+++ b/modular_nova/modules/decay_subsystem/code/decaySS.dm
@@ -7,7 +7,7 @@ These procs are incredibly expensive and should only really be run once. That's 
 #define FLOOR_BLOOD_PERCENT_CHANCE 1
 #define FLOOR_VOMIT_PERCENT_CHANCE 1
 #define FLOOR_OIL_PERCENT_CHANCE 5
-#define FLOOR_TILE_MISSING_PERCENT_CHANCE 1
+#define FLOOR_TILE_MISSING_PERCENT_CHANCE 0
 #define FLOOR_COBWEB_PERCENT_CHANCE 1
 
 #define NEST_PERCENT_CHANCE 1


### PR DESCRIPTION
## About The Pull Request

about what it says on the tin - sets the decay subsystem's missing floor tile chance from 1% to 0%

## How This Contributes To The Nova Sector Roleplay Experience

If I have to look at broken tiles with irreplaceable decals one more time I'm going to lose it.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

uh yeah give me a second
  
</details>

## Changelog
:cl:
qol: Following complaints from engineering and janitorial staff, Nanotrasen station construction and refurbishment teams have been informed that their job includes making sure floor tiles are being properly placed. (The roundstart decay subsystem that places muck and broken tiles everywhere no longer breaks tiles.)
config: Decay subsystem now uses configs. Check config_nova.txt!
/:cl:
