### PR TITLE
Fixes Nightmares Spawning with Preferences

### DIFF
--- a/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
+++ b/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
@@ -23,6 +23,22 @@
 		else
 			player.playsound_local(player, 'sound/machines/terminal/terminal_prompt_deny.ogg', 50, FALSE)
 
+// Nightmares should not load client appearance/loadout prefs on spawn.
+// This is identical to the normal prepare_for_role with the omission of the line
+// body.client?.prefs.safe_transfer_prefs_to(body)
+/datum/dynamic_ruleset/midround/from_ghosts/nightmare/prepare_for_role(datum/mind/candidate)
+	var/mob/living/body = create_ruleset_body()
+	if(isnull(body))
+		return
+	candidate.transfer_to(body, force_key_move = TRUE)
+	if(ishuman(body))
+		var/mob/living/carbon/human/human_body = body
+		human_body.dna.remove_all_mutations()
+		human_body.dna.update_dna_identity()
+
+
+
+
 
 /datum/dynamic_ruleset/midround/from_living/traitor
 	var/static/list/sleeper_current_polling = list()

--- a/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
+++ b/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
@@ -36,10 +36,6 @@
 		human_body.dna.remove_all_mutations()
 		human_body.dna.update_dna_identity()
 
-
-
-
-
 /datum/dynamic_ruleset/midround/from_living/traitor
 	var/static/list/sleeper_current_polling = list()
 	var/static/list/rejected_traitor = list()


### PR DESCRIPTION

## About The Pull Request

Title, once again. 

## How This Contributes To The Nova Sector Roleplay Experience

Nightmares no longer spawning with all sorts of markings and implants? Spawning as nightmares? Shocking. 

Also fixes #6213

## Changelog

:cl:
fix: nightmares no longer apply the client preferences when spawning.
/:cl:

