### PR TITLE
Shadekin have sensitive hearing (and related code improvements)

### DIFF
--- a/modular_nova/master_files/code/datums/traits/good.dm
+++ b/modular_nova/master_files/code/datums/traits/good.dm
@@ -158,9 +158,10 @@
 
 	old_appendix = null
 
-/datum/quirk/sensitive_hearing // Teshari hearing but as a quirk
+/datum/quirk/sensitive_hearing
 	name = "Sensitive Hearing"
-	desc = "You can hear even the quietest of sounds, but you're more vulnerable to hearing damage as a result. NOTE: This is a direct downgrade for Teshari!"
+	desc = "You can hear even the quietest of sounds, but you're more vulnerable to hearing damage as a result. \
+			This is a direct downgrade for any species that has innate sensitive hearing!"
 	icon = FA_ICON_HEADPHONES_SIMPLE
 	value = 6
 	hidden_quirk = TRUE // disabled until reworked.
@@ -168,12 +169,12 @@
 	gain_text = span_notice("You could hear a pin drop from 10 feet away.")
 	lose_text = span_danger("Your hearing feels less sensitive.")
 	medical_record_text = "Patient scored very highly in hearing tests."
-	/// Teshari hearing is an action, so here is its holder
-	var/datum/action/cooldown/spell/teshari_hearing/hearing_action
+	/// Holds the sensitive hearing action
+	var/datum/action/cooldown/spell/sensitive_hearing/hearing_action
 
 /datum/quirk/sensitive_hearing/add_unique()
 	var/obj/item/organ/ears/ears = quirk_holder.get_organ_slot(ORGAN_SLOT_EARS)
-
+	ears.damage_multiplier *= 2 // You do want to think twice about taking this on certain species
 	hearing_action = new
 	LAZYADD(ears.actions_types, hearing_action.type)
 	ears.add_item_action(hearing_action)
@@ -189,7 +190,6 @@
 	LAZYREMOVE(ears.actions_types, hearing_action.type)
 	ears.remove_item_action(hearing_action)
 	hearing_action.Remove(quirk_holder)
-	//restore dmg multiplier of our current ears
-	//we could have any subtype at this point so just take that one's initial value
-	//as opposed to making a copy at the start of the player's round (what if they transplant it, etc)
+	// Doing ears.damage_multiplier /= 2 is not safe because the ears may've
+	// changed, so just set it to the initial value of the current ears
 	ears.damage_multiplier = initial(ears.damage_multiplier)

--- a/modular_nova/modules/organs/code/ears.dm
+++ b/modular_nova/modules/organs/code/ears.dm
@@ -1,36 +1,12 @@
-/// Teshari ears, hold the teshari
-/obj/item/organ/ears/sensitive
-	name = "sensitive ears"
-	desc = "Highly sensitive ears capable of detecting even the smallest noises."
-	damage_multiplier = 2
-	organ_traits = list(TRAIT_SENSITIVE_HEARING)
-	actions_types = list(/datum/action/cooldown/spell/teshari_hearing)
-
-/obj/item/organ/ears/sensitive/on_mob_remove(mob/living/carbon/ear_owner)
-	. = ..()
-	// Prevents sensitive hearing from being broken without admin intervention if the quirk/organ is removed while active
-	if(ear_owner.has_status_effect(/datum/status_effect/teshari_hearing))
-		ear_owner.remove_status_effect(/datum/status_effect/teshari_hearing)
-
-	REMOVE_TRAIT(ear_owner, TRAIT_GOOD_HEARING, ORGAN_TRAIT)
-
 /obj/item/organ/ears/teshari
 	name = "teshari ears"
 	desc = "A set of four long rabbit-like ears, a Teshari's main tool while hunting. Naturally extremely sensitive to loud sounds."
 	damage_multiplier = 1.5
-	actions_types = list(/datum/action/cooldown/spell/teshari_hearing)
+	actions_types = list(/datum/action/cooldown/spell/sensitive_hearing)
 
-/obj/item/organ/ears/teshari/on_mob_remove(mob/living/carbon/ear_owner)
-	. = ..()
-	// Prevents teshari hearing from being broken without admin intervention if the organ is removed while active
-	if(ear_owner.has_status_effect(/datum/status_effect/teshari_hearing))
-		ear_owner.remove_status_effect(/datum/status_effect/teshari_hearing)
-
-	REMOVE_TRAIT(ear_owner, TRAIT_GOOD_HEARING, ORGAN_TRAIT)
-
-/datum/action/cooldown/spell/teshari_hearing
+/datum/action/cooldown/spell/sensitive_hearing
 	name = "Toggle Sensitive Hearing"
-	desc = "Listen for quiet sounds, useful for picking up whispering."
+	desc = "Listen for quiet sounds and hear whispers, but become extremely vulnerable to loud noises."
 	button_icon = 'modular_nova/master_files/icons/hud/actions.dmi'
 	button_icon_state = "echolocation_off"
 	background_icon_state = "bg_alien"
@@ -40,70 +16,77 @@
 	spell_requirements = NONE
 
 /// Updates the icon on the teshari hearing action for when it's on/off
-/datum/action/cooldown/spell/teshari_hearing/proc/update_button_state(new_state)
+/datum/action/cooldown/spell/sensitive_hearing/proc/update_button_state(new_state)
 	button_icon_state = new_state
 	owner.update_action_buttons()
 
-/datum/action/cooldown/spell/teshari_hearing/Remove(mob/living/remove_from)
+/datum/action/cooldown/spell/sensitive_hearing/Remove(mob/living/remove_from)
 	REMOVE_TRAIT(remove_from, TRAIT_GOOD_HEARING, ORGAN_TRAIT)
 	remove_from.update_sight()
-	if(remove_from.has_status_effect(/datum/status_effect/teshari_hearing))
-		//we haven't deactivated yet...
-		teshari_hearing_deactivate(remove_from)
+	if(remove_from.has_status_effect(/datum/status_effect/sensitive_hearing))
+		// we haven't deactivated yet...
+		sensitive_hearing_deactivate(remove_from)
 	return ..()
 
-/datum/action/cooldown/spell/teshari_hearing/cast(list/targets, mob/living/carbon/human/user = usr)
+/datum/action/cooldown/spell/sensitive_hearing/cast(list/targets, mob/living/carbon/human/user = usr)
 	. = ..()
 
-	if(user.has_status_effect(/datum/status_effect/teshari_hearing))
-		teshari_hearing_deactivate(user)
+	if(user.has_status_effect(/datum/status_effect/sensitive_hearing))
+		sensitive_hearing_deactivate(user)
 		return
 
-	var/hearing_enable_message = "[user] perks up [user.p_their()] four ears, each twitching intently!"
-	var/hearing_enable_usermessage = "You perk up all four of your ears, hunting for even the quietest sounds."
-	if(HAS_TRAIT(user, TRAIT_SENSITIVE_HEARING))
-		hearing_enable_message = "[user] starts to listen intently!"
-		hearing_enable_usermessage = "You start to listen intently for quiet sounds."
+	sensitive_hearing_activate(user)
 
-	user.apply_status_effect(/datum/status_effect/teshari_hearing)
-	user.visible_message(span_notice(hearing_enable_message), span_notice(hearing_enable_usermessage))
+/// Applies the sensitive hearing status effect and updates icon
+/datum/action/cooldown/spell/sensitive_hearing/proc/sensitive_hearing_activate(mob/living/carbon/human/user)
+	user.apply_status_effect(/datum/status_effect/sensitive_hearing)
 	update_button_state("echolocation_on")
 
-	var/obj/item/organ/ears/ears = user.get_organ_slot(ORGAN_SLOT_EARS)
-	if(ears)
-		ears.damage_multiplier = 3
-
-/// Called when you cast teshari hearing again after enabling it, thereby making it a one-button toggle
-/datum/action/cooldown/spell/teshari_hearing/proc/teshari_hearing_deactivate(mob/living/carbon/human/user)
-	var/hearing_disable_message = "[user] drops [user.p_their()] ears down a bit, no longer listening as closely."
-	var/hearing_disable_usermessage = "You drop your ears down, no longer paying close attention."
-	if(HAS_TRAIT(user, TRAIT_SENSITIVE_HEARING))
-		hearing_disable_message = "[user] stops listening for quiet sounds."
-		hearing_disable_usermessage = "You stop listening for quiet sounds."
-
-	user.remove_status_effect(/datum/status_effect/teshari_hearing)
-	user.visible_message(span_notice(hearing_disable_message), span_notice(hearing_disable_usermessage))
+/// Removes the sensitive hearing status effect and updates icon
+/datum/action/cooldown/spell/sensitive_hearing/proc/sensitive_hearing_deactivate(mob/living/carbon/human/user)
+	user.remove_status_effect(/datum/status_effect/sensitive_hearing)
 	update_button_state("echolocation_off")
 
-	var/obj/item/organ/ears/ears = user.get_organ_slot(ORGAN_SLOT_EARS)
-	if(ears)
-		// Sensitive Hearing users take more hearing damage when they're not listening
-		ears.damage_multiplier = HAS_TRAIT(user, TRAIT_SENSITIVE_HEARING) ? /obj/item/organ/ears/sensitive::damage_multiplier : /obj/item/organ/ears/teshari::damage_multiplier
-
-/datum/status_effect/teshari_hearing
-	id = "teshari_hearing"
+/// Status effect that actually manages sensitive hearing and its feedback
+/datum/status_effect/sensitive_hearing
+	id = "sensitive_hearing"
 	alert_type = null
 	status_type = STATUS_EFFECT_UNIQUE
 
-/datum/status_effect/teshari_hearing/on_apply()
+/datum/status_effect/sensitive_hearing/on_apply()
 	ADD_TRAIT(owner, TRAIT_GOOD_HEARING, ORGAN_TRAIT)
+
+	var/hearing_enable_message = "[owner] perks up [owner.p_their()] ears, each twitching intently!"
+	var/hearing_enable_usermessage = "You perk up your ears, hunting for even the quietest sounds."
+	if(HAS_TRAIT(owner, TRAIT_SENSITIVE_HEARING))
+		hearing_enable_message = "[owner] starts to listen intently!"
+		hearing_enable_usermessage = "You start to listen intently for quiet sounds."
+	owner.visible_message(span_notice(hearing_enable_message), span_notice(hearing_enable_usermessage))
+
+	var/obj/item/organ/ears/ears = owner.get_organ_slot(ORGAN_SLOT_EARS)
+	if(ears)
+		ears.damage_multiplier *= 2
+
 	return ..()
 
-/datum/status_effect/teshari_hearing/on_remove()
+/datum/status_effect/sensitive_hearing/on_remove()
 	REMOVE_TRAIT(owner, TRAIT_GOOD_HEARING, ORGAN_TRAIT)
+	UnregisterSignal(owner, COMSIG_ORGAN_REMOVED)
+
+	var/hearing_disable_message = "[owner] drops [owner.p_their()] ears down a bit, no longer listening as closely."
+	var/hearing_disable_usermessage = "You drop your ears down, no longer paying close attention."
+	if(HAS_TRAIT(owner, TRAIT_SENSITIVE_HEARING))
+		hearing_disable_message = "[owner] stops listening for quiet sounds."
+		hearing_disable_usermessage = "You stop listening for quiet sounds."
+	owner.visible_message(span_notice(hearing_disable_message), span_notice(hearing_disable_usermessage))
+
+	var/obj/item/organ/ears/ears = owner.get_organ_slot(ORGAN_SLOT_EARS)
+	if(ears)
+		ears.damage_multiplier /= 2
+
 	return ..()
 
-/datum/status_effect/teshari_hearing/get_examine_text()
+/datum/status_effect/sensitive_hearing/get_examine_text()
 	var/hearing_examine_text = "[owner.p_They()] [owner.p_have()] [owner.p_their()] ears perked up, listening closely to whisper-quiet sounds."
 	if(HAS_TRAIT(owner, TRAIT_SENSITIVE_HEARING))
 		hearing_examine_text = "[owner.p_Theyre()] listening intently for whisper-quiet sounds."

--- a/modular_nova/modules/organs/code/ears.dm
+++ b/modular_nova/modules/organs/code/ears.dm
@@ -71,7 +71,6 @@
 
 /datum/status_effect/sensitive_hearing/on_remove()
 	REMOVE_TRAIT(owner, TRAIT_GOOD_HEARING, ORGAN_TRAIT)
-	UnregisterSignal(owner, COMSIG_ORGAN_REMOVED)
 
 	var/hearing_disable_message = "[owner] drops [owner.p_their()] ears down a bit, no longer listening as closely."
 	var/hearing_disable_usermessage = "You drop your ears down, no longer paying close attention."

--- a/modular_nova/modules/shadekin/code/organs.dm
+++ b/modular_nova/modules/shadekin/code/organs.dm
@@ -186,4 +186,5 @@
 /obj/item/organ/ears/shadekin
 	name = "shadekin ears"
 	desc = "Ears, covered in fur."
-	damage_multiplier = 2.5
+	damage_multiplier = 1.5
+	actions_types = list(/datum/action/cooldown/spell/sensitive_hearing)

--- a/modular_nova/modules/shadekin/code/organs.dm
+++ b/modular_nova/modules/shadekin/code/organs.dm
@@ -186,5 +186,5 @@
 /obj/item/organ/ears/shadekin
 	name = "shadekin ears"
 	desc = "Ears, covered in fur."
-	damage_multiplier = 1.7
+	damage_multiplier = 1.5
 	actions_types = list(/datum/action/cooldown/spell/sensitive_hearing)

--- a/modular_nova/modules/shadekin/code/organs.dm
+++ b/modular_nova/modules/shadekin/code/organs.dm
@@ -186,5 +186,5 @@
 /obj/item/organ/ears/shadekin
 	name = "shadekin ears"
 	desc = "Ears, covered in fur."
-	damage_multiplier = 1.675
+	damage_multiplier = 1.7
 	actions_types = list(/datum/action/cooldown/spell/sensitive_hearing)

--- a/modular_nova/modules/shadekin/code/organs.dm
+++ b/modular_nova/modules/shadekin/code/organs.dm
@@ -186,5 +186,5 @@
 /obj/item/organ/ears/shadekin
 	name = "shadekin ears"
 	desc = "Ears, covered in fur."
-	damage_multiplier = 1.5
+	damage_multiplier = 1.7
 	actions_types = list(/datum/action/cooldown/spell/sensitive_hearing)

--- a/modular_nova/modules/shadekin/code/organs.dm
+++ b/modular_nova/modules/shadekin/code/organs.dm
@@ -186,5 +186,5 @@
 /obj/item/organ/ears/shadekin
 	name = "shadekin ears"
 	desc = "Ears, covered in fur."
-	damage_multiplier = 1.7
+	damage_multiplier = 1.675
 	actions_types = list(/datum/action/cooldown/spell/sensitive_hearing)


### PR DESCRIPTION
## About The Pull Request
- Damage multipliers are changed using multiplication/division instead of arbitrary numbers with no correlation to your existing hearing damage multiplier
- The Sensitive Hearing quirk doubles the base damage multiplier on your ears as well (I think it was supposed to do this, but the quirk's refactor removed it in an oversight?)
- The above two points make it so sensitive hearing affects certain ear types more severely
- Shadekin ears have their damage multiplier reduced from 250% to 150%, and gain sensitive hearing (300% damage when active)
- "Teshari hearing" gets refactored and genericized into just "sensitive hearing", because it's not specific to Teshari and has a few different sources
## How This Contributes To The Nova Sector Roleplay Experience
I think these ears can have their base damage multiplier reduced and get whisper-sensitive hearing in addition to their very niche ability of hearing Empathy messages from other Shadekin. It's a non-negligible buff, but I think the 300% damage when active offsets it. It also makes sense because... four very big, sensitive ears that can "detect Empathic communication" should also get to hear people whispering nearby.

Also, this code is kinda weird. It should use your current hearing damage multiplier instead of arbitrary numbers with no correlation. 
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="1114" height="842" alt="Screenshot_3083" src="https://github.com/user-attachments/assets/6b6ce098-c048-465d-ba92-e1159286c6db" />

The `on_mob_remove` bits appeared to not be needed, dropping/removing your ears still removes your sensitive hearing:
<img width="466" height="79" alt="Screenshot_3084" src="https://github.com/user-attachments/assets/c02d5102-9e9f-44b9-9d2f-ae0f776a35eb" />

</details>

## Changelog
:cl:
balance: Shadekin ears have their base damage multiplier reduced from 250% to 150%.
balance: Shadekin ears have toggleable whisper-sensitive hearing (300% damage multiplier when active).
/:cl:
