### PR TITLE
Fixes An Inconsistency with the Blueshield's Naval Uniform

### DIFF
--- a/modular_nova/master_files/code/modules/clothing/under/jobs/command.dm
+++ b/modular_nova/master_files/code/modules/clothing/under/jobs/command.dm
@@ -117,9 +117,9 @@
 	icon_state = "bs_formal"
 
 /obj/item/clothing/under/imperialvest/blueshield
-	name = "blueshield's naval skirt"
+	name = "blueshield's naval uniform"
 	desc = "An upper level uniform granted to shields alike, representing CentCom's grand naval fleet."
-	icon_state = "/obj/item/clothing/under/imperialvest/bs"
+	icon_state = "/obj/item/clothing/under/imperialvest/blueshield"
 	greyscale_colors = "#363740#363740#3c485a#373741#bbbbbb#21212B#bbbbbb#bbbbbb"
 	flags_1 = NONE
 	armor_type = /datum/armor/clothing_under/rank_blueshield
@@ -128,7 +128,7 @@
 	name = "blueshield's naval skirt"
 	desc = "An upper level uniform granted to shields alike, representing CentCom's grand naval fleet."
 	greyscale_colors = "#363740#3c485a#373741#bbbbbb#21212B#bbbbbb#bbbbbb"
-	icon_state = "/obj/item/clothing/under/imperialskirtvest/bs"
+	icon_state = "/obj/item/clothing/under/imperialskirtvest/blueshield"
 	flags_1 = NONE
 	armor_type = /datum/armor/clothing_under/rank_blueshield
 

--- a/modular_nova/modules/blueshield/code/closet.dm
+++ b/modular_nova/modules/blueshield/code/closet.dm
@@ -19,7 +19,7 @@
 	new /obj/item/clothing/under/rank/blueshield/formal(src)
 	new /obj/item/clothing/under/rank/blueshield/russian(src)
 	new /obj/item/clothing/under/imperialvest/blueshield(src)
-	new /obj/item/clothing/under/imperialvest/blueshield(src)
+	new /obj/item/clothing/under/imperialskirtvest/blueshield(src)
 
 /obj/structure/closet/secure_closet/blueshield
 	name = "blueshield's locker"


### PR DESCRIPTION

## About The Pull Request
Previously the Blueshields naval uniform was only a uniform, missing it's skirt.
## How This Contributes To The Nova Sector Roleplay Experience
Fixxies
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl: Macaroni
fix: The Blueshield's naval skirt now references the correct icon.
/:cl:
