### PR TITLE
Fixes Small Issues I Found Across Snowglobe

### DIFF
--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -107,6 +107,12 @@
 	dir = 4
 	},
 /area/station/ai/satellite/foyer)
+"abI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "abO" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -598,6 +604,11 @@
 	dir = 8
 	},
 /area/station/hallway/primary/aftstarboardhall)
+"ahx" = (
+/obj/machinery/power/weather_tower,
+/obj/structure/cable,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
 "ahB" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/white/filled/warning{
@@ -979,14 +990,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
-"amj" = (
-/obj/structure/table/wood,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/fax/heads/nanotrasen_consultant,
-/turf/open/floor/carpet/green,
-/area/station/command/heads_quarters/nt_rep)
 "amm" = (
 /obj/effect/turf_decal/trimline/white/filled/warning{
 	dir = 4
@@ -1024,13 +1027,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/law)
-"amO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/delam_scram/directional/east,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "amQ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/warning/corner,
@@ -1656,6 +1652,15 @@
 "atQ" = (
 /turf/open/floor/iron/freezer,
 /area/station/commons/dorms/room4)
+"atR" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "atV" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/east,
@@ -2508,15 +2513,6 @@
 	},
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/secondary/recreation)
-"aEM" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/west,
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "aEQ" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -3697,6 +3693,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
+"aUw" = (
+/obj/structure/cable,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
 "aUT" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
@@ -3960,19 +3960,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"aYz" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Gas to Filter"
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/effect/mapping_helpers/airalarm/link{
-	chamber_id = "engine"
-	},
-/obj/effect/mapping_helpers/airalarm/engine_access,
-/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "aYC" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 10
@@ -4933,6 +4920,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
+"bnl" = (
+/obj/structure/table/wood,
+/obj/machinery/button/curtain{
+	id = "rdprivacy";
+	pixel_x = 24;
+	pixel_y = -3
+	},
+/obj/machinery/fax/heads/rd,
+/turf/open/floor/carpet/purple,
+/area/station/command/heads_quarters/rd)
 "bnp" = (
 /obj/structure/fans/tiny/forcefield{
 	dir = 4
@@ -6081,6 +6078,22 @@
 "bCS" = (
 /turf/open/floor/plating,
 /area/station/maintenance/dorm_room)
+"bCV" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 2;
+	pixel_y = -4
+	},
+/obj/item/storage/box/matches{
+	pixel_y = 8;
+	pixel_x = -2
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/item/megaphone/clown,
+/turf/open/floor/carpet/donk,
+/area/station/service/greenroom)
 "bCZ" = (
 /obj/structure/flora/bush/flowers_pp,
 /obj/structure/window/fulltile,
@@ -7175,15 +7188,6 @@
 /obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/iron/edge,
 /area/station/commons/storage/tools)
-"bTm" = (
-/obj/structure/railing{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 9
-	},
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
 "bTu" = (
 /turf/closed/wall/r_wall,
 /area/station/security/interrogation)
@@ -7835,9 +7839,6 @@
 	dir = 4
 	},
 /area/station/science/xenobiology)
-"cbk" = (
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "cbq" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -8401,18 +8402,6 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/wood/tile,
 /area/station/hallway/secondary/dock)
-"cji" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/obj/structure/flora/bush/sparsegrass{
-	pixel_x = 8
-	},
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
 "cjk" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Brig Closet"
@@ -9002,11 +8991,6 @@
 	},
 /turf/open/floor/iron/corner,
 /area/station/engineering/atmos)
-"crp" = (
-/obj/structure/cable,
-/obj/machinery/light/floor,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "crw" = (
 /obj/machinery/light/floor,
 /turf/open/floor/iron/large,
@@ -9312,10 +9296,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos/lesser)
-"cwA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "cwD" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -9774,10 +9754,6 @@
 	dir = 1
 	},
 /area/station/commons/locker)
-"cDJ" = (
-/obj/machinery/power/supermatter_crystal/engine,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "cDQ" = (
 /obj/effect/spawner/random/trash/box,
 /turf/open/floor/iron/kitchen,
@@ -10016,6 +9992,9 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms)
+"cGV" = (
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "cGW" = (
 /obj/effect/spawner/random/entertainment/drugs,
 /turf/open/floor/plating,
@@ -10477,6 +10456,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/command/vault)
+"cMk" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "cMm" = (
 /obj/structure/toilet{
 	pixel_y = 10
@@ -11485,18 +11473,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/floor2)
-"dav" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 6
-	},
-/obj/structure/flora/bush/reed{
-	pixel_y = 5
-	},
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
 "daw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -11552,6 +11528,18 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"dbq" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Server Room"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "tcommcradlecycle"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/smooth_half,
+/area/station/tcommsat/computer)
 "dbs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12770,6 +12758,10 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/lab)
+"duy" = (
+/obj/machinery/air_sensor/engine_chamber,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "duK" = (
 /obj/machinery/newscaster/directional/east,
 /obj/effect/turf_decal/tile/dark_green/full,
@@ -13352,6 +13344,19 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/science/server)
+"dDf" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 4
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "dDj" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
@@ -13626,22 +13631,6 @@
 	dir = 4
 	},
 /area/station/commons/lounge)
-"dHx" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining"
-	},
-/obj/machinery/bouldertech/refinery/smelter{
-	dir = 8
-	},
-/obj/machinery/light/directional/north,
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/cargo/miningfoundry)
 "dHH" = (
 /obj/machinery/camera/autoname/directional/north{
 	network = list("ss13","rd")
@@ -14234,6 +14223,19 @@
 	},
 /turf/open/floor/iron/sepia,
 /area/station/service/kitchen/diner)
+"dPe" = (
+/obj/machinery/light/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/tile,
+/area/station/commons/fitness/recreation)
 "dPi" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -14595,6 +14597,14 @@
 	},
 /turf/open/floor/iron/edge,
 /area/station/hallway/secondary/recreation)
+"dTR" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/engine)
 "dUa" = (
 /obj/effect/turf_decal/siding/dark/corner,
 /obj/structure/cable,
@@ -14626,12 +14636,6 @@
 	dir = 1
 	},
 /area/station/science/ordnance/testlab)
-"dUh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "dUz" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm1";
@@ -15179,6 +15183,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/secondary/recreation)
+"ebX" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 10
+	},
+/obj/structure/flora/bush/stalky/style_2,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "ecj" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/box,
@@ -15486,15 +15504,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"efF" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/east,
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "efT" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -15739,14 +15748,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos/pumproom)
-"eki" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/obj/structure/fans/tiny,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "eky" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16202,18 +16203,6 @@
 /obj/effect/turf_decal/trimline/green/line,
 /turf/open/floor/iron/dark/side,
 /area/station/commons/storage/mining)
-"eqa" = (
-/obj/machinery/light/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/south,
-/turf/open/floor/wood/tile,
-/area/station/commons/fitness/recreation)
 "eqm" = (
 /obj/structure/marker_beacon/yellow,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -17293,12 +17282,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/arrivalsshop)
-"eFw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "eFx" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -17708,11 +17691,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"eLX" = (
-/obj/structure/flora/ocean/seaweed,
-/obj/structure/flora/bush/sparsegrass,
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
 "eLZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18357,6 +18335,14 @@
 /obj/structure/sign/departments/xenobio/alt/directional/west,
 /turf/open/floor/iron/stairs/left,
 /area/station/science/research)
+"eVf" = (
+/obj/structure/table/wood,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/fax/heads/nanotrasen_consultant,
+/turf/open/floor/carpet/green,
+/area/station/command/heads_quarters/nt_rep)
 "eVg" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -18796,15 +18782,6 @@
 	dir = 8
 	},
 /area/station/commons/locker)
-"faY" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
 "faZ" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -20809,6 +20786,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"fDd" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "fDh" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark/filled/line{
@@ -21155,6 +21139,13 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/science/server)
+"fGH" = (
+/obj/machinery/camera/autoname/directional/north{
+	c_tag = "Engineering - Supermatter";
+	name = "engineering camera"
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "fGK" = (
 /obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron/dark,
@@ -21371,13 +21362,6 @@
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"fJy" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "fJG" = (
 /obj/item/stack/license_plates/empty/fifty,
 /obj/item/stack/license_plates/empty/fifty{
@@ -21602,18 +21586,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/patients_rooms)
-"fNe" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/station/hallway/primary/starboard)
 "fNu" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/smooth_half{
@@ -21953,6 +21925,16 @@
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/ce)
+"fSt" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/closet/firecloset,
+/obj/item/clothing/mask/gas/atmos,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "fSz" = (
 /obj/structure/chair/office,
 /obj/structure/cable,
@@ -22095,6 +22077,19 @@
 	dir = 4
 	},
 /area/station/commons/fitness)
+"fUB" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Server Room"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "tcommcradlecycle"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/plasticflaps/kitchen,
+/turf/open/floor/iron/dark/smooth_half,
+/area/station/tcommsat/server)
 "fUE" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/bot_white,
@@ -22202,14 +22197,6 @@
 	dir = 1
 	},
 /area/station/medical/virology)
-"fVL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/fax/heads/hos,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/hos)
 "fVV" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners{
 	dir = 1
@@ -22848,10 +22835,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/lower)
-"geM" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "geO" = (
 /obj/structure/table,
 /obj/machinery/light_switch/directional/south,
@@ -23311,21 +23294,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
-"gmW" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 10
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/button/door/directional/south{
-	id = "HopPrivacy";
-	name = "Privacy Shutters"
-	},
-/obj/machinery/fax/heads/hop,
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 4
-	},
-/area/station/command/heads_quarters/hop)
 "gnf" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/siding/dark{
@@ -23429,15 +23397,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/condemned_sci)
-"goz" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/west,
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "goE" = (
 /obj/structure/chair/comfy/barber_chair,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
@@ -23520,10 +23479,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/brick,
 /area/station/hallway/primary)
-"gpz" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/tcommsat/server)
 "gpU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -23727,11 +23682,6 @@
 	dir = 1
 	},
 /area/station/science/robotics/lab)
-"gsA" = (
-/obj/structure/flora/ocean/longseaweed,
-/mob/living/basic/frog,
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
 "gsH" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/item/reagent_containers/cup/watering_can,
@@ -23856,14 +23806,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/common/night_club)
-"gtZ" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/engine)
 "guc" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/blue/full,
@@ -23972,6 +23914,12 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/wood/tile,
 /area/station/service/kitchen/diner)
+"guS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "guU" = (
 /obj/effect/spawner/random/trash/crushed_can,
 /turf/open/floor/plating,
@@ -24181,6 +24129,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/purple,
 /area/station/service/barber)
+"gxj" = (
+/obj/structure/table/wood,
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/fax/heads/cmo,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/cmo)
 "gxm" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -24439,16 +24396,6 @@
 	dir = 1
 	},
 /area/station/medical/chemistry)
-"gBC" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/obj/structure/flora/bush/stalky,
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
 "gBJ" = (
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/fore)
@@ -24461,13 +24408,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/forestarboardhall)
-"gBQ" = (
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/engine)
 "gBT" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -25913,21 +25853,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
-"gUV" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/service/glass{
-	name = "Barbershop";
-	id_tag = "barberspa"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/general,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/service/barber/spa)
 "gVb" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 6
@@ -26253,15 +26178,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/port)
-"han" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/west,
-/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "hav" = (
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/carpet,
@@ -28486,25 +28402,6 @@
 	dir = 8
 	},
 /area/station/security/prison/rec)
-"hEr" = (
-/obj/machinery/bouldertech/refinery{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "mining"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/cargo/miningfoundry)
 "hEt" = (
 /obj/structure/chair/pew/left{
 	dir = 1
@@ -29450,13 +29347,6 @@
 /obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/iron/pool,
 /area/station/common/pool)
-"hRo" = (
-/obj/machinery/camera/autoname/directional/north{
-	c_tag = "Engineering - Supermatter";
-	name = "engineering camera"
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "hRp" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
@@ -29602,6 +29492,20 @@
 "hUc" = (
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_cafeteria/hydro)
+"hUm" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/structure/flora/bush/reed/style_2,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "hUn" = (
 /turf/open/floor/iron/dark/diagonal,
 /area/station/hallway/primary/foreporthall)
@@ -29770,16 +29674,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/brick,
 /area/station/hallway/primary/aft)
-"hWu" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/closet/firecloset,
-/obj/item/clothing/mask/gas/atmos,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "hWH" = (
 /obj/effect/turf_decal/trimline/dark_green/line,
 /obj/machinery/cryopod{
@@ -30920,12 +30814,6 @@
 	dir = 1
 	},
 /area/station/medical/treatment_center)
-"ilk" = (
-/obj/structure/flora/ocean/seaweed{
-	pixel_y = 12
-	},
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
 "ilr" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/structure/sign/poster/random/directional/south,
@@ -32110,6 +31998,12 @@
 	dir = 4
 	},
 /area/station/medical/treatment_center)
+"iBf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "iBg" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -32424,6 +32318,12 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
+"iFW" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "iGq" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -32493,6 +32393,19 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/floor2)
+"iHd" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Gas to Filter"
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/effect/mapping_helpers/airalarm/link{
+	chamber_id = "engine"
+	},
+/obj/effect/mapping_helpers/airalarm/engine_access,
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "iHf" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
@@ -32509,6 +32422,15 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms)
+"iHo" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "iHp" = (
 /obj/effect/heretic_rune/big,
 /turf/open/floor/cult,
@@ -32724,6 +32646,10 @@
 /obj/machinery/computer/atmos_alert/station_only,
 /turf/open/floor/iron/white/smooth_half,
 /area/station/engineering/lobby)
+"iJV" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "iKk" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 2
@@ -33400,23 +33326,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engineering/engine_aft_port)
-"iSP" = (
-/obj/machinery/newscaster/directional/east,
-/obj/item/flashlight/lamp/green{
-	pixel_y = 13
-	},
-/obj/structure/table/wood,
-/obj/item/storage/box/gum{
-	pixel_x = -10;
-	pixel_y = 5
-	},
-/obj/item/storage/box/sparklers{
-	pixel_x = 4
-	},
-/obj/structure/sign/calendar/directional/south,
-/obj/item/pneumatic_cannon/pie,
-/turf/open/floor/carpet/donk,
-/area/station/service/greenroom)
 "iSR" = (
 /obj/machinery/mineral/ore_redemption,
 /obj/machinery/door/firedoor,
@@ -33778,6 +33687,22 @@
 	dir = 4
 	},
 /area/station/medical/chemistry)
+"iXN" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
+	},
+/obj/structure/flora/bush/reed{
+	pixel_y = 5
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "iXP" = (
 /obj/structure/table/wood,
 /obj/item/folder/yellow{
@@ -34202,6 +34127,15 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
+"jdf" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "jdg" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
@@ -34395,15 +34329,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/wood,
 /area/station/maintenance/hiddenlibrary)
-"jgm" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "jgo" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/stripes{
@@ -34645,16 +34570,6 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/security/medical)
-"jji" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/obj/structure/sign/barber,
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/station/hallway/primary/starboard)
 "jjj" = (
 /turf/closed/wall/r_wall,
 /area/station/ai/upload/foyer)
@@ -34927,6 +34842,10 @@
 "jnH" = (
 /turf/closed/wall,
 /area/station/service/library/private)
+"jnI" = (
+/obj/machinery/power/supermatter_crystal/engine,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "jnM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/side{
@@ -36001,15 +35920,6 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/forestarboardhall)
-"jCQ" = (
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "jCV" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -36666,6 +36576,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"jKG" = (
+/obj/structure/cable,
+/obj/machinery/light/floor,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "jKK" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/closet_maintenance,
@@ -36790,22 +36705,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"jMs" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 2;
-	pixel_y = -4
-	},
-/obj/item/storage/box/matches{
-	pixel_y = 8;
-	pixel_x = -2
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/item/megaphone/clown,
-/turf/open/floor/carpet/donk,
-/area/station/service/greenroom)
 "jMt" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -36934,6 +36833,33 @@
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"jOd" = (
+/obj/structure/table,
+/obj/item/folder/yellow{
+	pixel_x = -2;
+	pixel_y = -4
+	},
+/obj/item/stamp/granted{
+	pixel_y = 11;
+	pixel_x = 9
+	},
+/obj/item/stamp/denied{
+	pixel_y = 12
+	},
+/obj/item/pen{
+	pixel_x = -3;
+	pixel_y = -1
+	},
+/obj/item/lightreplacer{
+	pixel_x = -13;
+	pixel_y = 11
+	},
+/obj/item/storage/box/shipping{
+	pixel_x = 12
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/cargo/storage)
 "jOr" = (
 /obj/structure/table,
 /obj/item/plate/small{
@@ -37236,6 +37162,15 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
+"jSa" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "jSw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -37286,18 +37221,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/port)
-"jSO" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/obj/structure/flora/bush/reed{
-	pixel_y = 5
-	},
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
 "jTm" = (
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -37588,17 +37511,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_art_studio)
-"jWT" = (
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "jWV" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37679,6 +37591,17 @@
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
+"jYl" = (
+/obj/structure/flora/ocean/coral,
+/obj/structure/flora/bush/sparsegrass{
+	pixel_x = -6
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "jYw" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/disposal/delivery_chute{
@@ -37743,6 +37666,22 @@
 "jZY" = (
 /turf/closed/wall/r_wall,
 /area/station/security/execution/transfer)
+"kab" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 6
+	},
+/obj/structure/flora/bush/reed{
+	pixel_y = 5
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "kai" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 4
@@ -38999,6 +38938,19 @@
 	},
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
+"kqh" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 9
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "kqk" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 8
@@ -39316,10 +39268,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"kuu" = (
-/obj/machinery/air_sensor/engine_chamber,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "kuw" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/cable,
@@ -39991,6 +39939,10 @@
 "kCo" = (
 /turf/closed/wall,
 /area/station/service/bar/backroom)
+"kCs" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "kCC" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -40575,12 +40527,6 @@
 /obj/structure/falsewall,
 /turf/open/floor/plating,
 /area/station/maintenance/gamer_lair)
-"kJC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "kJG" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/warning{
@@ -41280,16 +41226,6 @@
 "kTq" = (
 /turf/closed/wall,
 /area/icemoon/underground/explored)
-"kTs" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/obj/structure/flora/bush/reed/style_2,
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
 "kTt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -42152,12 +42088,6 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/recreation)
-"lgB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "lgC" = (
 /obj/structure/table,
 /obj/effect/spawner/random/mod/maint{
@@ -42222,18 +42152,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/edge,
 /area/station/engineering/atmos/hallway)
-"lhn" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 4
-	},
-/obj/structure/flora/bush/sparsegrass{
-	pixel_x = -6
-	},
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
 "lhq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -42715,6 +42633,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/floor2)
+"lpt" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 10
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/button/door/directional/south{
+	id = "HopPrivacy";
+	name = "Privacy Shutters"
+	},
+/obj/machinery/fax/heads/hop,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
+/area/station/command/heads_quarters/hop)
 "lpB" = (
 /obj/structure/fireplace,
 /obj/effect/turf_decal/siding/dark{
@@ -43450,12 +43383,6 @@
 /obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/iron/edge,
 /area/station/engineering/atmos)
-"lzG" = (
-/obj/machinery/camera/autoname/directional/south{
-	network = list("ss13","engine")
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "lzV" = (
 /obj/machinery/computer/operating{
 	dir = 8;
@@ -43536,6 +43463,15 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/eighties,
 /area/station/maintenance/abandon_arcade)
+"lAG" = (
+/obj/structure/flora/ocean/seaweed,
+/obj/structure/flora/bush/sparsegrass,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "lAL" = (
 /obj/machinery/light/directional/west,
 /obj/structure/table/reinforced,
@@ -43803,6 +43739,13 @@
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/wood/large,
 /area/station/security/prison)
+"lDA" = (
+/obj/structure/cable,
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/fax/heads/captain,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/captain)
 "lDD" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/siding/dark{
@@ -44235,6 +44178,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
+"lKp" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
+	},
+/obj/structure/flora/bush/sparsegrass{
+	pixel_x = 8
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "lKE" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 8
@@ -45033,10 +44992,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engineering/engie_aft_starboard)
-"lWu" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "lWA" = (
 /obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/iron/edge,
@@ -45815,6 +45770,28 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/brick,
 /area/station/hallway/primary)
+"miX" = (
+/obj/structure/table/wood,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","rd")
+	},
+/obj/item/stamp/head/rd{
+	pixel_w = -8;
+	pixel_z = 9
+	},
+/obj/item/screwdriver{
+	pixel_z = -4
+	},
+/obj/item/paper_bin{
+	pixel_w = 5;
+	pixel_z = 8
+	},
+/obj/item/pen{
+	pixel_w = 5;
+	pixel_z = 8
+	},
+/turf/open/floor/carpet/purple,
+/area/station/command/heads_quarters/rd)
 "miY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46241,6 +46218,15 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet/red,
 /area/station/service/chapel/funeral)
+"mnC" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 10
+	},
+/turf/open/floor/iron/corner{
+	dir = 4
+	},
+/area/station/tcommsat/computer)
 "mnE" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -46631,6 +46617,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/visit)
+"mtQ" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Gas to Chamber"
+	},
+/obj/machinery/camera/autoname/directional/east{
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "mtU" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -46867,6 +46862,16 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/station/commons/dorms/room6)
+"mwI" = (
+/obj/structure/flora/ocean/seaweed{
+	pixel_y = 12
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "mwJ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
@@ -47113,6 +47118,19 @@
 	dir = 8
 	},
 /area/station/security/brig)
+"mzq" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "mzt" = (
 /turf/closed/wall/r_wall,
 /area/station/commons/dorms/room7)
@@ -47497,10 +47515,6 @@
 "mFk" = (
 /turf/closed/wall,
 /area/station/security/checkpoint/engineering)
-"mFr" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/engine)
 "mFM" = (
 /obj/structure/chair/sofa/corp{
 	dir = 8
@@ -48265,6 +48279,15 @@
 	},
 /turf/open/floor/iron/edge,
 /area/station/engineering/atmos)
+"mRm" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/hallway/primary/starboard)
 "mRn" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/qm)
@@ -48909,6 +48932,26 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
+"naD" = (
+/obj/structure/table/wood,
+/obj/machinery/door/window/left/directional/south,
+/obj/structure/cable,
+/obj/item/folder/yellow,
+/obj/item/stamp/head/qm{
+	pixel_y = 5;
+	pixel_x = -4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/stamp/denied{
+	pixel_y = 12
+	},
+/obj/item/stamp/granted{
+	pixel_y = 5;
+	pixel_x = 9
+	},
+/turf/open/floor/wood/tile,
+/area/station/command/heads_quarters/qm)
 "naE" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/wood{
@@ -48952,33 +48995,25 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/security/courtroom)
+"nbp" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
+	},
+/obj/structure/flora/bush/stalky/style_3,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "nbq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/diagonal,
 /area/station/command/secure_bunker)
-"nbR" = (
-/obj/structure/table/wood,
-/obj/machinery/camera/autoname/directional/south{
-	network = list("ss13","rd")
-	},
-/obj/item/stamp/head/rd{
-	pixel_w = -8;
-	pixel_z = 9
-	},
-/obj/item/screwdriver{
-	pixel_z = -4
-	},
-/obj/item/paper_bin{
-	pixel_w = 5;
-	pixel_z = 8
-	},
-/obj/item/pen{
-	pixel_w = 5;
-	pixel_z = 8
-	},
-/turf/open/floor/carpet/purple,
-/area/station/command/heads_quarters/rd)
 "nbT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49092,14 +49127,13 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/barber)
-"nen" = (
-/obj/structure/railing{
-	dir = 5
+"ndU" = (
+/obj/structure/flora/bush/sparsegrass/style_3,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
 	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 5
-	},
-/turf/open/water/overlay,
 /area/station/hallway/floor2)
 "net" = (
 /obj/structure/cable,
@@ -50097,6 +50131,15 @@
 /obj/machinery/rnd/experimentor,
 /turf/open/floor/engine,
 /area/station/science/explab)
+"nss" = (
+/obj/structure/flora/ocean/longseaweed,
+/mob/living/basic/frog,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "nsA" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /obj/structure/disposalpipe/segment,
@@ -50399,12 +50442,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/cargo/miningfoyer)
-"nwv" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/eighties/red,
-/area/station/commons/fitness/recreation)
 "nwz" = (
 /turf/closed/wall,
 /area/station/cargo/sorting)
@@ -50660,15 +50697,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"nzK" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/table/wood/fancy/orange,
-/obj/item/radio/intercom/directional/west,
-/obj/machinery/fax/heads/ce,
-/turf/open/floor/wood/tile,
-/area/station/command/heads_quarters/ce)
 "nzP" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/line,
@@ -50739,6 +50767,10 @@
 	dir = 6
 	},
 /area/station/cargo/storage)
+"nAO" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/tcommsat/server)
 "nBh" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/structure/closet/secure_closet/barber,
@@ -50982,15 +51014,6 @@
 "nDN" = (
 /turf/open/floor/iron/dark/side,
 /area/station/ai/satellite/hallway)
-"nDZ" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 10
-	},
-/turf/open/floor/iron/corner{
-	dir = 4
-	},
-/area/station/tcommsat/computer)
 "nEi" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
@@ -52433,6 +52456,14 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/carpet/green,
 /area/station/command/heads_quarters/nt_rep)
+"nWL" = (
+/obj/structure/flora/ocean/longseaweed,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "nWM" = (
 /turf/open/floor/iron/corner,
 /area/station/command/secure_bunker)
@@ -52587,10 +52618,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos/lesser)
-"nYE" = (
-/obj/structure/flora/ocean/longseaweed,
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
 "nYL" = (
 /obj/structure/cable,
 /turf/open/floor/carpet/red,
@@ -53601,19 +53628,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms)
-"olA" = (
-/obj/structure/flora/ocean/coral,
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
-"olC" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 4
-	},
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
 "olF" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -55173,12 +55187,6 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/security/medical)
-"oKi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "oKl" = (
 /obj/effect/turf_decal/tile/yellow/full,
 /obj/effect/landmark/event_spawn,
@@ -55217,11 +55225,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"oKH" = (
-/obj/machinery/power/weather_tower,
-/obj/structure/cable,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/explored)
 "oKI" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -55343,6 +55346,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/grass,
 /area/station/science/genetics)
+"oMe" = (
+/obj/structure/flora/bush/sparsegrass,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "oMn" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 1
@@ -55865,33 +55876,6 @@
 	dir = 4
 	},
 /area/station/command/gateway)
-"oTo" = (
-/obj/structure/table,
-/obj/item/folder/yellow{
-	pixel_x = -2;
-	pixel_y = -4
-	},
-/obj/item/stamp/granted{
-	pixel_y = 11;
-	pixel_x = 9
-	},
-/obj/item/stamp/denied{
-	pixel_y = 12
-	},
-/obj/item/pen{
-	pixel_x = -3;
-	pixel_y = -1
-	},
-/obj/item/lightreplacer{
-	pixel_x = -13;
-	pixel_y = 11
-	},
-/obj/item/storage/box/shipping{
-	pixel_x = 12
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/cargo/storage)
 "oTt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -56573,6 +56557,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/common/pool/sauna)
+"pcf" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 4
+	},
+/obj/structure/flora/bush/sparsegrass{
+	pixel_x = -6
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "pcm" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/medbay/lobby)
@@ -58145,6 +58145,17 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
+"pzH" = (
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "pzI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -58917,6 +58928,20 @@
 "pLM" = (
 /turf/open/floor/wood/tile,
 /area/station/security/courtroom)
+"pLW" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/structure/flora/bush/stalky,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "pLX" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron,
@@ -60272,6 +60297,25 @@
 /obj/structure/curtain/cloth,
 /turf/open/floor/iron/freezer,
 /area/station/command/heads_quarters/qm)
+"qgS" = (
+/obj/machinery/bouldertech/refinery{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "mining"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/cargo/miningfoundry)
 "qgV" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -60315,16 +60359,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/checker,
 /area/station/security/prison/mess)
-"qhK" = (
-/obj/structure/flora/bush/sparsegrass/style_3,
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
-"qix" = (
-/obj/structure/table/wood,
-/obj/machinery/keycard_auth/wall_mounted/directional/north,
-/obj/machinery/fax/heads/qm,
-/turf/open/floor/wood/tile,
-/area/station/command/heads_quarters/qm)
 "qiF" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/steam_vent,
@@ -61616,6 +61650,23 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/condemned_med)
+"qAS" = (
+/obj/machinery/newscaster/directional/east,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 13
+	},
+/obj/structure/table/wood,
+/obj/item/storage/box/gum{
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/obj/item/storage/box/sparklers{
+	pixel_x = 4
+	},
+/obj/structure/sign/calendar/directional/south,
+/obj/item/pneumatic_cannon/pie,
+/turf/open/floor/carpet/donk,
+/area/station/service/greenroom)
 "qAU" = (
 /obj/structure/railing,
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -61795,18 +61846,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"qCZ" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Server Room"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "tcommcradlecycle"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/smooth_half,
-/area/station/tcommsat/computer)
+"qCX" = (
+/obj/structure/table/wood,
+/obj/machinery/keycard_auth/wall_mounted/directional/north,
+/obj/machinery/fax/heads/qm,
+/turf/open/floor/wood/tile,
+/area/station/command/heads_quarters/qm)
 "qDi" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -61884,6 +61929,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
+"qEl" = (
+/obj/structure/cable,
+/obj/machinery/power/weather_tower,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "qEy" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
@@ -62711,16 +62761,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/ordnance/testlab)
-"qPJ" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 10
-	},
-/obj/structure/flora/bush/stalky/style_2,
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
 "qPP" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -63002,10 +63042,6 @@
 /obj/machinery/status_display/supply,
 /turf/closed/wall/r_wall,
 /area/station/cargo/storage)
-"qUA" = (
-/obj/structure/flora/bush/sparsegrass,
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
 "qUJ" = (
 /obj/machinery/space_heater,
 /turf/open/floor/iron,
@@ -63503,6 +63539,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"rbt" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "rbv" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -63750,16 +63790,6 @@
 /obj/machinery/computer/records/security,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/security/detectives_office)
-"reu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
-"rey" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "reA" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
@@ -64173,11 +64203,6 @@
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
 /turf/open/floor/iron/freezer,
 /area/station/commons/dorms/room7)
-"rlx" = (
-/obj/machinery/mining_weather_monitor/directional/east,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "rlE" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/wrestle)
@@ -64626,6 +64651,9 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
+"rtx" = (
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "rty" = (
 /obj/structure/closet/secure_closet/psychology,
 /turf/open/floor/plating,
@@ -65006,12 +65034,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_art_studio)
-"rzJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "rzP" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -65076,6 +65098,15 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/sorting)
+"rAH" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "rAK" = (
 /obj/structure/table/wood,
 /obj/machinery/light/directional/north,
@@ -65658,15 +65689,6 @@
 	dir = 8
 	},
 /area/station/engineering/atmos/project)
-"rJu" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/east,
-/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "rJB" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 8
@@ -65835,13 +65857,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"rLR" = (
-/obj/structure/flora/ocean/coral,
-/obj/structure/flora/bush/sparsegrass{
-	pixel_x = -6
-	},
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
 "rLY" = (
 /obj/structure/railing/wooden_fence,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -67207,6 +67222,13 @@
 	dir = 4
 	},
 /area/station/hallway/primary/foreporthall)
+"sbG" = (
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/engine)
 "sbH" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
@@ -67229,15 +67251,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/ordnance_maint_lesser)
-"sch" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/east,
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "sci" = (
 /obj/structure/chair/sofa/corp{
 	dir = 8;
@@ -67743,6 +67756,12 @@
 /obj/effect/turf_decal/trimline/blue/warning,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/chemistry)
+"siX" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "sjb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68033,10 +68052,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/red,
 /area/station/common/nightclubbooth2)
-"smC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "smN" = (
 /obj/machinery/component_printer,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -69567,6 +69582,20 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
+"sFo" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/service/glass{
+	name = "Barbershop";
+	id_tag = "barberspa"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/service/barber/spa)
 "sFB" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -70008,6 +70037,10 @@
 	dir = 1
 	},
 /area/station/hallway/floor2)
+"sLZ" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "sMi" = (
 /obj/effect/turf_decal/trimline/green/line,
 /obj/effect/turf_decal/tile/dark_green{
@@ -70746,6 +70779,14 @@
 "sWQ" = (
 /turf/closed/wall,
 /area/station/maintenance/abandon_wrestle)
+"sWW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/fax/heads/hos,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/hos)
 "sWY" = (
 /obj/effect/turf_decal/tile/blue/full,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -71125,6 +71166,15 @@
 /mob/living/basic/bot/secbot/beepsky/officer,
 /turf/open/floor/iron,
 /area/station/hallway/floor2)
+"tcr" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "tcu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -72071,15 +72121,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
-"tpp" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Gas to Chamber"
-	},
-/obj/machinery/camera/autoname/directional/east{
-	network = list("ss13","engine")
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "tps" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction/yjunction{
@@ -72295,6 +72336,13 @@
 	},
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/fore)
+"trU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/delam_scram/directional/east,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "trY" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/yellow,
@@ -72559,17 +72607,20 @@
 	},
 /turf/open/floor/iron/brick,
 /area/station/hallway/primary/forestarboardhall)
-"tvO" = (
-/obj/structure/cable,
-/obj/machinery/power/weather_tower,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "tvW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
+"twj" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/structure/fans/tiny,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "twl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -73309,6 +73360,22 @@
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/station/hallway/primary)
+"tFG" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining"
+	},
+/obj/machinery/bouldertech/refinery/smelter{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/cargo/miningfoundry)
 "tFK" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
@@ -74543,13 +74610,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/service/library)
-"tVn" = (
-/obj/structure/cable,
-/obj/structure/table/wood,
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/fax/heads/captain,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/captain)
 "tVP" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/landmark/event_spawn,
@@ -74743,16 +74803,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"tYg" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/obj/structure/flora/bush/stalky/style_random,
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
 "tYj" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -74813,14 +74863,6 @@
 	dir = 8
 	},
 /area/station/tcommsat/computer)
-"tYI" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/siding/wideplating,
-/obj/structure/flora/bush/reed{
-	pixel_y = 5
-	},
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
 "tYL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -75311,6 +75353,12 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
+"ufN" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "ufR" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/holopad,
@@ -76829,6 +76877,20 @@
 	},
 /turf/open/floor/iron/edge,
 /area/station/engineering/atmos/hallway)
+"uCk" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 4
+	},
+/obj/structure/flora/bush/stalky/style_random,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "uCv" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/machinery/light/directional/south,
@@ -77971,9 +78033,6 @@
 	dir = 9
 	},
 /area/station/cargo/miningstairs)
-"uTc" = (
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "uTd" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8
@@ -78092,26 +78151,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary)
-"uUR" = (
-/obj/structure/table/wood,
-/obj/machinery/door/window/left/directional/south,
-/obj/structure/cable,
-/obj/item/folder/yellow,
-/obj/item/stamp/head/qm{
-	pixel_y = 5;
-	pixel_x = -4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/stamp/denied{
-	pixel_y = 12
-	},
-/obj/item/stamp/granted{
-	pixel_y = 5;
-	pixel_x = 9
-	},
-/turf/open/floor/wood/tile,
-/area/station/command/heads_quarters/qm)
 "uUV" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/effect/turf_decal/siding/brown,
@@ -79406,16 +79445,6 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/medical/office)
-"vmv" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/obj/structure/flora/bush/stalky/style_3,
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
 "vmy" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -79643,6 +79672,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"voN" = (
+/obj/machinery/mining_weather_monitor/directional/east,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "voQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
@@ -79746,11 +79780,6 @@
 /obj/structure/flora/bush/flowers_br/style_2,
 /turf/open/floor/grass,
 /area/station/hallway/primary/starboard)
-"vpA" = (
-/obj/machinery/power/weather_tower,
-/obj/structure/cable,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "vpD" = (
 /obj/item/toy/plush/lizard_plushie{
 	name = "Montresaur";
@@ -80482,6 +80511,14 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/eighties,
 /area/station/common/arcade)
+"vAH" = (
+/obj/structure/flora/ocean/coral,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "vAK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -81943,16 +81980,6 @@
 /obj/machinery/light/cold/directional/west,
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/science/xenobiology)
-"vST" = (
-/obj/structure/table/wood,
-/obj/machinery/button/curtain{
-	id = "rdprivacy";
-	pixel_x = 24;
-	pixel_y = -3
-	},
-/obj/machinery/fax/heads/rd,
-/turf/open/floor/carpet/purple,
-/area/station/command/heads_quarters/rd)
 "vSX" = (
 /turf/open/floor/iron,
 /area/station/maintenance/department/science/xenobiology)
@@ -82137,6 +82164,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"vWI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/table/wood/fancy/orange,
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/fax/heads/ce,
+/turf/open/floor/wood/tile,
+/area/station/command/heads_quarters/ce)
 "vWK" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/machinery/camera/autoname/directional/east{
@@ -82390,6 +82426,15 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/mining)
+"vZR" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/siding/wideplating,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "wag" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
@@ -83664,16 +83709,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/qm)
-"wsi" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 4
-	},
-/obj/structure/flora/bush/stalky/style_random,
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
 "wss" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -84945,6 +84980,11 @@
 /obj/machinery/netpod,
 /turf/open/floor/iron/dark/side,
 /area/station/cargo/bitrunning/den)
+"wId" = (
+/obj/machinery/power/weather_tower,
+/obj/structure/cable,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "wIh" = (
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
@@ -85017,6 +85057,18 @@
 	dir = 9
 	},
 /area/station/hallway/secondary/service)
+"wJf" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/siding/wideplating,
+/obj/structure/flora/bush/reed{
+	pixel_y = 5
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "wJt" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -86763,15 +86815,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"xeR" = (
-/obj/structure/table/wood,
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/obj/machinery/fax/heads/cmo,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/cmo)
 "xeY" = (
 /obj/machinery/digital_clock/directional/north,
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
@@ -87246,19 +87289,6 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/barber)
-"xld" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Server Room"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "tcommcradlecycle"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/plasticflaps/kitchen,
-/turf/open/floor/iron/dark/smooth_half,
-/area/station/tcommsat/server)
 "xle" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /obj/structure/window/reinforced/tinted/spawner/directional/north,
@@ -87522,10 +87552,6 @@
 	dir = 1
 	},
 /area/station/engineering/main)
-"xoF" = (
-/obj/structure/cable,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/explored)
 "xoJ" = (
 /obj/machinery/computer/dna_console{
 	dir = 8
@@ -87967,6 +87993,19 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"xty" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 5
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "xtT" = (
 /obj/structure/chair{
 	dir = 4
@@ -88026,6 +88065,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
+"xuM" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/obj/structure/sign/barber/directional/north{
+	pixel_y = 28
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/hallway/primary/starboard)
 "xuP" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -88063,11 +88117,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/ai/satellite/hallway)
-"xvv" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/siding/wideplating,
-/turf/open/water/overlay,
-/area/station/hallway/floor2)
 "xvB" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -88625,6 +88674,20 @@
 	dir = 4
 	},
 /area/station/hallway/primary/aftstarboardhall)
+"xCD" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
+	},
+/obj/structure/flora/bush/stalky/style_random,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "xCF" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/food_or_drink/condiment{
@@ -89435,6 +89498,12 @@
 /obj/structure/curtain/bounty/start_closed,
 /turf/open/floor/plating,
 /area/station/cargo/bitrunning/den)
+"xNF" = (
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "xNM" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -89955,6 +90024,12 @@
 	dir = 1
 	},
 /area/station/medical/chemistry)
+"xUo" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "xUz" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
@@ -90493,10 +90568,6 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/wood/tile,
 /area/station/service/kitchen/diner)
-"ybA" = (
-/obj/effect/turf_decal/trimline/green/filled/corner,
-/turf/closed/wall,
-/area/station/service/chapel)
 "ybB" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/siding/dark{
@@ -90522,6 +90593,10 @@
 /obj/item/flashlight/lantern/on,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
+"ybV" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "yca" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -90981,6 +91056,10 @@
 /obj/machinery/photocopier/prebuilt,
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/science/ordnance/office)
+"yhJ" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/engine)
 "yhP" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/flora/bush/generic/style_random,
@@ -91165,6 +91244,15 @@
 	dir = 1
 	},
 /area/station/hallway/primary/fore)
+"ykB" = (
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "ykM" = (
 /turf/closed/wall/r_wall,
 /area/station/common/nightclubbooth1)
@@ -180030,10 +180118,10 @@ tPn
 iLK
 tPn
 uuP
-xoF
-eki
-geM
-geM
+aUw
+twj
+iJV
+iJV
 dqy
 dqy
 cSb
@@ -180092,7 +180180,7 @@ iuo
 sNw
 sKF
 gZi
-jMs
+bCV
 xpR
 lPN
 tPn
@@ -180287,7 +180375,7 @@ tPn
 hJF
 tPn
 uuP
-xoF
+aUw
 hew
 gcV
 xkN
@@ -180544,7 +180632,7 @@ tPn
 hJF
 tPn
 uuP
-xoF
+aUw
 hew
 hew
 azq
@@ -180607,7 +180695,7 @@ oUd
 sNw
 blJ
 uvm
-iSP
+qAS
 kbV
 tPn
 tPn
@@ -180801,7 +180889,7 @@ tPn
 hJF
 tPn
 uuP
-xoF
+aUw
 nFi
 tPn
 tPn
@@ -181058,7 +181146,7 @@ tKY
 hJF
 tPn
 uuP
-xoF
+aUw
 tPn
 tPn
 rGV
@@ -181315,9 +181403,9 @@ tKY
 bKB
 bIS
 uuP
-xoF
-xoF
-oKH
+aUw
+aUw
+ahx
 tPn
 tPn
 tPn
@@ -184426,7 +184514,7 @@ sfy
 fMb
 iTD
 eTb
-ybA
+eZg
 bYH
 iLj
 wyT
@@ -185504,7 +185592,7 @@ qVh
 smi
 nXb
 iPX
-hWu
+fSt
 cgu
 jdO
 jdO
@@ -185761,15 +185849,15 @@ uwV
 nqV
 uhj
 iPX
-eFw
-lWu
-fJy
-lWu
-rlx
-jgm
-xoF
-xoF
-xoF
+guS
+sLZ
+fDd
+sLZ
+voN
+jSa
+aUw
+aUw
+aUw
 tPn
 tPn
 uuP
@@ -186026,7 +186114,7 @@ jdO
 jdO
 nFi
 tPn
-xoF
+aUw
 tPn
 tPn
 uuP
@@ -186283,7 +186371,7 @@ vBO
 vBO
 tPn
 tPn
-xoF
+aUw
 tPn
 tPn
 tPn
@@ -186540,9 +186628,9 @@ vBO
 tPn
 tPn
 tPn
-xoF
-xoF
-oKH
+aUw
+aUw
+ahx
 tPn
 tPn
 tPn
@@ -187514,12 +187602,12 @@ iex
 qdp
 akq
 ybB
-bTm
-vmv
-cji
-tYg
-jSO
-qPJ
+kqh
+nbp
+lKp
+xCD
+iXN
+ebX
 gbz
 cCs
 sbt
@@ -187545,7 +187633,7 @@ jdX
 oij
 azX
 lvN
-cwA
+ybV
 awt
 jth
 oYM
@@ -187771,12 +187859,12 @@ adZ
 adZ
 rbB
 oin
-kTs
-nYE
-ilk
-qUA
-nYE
-xvv
+hUm
+nWL
+mwI
+oMe
+nWL
+vZR
 gbz
 qht
 sbt
@@ -188028,12 +188116,12 @@ jIL
 adZ
 ayc
 oin
-faY
-olA
-nYE
-eLX
-qhK
-tYI
+mzq
+vAH
+nWL
+lAG
+ndU
+wJf
 gbz
 gOv
 hLN
@@ -188285,12 +188373,12 @@ xQu
 adZ
 ueM
 oin
-gBC
-ilk
-gsA
-rLR
-nYE
-xvv
+pLW
+mwI
+nss
+jYl
+nWL
+vZR
 gbz
 ecD
 hLN
@@ -188542,12 +188630,12 @@ cEj
 adZ
 sLA
 oin
-nen
-wsi
-olC
-lhn
-olC
-dav
+xty
+uCk
+dDf
+pcf
+dDf
+kab
 gbz
 geE
 hLN
@@ -188573,7 +188661,7 @@ jdX
 rXk
 kSc
 noA
-cwA
+ybV
 lsX
 jth
 oYM
@@ -189601,7 +189689,7 @@ jdX
 cVS
 wPT
 uOM
-cwA
+ybV
 wpp
 jth
 oYM
@@ -189615,7 +189703,7 @@ jth
 jth
 jth
 gKI
-cwA
+ybV
 kFB
 eWg
 cdm
@@ -190629,7 +190717,7 @@ jdX
 szM
 ouQ
 ePf
-cwA
+ybV
 rYM
 jth
 oYM
@@ -190643,7 +190731,7 @@ jth
 cGl
 jth
 bYK
-cwA
+ybV
 kQx
 hzM
 hJr
@@ -191671,7 +191759,7 @@ uBc
 nNe
 rfH
 pBC
-cwA
+ybV
 ett
 nFb
 bvg
@@ -194195,7 +194283,7 @@ wfG
 ePb
 vCs
 ofl
-eqa
+dPe
 biU
 tyb
 xvl
@@ -194451,7 +194539,7 @@ dYY
 vby
 gcO
 uiF
-nwv
+sez
 cSA
 biU
 biU
@@ -240960,7 +241048,7 @@ aZw
 mRn
 mRn
 hbW
-uUR
+naD
 wse
 vff
 bHE
@@ -240977,7 +241065,7 @@ gKQ
 uve
 pMZ
 tUZ
-oTo
+jOd
 vJn
 vMu
 otf
@@ -241216,7 +241304,7 @@ qgO
 gde
 wCw
 mRn
-qix
+qCX
 vHN
 mwl
 wpv
@@ -241966,7 +242054,7 @@ lsM
 wwK
 qOa
 wwK
-fVL
+sWW
 qFv
 qUR
 xzT
@@ -246100,7 +246188,7 @@ aed
 vch
 qeX
 dzX
-dHx
+tFG
 rCp
 xyo
 wvk
@@ -246359,7 +246447,7 @@ iYL
 dzX
 ujC
 axx
-hEr
+qgS
 gSt
 xjq
 gBU
@@ -247198,7 +247286,7 @@ xfD
 fws
 nwL
 nwL
-gpz
+nAO
 dyu
 jwY
 vHH
@@ -247451,11 +247539,11 @@ fws
 plG
 tHe
 mUZ
-nDZ
-qCZ
+mnC
+dbq
 xVp
-xld
-gpz
+fUB
+nAO
 msO
 yaf
 plB
@@ -248465,7 +248553,7 @@ ioy
 lFT
 bDG
 inr
-nzK
+vWI
 mBQ
 bPG
 otf
@@ -248911,7 +248999,7 @@ llx
 ubu
 tlh
 mQd
-gmW
+lpt
 llx
 iEx
 emh
@@ -253104,11 +253192,11 @@ vqy
 dKA
 gwb
 oWj
-cbk
-gBQ
-gtZ
-gBQ
-cbk
+rtx
+sbG
+dTR
+sbG
+rtx
 pJb
 wTv
 bvd
@@ -253361,11 +253449,11 @@ lhS
 erm
 npn
 oWj
-cbk
-hRo
-crp
-uTc
-cbk
+rtx
+fGH
+jKG
+cGV
+rtx
 rSE
 rZE
 ilP
@@ -253616,13 +253704,13 @@ aRH
 aRH
 tir
 iOe
-cbk
-cbk
-oKi
-efF
-rJu
-sch
-cbk
+rtx
+rtx
+xUo
+cMk
+iHo
+atR
+rtx
 fLd
 usK
 oks
@@ -253873,13 +253961,13 @@ ugJ
 aRH
 tir
 jec
-reu
-aYz
-kJC
-lgB
-lgB
-lgB
-cbk
+rbt
+iHd
+iFW
+abI
+abI
+abI
+rtx
 tOU
 uYP
 fUP
@@ -254130,13 +254218,13 @@ fOA
 aRH
 tir
 tRx
-jCQ
-uTc
-jWT
-kuu
-cDJ
-uTc
-mFr
+ykB
+cGV
+pzH
+duy
+jnI
+cGV
+yhJ
 rVn
 jbi
 bMn
@@ -254387,13 +254475,13 @@ vNz
 aRH
 tir
 iRo
-smC
-tpp
-dUh
-amO
-rzJ
-rzJ
-cbk
+kCs
+mtQ
+ufN
+trU
+iBf
+iBf
+rtx
 tOU
 uYP
 bvd
@@ -254644,13 +254732,13 @@ aRH
 aRH
 tir
 bfa
-cbk
-cbk
-rey
-aEM
-han
-goz
-cbk
+rtx
+rtx
+siX
+tcr
+rAH
+jdf
+rtx
 tSl
 usK
 oks
@@ -254903,11 +254991,11 @@ daw
 iRo
 jiM
 bEb
-cbk
-uTc
-crp
-lzG
-cbk
+rtx
+cGV
+jKG
+xNF
+rtx
 gsT
 uYP
 tew
@@ -255160,11 +255248,11 @@ vqy
 iRo
 jiM
 amd
-cbk
-gBQ
-gtZ
-gBQ
-cbk
+rtx
+sbG
+dTR
+sbG
+rtx
 tSl
 usK
 oiC
@@ -256600,7 +256688,7 @@ wBf
 bLo
 dPT
 ulM
-tVn
+lDA
 geG
 oXa
 ygs
@@ -260772,7 +260860,7 @@ akc
 akc
 gal
 akc
-gUV
+sFo
 akc
 akc
 iJc
@@ -262568,11 +262656,11 @@ abd
 abd
 abd
 etY
-fNe
+xuM
 bWM
 fMC
 mfF
-jji
+mRm
 etY
 wvL
 wvL
@@ -266633,7 +266721,7 @@ iUT
 jLZ
 aoi
 keS
-amj
+eVf
 sMj
 jaF
 gqZ
@@ -268742,7 +268830,7 @@ oDI
 nGx
 pzV
 bXO
-nbR
+miX
 nGx
 kQP
 npQ
@@ -268777,7 +268865,7 @@ jcZ
 jcZ
 aIO
 stA
-tvO
+qEl
 jcZ
 oaq
 jcZ
@@ -268999,7 +269087,7 @@ diu
 nGx
 wgt
 kdJ
-vST
+bnl
 nKI
 ivX
 npQ
@@ -272056,7 +272144,7 @@ oVi
 oYc
 ciI
 bQg
-xeR
+gxj
 tyN
 mAE
 hFw
@@ -274655,7 +274743,7 @@ jcZ
 jcZ
 stA
 stA
-vpA
+wId
 jcZ
 jcZ
 jcZ

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -107,6 +107,11 @@
 	dir = 4
 	},
 /area/station/ai/satellite/foyer)
+"abo" = (
+/obj/structure/cable,
+/obj/machinery/light/floor,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "abO" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -368,14 +373,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/medical/medbay/central)
-"aeA" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/obj/structure/fans/tiny,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "aeN" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/freezer,
@@ -518,6 +515,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/command/eva)
+"agd" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/station/hallway/floor2)
 "age" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/smooth_large,
@@ -560,6 +569,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblack,
 /area/station/command/heads_quarters/hos)
+"ahh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "ahk" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/landmark/start/hangover,
@@ -703,6 +718,15 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel/office)
+"aix" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/table/wood/fancy/orange,
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/fax/heads/ce,
+/turf/open/floor/wood/tile,
+/area/station/command/heads_quarters/ce)
 "aiA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public{
@@ -867,12 +891,6 @@
 /area/station/medical/treatment_center)
 "alb" = (
 /obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
-"alc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos/lesser)
 "ald" = (
@@ -1356,23 +1374,6 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
-"aqI" = (
-/obj/effect/turf_decal/trimline/yellow/line,
-/obj/item/screwdriver{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/storage/toolbox/fishing{
-	pixel_y = 7;
-	pixel_x = 8
-	},
-/obj/item/wrench{
-	pixel_y = 6;
-	pixel_x = -6
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/edge,
-/area/station/commons/storage/tools)
 "aqK" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/white/line{
@@ -1428,6 +1429,15 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos/office)
+"arq" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 10
+	},
+/turf/open/floor/iron/corner{
+	dir = 4
+	},
+/area/station/tcommsat/computer)
 "arN" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -1566,6 +1576,12 @@
 	dir = 4
 	},
 /area/station/hallway/primary/foreporthall)
+"asX" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "asY" = (
 /obj/machinery/computer/atmos_control/nocontrol/incinerator{
 	dir = 8
@@ -2386,6 +2402,9 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/common/night_club)
+"aCl" = (
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "aCp" = (
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/status_display/ai/directional/north,
@@ -2427,6 +2446,13 @@
 	dir = 8
 	},
 /area/station/medical/virology)
+"aCY" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "aDr" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -2632,6 +2658,25 @@
 	dir = 1
 	},
 /area/station/service/chapel)
+"aGZ" = (
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 7
+	},
+/obj/item/storage/toolbox/emergency{
+	pixel_x = 3
+	},
+/obj/item/weldingtool{
+	pixel_x = -8;
+	pixel_y = -13
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/station/commons/storage/tools)
 "aHc" = (
 /obj/machinery/light/floor,
 /turf/open/floor/engine,
@@ -3281,6 +3326,23 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/brick,
 /area/station/hallway/primary)
+"aQb" = (
+/obj/machinery/newscaster/directional/east,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 13
+	},
+/obj/structure/table/wood,
+/obj/item/storage/box/gum{
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/obj/item/storage/box/sparklers{
+	pixel_x = 4
+	},
+/obj/structure/sign/calendar/directional/south,
+/obj/item/pneumatic_cannon/pie,
+/turf/open/floor/carpet/donk,
+/area/station/service/greenroom)
 "aQi" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/structure/chair/office/light{
@@ -3653,6 +3715,12 @@
 	},
 /turf/open/floor/iron/edge,
 /area/station/engineering/atmos)
+"aTQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "aUi" = (
 /obj/machinery/space_heater,
 /obj/machinery/light_switch/directional/north,
@@ -3999,17 +4067,22 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
-"aZg" = (
-/obj/structure/cable,
-/obj/machinery/light/floor,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "aZw" = (
 /obj/machinery/door/airlock/bathroom{
 	name = "Restroom"
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/qm)
+"aZM" = (
+/obj/structure/table/wood,
+/obj/machinery/button/curtain{
+	id = "rdprivacy";
+	pixel_x = 24;
+	pixel_y = -3
+	},
+/obj/machinery/fax/heads/rd,
+/turf/open/floor/carpet/purple,
+/area/station/command/heads_quarters/rd)
 "aZW" = (
 /obj/structure/wrestling_corner{
 	dir = 4
@@ -4569,15 +4642,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
-"bid" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/west,
-/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "bio" = (
 /obj/structure/curtain/cloth,
 /obj/structure/drain,
@@ -5019,6 +5083,23 @@
 	},
 /turf/open/floor/wood,
 /area/station/common/arcade)
+"boq" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/engine)
+"bor" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "bou" = (
 /obj/effect/landmark/start/cyborg,
 /obj/structure/cable/layer1,
@@ -5585,10 +5666,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/fore)
-"bwc" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/engine)
 "bwh" = (
 /obj/machinery/light/directional/west,
 /obj/structure/disposalpipe/segment,
@@ -5767,6 +5844,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"byX" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/flora/bush/reed/style_2,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "bzc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -6065,6 +6153,17 @@
 /obj/structure/window/fulltile,
 /turf/open/floor/grass,
 /area/station/service/library)
+"bDb" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/light/small/dim/directional/north,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/iron/edge,
+/area/station/hallway/floor2)
 "bDn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6497,14 +6596,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/hallway/primary/foreporthall)
-"bJt" = (
-/obj/effect/turf_decal/trimline/yellow/corner{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/sign/poster/random/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/floor2)
 "bJF" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/effect/turf_decal/weather/dirt{
@@ -6695,21 +6786,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/medical/psychology)
-"bLK" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 10
+"bLD" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Server Room"
 	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/button/door/directional/south{
-	id = "HopPrivacy";
-	name = "Privacy Shutters"
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "tcommcradlecycle"
 	},
-/obj/machinery/fax/heads/hop,
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 4
-	},
-/area/station/command/heads_quarters/hop)
+/obj/machinery/door/firedoor,
+/obj/structure/plasticflaps/kitchen,
+/turf/open/floor/iron/dark/smooth_half,
+/area/station/tcommsat/server)
 "bLY" = (
 /obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/trimline/yellow/line,
@@ -7165,25 +7254,6 @@
 /obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/iron/edge,
 /area/station/commons/storage/tools)
-"bTm" = (
-/obj/structure/railing{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 9
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
-"bTr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "bTu" = (
 /turf/closed/wall/r_wall,
 /area/station/security/interrogation)
@@ -8299,10 +8369,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/service/greenroom)
-"chx" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "chN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8402,22 +8468,6 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/wood/tile,
 /area/station/hallway/secondary/dock)
-"cji" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/obj/structure/flora/bush/sparsegrass{
-	pixel_x = 8
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "cjk" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Brig Closet"
@@ -10954,10 +11004,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/engineering/lobby)
-"cSM" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/commons/storage/tools)
 "cST" = (
 /obj/effect/decal/cleanable/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11484,22 +11530,6 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/floor2)
-"dav" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 6
-	},
-/obj/structure/flora/bush/reed{
-	pixel_y = 5
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
 /area/station/hallway/floor2)
 "daw" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -12321,12 +12351,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"dnu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "dnH" = (
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination/vault,
@@ -13242,11 +13266,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/cargo/sorting)
-"dBu" = (
-/obj/machinery/mining_weather_monitor/directional/east,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "dBw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13288,10 +13307,6 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"dBS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "dCb" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -13615,6 +13630,16 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
+"dHo" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "dHr" = (
 /obj/structure/sink/directional/south,
 /turf/open/floor/iron/freezer,
@@ -15029,18 +15054,6 @@
 	dir = 8
 	},
 /area/station/engineering/atmos/project)
-"dZm" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/station/hallway/floor2)
 "dZF" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/purple,
@@ -15116,19 +15129,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"eaF" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Server Room"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "tcommcradlecycle"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/plasticflaps/kitchen,
-/turf/open/floor/iron/dark/smooth_half,
-/area/station/tcommsat/server)
 "eaR" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 1
@@ -16194,13 +16194,6 @@
 /obj/effect/turf_decal/trimline/green/line,
 /turf/open/floor/iron/dark/side,
 /area/station/commons/storage/mining)
-"epV" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "eqa" = (
 /obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
@@ -16384,6 +16377,12 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron,
 /area/station/maintenance/law)
+"esf" = (
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "esk" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/dark,
@@ -16474,25 +16473,6 @@
 /obj/effect/turf_decal/trimline/yellow/corner,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"etp" = (
-/obj/machinery/bouldertech/refinery{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "mining"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/cargo/miningfoundry)
 "etr" = (
 /obj/effect/turf_decal/tile/dark_green/diagonal_edge,
 /obj/effect/turf_decal/tile/green/diagonal_centre,
@@ -17396,11 +17376,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary)
-"eGX" = (
-/obj/machinery/power/weather_tower,
-/obj/structure/cable,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "eHs" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/stairs/right{
@@ -17424,10 +17399,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood/large,
 /area/station/security/courtroom)
-"eHG" = (
-/obj/machinery/power/supermatter_crystal/engine,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "eHQ" = (
 /obj/effect/turf_decal/trimline/green/line,
 /obj/structure/disposalpipe/segment,
@@ -18613,6 +18584,17 @@
 	dir = 8
 	},
 /area/station/science/xenobiology)
+"eXx" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/flora/bush/stalky/style_random,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "eXN" = (
 /turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
@@ -18713,6 +18695,16 @@
 	dir = 4
 	},
 /area/station/commons/fitness/locker_room)
+"eZm" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "eZw" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction{
@@ -18822,19 +18814,6 @@
 	dir = 8
 	},
 /area/station/commons/locker)
-"faY" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "faZ" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -19072,16 +19051,6 @@
 /obj/structure/sacrificealtar,
 /turf/open/floor/cult,
 /area/station/maintenance/condemnedroom)
-"feI" = (
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 8
-	},
-/obj/machinery/newscaster/directional/west,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/edge{
-	dir = 8
-	},
-/area/station/commons/storage/tools)
 "feK" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 10
@@ -19715,23 +19684,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"fmu" = (
-/obj/effect/turf_decal/trimline/yellow/line,
-/obj/item/flashlight{
-	pixel_y = 12;
-	pixel_x = -7
-	},
-/obj/item/weldingtool{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/obj/item/flashlight{
-	pixel_y = 6;
-	pixel_x = -3
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/edge,
-/area/station/commons/storage/tools)
 "fmT" = (
 /turf/open/floor/carpet,
 /area/station/service/theater)
@@ -21606,6 +21558,23 @@
 	dir = 1
 	},
 /area/station/ai/satellite/foyer)
+"fMA" = (
+/obj/effect/turf_decal/trimline/yellow/line,
+/obj/item/flashlight{
+	pixel_y = 12;
+	pixel_x = -7
+	},
+/obj/item/weldingtool{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/flashlight{
+	pixel_y = 6;
+	pixel_x = -3
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/edge,
+/area/station/commons/storage/tools)
 "fMC" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -22129,9 +22098,6 @@
 	dir = 4
 	},
 /area/station/commons/fitness)
-"fUs" = (
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "fUE" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/bot_white,
@@ -22239,13 +22205,6 @@
 	dir = 1
 	},
 /area/station/medical/virology)
-"fVI" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/firealarm/directional/north,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/commons/storage/tools)
 "fVV" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners{
 	dir = 1
@@ -23532,11 +23491,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/transit_tube)
-"gpV" = (
-/obj/machinery/power/weather_tower,
-/obj/structure/cable,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/explored)
 "gqa" = (
 /turf/open/floor/iron/smooth_edge{
 	dir = 4
@@ -24214,6 +24168,13 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/medical/psychology)
+"gxw" = (
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/engine)
 "gxE" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -24444,20 +24405,6 @@
 	dir = 1
 	},
 /area/station/medical/chemistry)
-"gBC" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/obj/structure/flora/bush/stalky,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "gBJ" = (
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/fore)
@@ -24662,14 +24609,15 @@
 	dir = 1
 	},
 /area/station/cargo/miningfoyer)
+"gDA" = (
+/obj/machinery/power/weather_tower,
+/obj/structure/cable,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
 "gDD" = (
 /obj/effect/spawner/random/trash/graffiti,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/medical/morgue)
-"gDF" = (
-/obj/structure/cable,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/explored)
 "gDG" = (
 /obj/structure/curtain/cloth/fancy/mechanical{
 	icon_state = "bounty-open";
@@ -25134,6 +25082,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/gag_room)
+"gKa" = (
+/obj/structure/railing,
+/obj/structure/flora/bush/reed{
+	pixel_y = 5
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "gKb" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/incinerator_input{
 	dir = 1
@@ -25155,15 +25114,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/supply)
-"gKg" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/east,
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "gKu" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "theatshutters";
@@ -25827,35 +25777,6 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
-"gTD" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 9
-	},
-/obj/item/t_scanner{
-	pixel_y = 7;
-	pixel_x = 8
-	},
-/obj/item/crowbar{
-	pixel_y = 14;
-	pixel_x = -4
-	},
-/obj/item/electronics/airlock{
-	pixel_x = -4
-	},
-/obj/item/electronics/airlock{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/electronics/airlock{
-	pixel_x = -1;
-	pixel_y = 5
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
-/area/station/commons/storage/tools)
 "gTI" = (
 /obj/structure/rack/shelf,
 /obj/effect/turf_decal/tile/purple/opposingcorners{
@@ -26603,15 +26524,6 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/entry)
-"heJ" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/east,
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "heS" = (
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/trimline/white/line{
@@ -27039,6 +26951,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/floor2)
+"hlb" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "hle" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -27348,15 +27270,6 @@
 	},
 /turf/open/floor/iron/brick,
 /area/station/hallway/primary/aft)
-"hoy" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Gas to Chamber"
-	},
-/obj/machinery/camera/autoname/directional/east{
-	network = list("ss13","engine")
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "hoF" = (
 /obj/machinery/door/window/right/directional/north{
 	req_access = list("cargo");
@@ -27825,6 +27738,12 @@
 "huw" = (
 /turf/closed/wall,
 /area/station/engineering/atmos/office)
+"huD" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "huH" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -28182,33 +28101,6 @@
 /obj/item/clipboard,
 /turf/open/floor/iron/edge,
 /area/station/commons/locker)
-"hAa" = (
-/obj/structure/table,
-/obj/item/folder/yellow{
-	pixel_x = -2;
-	pixel_y = -4
-	},
-/obj/item/stamp/granted{
-	pixel_y = 11;
-	pixel_x = 9
-	},
-/obj/item/stamp/denied{
-	pixel_y = 12
-	},
-/obj/item/pen{
-	pixel_x = -3;
-	pixel_y = -1
-	},
-/obj/item/lightreplacer{
-	pixel_x = -13;
-	pixel_y = 11
-	},
-/obj/item/storage/box/shipping{
-	pixel_x = 12
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/cargo/storage)
 "hAd" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -29097,6 +28989,10 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/execution/transfer)
+"hMr" = (
+/obj/machinery/power/supermatter_crystal/engine,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "hMG" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29652,6 +29548,14 @@
 	},
 /turf/open/floor/grass,
 /area/station/commons/dorms/room4)
+"hUb" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/structure/fans/tiny,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "hUc" = (
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_cafeteria/hydro)
@@ -30253,15 +30157,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/edge,
 /area/station/hallway/secondary/entry)
-"ibt" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "ibw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30548,10 +30443,6 @@
 	},
 /turf/open/floor/grass,
 /area/station/commons/dorms/room1)
-"ifk" = (
-/obj/machinery/air_sensor/engine_chamber,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "ifp" = (
 /turf/open/floor/iron,
 /area/station/maintenance/dorm_room)
@@ -30967,6 +30858,15 @@
 	dir = 1
 	},
 /area/station/command/secure_bunker)
+"ikB" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Gas to Chamber"
+	},
+/obj/machinery/camera/autoname/directional/east{
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "ikV" = (
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 1
@@ -31185,6 +31085,16 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_holding_cell)
+"inT" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "inZ" = (
 /obj/structure/chair{
 	dir = 4
@@ -31771,15 +31681,6 @@
 	dir = 4
 	},
 /area/station/security/office)
-"ivt" = (
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "ivA" = (
 /obj/structure/sink/kitchen/directional/west,
 /obj/machinery/light/directional/east,
@@ -32329,6 +32230,17 @@
 	},
 /turf/open/floor/iron/checker,
 /area/station/commons/lounge)
+"iDJ" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/flora/bush/stalky,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "iDS" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/bush/flowers_pp/style_random{
@@ -33081,22 +32993,6 @@
 /obj/structure/sign/warning/cold_temp/directional/west,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"iNw" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining"
-	},
-/obj/machinery/bouldertech/refinery/smelter{
-	dir = 8
-	},
-/obj/machinery/light/directional/north,
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/cargo/miningfoundry)
 "iNA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -33114,6 +33010,19 @@
 	dir = 8
 	},
 /area/station/command/heads_quarters/hos)
+"iNI" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Gas to Filter"
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/effect/mapping_helpers/airalarm/link{
+	chamber_id = "engine"
+	},
+/obj/effect/mapping_helpers/airalarm/engine_access,
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "iNJ" = (
 /turf/closed/wall,
 /area/station/commons/toilet/restrooms)
@@ -33821,6 +33730,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
+"iXG" = (
+/obj/machinery/power/weather_tower,
+/obj/structure/cable,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "iXH" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
@@ -33846,6 +33760,22 @@
 	dir = 4
 	},
 /area/station/medical/chemistry)
+"iXM" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining"
+	},
+/obj/machinery/bouldertech/refinery/smelter{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/cargo/miningfoundry)
 "iXP" = (
 /obj/structure/table/wood,
 /obj/item/folder/yellow{
@@ -33946,13 +33876,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
-"iYR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/delam_scram/directional/east,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "iYV" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/green/line{
@@ -35128,6 +35051,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"jpf" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "jpk" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 8
@@ -36217,32 +36149,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
 /area/station/service/quietroom)
-"jEx" = (
-/obj/machinery/newscaster/directional/north,
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 5
-	},
-/obj/item/airlock_painter/decal{
-	pixel_y = -17
-	},
-/obj/item/storage/box/lights/mixed{
-	pixel_y = 11;
-	pixel_x = 5
-	},
-/obj/item/storage/box/lights/mixed{
-	pixel_y = 2;
-	pixel_x = 5
-	},
-/obj/item/clipboard{
-	pixel_x = -12;
-	pixel_y = 5
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/corner{
-	dir = 1
-	},
-/area/station/commons/storage/tools)
 "jEA" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm4";
@@ -36966,6 +36872,15 @@
 "jNz" = (
 /turf/open/floor/wood/large,
 /area/station/security/courtroom)
+"jNC" = (
+/obj/structure/table/wood,
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/fax/heads/cmo,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/cmo)
 "jNI" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -37352,22 +37267,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/port)
-"jSO" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/obj/structure/flora/bush/reed{
-	pixel_y = 5
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "jTm" = (
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -39135,16 +39034,6 @@
 	},
 /turf/closed/wall,
 /area/station/maintenance/department/crew_quarters/dorms)
-"krk" = (
-/obj/structure/table/wood,
-/obj/machinery/button/curtain{
-	id = "rdprivacy";
-	pixel_x = 24;
-	pixel_y = -3
-	},
-/obj/machinery/fax/heads/rd,
-/turf/open/floor/carpet/purple,
-/area/station/command/heads_quarters/rd)
 "krm" = (
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/freezer,
@@ -39430,6 +39319,12 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/engineering/atmospherics_engine)
+"kuS" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "kuT" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 10
@@ -40010,6 +39905,19 @@
 	dir = 8
 	},
 /area/station/cargo/miningfoyer)
+"kBN" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/structure/flora/bush/reed{
+	pixel_y = 5
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "kBZ" = (
 /obj/item/universal_scanner{
 	pixel_y = 27
@@ -41339,20 +41247,6 @@
 "kTq" = (
 /turf/closed/wall,
 /area/icemoon/underground/explored)
-"kTs" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/obj/structure/flora/bush/reed/style_2,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "kTt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -41740,6 +41634,17 @@
 	dir = 1
 	},
 /area/station/hallway/primary/port)
+"kZb" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/structure/flora/bush/stalky/style_2,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "kZz" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/green/filled/warning{
@@ -41902,10 +41807,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/prison)
-"lbX" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/tcommsat/server)
 "lbY" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8;
@@ -41915,18 +41816,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood/tile,
 /area/station/hallway/secondary/dock)
-"lcd" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Server Room"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "tcommcradlecycle"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/smooth_half,
-/area/station/tcommsat/computer)
 "lce" = (
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/east,
@@ -42295,22 +42184,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/edge,
 /area/station/engineering/atmos/hallway)
-"lhn" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 4
-	},
-/obj/structure/flora/bush/sparsegrass{
-	pixel_x = -6
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "lhq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -42370,6 +42243,16 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_art_studio)
+"lih" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/closet/firecloset,
+/obj/item/clothing/mask/gas/atmos,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "lis" = (
 /obj/effect/spawner/random/entertainment/drugs{
 	pixel_x = -7;
@@ -42661,6 +42544,12 @@
 	dir = 1
 	},
 /area/station/engineering/atmos/hallway)
+"lmr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "lmz" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -42963,6 +42852,14 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/tcommsat/server)
+"lrf" = (
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/floor2)
 "lrp" = (
 /obj/structure/flora/tree/jungle/small/style_3,
 /turf/open/floor/grass,
@@ -43067,6 +42964,33 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblack,
 /area/station/command/heads_quarters/hos)
+"lsf" = (
+/obj/structure/table,
+/obj/item/folder/yellow{
+	pixel_x = -2;
+	pixel_y = -4
+	},
+/obj/item/stamp/granted{
+	pixel_y = 11;
+	pixel_x = 9
+	},
+/obj/item/stamp/denied{
+	pixel_y = 12
+	},
+/obj/item/pen{
+	pixel_x = -3;
+	pixel_y = -1
+	},
+/obj/item/lightreplacer{
+	pixel_x = -13;
+	pixel_y = 11
+	},
+/obj/item/storage/box/shipping{
+	pixel_x = 12
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/cargo/storage)
 "lsg" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/button/door/directional/west{
@@ -43103,6 +43027,35 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
+"lsP" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 9
+	},
+/obj/item/t_scanner{
+	pixel_y = 7;
+	pixel_x = 8
+	},
+/obj/item/crowbar{
+	pixel_y = 14;
+	pixel_x = -4
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -4
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/station/commons/storage/tools)
 "lsX" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 1
@@ -43395,17 +43348,6 @@
 "lxf" = (
 /turf/open/floor/carpet/red,
 /area/station/command/bridge)
-"lxj" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light/small/dim/directional/north,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/iron/edge,
-/area/station/hallway/floor2)
 "lxu" = (
 /obj/effect/turf_decal/tile/dark_green/opposingcorners,
 /obj/structure/disposalpipe/segment{
@@ -43424,23 +43366,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
-"lxX" = (
-/obj/machinery/newscaster/directional/east,
-/obj/item/flashlight/lamp/green{
-	pixel_y = 13
-	},
-/obj/structure/table/wood,
-/obj/item/storage/box/gum{
-	pixel_x = -10;
-	pixel_y = 5
-	},
-/obj/item/storage/box/sparklers{
-	pixel_x = 4
-	},
-/obj/structure/sign/calendar/directional/south,
-/obj/item/pneumatic_cannon/pie,
-/turf/open/floor/carpet/donk,
-/area/station/service/greenroom)
 "lya" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -44192,14 +44117,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos/lesser)
-"lIN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/fax/heads/hos,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/hos)
 "lIR" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -44681,6 +44598,26 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/medical/morgue)
+"lQw" = (
+/obj/structure/table/wood,
+/obj/machinery/door/window/left/directional/south,
+/obj/structure/cable,
+/obj/item/folder/yellow,
+/obj/item/stamp/head/qm{
+	pixel_y = 5;
+	pixel_x = -4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/stamp/denied{
+	pixel_y = 12
+	},
+/obj/item/stamp/granted{
+	pixel_y = 5;
+	pixel_x = 9
+	},
+/turf/open/floor/wood/tile,
+/area/station/command/heads_quarters/qm)
 "lQx" = (
 /obj/machinery/newscaster/directional/north,
 /turf/open/openspace,
@@ -45268,10 +45205,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/primaryservicestairs)
-"lYM" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "lYN" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 6
@@ -45823,15 +45756,6 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
-"mil" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/west,
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "mim" = (
 /obj/effect/turf_decal/siding/yellow,
 /obj/effect/turf_decal/siding/yellow{
@@ -48057,6 +47981,37 @@
 /obj/item/pen,
 /turf/open/floor/carpet,
 /area/station/service/library/private)
+"mMj" = (
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 6
+	},
+/obj/item/electronics/airalarm{
+	pixel_y = 1;
+	pixel_x = 6
+	},
+/obj/item/electronics/airalarm{
+	pixel_y = 5;
+	pixel_x = 4
+	},
+/obj/item/electronics/apc{
+	pixel_x = -5
+	},
+/obj/item/electronics/apc{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/vending_refill/games{
+	pixel_y = 16;
+	pixel_x = 7
+	},
+/obj/item/wirecutters{
+	pixel_y = 2
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/corner{
+	dir = 1
+	},
+/area/station/commons/storage/tools)
 "mMl" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -48101,18 +48056,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary)
-"mMA" = (
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = -3;
-	pixel_y = 10
-	},
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron,
-/area/station/commons/storage/tools)
 "mMC" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -48223,6 +48166,19 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/entry)
+"mPj" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/flora/bush/reed{
+	pixel_y = 5
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "mPq" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -48321,12 +48277,6 @@
 	},
 /turf/open/floor/iron/edge,
 /area/station/engineering/atmos)
-"mRa" = (
-/obj/structure/table/wood,
-/obj/machinery/keycard_auth/wall_mounted/directional/north,
-/obj/machinery/fax/heads/qm,
-/turf/open/floor/wood/tile,
-/area/station/command/heads_quarters/qm)
 "mRn" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/qm)
@@ -49132,19 +49082,6 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/barber)
-"nen" = (
-/obj/structure/railing{
-	dir = 5
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 5
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "net" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_red/filled/line,
@@ -49347,6 +49284,9 @@
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/science/robotics)
+"nhR" = (
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "nhW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -49573,12 +49513,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/station/security/courtroom)
-"nlU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "nmb" = (
 /obj/structure/hedge,
 /obj/structure/window/reinforced/fulltile,
@@ -53054,6 +52988,10 @@
 	dir = 1
 	},
 /area/station/engineering/atmos/project)
+"oeF" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/engine)
 "oeH" = (
 /obj/effect/landmark/start/prisoner,
 /obj/structure/cable,
@@ -53633,19 +53571,6 @@
 /area/station/commons/dorms)
 "olA" = (
 /obj/structure/flora/ocean/coral,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
-"olC" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 4
-	},
 /obj/effect/spawner/liquids_spawner,
 /turf/open/floor/iron/pool{
 	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
@@ -54996,12 +54921,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/aftporthall)
-"oHk" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/machinery/door/firedoor,
-/obj/machinery/status_display/ai/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/floor2)
 "oHl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -55388,25 +55307,6 @@
 /obj/effect/landmark/firealarm_sanity,
 /turf/open/floor/carpet/green,
 /area/station/commons/dorms/room7)
-"oMz" = (
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/item/storage/toolbox/emergency{
-	pixel_y = 7
-	},
-/obj/item/storage/toolbox/emergency{
-	pixel_x = 3
-	},
-/obj/item/weldingtool{
-	pixel_x = -8;
-	pixel_y = -13
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/station/commons/storage/tools)
 "oMC" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/dark,
@@ -56432,6 +56332,14 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating/icemoon,
 /area/station/science/ordnance/bomb)
+"oZQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/fax/heads/hos,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/hos)
 "pac" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -56563,15 +56471,6 @@
 	},
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/virology)
-"pbJ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/table/wood/fancy/orange,
-/obj/item/radio/intercom/directional/west,
-/obj/machinery/fax/heads/ce,
-/turf/open/floor/wood/tile,
-/area/station/command/heads_quarters/ce)
 "pbN" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -57257,6 +57156,21 @@
 	dir = 4
 	},
 /area/station/science/research)
+"pkX" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/station/hallway/floor2)
 "plc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -57311,6 +57225,23 @@
 	dir = 1
 	},
 /area/station/medical/treatment_center)
+"plL" = (
+/obj/effect/turf_decal/trimline/yellow/line,
+/obj/item/screwdriver{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/storage/toolbox/fishing{
+	pixel_y = 7;
+	pixel_x = 8
+	},
+/obj/item/wrench{
+	pixel_y = 6;
+	pixel_x = -6
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/edge,
+/area/station/commons/storage/tools)
 "plN" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 9
@@ -58169,15 +58100,6 @@
 /obj/machinery/keycard_auth/wall_mounted/directional/north,
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/rd)
-"pzX" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 10
-	},
-/turf/open/floor/iron/corner{
-	dir = 4
-	},
-/area/station/tcommsat/computer)
 "pzY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58523,6 +58445,19 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms/room2)
+"pFM" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/flora/bush/sparsegrass{
+	pixel_x = 8
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "pGg" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -59901,12 +59836,6 @@
 "qaj" = (
 /turf/closed/wall,
 /area/station/maintenance/department/security/brig)
-"qal" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "qan" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Patient Rooms"
@@ -60568,6 +60497,32 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/freezer,
 /area/station/common/locker_room_shower)
+"qmh" = (
+/obj/machinery/newscaster/directional/north,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 5
+	},
+/obj/item/airlock_painter/decal{
+	pixel_y = -17
+	},
+/obj/item/storage/box/lights/mixed{
+	pixel_y = 11;
+	pixel_x = 5
+	},
+/obj/item/storage/box/lights/mixed{
+	pixel_y = 2;
+	pixel_x = 5
+	},
+/obj/item/clipboard{
+	pixel_x = -12;
+	pixel_y = 5
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/corner{
+	dir = 1
+	},
+/area/station/commons/storage/tools)
 "qmk" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -60797,19 +60752,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/exit/departure_lounge)
-"qoP" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Gas to Filter"
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/effect/mapping_helpers/airalarm/link{
-	chamber_id = "engine"
-	},
-/obj/effect/mapping_helpers/airalarm/engine_access,
-/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "qoU" = (
 /obj/machinery/suit_storage_unit/medical,
 /obj/effect/turf_decal/tile/blue/anticorner,
@@ -60973,13 +60915,6 @@
 "qqK" = (
 /turf/open/floor/iron,
 /area/station/maintenance/department/security)
-"qqO" = (
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/engine)
 "qqV" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plating,
@@ -61893,13 +61828,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/library)
-"qED" = (
-/obj/machinery/camera/autoname/directional/north{
-	c_tag = "Engineering - Supermatter";
-	name = "engineering camera"
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "qEY" = (
 /obj/structure/stairs/south,
 /turf/open/floor/iron,
@@ -61976,6 +61904,15 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/barber)
+"qFT" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "qGf" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
@@ -62716,20 +62653,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/ordnance/testlab)
-"qPJ" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 10
-	},
-/obj/structure/flora/bush/stalky/style_2,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "qPP" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -63124,37 +63047,6 @@
 	dir = 8
 	},
 /area/station/engineering/storage)
-"qVK" = (
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 6
-	},
-/obj/item/electronics/airalarm{
-	pixel_y = 1;
-	pixel_x = 6
-	},
-/obj/item/electronics/airalarm{
-	pixel_y = 5;
-	pixel_x = 4
-	},
-/obj/item/electronics/apc{
-	pixel_x = -5
-	},
-/obj/item/electronics/apc{
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/obj/item/vending_refill/games{
-	pixel_y = 16;
-	pixel_x = 7
-	},
-/obj/item/wirecutters{
-	pixel_y = 2
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/corner{
-	dir = 1
-	},
-/area/station/commons/storage/tools)
 "qVT" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/white/line{
@@ -63637,17 +63529,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet/purple,
 /area/station/service/barber/spa)
-"rch" = (
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "rcp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
 	dir = 4
@@ -63786,6 +63667,10 @@
 	dir = 4
 	},
 /area/station/hallway/primary/forestarboardhall)
+"reg" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "rek" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64617,11 +64502,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"rsE" = (
-/obj/structure/cable,
-/obj/machinery/power/weather_tower,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "rsG" = (
 /obj/structure/cable,
 /obj/structure/chair/sofa/bench/left,
@@ -64666,6 +64546,28 @@
 "rtj" = (
 /turf/open/floor/glass/reinforced/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"rtr" = (
+/obj/structure/table/wood,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","rd")
+	},
+/obj/item/stamp/head/rd{
+	pixel_w = -8;
+	pixel_z = 9
+	},
+/obj/item/screwdriver{
+	pixel_z = -4
+	},
+/obj/item/paper_bin{
+	pixel_w = 5;
+	pixel_z = 8
+	},
+/obj/item/pen{
+	pixel_w = 5;
+	pixel_z = 8
+	},
+/turf/open/floor/carpet/purple,
+/area/station/command/heads_quarters/rd)
 "rts" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/turf_decal/delivery,
@@ -64982,6 +64884,22 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/common/pool)
+"ryw" = (
+/obj/item/folder/yellow{
+	pixel_x = -11;
+	pixel_y = 7
+	},
+/obj/item/toner,
+/obj/item/toner{
+	pixel_y = 3
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron,
+/area/station/commons/storage/tools)
 "ryA" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/machinery/light/small/directional/north,
@@ -65016,6 +64934,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/barber)
+"ryQ" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "ryW" = (
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/plating,
@@ -66244,6 +66166,11 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"rRN" = (
+/obj/structure/cable,
+/obj/machinery/power/weather_tower,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "rRO" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -66560,12 +66487,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/medical/office)
-"rUS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "rUT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -67253,6 +67174,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/ordnance_maint_lesser)
+"scg" = (
+/obj/machinery/mining_weather_monitor/directional/east,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "sci" = (
 /obj/structure/chair/sofa/corp{
 	dir = 8;
@@ -67473,6 +67399,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/service/janitor)
+"sfc" = (
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = -3;
+	pixel_y = 10
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron,
+/area/station/commons/storage/tools)
 "sfd" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -67546,6 +67484,15 @@
 "sgt" = (
 /turf/closed/wall,
 /area/station/security/checkpoint/supply)
+"sgC" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "sgG" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 10
@@ -67993,6 +67940,13 @@
 	dir = 4
 	},
 /area/station/hallway/floor2)
+"slV" = (
+/obj/structure/cable,
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/fax/heads/captain,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/captain)
 "slZ" = (
 /obj/machinery/disposal/delivery_chute{
 	name = "Sci Deliveries"
@@ -68426,22 +68380,6 @@
 	},
 /turf/open/floor/eighties,
 /area/station/maintenance/abandon_arcade)
-"ssi" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 2;
-	pixel_y = -4
-	},
-/obj/item/storage/box/matches{
-	pixel_y = 8;
-	pixel_x = -2
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/item/megaphone/clown,
-/turf/open/floor/carpet/donk,
-/area/station/service/greenroom)
 "ssl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68580,14 +68518,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"stC" = (
-/obj/structure/table/wood,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/fax/heads/nanotrasen_consultant,
-/turf/open/floor/carpet/green,
-/area/station/command/heads_quarters/nt_rep)
 "stV" = (
 /obj/machinery/door/airlock/atmos/glass,
 /obj/structure/cable,
@@ -69106,22 +69036,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/law)
-"szT" = (
-/obj/item/folder/yellow{
-	pixel_x = -11;
-	pixel_y = 7
-	},
-/obj/item/toner,
-/obj/item/toner{
-	pixel_y = 3
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron,
-/area/station/commons/storage/tools)
 "sAf" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/smooth_large,
@@ -69489,15 +69403,6 @@
 /obj/structure/dresser,
 /turf/open/floor/carpet/royalblack,
 /area/station/command/heads_quarters/hos)
-"sDD" = (
-/obj/structure/table/wood,
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/obj/machinery/fax/heads/cmo,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/cmo)
 "sDM" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -69615,6 +69520,25 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
+"sFs" = (
+/obj/machinery/bouldertech/refinery{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "mining"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/cargo/miningfoundry)
 "sFB" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -70026,14 +69950,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/patients_rooms)
-"sLF" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/engine)
 "sLG" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -70112,6 +70028,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/commons/toilet/restrooms)
+"sMO" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Server Room"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "tcommcradlecycle"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/smooth_half,
+/area/station/tcommsat/computer)
 "sMS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -70275,6 +70203,9 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/aft)
+"sPg" = (
+/turf/open/space/basic,
+/area/icemoon/underground/unexplored/rivers/deep)
 "sPo" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -70461,6 +70392,14 @@
 /obj/item/stock_parts/power_store/cell/high,
 /turf/open/floor/plating,
 /area/station/maintenance/condemned_sci)
+"sRK" = (
+/obj/structure/railing,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "sRN" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/table/wood,
@@ -70546,21 +70485,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/office)
-"sTB" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/station/hallway/floor2)
 "sTE" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -72311,6 +72235,10 @@
 	dir = 8
 	},
 /area/station/engineering/engine_smes)
+"tre" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "trm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72696,6 +72624,15 @@
 /obj/effect/turf_decal/box/red,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain/private)
+"txB" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "txD" = (
 /obj/structure/railing,
 /turf/open/floor/iron/stairs{
@@ -73366,6 +73303,12 @@
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/station/hallway/primary)
+"tFH" = (
+/obj/structure/table/wood,
+/obj/machinery/keycard_auth/wall_mounted/directional/north,
+/obj/machinery/fax/heads/qm,
+/turf/open/floor/wood/tile,
+/area/station/command/heads_quarters/qm)
 "tFK" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
@@ -73439,6 +73382,13 @@
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/brick,
 /area/station/hallway/primary)
+"tGy" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/firealarm/directional/north,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/commons/storage/tools)
 "tGB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -73697,13 +73647,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/checker,
 /area/station/commons/fitness)
-"tJC" = (
-/obj/structure/cable,
-/obj/structure/table/wood,
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/fax/heads/captain,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/captain)
 "tJG" = (
 /obj/structure/railing,
 /turf/open/openspace,
@@ -74071,12 +74014,6 @@
 "tNQ" = (
 /turf/open/floor/engine,
 /area/station/security/armory)
-"tNT" = (
-/obj/machinery/camera/autoname/directional/south{
-	network = list("ss13","engine")
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "tNX" = (
 /obj/machinery/modular_computer/preset/command,
 /obj/structure/window/reinforced/tinted/spawner/directional/north,
@@ -74104,6 +74041,21 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/secondary/dock)
+"tOk" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 10
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/button/door/directional/south{
+	id = "HopPrivacy";
+	name = "Privacy Shutters"
+	},
+/obj/machinery/fax/heads/hop,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
+/area/station/command/heads_quarters/hop)
 "tOm" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -74607,6 +74559,15 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/service/library)
+"tVN" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "tVP" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/landmark/event_spawn,
@@ -74800,20 +74761,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"tYg" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/obj/structure/flora/bush/stalky/style_random,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "tYj" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -74874,18 +74821,6 @@
 	dir = 8
 	},
 /area/station/tcommsat/computer)
-"tYI" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/siding/wideplating,
-/obj/structure/flora/bush/reed{
-	pixel_y = 5
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "tYL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -75180,6 +75115,19 @@
 	dir = 4
 	},
 /turf/open/floor/iron/diagonal,
+/area/station/hallway/floor2)
+"udf" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/flora/bush/sparsegrass{
+	pixel_x = -6
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
 /area/station/hallway/floor2)
 "udh" = (
 /obj/structure/table/wood/fancy/orange,
@@ -75805,6 +75753,17 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_arcade)
+"umJ" = (
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "umN" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 9
@@ -76352,6 +76311,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/lobby)
+"uuy" = (
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/item/lightreplacer{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/station/commons/storage/tools)
 "uuA" = (
 /obj/machinery/door/poddoor{
 	id = "Secure Storage";
@@ -76513,19 +76485,6 @@
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron/large,
 /area/station/cargo/storage)
-"uxy" = (
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/item/lightreplacer{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/station/commons/storage/tools)
 "uxF" = (
 /obj/structure/sign/directions/security{
 	dir = 1;
@@ -76728,29 +76687,23 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"uzL" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/flora/bush/stalky/style_3,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "uzX" = (
 /obj/machinery/computer/cargo/express{
 	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/station/command/bridge)
-"uzY" = (
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 10
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 8;
-	pixel_x = 3
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -1;
-	pixel_y = 1
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/corner{
-	dir = 4
-	},
-/area/station/commons/storage/tools)
 "uAh" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -77083,15 +77036,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/diagonal,
 /area/station/service/hydroponics)
-"uEU" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/east,
-/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "uEX" = (
 /obj/structure/flora/tree/jungle/small/style_4,
 /turf/open/floor/grass,
@@ -77324,6 +77268,10 @@
 	dir = 1
 	},
 /area/station/hallway/floor2)
+"uHD" = (
+/obj/structure/cable,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
 "uHI" = (
 /obj/structure/fireaxecabinet/mechremoval/directional/east,
 /obj/structure/table,
@@ -77343,15 +77291,6 @@
 	dir = 4
 	},
 /area/station/science/robotics/lab)
-"uHL" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/west,
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "uHP" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Old Sci"
@@ -78679,6 +78618,16 @@
 	dir = 4
 	},
 /area/station/hallway/primary/port)
+"vbl" = (
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/west,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/station/commons/storage/tools)
 "vbs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -78714,6 +78663,13 @@
 "vbR" = (
 /turf/closed/wall,
 /area/station/commons/vacant_room/commissary)
+"vca" = (
+/obj/machinery/camera/autoname/directional/north{
+	c_tag = "Engineering - Supermatter";
+	name = "engineering camera"
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "vch" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
@@ -79443,28 +79399,6 @@
 	dir = 4
 	},
 /area/station/security/prison/work)
-"vml" = (
-/obj/structure/table/wood,
-/obj/machinery/camera/autoname/directional/south{
-	network = list("ss13","rd")
-	},
-/obj/item/stamp/head/rd{
-	pixel_w = -8;
-	pixel_z = 9
-	},
-/obj/item/screwdriver{
-	pixel_z = -4
-	},
-/obj/item/paper_bin{
-	pixel_w = 5;
-	pixel_z = 8
-	},
-/obj/item/pen{
-	pixel_w = 5;
-	pixel_z = 8
-	},
-/turf/open/floor/carpet/purple,
-/area/station/command/heads_quarters/rd)
 "vmm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -79489,20 +79423,6 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/medical/office)
-"vmv" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/obj/structure/flora/bush/stalky/style_3,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "vmy" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -80432,26 +80352,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/common/night_club)
-"vyF" = (
-/obj/structure/table/wood,
-/obj/machinery/door/window/left/directional/south,
-/obj/structure/cable,
-/obj/item/folder/yellow,
-/obj/item/stamp/head/qm{
-	pixel_y = 5;
-	pixel_x = -4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/stamp/denied{
-	pixel_y = 12
-	},
-/obj/item/stamp/granted{
-	pixel_y = 5;
-	pixel_x = 9
-	},
-/turf/open/floor/wood/tile,
-/area/station/command/heads_quarters/qm)
 "vyM" = (
 /obj/structure/marker_beacon/burgundy,
 /obj/structure/sign/warning/docking/directional/west,
@@ -82453,6 +82353,12 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/plating,
 /area/station/ai/satellite/hallway)
+"vZl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "vZo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -83549,6 +83455,12 @@
 	dir = 1
 	},
 /area/station/engineering/transit_tube)
+"wpd" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/floor2)
 "wpe" = (
 /obj/effect/turf_decal/trimline/yellow/line,
 /obj/item/radio/intercom/directional/south,
@@ -83751,20 +83663,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/qm)
-"wsi" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 4
-	},
-/obj/structure/flora/bush/stalky/style_random,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "wss" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -83872,6 +83770,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/ordnance_maint)
+"wtR" = (
+/obj/structure/table/wood,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/fax/heads/nanotrasen_consultant,
+/turf/open/floor/carpet/green,
+/area/station/command/heads_quarters/nt_rep)
 "wtV" = (
 /obj/structure/closet/secure_closet/brig/genpop,
 /obj/effect/turf_decal/trimline/white/line{
@@ -84678,6 +84584,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/brick,
 /area/station/hallway/floor2)
+"wCz" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "wCK" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/status_display/evac/directional/north,
@@ -85583,9 +85498,6 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/openspace/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"wOJ" = (
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "wOO" = (
 /obj/effect/turf_decal/stripes,
 /obj/structure/cable,
@@ -85979,6 +85891,10 @@
 	dir = 4
 	},
 /area/station/hallway/primary/forestarboardhall)
+"wTQ" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "wTU" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 1
@@ -86137,6 +86053,10 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/break_room)
+"wVB" = (
+/obj/machinery/air_sensor/engine_chamber,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "wVD" = (
 /turf/open/floor/carpet,
 /area/station/command/bridge)
@@ -86719,6 +86639,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"xcV" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/flora/bush/stalky/style_random,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "xcW" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -87486,6 +87417,15 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/lab)
+"xna" = (
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "xne" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -88131,15 +88071,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/ai/satellite/hallway)
-"xvv" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/siding/wideplating,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "xvB" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -88214,16 +88145,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/nt_rep)
-"xwM" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/closet/firecloset,
-/obj/item/clothing/mask/gas/atmos,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "xwV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -89039,10 +88960,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/engine,
 /area/station/ai/satellite/hallway)
-"xHm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "xHu" = (
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
@@ -89521,6 +89438,23 @@
 /obj/structure/curtain/bounty/start_closed,
 /turf/open/floor/plating,
 /area/station/cargo/bitrunning/den)
+"xNM" = (
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 10
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 8;
+	pixel_x = 3
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/corner{
+	dir = 4
+	},
+/area/station/commons/storage/tools)
 "xNU" = (
 /obj/structure/chair/comfy/barber_chair,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
@@ -90172,6 +90106,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_psych)
+"xWj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/delam_scram/directional/east,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "xWn" = (
 /obj/structure/table/wood,
 /obj/item/statuebust{
@@ -90465,12 +90406,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/tcommsat/server)
-"yak" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "yao" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/disposalpipe/segment{
@@ -90568,6 +90503,10 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/wood/tile,
 /area/station/service/kitchen/diner)
+"ybA" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/commons/storage/tools)
 "ybB" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/siding/dark{
@@ -90654,6 +90593,22 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/entry)
+"ycA" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 2;
+	pixel_y = -4
+	},
+/obj/item/storage/box/matches{
+	pixel_y = 8;
+	pixel_x = -2
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/item/megaphone/clown,
+/turf/open/floor/carpet/donk,
+/area/station/service/greenroom)
 "ycB" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -90913,6 +90868,10 @@
 /obj/effect/spawner/random/trash/box,
 /turf/open/floor/plating,
 /area/station/maintenance/wrestle)
+"yge" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/tcommsat/server)
 "ygj" = (
 /obj/effect/turf_decal/tile/dark_green/anticorner{
 	dir = 8
@@ -122568,7 +122527,7 @@ jKe
 jKe
 jKe
 jKe
-jKe
+sPg
 jKe
 jKe
 jKe
@@ -180101,10 +180060,10 @@ tPn
 iLK
 tPn
 uuP
-gDF
-aeA
-chx
-chx
+uHD
+hUb
+ryQ
+ryQ
 dqy
 dqy
 cSb
@@ -180163,7 +180122,7 @@ iuo
 sNw
 sKF
 gZi
-ssi
+ycA
 xpR
 lPN
 tPn
@@ -180358,7 +180317,7 @@ tPn
 hJF
 tPn
 uuP
-gDF
+uHD
 hew
 gcV
 xkN
@@ -180615,7 +180574,7 @@ tPn
 hJF
 tPn
 uuP
-gDF
+uHD
 hew
 hew
 azq
@@ -180678,7 +180637,7 @@ oUd
 sNw
 blJ
 uvm
-lxX
+aQb
 kbV
 tPn
 tPn
@@ -180872,7 +180831,7 @@ tPn
 hJF
 tPn
 uuP
-gDF
+uHD
 nFi
 tPn
 tPn
@@ -181129,7 +181088,7 @@ tKY
 hJF
 tPn
 uuP
-gDF
+uHD
 tPn
 tPn
 rGV
@@ -181386,9 +181345,9 @@ tKY
 bKB
 bIS
 uuP
-gDF
-gDF
-gpV
+uHD
+uHD
+gDA
 tPn
 tPn
 tPn
@@ -185019,8 +184978,8 @@ pon
 iPG
 pon
 pon
-bJt
-oHk
+lrf
+wpd
 hLN
 hLN
 hLN
@@ -185270,11 +185229,11 @@ sWz
 eZg
 eZg
 pon
-fVI
+tGy
 rRc
-feI
+vbl
 iUv
-uzY
+xNM
 pon
 wbq
 pnw
@@ -185529,10 +185488,10 @@ hkT
 pon
 kNn
 rBQ
-mMA
+sfc
 oEz
-fmu
-cSM
+fMA
+ybA
 xCo
 lqV
 rcZ
@@ -185575,7 +185534,7 @@ qVh
 smi
 nXb
 iPX
-xwM
+lih
 cgu
 jdO
 jdO
@@ -185786,7 +185745,7 @@ hQc
 pon
 fYC
 rBQ
-szT
+ryw
 pBQ
 faf
 elX
@@ -185832,15 +185791,15 @@ uwV
 nqV
 uhj
 iPX
-alc
-lYM
-epV
-lYM
-dBu
-ibt
-gDF
-gDF
-gDF
+ahh
+wTQ
+aCY
+wTQ
+scg
+jpf
+uHD
+uHD
+uHD
 tPn
 tPn
 uuP
@@ -186097,7 +186056,7 @@ jdO
 jdO
 nFi
 tPn
-gDF
+uHD
 tPn
 tPn
 uuP
@@ -186298,12 +186257,12 @@ hLN
 tmc
 tmX
 pon
-gTD
+lsP
 boB
 uVo
 phz
-aqI
-cSM
+plL
+ybA
 xCo
 pAr
 jNr
@@ -186354,7 +186313,7 @@ vBO
 vBO
 tPn
 tPn
-gDF
+uHD
 tPn
 tPn
 tPn
@@ -186555,13 +186514,13 @@ hLN
 hCs
 tmX
 pon
-jEx
-uxy
+qmh
+uuy
 aag
-oMz
-qVK
-cSM
-lxj
+aGZ
+mMj
+ybA
+bDb
 pAr
 vXc
 sLU
@@ -186611,9 +186570,9 @@ vBO
 tPn
 tPn
 tPn
-gDF
-gDF
-gpV
+uHD
+uHD
+gDA
 tPn
 tPn
 tPn
@@ -186813,11 +186772,11 @@ xmQ
 lkx
 pon
 pon
-cSM
+ybA
 muo
-cSM
-cSM
-cSM
+ybA
+ybA
+ybA
 sws
 pAr
 tzo
@@ -187069,12 +187028,12 @@ wqG
 hIq
 afI
 iMp
-sTB
+pkX
 kWf
 kWf
-dZm
+agd
 pwM
-dZm
+agd
 xoK
 gxp
 pZS
@@ -187585,12 +187544,12 @@ iex
 qdp
 akq
 ybB
-bTm
-vmv
-cji
-tYg
-jSO
-qPJ
+hlb
+uzL
+pFM
+eXx
+mPj
+kZb
 gbz
 cCs
 sbt
@@ -187842,12 +187801,12 @@ adZ
 adZ
 rbB
 oin
-kTs
+byX
 nYE
 ilk
 qUA
 nYE
-xvv
+sRK
 gbz
 qht
 sbt
@@ -188099,12 +188058,12 @@ jIL
 adZ
 ayc
 oin
-faY
+eZm
 olA
 nYE
 eLX
 qhK
-tYI
+gKa
 gbz
 gOv
 hLN
@@ -188356,12 +188315,12 @@ xQu
 adZ
 ueM
 oin
-gBC
+iDJ
 ilk
 gsA
 rLR
 nYE
-xvv
+sRK
 gbz
 ecD
 hLN
@@ -188613,12 +188572,12 @@ cEj
 adZ
 sLA
 oin
-nen
-wsi
-olC
-lhn
-olC
-dav
+dHo
+xcV
+inT
+udf
+inT
+kBN
 gbz
 geE
 hLN
@@ -241031,7 +240990,7 @@ aZw
 mRn
 mRn
 hbW
-vyF
+lQw
 wse
 vff
 bHE
@@ -241048,7 +241007,7 @@ gKQ
 uve
 pMZ
 tUZ
-hAa
+lsf
 vJn
 vMu
 otf
@@ -241287,7 +241246,7 @@ qgO
 gde
 wCw
 mRn
-mRa
+tFH
 vHN
 mwl
 wpv
@@ -242037,7 +241996,7 @@ lsM
 wwK
 qOa
 wwK
-lIN
+oZQ
 qFv
 qUR
 xzT
@@ -246171,7 +246130,7 @@ aed
 vch
 qeX
 dzX
-iNw
+iXM
 rCp
 xyo
 wvk
@@ -246430,7 +246389,7 @@ iYL
 dzX
 ujC
 axx
-etp
+sFs
 gSt
 xjq
 gBU
@@ -247269,7 +247228,7 @@ xfD
 fws
 nwL
 nwL
-lbX
+yge
 dyu
 jwY
 vHH
@@ -247522,11 +247481,11 @@ fws
 plG
 tHe
 mUZ
-pzX
-lcd
+arq
+sMO
 xVp
-eaF
-lbX
+bLD
+yge
 msO
 yaf
 plB
@@ -248536,7 +248495,7 @@ ioy
 lFT
 bDG
 inr
-pbJ
+aix
 mBQ
 bPG
 otf
@@ -248982,7 +248941,7 @@ llx
 ubu
 tlh
 mQd
-bLK
+tOk
 llx
 iEx
 emh
@@ -253175,11 +253134,11 @@ vqy
 dKA
 gwb
 oWj
-wOJ
-qqO
-sLF
-qqO
-wOJ
+aCl
+gxw
+boq
+gxw
+aCl
 pJb
 wTv
 bvd
@@ -253432,11 +253391,11 @@ lhS
 erm
 npn
 oWj
-wOJ
-qED
-aZg
-fUs
-wOJ
+aCl
+vca
+abo
+nhR
+aCl
 rSE
 rZE
 ilP
@@ -253687,13 +253646,13 @@ aRH
 aRH
 tir
 iOe
-wOJ
-wOJ
-bTr
-heJ
-uEU
-gKg
-wOJ
+aCl
+aCl
+vZl
+txB
+sgC
+tVN
+aCl
 fLd
 usK
 oks
@@ -253944,13 +253903,13 @@ ugJ
 aRH
 tir
 jec
-dBS
-qoP
-rUS
-dnu
-dnu
-dnu
-wOJ
+tre
+iNI
+aTQ
+lmr
+lmr
+lmr
+aCl
 tOU
 uYP
 fUP
@@ -254201,13 +254160,13 @@ fOA
 aRH
 tir
 tRx
-ivt
-fUs
-rch
-ifk
-eHG
-fUs
-bwc
+xna
+nhR
+umJ
+wVB
+hMr
+nhR
+oeF
 rVn
 jbi
 bMn
@@ -254458,13 +254417,13 @@ vNz
 aRH
 tir
 iRo
-xHm
-hoy
-qal
-iYR
-yak
-yak
-wOJ
+reg
+ikB
+huD
+xWj
+asX
+asX
+aCl
 tOU
 uYP
 bvd
@@ -254715,13 +254674,13 @@ aRH
 aRH
 tir
 bfa
-wOJ
-wOJ
-nlU
-uHL
-bid
-mil
-wOJ
+aCl
+aCl
+kuS
+qFT
+bor
+wCz
+aCl
 tSl
 usK
 oks
@@ -254974,11 +254933,11 @@ daw
 iRo
 jiM
 bEb
-wOJ
-fUs
-aZg
-tNT
-wOJ
+aCl
+nhR
+abo
+esf
+aCl
 gsT
 uYP
 tew
@@ -255231,11 +255190,11 @@ vqy
 iRo
 jiM
 amd
-wOJ
-qqO
-sLF
-qqO
-wOJ
+aCl
+gxw
+boq
+gxw
+aCl
 tSl
 usK
 oiC
@@ -256671,7 +256630,7 @@ wBf
 bLo
 dPT
 ulM
-tJC
+slV
 geG
 oXa
 ygs
@@ -266704,7 +266663,7 @@ iUT
 jLZ
 aoi
 keS
-stC
+wtR
 sMj
 jaF
 gqZ
@@ -268813,7 +268772,7 @@ oDI
 nGx
 pzV
 bXO
-vml
+rtr
 nGx
 kQP
 npQ
@@ -268848,7 +268807,7 @@ jcZ
 jcZ
 aIO
 stA
-rsE
+rRN
 jcZ
 oaq
 jcZ
@@ -269070,7 +269029,7 @@ diu
 nGx
 wgt
 kdJ
-krk
+aZM
 nKI
 ivX
 npQ
@@ -272127,7 +272086,7 @@ oVi
 oYc
 ciI
 bQg
-sDD
+jNC
 tyN
 mAE
 hFw
@@ -274726,7 +274685,7 @@ jcZ
 jcZ
 stA
 stA
-eGX
+iXG
 jcZ
 jcZ
 jcZ

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -107,11 +107,6 @@
 	dir = 4
 	},
 /area/station/ai/satellite/foyer)
-"abo" = (
-/obj/structure/cable,
-/obj/machinery/light/floor,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "abO" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -569,12 +564,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblack,
 /area/station/command/heads_quarters/hos)
-"ahh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "ahk" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/landmark/start/hangover,
@@ -718,15 +707,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel/office)
-"aix" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/table/wood/fancy/orange,
-/obj/item/radio/intercom/directional/west,
-/obj/machinery/fax/heads/ce,
-/turf/open/floor/wood/tile,
-/area/station/command/heads_quarters/ce)
 "aiA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public{
@@ -1429,15 +1409,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos/office)
-"arq" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 10
-	},
-/turf/open/floor/iron/corner{
-	dir = 4
-	},
-/area/station/tcommsat/computer)
 "arN" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -1576,12 +1547,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/foreporthall)
-"asX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "asY" = (
 /obj/machinery/computer/atmos_control/nocontrol/incinerator{
 	dir = 8
@@ -2402,9 +2367,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/common/night_club)
-"aCl" = (
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "aCp" = (
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/status_display/ai/directional/north,
@@ -2446,13 +2408,6 @@
 	dir = 8
 	},
 /area/station/medical/virology)
-"aCY" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "aDr" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -3326,23 +3281,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/brick,
 /area/station/hallway/primary)
-"aQb" = (
-/obj/machinery/newscaster/directional/east,
-/obj/item/flashlight/lamp/green{
-	pixel_y = 13
-	},
-/obj/structure/table/wood,
-/obj/item/storage/box/gum{
-	pixel_x = -10;
-	pixel_y = 5
-	},
-/obj/item/storage/box/sparklers{
-	pixel_x = 4
-	},
-/obj/structure/sign/calendar/directional/south,
-/obj/item/pneumatic_cannon/pie,
-/turf/open/floor/carpet/donk,
-/area/station/service/greenroom)
 "aQi" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/structure/chair/office/light{
@@ -3715,12 +3653,6 @@
 	},
 /turf/open/floor/iron/edge,
 /area/station/engineering/atmos)
-"aTQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "aUi" = (
 /obj/machinery/space_heater,
 /obj/machinery/light_switch/directional/north,
@@ -3786,13 +3718,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/brick,
 /area/station/hallway/primary/aft)
-"aVt" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Auxiliary Tool Storage"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/small,
-/area/station/commons/storage/tools)
 "aVv" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/closet/emcloset,
@@ -3838,6 +3763,19 @@
 	dir = 8
 	},
 /area/station/engineering/main)
+"aVW" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Gas to Filter"
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/effect/mapping_helpers/airalarm/link{
+	chamber_id = "engine"
+	},
+/obj/effect/mapping_helpers/airalarm/engine_access,
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "aWk" = (
 /obj/machinery/conveyor/inverted{
 	dir = 9;
@@ -4073,16 +4011,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/qm)
-"aZM" = (
-/obj/structure/table/wood,
-/obj/machinery/button/curtain{
-	id = "rdprivacy";
-	pixel_x = 24;
-	pixel_y = -3
-	},
-/obj/machinery/fax/heads/rd,
-/turf/open/floor/carpet/purple,
-/area/station/command/heads_quarters/rd)
 "aZW" = (
 /obj/structure/wrestling_corner{
 	dir = 4
@@ -4738,6 +4666,19 @@
 /obj/machinery/light/floor,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/entry)
+"bjV" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Server Room"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "tcommcradlecycle"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/plasticflaps/kitchen,
+/turf/open/floor/iron/dark/smooth_half,
+/area/station/tcommsat/server)
 "bkd" = (
 /obj/structure/cable,
 /obj/machinery/newscaster/directional/north,
@@ -5083,23 +5024,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/common/arcade)
-"boq" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/engine)
-"bor" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/west,
-/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "bou" = (
 /obj/effect/landmark/start/cyborg,
 /obj/structure/cable/layer1,
@@ -5844,17 +5768,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"byX" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/flora/bush/reed/style_2,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "bzc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -6012,6 +5925,16 @@
 	},
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/primary/starboard)
+"bBr" = (
+/obj/structure/table/wood,
+/obj/machinery/button/curtain{
+	id = "rdprivacy";
+	pixel_x = 24;
+	pixel_y = -3
+	},
+/obj/machinery/fax/heads/rd,
+/turf/open/floor/carpet/purple,
+/area/station/command/heads_quarters/rd)
 "bBt" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/effect/turf_decal/siding/dark{
@@ -6153,17 +6076,6 @@
 /obj/structure/window/fulltile,
 /turf/open/floor/grass,
 /area/station/service/library)
-"bDb" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light/small/dim/directional/north,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/iron/edge,
-/area/station/hallway/floor2)
 "bDn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6620,6 +6532,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/hallway/primary/starboard)
+"bJQ" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "bJR" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical{
@@ -6786,19 +6707,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/medical/psychology)
-"bLD" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Server Room"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "tcommcradlecycle"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/plasticflaps/kitchen,
-/turf/open/floor/iron/dark/smooth_half,
-/area/station/tcommsat/server)
 "bLY" = (
 /obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/trimline/yellow/line,
@@ -7250,10 +7158,21 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/commons/dorms/room5)
-"bTk" = (
-/obj/effect/turf_decal/trimline/yellow/line,
-/turf/open/floor/iron/edge,
-/area/station/commons/storage/tools)
+"bTi" = (
+/obj/structure/cable,
+/obj/machinery/power/weather_tower,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"bTm" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "bTu" = (
 /turf/closed/wall/r_wall,
 /area/station/security/interrogation)
@@ -8468,6 +8387,19 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/wood/tile,
 /area/station/hallway/secondary/dock)
+"cji" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/flora/bush/sparsegrass{
+	pixel_x = 8
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "cjk" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Brig Closet"
@@ -8658,6 +8590,12 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/atmos/hallway)
+"clT" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "cmd" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
@@ -9265,6 +9203,12 @@
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/iron,
 /area/station/maintenance/abandon_wrestle)
+"cuU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "cuW" = (
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/dark,
@@ -9581,6 +9525,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/brick,
 /area/station/hallway/primary/aft)
+"czK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "czT" = (
 /obj/effect/turf_decal/tile/dark_green/diagonal_edge,
 /obj/effect/turf_decal/tile/green/diagonal_centre,
@@ -10489,6 +10439,11 @@
 	dir = 8
 	},
 /area/station/command/teleporter)
+"cLA" = (
+/obj/machinery/power/weather_tower,
+/obj/structure/cable,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
 "cLJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11531,6 +11486,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/floor2)
+"dav" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/structure/flora/bush/reed{
+	pixel_y = 5
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "daw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -12178,6 +12146,13 @@
 	dir = 1
 	},
 /area/station/security/prison/work)
+"dlm" = (
+/obj/machinery/camera/autoname/directional/north{
+	c_tag = "Engineering - Supermatter";
+	name = "engineering camera"
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "dlp" = (
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/vending/dorms,
@@ -12901,6 +12876,16 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
+"dwK" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/edge,
+/area/station/hallway/floor2)
 "dwL" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -13160,15 +13145,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/aft)
-"dAv" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/edge{
-	dir = 8
-	},
-/area/station/hallway/floor2)
 "dAx" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 1
@@ -13630,16 +13606,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
-"dHo" = (
-/obj/structure/railing{
-	dir = 5
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "dHr" = (
 /obj/structure/sink/directional/south,
 /turf/open/floor/iron/freezer,
@@ -14451,6 +14417,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
+"dRs" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/table/wood/fancy/orange,
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/fax/heads/ce,
+/turf/open/floor/wood/tile,
+/area/station/command/heads_quarters/ce)
 "dRv" = (
 /turf/closed/wall,
 /area/station/maintenance/wrestle)
@@ -15054,6 +15029,15 @@
 	dir = 8
 	},
 /area/station/engineering/atmos/project)
+"dZs" = (
+/obj/structure/table/wood,
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/fax/heads/cmo,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/cmo)
 "dZF" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/purple,
@@ -15166,6 +15150,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
+"ebm" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/machinery/status_display/evac/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/station/hallway/floor2)
 "ebp" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -16377,12 +16372,6 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron,
 /area/station/maintenance/law)
-"esf" = (
-/obj/machinery/camera/autoname/directional/south{
-	network = list("ss13","engine")
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "esk" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/dark,
@@ -17334,6 +17323,11 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"eGk" = (
+/obj/machinery/power/weather_tower,
+/obj/structure/cable,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "eGC" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -17764,6 +17758,10 @@
 /obj/structure/curtain/cloth,
 /turf/open/floor/iron/freezer,
 /area/station/common/locker_room_shower)
+"eMB" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/engine)
 "eME" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/structure/disposalpipe/segment{
@@ -18584,17 +18582,6 @@
 	dir = 8
 	},
 /area/station/science/xenobiology)
-"eXx" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/flora/bush/stalky/style_random,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "eXN" = (
 /turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
@@ -18695,16 +18682,6 @@
 	dir = 4
 	},
 /area/station/commons/fitness/locker_room)
-"eZm" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "eZw" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction{
@@ -18814,6 +18791,16 @@
 	dir = 8
 	},
 /area/station/commons/locker)
+"faY" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "faZ" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -20197,6 +20184,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"fuL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "fuW" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/public{
@@ -20620,6 +20613,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/brick,
 /area/station/hallway/primary)
+"fAl" = (
+/obj/machinery/power/supermatter_crystal/engine,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "fAu" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -21623,6 +21620,15 @@
 	dir = 1
 	},
 /area/station/cargo/miningfoyer)
+"fNC" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "fNJ" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/east,
@@ -22813,16 +22819,6 @@
 "geA" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/starboard/aft)
-"geE" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
-/area/station/hallway/floor2)
 "geG" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -22995,6 +22991,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"ghh" = (
+/obj/effect/turf_decal/trimline/yellow/line,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron/edge,
+/area/station/commons/storage/tools)
 "ghj" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/east,
@@ -23401,6 +23404,10 @@
 /obj/item/storage/box/lewd_toys,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"gor" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "goy" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
@@ -24168,13 +24175,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/medical/psychology)
-"gxw" = (
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/engine)
 "gxE" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -24405,6 +24405,17 @@
 	dir = 1
 	},
 /area/station/medical/chemistry)
+"gBC" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/flora/bush/stalky,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "gBJ" = (
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/fore)
@@ -24609,11 +24620,6 @@
 	dir = 1
 	},
 /area/station/cargo/miningfoyer)
-"gDA" = (
-/obj/machinery/power/weather_tower,
-/obj/structure/cable,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/explored)
 "gDD" = (
 /obj/effect/spawner/random/trash/graffiti,
 /turf/closed/wall/r_wall,
@@ -25082,17 +25088,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/gag_room)
-"gKa" = (
-/obj/structure/railing,
-/obj/structure/flora/bush/reed{
-	pixel_y = 5
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "gKb" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/incinerator_input{
 	dir = 1
@@ -25818,6 +25813,29 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/gag_room)
+"gUa" = (
+/obj/structure/cable,
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/navigate_destination{
+	location = "Aux Tool Storage"
+	},
+/obj/item/screwdriver{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/storage/toolbox/fishing{
+	pixel_y = 7;
+	pixel_x = 8
+	},
+/obj/item/wrench{
+	pixel_y = 6;
+	pixel_x = -6
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron,
+/area/station/commons/storage/tools)
 "gUq" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 4
@@ -26132,6 +26150,14 @@
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/iron/checker,
 /area/station/security/prison/mess)
+"gZf" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/station/hallway/floor2)
 "gZg" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -26354,6 +26380,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/brick_aligned,
 /area/station/hallway/primary)
+"hcv" = (
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "hcA" = (
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 4
@@ -26583,6 +26615,21 @@
 	dir = 4
 	},
 /area/station/security/prison)
+"hfx" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 10
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/button/door/directional/south{
+	id = "HopPrivacy";
+	name = "Privacy Shutters"
+	},
+/obj/machinery/fax/heads/hop,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
+/area/station/command/heads_quarters/hop)
 "hfG" = (
 /obj/effect/turf_decal/trimline/white/filled/line,
 /obj/machinery/door/firedoor,
@@ -26950,16 +26997,6 @@
 	codes_txt = "patrol;next_patrol=LH10"
 	},
 /turf/open/floor/iron,
-/area/station/hallway/floor2)
-"hlb" = (
-/obj/structure/railing{
-	dir = 9
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
 /area/station/hallway/floor2)
 "hle" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -27396,6 +27433,14 @@
 	dir = 8
 	},
 /area/station/engineering/atmospherics_engine)
+"hqu" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/engine)
 "hqv" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -27738,12 +27783,6 @@
 "huw" = (
 /turf/closed/wall,
 /area/station/engineering/atmos/office)
-"huD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "huH" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -27898,6 +27937,15 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/foreporthall)
+"hxc" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "hxm" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chapel Storage"
@@ -28989,10 +29037,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/execution/transfer)
-"hMr" = (
-/obj/machinery/power/supermatter_crystal/engine,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "hMG" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29548,14 +29592,6 @@
 	},
 /turf/open/floor/grass,
 /area/station/commons/dorms/room4)
-"hUb" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/obj/structure/fans/tiny,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "hUc" = (
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_cafeteria/hydro)
@@ -30386,19 +30422,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/small,
 /area/station/common/pool)
-"iex" = (
-/obj/machinery/newscaster/directional/east,
-/obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron/edge{
-	dir = 8
-	},
-/area/station/hallway/floor2)
 "ieN" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor3-old"
@@ -30642,6 +30665,12 @@
 	},
 /turf/open/floor/iron/brick,
 /area/station/hallway/primary/port)
+"ihM" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "ihO" = (
 /obj/machinery/light/directional/south,
 /obj/item/radio/intercom/directional/south,
@@ -30858,15 +30887,6 @@
 	dir = 1
 	},
 /area/station/command/secure_bunker)
-"ikB" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Gas to Chamber"
-	},
-/obj/machinery/camera/autoname/directional/east{
-	network = list("ss13","engine")
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "ikV" = (
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 1
@@ -31085,16 +31105,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_holding_cell)
-"inT" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "inZ" = (
 /obj/structure/chair{
 	dir = 4
@@ -31572,6 +31582,25 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/rec)
+"itn" = (
+/obj/machinery/bouldertech/refinery{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "mining"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/cargo/miningfoundry)
 "itr" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
 	dir = 9
@@ -32230,17 +32259,6 @@
 	},
 /turf/open/floor/iron/checker,
 /area/station/commons/lounge)
-"iDJ" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/flora/bush/stalky,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "iDS" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/bush/flowers_pp/style_random{
@@ -32389,6 +32407,11 @@
 /obj/effect/landmark/firealarm_sanity,
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms/room2)
+"iFC" = (
+/obj/structure/cable,
+/obj/machinery/light/floor,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "iFM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -33010,19 +33033,6 @@
 	dir = 8
 	},
 /area/station/command/heads_quarters/hos)
-"iNI" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Gas to Filter"
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/effect/mapping_helpers/airalarm/link{
-	chamber_id = "engine"
-	},
-/obj/effect/mapping_helpers/airalarm/engine_access,
-/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "iNJ" = (
 /turf/closed/wall,
 /area/station/commons/toilet/restrooms)
@@ -33730,11 +33740,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
-"iXG" = (
-/obj/machinery/power/weather_tower,
-/obj/structure/cable,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "iXH" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
@@ -33760,22 +33765,6 @@
 	dir = 4
 	},
 /area/station/medical/chemistry)
-"iXM" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining"
-	},
-/obj/machinery/bouldertech/refinery/smelter{
-	dir = 8
-	},
-/obj/machinery/light/directional/north,
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/cargo/miningfoundry)
 "iXP" = (
 /obj/structure/table/wood,
 /obj/item/folder/yellow{
@@ -35051,15 +35040,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"jpf" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "jpk" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 8
@@ -36872,15 +36852,6 @@
 "jNz" = (
 /turf/open/floor/wood/large,
 /area/station/security/courtroom)
-"jNC" = (
-/obj/structure/table/wood,
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/obj/machinery/fax/heads/cmo,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/cmo)
 "jNI" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -37267,6 +37238,19 @@
 	dir = 1
 	},
 /area/station/hallway/primary/port)
+"jSO" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/flora/bush/reed{
+	pixel_y = 5
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "jTm" = (
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -37661,6 +37645,11 @@
 	dir = 1
 	},
 /area/station/command/heads_quarters/hop)
+"jYJ" = (
+/obj/machinery/mining_weather_monitor/directional/east,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "jZk" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
@@ -37845,6 +37834,15 @@
 /obj/structure/noticeboard/directional/east,
 /turf/open/floor/plating,
 /area/station/commons/vacant_room/commissary)
+"kbF" = (
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "kbV" = (
 /turf/closed/wall/r_wall,
 /area/station/service/greenroom)
@@ -39319,12 +39317,6 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/engineering/atmospherics_engine)
-"kuS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "kuT" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 10
@@ -39905,19 +39897,6 @@
 	dir = 8
 	},
 /area/station/cargo/miningfoyer)
-"kBN" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/obj/structure/flora/bush/reed{
-	pixel_y = 5
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "kBZ" = (
 /obj/item/universal_scanner{
 	pixel_y = 27
@@ -41247,6 +41226,17 @@
 "kTq" = (
 /turf/closed/wall,
 /area/icemoon/underground/explored)
+"kTs" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/flora/bush/reed/style_2,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "kTt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -41276,6 +41266,17 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
+"kTC" = (
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "kTD" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 1
@@ -41508,6 +41509,10 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_holding_cell)
+"kXl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "kXr" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -41634,17 +41639,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/port)
-"kZb" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/structure/flora/bush/stalky/style_2,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "kZz" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/green/filled/warning{
@@ -42153,16 +42147,6 @@
 	dir = 1
 	},
 /area/station/medical/chemistry)
-"lgQ" = (
-/obj/structure/cable,
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/navigate_destination{
-	location = "Aux Tool Storage"
-	},
-/turf/open/floor/iron,
-/area/station/commons/storage/tools)
 "lgV" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner{
 	dir = 1
@@ -42184,6 +42168,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/edge,
 /area/station/engineering/atmos/hallway)
+"lhn" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/flora/bush/sparsegrass{
+	pixel_x = -6
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "lhq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -42243,16 +42240,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_art_studio)
-"lih" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/closet/firecloset,
-/obj/item/clothing/mask/gas/atmos,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "lis" = (
 /obj/effect/spawner/random/entertainment/drugs{
 	pixel_x = -7;
@@ -42544,12 +42531,14 @@
 	dir = 1
 	},
 /area/station/engineering/atmos/hallway)
-"lmr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+"lml" = (
+/obj/effect/turf_decal/trimline/yellow/line,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
+/turf/open/floor/iron/edge,
+/area/station/commons/storage/tools)
 "lmz" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -42964,33 +42953,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblack,
 /area/station/command/heads_quarters/hos)
-"lsf" = (
-/obj/structure/table,
-/obj/item/folder/yellow{
-	pixel_x = -2;
-	pixel_y = -4
-	},
-/obj/item/stamp/granted{
-	pixel_y = 11;
-	pixel_x = 9
-	},
-/obj/item/stamp/denied{
-	pixel_y = 12
-	},
-/obj/item/pen{
-	pixel_x = -3;
-	pixel_y = -1
-	},
-/obj/item/lightreplacer{
-	pixel_x = -13;
-	pixel_y = 11
-	},
-/obj/item/storage/box/shipping{
-	pixel_x = 12
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/cargo/storage)
 "lsg" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/button/door/directional/west{
@@ -44025,6 +43987,16 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/medical)
+"lGy" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/closet/firecloset,
+/obj/item/clothing/mask/gas/atmos,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "lGz" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -44598,26 +44570,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/medical/morgue)
-"lQw" = (
-/obj/structure/table/wood,
-/obj/machinery/door/window/left/directional/south,
-/obj/structure/cable,
-/obj/item/folder/yellow,
-/obj/item/stamp/head/qm{
-	pixel_y = 5;
-	pixel_x = -4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/stamp/denied{
-	pixel_y = 12
-	},
-/obj/item/stamp/granted{
-	pixel_y = 5;
-	pixel_x = 9
-	},
-/turf/open/floor/wood/tile,
-/area/station/command/heads_quarters/qm)
 "lQx" = (
 /obj/machinery/newscaster/directional/north,
 /turf/open/openspace,
@@ -45030,6 +44982,13 @@
 	dir = 4
 	},
 /area/station/security/prison/work)
+"lWj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/delam_scram/directional/east,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "lWl" = (
 /obj/structure/closet/secure_closet/detective,
 /obj/item/camera_film,
@@ -47866,6 +47825,26 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/engine,
 /area/station/command/gateway)
+"mKA" = (
+/obj/structure/table/wood,
+/obj/machinery/door/window/left/directional/south,
+/obj/structure/cable,
+/obj/item/folder/yellow,
+/obj/item/stamp/head/qm{
+	pixel_y = 5;
+	pixel_x = -4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/stamp/denied{
+	pixel_y = 12
+	},
+/obj/item/stamp/granted{
+	pixel_y = 5;
+	pixel_x = 9
+	},
+/turf/open/floor/wood/tile,
+/area/station/command/heads_quarters/qm)
 "mKI" = (
 /obj/structure/table/wood,
 /obj/machinery/button/door/directional/north{
@@ -48166,19 +48145,6 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/entry)
-"mPj" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/flora/bush/reed{
-	pixel_y = 5
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "mPq" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -49017,18 +48983,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/interrogation)
-"ncT" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/chair/sofa/bench{
-	dir = 1
-	},
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
-/area/station/hallway/floor2)
 "ncV" = (
 /obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/trimline/dark_red/line{
@@ -49082,6 +49036,16 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/barber)
+"nen" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "net" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_red/filled/line,
@@ -49132,6 +49096,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/brick,
 /area/station/hallway/primary/forestarboardhall)
+"nfw" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Server Room"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "tcommcradlecycle"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/smooth_half,
+/area/station/tcommsat/computer)
 "nfB" = (
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
@@ -49284,9 +49260,6 @@
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/science/robotics)
-"nhR" = (
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "nhW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -49435,6 +49408,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain)
+"nkq" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "nkv" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -50410,6 +50392,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"nwT" = (
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/engine)
 "nwW" = (
 /obj/structure/table/optable{
 	name = "Robotics Operating Table"
@@ -52835,6 +52824,22 @@
 /obj/structure/chair/comfy/beige,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
+"ocK" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 2;
+	pixel_y = -4
+	},
+/obj/item/storage/box/matches{
+	pixel_y = 8;
+	pixel_x = -2
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/item/megaphone/clown,
+/turf/open/floor/carpet/donk,
+/area/station/service/greenroom)
 "ocN" = (
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
@@ -52988,10 +52993,6 @@
 	dir = 1
 	},
 /area/station/engineering/atmos/project)
-"oeF" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/engine)
 "oeH" = (
 /obj/effect/landmark/start/prisoner,
 /obj/structure/cable,
@@ -53372,6 +53373,23 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/storage)
+"ojG" = (
+/obj/machinery/newscaster/directional/east,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 13
+	},
+/obj/structure/table/wood,
+/obj/item/storage/box/gum{
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/obj/item/storage/box/sparklers{
+	pixel_x = 4
+	},
+/obj/structure/sign/calendar/directional/south,
+/obj/item/pneumatic_cannon/pie,
+/turf/open/floor/carpet/donk,
+/area/station/service/greenroom)
 "ojH" = (
 /obj/item/radio/intercom/directional/east,
 /turf/closed/wall/r_wall,
@@ -53571,6 +53589,16 @@
 /area/station/commons/dorms)
 "olA" = (
 /obj/structure/flora/ocean/coral,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
+"olC" = (
+/obj/structure/railing{
+	dir = 4
+	},
 /obj/effect/spawner/liquids_spawner,
 /turf/open/floor/iron/pool{
 	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
@@ -54039,6 +54067,12 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/miningoffice)
+"otR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "otT" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/disposalpipe/segment,
@@ -56242,6 +56276,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/eva)
+"oYx" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "oYM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
@@ -56332,14 +56375,12 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating/icemoon,
 /area/station/science/ordnance/bomb)
-"oZQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"oZW" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/fax/heads/hos,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/hos)
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "pac" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -56471,6 +56512,10 @@
 	},
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/virology)
+"pbH" = (
+/obj/structure/cable,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
 "pbN" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -56980,6 +57025,15 @@
 	dir = 1
 	},
 /area/station/hallway/primary/fore)
+"phF" = (
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/edge,
+/area/station/hallway/floor2)
 "phQ" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
@@ -57225,23 +57279,6 @@
 	dir = 1
 	},
 /area/station/medical/treatment_center)
-"plL" = (
-/obj/effect/turf_decal/trimline/yellow/line,
-/obj/item/screwdriver{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/storage/toolbox/fishing{
-	pixel_y = 7;
-	pixel_x = 8
-	},
-/obj/item/wrench{
-	pixel_y = 6;
-	pixel_x = -6
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/edge,
-/area/station/commons/storage/tools)
 "plN" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 9
@@ -57886,19 +57923,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
-"pwM" = (
-/obj/structure/cable,
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/station/hallway/floor2)
 "pwR" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -58404,6 +58428,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/office)
+"pFa" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/structure/fans/tiny,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "pFc" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/mess,
@@ -58445,19 +58477,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms/room2)
-"pFM" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/flora/bush/sparsegrass{
-	pixel_x = 8
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "pGg" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -59954,6 +59973,22 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"qbY" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining"
+	},
+/obj/machinery/bouldertech/refinery/smelter{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/cargo/miningfoundry)
 "qcg" = (
 /obj/structure/railing/wooden_fence{
 	dir = 6
@@ -60270,6 +60305,28 @@
 	icon_state = "cobble"
 	},
 /area/station/hallway/floor2)
+"qhR" = (
+/obj/structure/table/wood,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","rd")
+	},
+/obj/item/stamp/head/rd{
+	pixel_w = -8;
+	pixel_z = 9
+	},
+/obj/item/screwdriver{
+	pixel_z = -4
+	},
+/obj/item/paper_bin{
+	pixel_w = 5;
+	pixel_z = 8
+	},
+/obj/item/pen{
+	pixel_w = 5;
+	pixel_z = 8
+	},
+/turf/open/floor/carpet/purple,
+/area/station/command/heads_quarters/rd)
 "qiF" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/steam_vent,
@@ -61013,6 +61070,14 @@
 	dir = 8
 	},
 /area/station/hallway/primary/primaryservicestairs)
+"qst" = (
+/obj/structure/table/wood,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/fax/heads/nanotrasen_consultant,
+/turf/open/floor/carpet/green,
+/area/station/command/heads_quarters/nt_rep)
 "qsu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 9
@@ -61828,6 +61893,15 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/library)
+"qEX" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "qEY" = (
 /obj/structure/stairs/south,
 /turf/open/floor/iron,
@@ -61904,15 +61978,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/barber)
-"qFT" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/west,
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "qGf" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
@@ -62617,6 +62682,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/corner,
 /area/station/hallway/primary/foreporthall)
+"qOw" = (
+/obj/structure/cable,
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/fax/heads/captain,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/captain)
 "qOH" = (
 /obj/effect/turf_decal/tile/dark_blue,
 /obj/item/radio/intercom/directional/east,
@@ -62653,6 +62725,17 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/ordnance/testlab)
+"qPJ" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/structure/flora/bush/stalky/style_2,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "qPP" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -62880,6 +62963,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/service/cafeteria)
+"qTP" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "qTU" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/warning{
@@ -62984,6 +63071,10 @@
 	dir = 1
 	},
 /area/station/medical/treatment_center)
+"qVf" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/tcommsat/server)
 "qVh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -63667,10 +63758,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/forestarboardhall)
-"reg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "rek" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -63747,6 +63834,33 @@
 /obj/effect/turf_decal/tile/yellow/full,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chemistry)
+"rgq" = (
+/obj/structure/table,
+/obj/item/folder/yellow{
+	pixel_x = -2;
+	pixel_y = -4
+	},
+/obj/item/stamp/granted{
+	pixel_y = 11;
+	pixel_x = 9
+	},
+/obj/item/stamp/denied{
+	pixel_y = 12
+	},
+/obj/item/pen{
+	pixel_x = -3;
+	pixel_y = -1
+	},
+/obj/item/lightreplacer{
+	pixel_x = -13;
+	pixel_y = 11
+	},
+/obj/item/storage/box/shipping{
+	pixel_x = 12
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/cargo/storage)
 "rgr" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 9
@@ -64546,28 +64660,6 @@
 "rtj" = (
 /turf/open/floor/glass/reinforced/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"rtr" = (
-/obj/structure/table/wood,
-/obj/machinery/camera/autoname/directional/south{
-	network = list("ss13","rd")
-	},
-/obj/item/stamp/head/rd{
-	pixel_w = -8;
-	pixel_z = 9
-	},
-/obj/item/screwdriver{
-	pixel_z = -4
-	},
-/obj/item/paper_bin{
-	pixel_w = 5;
-	pixel_z = 8
-	},
-/obj/item/pen{
-	pixel_w = 5;
-	pixel_z = 8
-	},
-/turf/open/floor/carpet/purple,
-/area/station/command/heads_quarters/rd)
 "rts" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/turf_decal/delivery,
@@ -64934,10 +65026,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/barber)
-"ryQ" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "ryW" = (
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/plating,
@@ -66166,11 +66254,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"rRN" = (
-/obj/structure/cable,
-/obj/machinery/power/weather_tower,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "rRO" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -67174,11 +67257,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/ordnance_maint_lesser)
-"scg" = (
-/obj/machinery/mining_weather_monitor/directional/east,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "sci" = (
 /obj/structure/chair/sofa/corp{
 	dir = 8;
@@ -67484,15 +67562,6 @@
 "sgt" = (
 /turf/closed/wall,
 /area/station/security/checkpoint/supply)
-"sgC" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/east,
-/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "sgG" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 10
@@ -67940,13 +68009,6 @@
 	dir = 4
 	},
 /area/station/hallway/floor2)
-"slV" = (
-/obj/structure/cable,
-/obj/structure/table/wood,
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/fax/heads/captain,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/captain)
 "slZ" = (
 /obj/machinery/disposal/delivery_chute{
 	name = "Sci Deliveries"
@@ -69201,6 +69263,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/brig)
+"sBT" = (
+/obj/machinery/air_sensor/engine_chamber,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "sBU" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -69520,25 +69586,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
-"sFs" = (
-/obj/machinery/bouldertech/refinery{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "mining"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/cargo/miningfoundry)
 "sFB" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -70028,18 +70075,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/commons/toilet/restrooms)
-"sMO" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Server Room"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "tcommcradlecycle"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/smooth_half,
-/area/station/tcommsat/computer)
 "sMS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -70203,9 +70238,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/aft)
-"sPg" = (
-/turf/open/space/basic,
-/area/icemoon/underground/unexplored/rivers/deep)
 "sPo" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -70392,14 +70424,6 @@
 /obj/item/stock_parts/power_store/cell/high,
 /turf/open/floor/plating,
 /area/station/maintenance/condemned_sci)
-"sRK" = (
-/obj/structure/railing,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "sRN" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/table/wood,
@@ -71100,12 +71124,27 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/white/small,
 /area/station/common/pool)
+"tbB" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Gas to Chamber"
+	},
+/obj/machinery/camera/autoname/directional/east{
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "tbF" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/photocopier/prebuilt,
 /turf/open/floor/carpet/blue,
 /area/station/medical/office)
+"tbN" = (
+/obj/structure/table/wood,
+/obj/machinery/keycard_auth/wall_mounted/directional/north,
+/obj/machinery/fax/heads/qm,
+/turf/open/floor/wood/tile,
+/area/station/command/heads_quarters/qm)
 "tcg" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -72235,10 +72274,6 @@
 	dir = 8
 	},
 /area/station/engineering/engine_smes)
-"tre" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "trm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72490,6 +72525,9 @@
 	dir = 1
 	},
 /area/station/science/explab)
+"tvb" = (
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "tvc" = (
 /obj/structure/table,
 /turf/open/floor/iron/dark/smooth_large,
@@ -72624,15 +72662,6 @@
 /obj/effect/turf_decal/box/red,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain/private)
-"txB" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/east,
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "txD" = (
 /obj/structure/railing,
 /turf/open/floor/iron/stairs{
@@ -73303,12 +73332,6 @@
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/station/hallway/primary)
-"tFH" = (
-/obj/structure/table/wood,
-/obj/machinery/keycard_auth/wall_mounted/directional/north,
-/obj/machinery/fax/heads/qm,
-/turf/open/floor/wood/tile,
-/area/station/command/heads_quarters/qm)
 "tFK" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
@@ -73983,6 +74006,16 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
+"tNa" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/station/hallway/floor2)
 "tNd" = (
 /obj/machinery/light_switch/directional/north{
 	pixel_x = 17
@@ -74041,21 +74074,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/secondary/dock)
-"tOk" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 10
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/button/door/directional/south{
-	id = "HopPrivacy";
-	name = "Privacy Shutters"
-	},
-/obj/machinery/fax/heads/hop,
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 4
-	},
-/area/station/command/heads_quarters/hop)
 "tOm" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -74452,6 +74470,20 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"tUh" = (
+/obj/machinery/newscaster/directional/east,
+/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/station/hallway/floor2)
 "tUi" = (
 /obj/effect/spawner/random/trash/graffiti,
 /turf/closed/wall,
@@ -74559,15 +74591,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/service/library)
-"tVN" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/east,
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "tVP" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/landmark/event_spawn,
@@ -74761,6 +74784,17 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"tYg" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/flora/bush/stalky/style_random,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "tYj" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -74821,6 +74855,17 @@
 	dir = 8
 	},
 /area/station/tcommsat/computer)
+"tYI" = (
+/obj/structure/railing,
+/obj/structure/flora/bush/reed{
+	pixel_y = 5
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "tYL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -75116,19 +75161,6 @@
 	},
 /turf/open/floor/iron/diagonal,
 /area/station/hallway/floor2)
-"udf" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/flora/bush/sparsegrass{
-	pixel_x = -6
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "udh" = (
 /obj/structure/table/wood/fancy/orange,
 /obj/machinery/light_switch/directional/east,
@@ -75246,16 +75278,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/service/cafeteria)
-"ueM" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/edge,
-/area/station/hallway/floor2)
 "ueT" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -75557,6 +75579,14 @@
 	},
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/floor2)
+"uja" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/fax/heads/hos,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/hos)
 "ujp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -75753,17 +75783,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_arcade)
-"umJ" = (
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "umN" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 9
@@ -76687,17 +76706,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"uzL" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/flora/bush/stalky/style_3,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "uzX" = (
 /obj/machinery/computer/cargo/express{
 	dir = 4
@@ -77268,10 +77276,6 @@
 	dir = 1
 	},
 /area/station/hallway/floor2)
-"uHD" = (
-/obj/structure/cable,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/explored)
 "uHI" = (
 /obj/structure/fireaxecabinet/mechremoval/directional/east,
 /obj/structure/table,
@@ -77600,6 +77604,13 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/parquet,
 /area/station/common/night_club/back_stage)
+"uMQ" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "uMU" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/mess,
@@ -78663,13 +78674,6 @@
 "vbR" = (
 /turf/closed/wall,
 /area/station/commons/vacant_room/commissary)
-"vca" = (
-/obj/machinery/camera/autoname/directional/north{
-	c_tag = "Engineering - Supermatter";
-	name = "engineering camera"
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "vch" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
@@ -79423,6 +79427,17 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/medical/office)
+"vmv" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/flora/bush/stalky/style_3,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "vmy" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -80122,6 +80137,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos/lesser)
+"vvP" = (
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "vvV" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
@@ -81203,6 +81221,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
+"vJc" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "vJe" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -82353,12 +82380,6 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/plating,
 /area/station/ai/satellite/hallway)
-"vZl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "vZo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -83663,6 +83684,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/qm)
+"wsi" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/flora/bush/stalky/style_random,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "wss" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -83770,14 +83802,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/ordnance_maint)
-"wtR" = (
-/obj/structure/table/wood,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/fax/heads/nanotrasen_consultant,
-/turf/open/floor/carpet/green,
-/area/station/command/heads_quarters/nt_rep)
 "wtV" = (
 /obj/structure/closet/secure_closet/brig/genpop,
 /obj/effect/turf_decal/trimline/white/line{
@@ -84262,16 +84286,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_edge,
 /area/station/cargo/miningfoyer)
-"wzA" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/machinery/status_display/evac/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
-/area/station/hallway/floor2)
 "wzC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -84584,15 +84598,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/brick,
 /area/station/hallway/floor2)
-"wCz" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/west,
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "wCK" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/status_display/evac/directional/north,
@@ -85891,10 +85896,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/forestarboardhall)
-"wTQ" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "wTU" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 1
@@ -86053,10 +86054,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/break_room)
-"wVB" = (
-/obj/machinery/air_sensor/engine_chamber,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "wVD" = (
 /turf/open/floor/carpet,
 /area/station/command/bridge)
@@ -86463,6 +86460,15 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/grimy,
 /area/station/service/library)
+"xaF" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 10
+	},
+/turf/open/floor/iron/corner{
+	dir = 4
+	},
+/area/station/tcommsat/computer)
 "xaH" = (
 /obj/structure/transit_tube/horizontal{
 	dir = 1
@@ -86639,17 +86645,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"xcV" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/flora/bush/stalky/style_random,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "xcW" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -87417,15 +87412,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/lab)
-"xna" = (
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "xne" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -87487,6 +87473,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/brick,
 /area/station/hallway/primary)
+"xnz" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "xnC" = (
 /obj/item/kirbyplants/random{
 	pixel_x = -5;
@@ -88071,6 +88061,14 @@
 	},
 /turf/open/floor/engine,
 /area/station/ai/satellite/hallway)
+"xvv" = (
+/obj/structure/railing,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "xvB" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -90106,13 +90104,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_psych)
-"xWj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/delam_scram/directional/east,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "xWn" = (
 /obj/structure/table/wood,
 /obj/item/statuebust{
@@ -90593,22 +90584,6 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/entry)
-"ycA" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 2;
-	pixel_y = -4
-	},
-/obj/item/storage/box/matches{
-	pixel_y = 8;
-	pixel_x = -2
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/item/megaphone/clown,
-/turf/open/floor/carpet/donk,
-/area/station/service/greenroom)
 "ycB" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -90868,10 +90843,6 @@
 /obj/effect/spawner/random/trash/box,
 /turf/open/floor/plating,
 /area/station/maintenance/wrestle)
-"yge" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/tcommsat/server)
 "ygj" = (
 /obj/effect/turf_decal/tile/dark_green/anticorner{
 	dir = 8
@@ -122527,7 +122498,7 @@ jKe
 jKe
 jKe
 jKe
-sPg
+jKe
 jKe
 jKe
 jKe
@@ -180060,10 +180031,10 @@ tPn
 iLK
 tPn
 uuP
-uHD
-hUb
-ryQ
-ryQ
+pbH
+pFa
+qTP
+qTP
 dqy
 dqy
 cSb
@@ -180122,7 +180093,7 @@ iuo
 sNw
 sKF
 gZi
-ycA
+ocK
 xpR
 lPN
 tPn
@@ -180317,7 +180288,7 @@ tPn
 hJF
 tPn
 uuP
-uHD
+pbH
 hew
 gcV
 xkN
@@ -180574,7 +180545,7 @@ tPn
 hJF
 tPn
 uuP
-uHD
+pbH
 hew
 hew
 azq
@@ -180637,7 +180608,7 @@ oUd
 sNw
 blJ
 uvm
-aQb
+ojG
 kbV
 tPn
 tPn
@@ -180831,7 +180802,7 @@ tPn
 hJF
 tPn
 uuP
-uHD
+pbH
 nFi
 tPn
 tPn
@@ -181088,7 +181059,7 @@ tKY
 hJF
 tPn
 uuP
-uHD
+pbH
 tPn
 tPn
 rGV
@@ -181345,9 +181316,9 @@ tKY
 bKB
 bIS
 uuP
-uHD
-uHD
-gDA
+pbH
+pbH
+cLA
 tPn
 tPn
 tPn
@@ -185534,7 +185505,7 @@ qVh
 smi
 nXb
 iPX
-lih
+lGy
 cgu
 jdO
 jdO
@@ -185791,15 +185762,15 @@ uwV
 nqV
 uhj
 iPX
-ahh
-wTQ
-aCY
-wTQ
-scg
-jpf
-uHD
-uHD
-uHD
+otR
+xnz
+uMQ
+xnz
+jYJ
+hxc
+pbH
+pbH
+pbH
 tPn
 tPn
 uuP
@@ -186002,11 +185973,11 @@ xRU
 pon
 qjH
 rBQ
-lgQ
+gUa
 uAY
-bTk
-aVt
-xCo
+ghh
+elX
+phF
 wCx
 tzo
 grV
@@ -186056,7 +186027,7 @@ jdO
 jdO
 nFi
 tPn
-uHD
+pbH
 tPn
 tPn
 uuP
@@ -186261,12 +186232,12 @@ lsP
 boB
 uVo
 phz
-plL
+lml
 ybA
-xCo
+sws
 pAr
 jNr
-ncT
+sLU
 sbt
 wJd
 heX
@@ -186313,7 +186284,7 @@ vBO
 vBO
 tPn
 tPn
-uHD
+pbH
 tPn
 tPn
 tPn
@@ -186520,10 +186491,10 @@ aag
 aGZ
 mMj
 ybA
-bDb
+sws
 pAr
 vXc
-sLU
+cCs
 sbt
 voB
 kmX
@@ -186570,9 +186541,9 @@ vBO
 tPn
 tPn
 tPn
-uHD
-uHD
-gDA
+pbH
+pbH
+cLA
 tPn
 tPn
 tPn
@@ -187032,7 +187003,7 @@ pkX
 kWf
 kWf
 agd
-pwM
+agd
 agd
 xoK
 gxp
@@ -187294,7 +187265,7 @@ hxu
 fyk
 uiY
 lXX
-cCs
+tNa
 sbt
 ced
 ddv
@@ -187539,17 +187510,17 @@ cRg
 pkM
 iMZ
 ucg
-dAv
-iex
+gZf
+tUh
 qdp
 akq
 ybB
-hlb
-uzL
-pFM
-eXx
-mPj
-kZb
+bTm
+vmv
+cji
+tYg
+jSO
+qPJ
 gbz
 cCs
 sbt
@@ -187801,12 +187772,12 @@ adZ
 adZ
 rbB
 oin
-byX
+kTs
 nYE
 ilk
 qUA
 nYE
-sRK
+xvv
 gbz
 qht
 sbt
@@ -188058,12 +188029,12 @@ jIL
 adZ
 ayc
 oin
-eZm
+faY
 olA
 nYE
 eLX
 qhK
-gKa
+tYI
 gbz
 gOv
 hLN
@@ -188313,14 +188284,14 @@ xcC
 iOq
 xQu
 adZ
-ueM
+dwK
 oin
-iDJ
+gBC
 ilk
 gsA
 rLR
 nYE
-sRK
+xvv
 gbz
 ecD
 hLN
@@ -188572,14 +188543,14 @@ cEj
 adZ
 sLA
 oin
-dHo
-xcV
-inT
-udf
-inT
-kBN
+nen
+wsi
+olC
+lhn
+olC
+dav
 gbz
-geE
+cCs
 hLN
 pef
 sbt
@@ -188836,7 +188807,7 @@ gur
 mzA
 uHA
 hWd
-wzA
+ebm
 hLN
 pef
 sbt
@@ -240990,7 +240961,7 @@ aZw
 mRn
 mRn
 hbW
-lQw
+mKA
 wse
 vff
 bHE
@@ -241007,7 +240978,7 @@ gKQ
 uve
 pMZ
 tUZ
-lsf
+rgq
 vJn
 vMu
 otf
@@ -241246,7 +241217,7 @@ qgO
 gde
 wCw
 mRn
-tFH
+tbN
 vHN
 mwl
 wpv
@@ -241996,7 +241967,7 @@ lsM
 wwK
 qOa
 wwK
-oZQ
+uja
 qFv
 qUR
 xzT
@@ -246130,7 +246101,7 @@ aed
 vch
 qeX
 dzX
-iXM
+qbY
 rCp
 xyo
 wvk
@@ -246389,7 +246360,7 @@ iYL
 dzX
 ujC
 axx
-sFs
+itn
 gSt
 xjq
 gBU
@@ -247228,7 +247199,7 @@ xfD
 fws
 nwL
 nwL
-yge
+qVf
 dyu
 jwY
 vHH
@@ -247481,11 +247452,11 @@ fws
 plG
 tHe
 mUZ
-arq
-sMO
+xaF
+nfw
 xVp
-bLD
-yge
+bjV
+qVf
 msO
 yaf
 plB
@@ -248495,7 +248466,7 @@ ioy
 lFT
 bDG
 inr
-aix
+dRs
 mBQ
 bPG
 otf
@@ -248941,7 +248912,7 @@ llx
 ubu
 tlh
 mQd
-tOk
+hfx
 llx
 iEx
 emh
@@ -253134,11 +253105,11 @@ vqy
 dKA
 gwb
 oWj
-aCl
-gxw
-boq
-gxw
-aCl
+vvP
+nwT
+hqu
+nwT
+vvP
 pJb
 wTv
 bvd
@@ -253391,11 +253362,11 @@ lhS
 erm
 npn
 oWj
-aCl
-vca
-abo
-nhR
-aCl
+vvP
+dlm
+iFC
+tvb
+vvP
 rSE
 rZE
 ilP
@@ -253646,13 +253617,13 @@ aRH
 aRH
 tir
 iOe
-aCl
-aCl
-vZl
-txB
-sgC
-tVN
-aCl
+vvP
+vvP
+cuU
+oYx
+nkq
+bJQ
+vvP
 fLd
 usK
 oks
@@ -253903,13 +253874,13 @@ ugJ
 aRH
 tir
 jec
-tre
-iNI
-aTQ
-lmr
-lmr
-lmr
-aCl
+gor
+aVW
+ihM
+fuL
+fuL
+fuL
+vvP
 tOU
 uYP
 fUP
@@ -254160,13 +254131,13 @@ fOA
 aRH
 tir
 tRx
-xna
-nhR
-umJ
-wVB
-hMr
-nhR
-oeF
+kbF
+tvb
+kTC
+sBT
+fAl
+tvb
+eMB
 rVn
 jbi
 bMn
@@ -254417,13 +254388,13 @@ vNz
 aRH
 tir
 iRo
-reg
-ikB
-huD
-xWj
-asX
-asX
-aCl
+kXl
+tbB
+oZW
+lWj
+czK
+czK
+vvP
 tOU
 uYP
 bvd
@@ -254674,13 +254645,13 @@ aRH
 aRH
 tir
 bfa
-aCl
-aCl
-kuS
-qFT
-bor
-wCz
-aCl
+vvP
+vvP
+clT
+fNC
+qEX
+vJc
+vvP
 tSl
 usK
 oks
@@ -254933,11 +254904,11 @@ daw
 iRo
 jiM
 bEb
-aCl
-nhR
-abo
-esf
-aCl
+vvP
+tvb
+iFC
+hcv
+vvP
 gsT
 uYP
 tew
@@ -255190,11 +255161,11 @@ vqy
 iRo
 jiM
 amd
-aCl
-gxw
-boq
-gxw
-aCl
+vvP
+nwT
+hqu
+nwT
+vvP
 tSl
 usK
 oiC
@@ -256630,7 +256601,7 @@ wBf
 bLo
 dPT
 ulM
-slV
+qOw
 geG
 oXa
 ygs
@@ -266663,7 +266634,7 @@ iUT
 jLZ
 aoi
 keS
-wtR
+qst
 sMj
 jaF
 gqZ
@@ -268772,7 +268743,7 @@ oDI
 nGx
 pzV
 bXO
-rtr
+qhR
 nGx
 kQP
 npQ
@@ -268807,7 +268778,7 @@ jcZ
 jcZ
 aIO
 stA
-rRN
+bTi
 jcZ
 oaq
 jcZ
@@ -269029,7 +269000,7 @@ diu
 nGx
 wgt
 kdJ
-aZM
+bBr
 nKI
 ivX
 npQ
@@ -272086,7 +272057,7 @@ oVi
 oYc
 ciI
 bQg
-jNC
+dZs
 tyN
 mAE
 hFw
@@ -274685,7 +274656,7 @@ jcZ
 jcZ
 stA
 stA
-iXG
+eGk
 jcZ
 jcZ
 jcZ

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -107,12 +107,6 @@
 	dir = 4
 	},
 /area/station/ai/satellite/foyer)
-"abI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "abO" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -374,6 +368,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/medical/medbay/central)
+"aeA" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/structure/fans/tiny,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "aeN" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/freezer,
@@ -516,19 +518,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/command/eva)
-"agd" = (
-/obj/structure/cable,
-/obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/station/hallway/floor2)
 "age" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/smooth_large,
@@ -604,11 +593,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/aftstarboardhall)
-"ahx" = (
-/obj/machinery/power/weather_tower,
-/obj/structure/cable,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/explored)
 "ahB" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/white/filled/warning{
@@ -883,6 +867,12 @@
 /area/station/medical/treatment_center)
 "alb" = (
 /obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
+"alc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos/lesser)
 "ald" = (
@@ -1366,6 +1356,23 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
+"aqI" = (
+/obj/effect/turf_decal/trimline/yellow/line,
+/obj/item/screwdriver{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/storage/toolbox/fishing{
+	pixel_y = 7;
+	pixel_x = 8
+	},
+/obj/item/wrench{
+	pixel_y = 6;
+	pixel_x = -6
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/edge,
+/area/station/commons/storage/tools)
 "aqK" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/white/line{
@@ -1652,15 +1659,6 @@
 "atQ" = (
 /turf/open/floor/iron/freezer,
 /area/station/commons/dorms/room4)
-"atR" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/east,
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "atV" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/east,
@@ -2634,26 +2632,6 @@
 	dir = 1
 	},
 /area/station/service/chapel)
-"aGZ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/item/storage/toolbox/emergency{
-	pixel_y = 7
-	},
-/obj/item/storage/toolbox/emergency{
-	pixel_x = 3
-	},
-/obj/item/weldingtool{
-	pixel_x = -8;
-	pixel_y = -13
-	},
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/station/commons/storage/tools)
 "aHc" = (
 /obj/machinery/light/floor,
 /turf/open/floor/engine,
@@ -3693,10 +3671,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
-"aUw" = (
-/obj/structure/cable,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/explored)
 "aUT" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
@@ -4025,6 +3999,11 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
+"aZg" = (
+/obj/structure/cable,
+/obj/machinery/light/floor,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "aZw" = (
 /obj/machinery/door/airlock/bathroom{
 	name = "Restroom"
@@ -4590,6 +4569,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
+"bid" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "bio" = (
 /obj/structure/curtain/cloth,
 /obj/structure/drain,
@@ -4920,16 +4908,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
-"bnl" = (
-/obj/structure/table/wood,
-/obj/machinery/button/curtain{
-	id = "rdprivacy";
-	pixel_x = 24;
-	pixel_y = -3
-	},
-/obj/machinery/fax/heads/rd,
-/turf/open/floor/carpet/purple,
-/area/station/command/heads_quarters/rd)
 "bnp" = (
 /obj/structure/fans/tiny/forcefield{
 	dir = 4
@@ -5607,6 +5585,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/fore)
+"bwc" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/engine)
 "bwh" = (
 /obj/machinery/light/directional/west,
 /obj/structure/disposalpipe/segment,
@@ -6078,39 +6060,11 @@
 "bCS" = (
 /turf/open/floor/plating,
 /area/station/maintenance/dorm_room)
-"bCV" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 2;
-	pixel_y = -4
-	},
-/obj/item/storage/box/matches{
-	pixel_y = 8;
-	pixel_x = -2
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/item/megaphone/clown,
-/turf/open/floor/carpet/donk,
-/area/station/service/greenroom)
 "bCZ" = (
 /obj/structure/flora/bush/flowers_pp,
 /obj/structure/window/fulltile,
 /turf/open/floor/grass,
 /area/station/service/library)
-"bDb" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light/small/dim/directional/north,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/iron/edge,
-/area/station/hallway/floor2)
 "bDn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6543,6 +6497,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/hallway/primary/foreporthall)
+"bJt" = (
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/floor2)
 "bJF" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/effect/turf_decal/weather/dirt{
@@ -6733,6 +6695,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/medical/psychology)
+"bLK" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 10
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/button/door/directional/south{
+	id = "HopPrivacy";
+	name = "Privacy Shutters"
+	},
+/obj/machinery/fax/heads/hop,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
+/area/station/command/heads_quarters/hop)
 "bLY" = (
 /obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/trimline/yellow/line,
@@ -7188,6 +7165,25 @@
 /obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/iron/edge,
 /area/station/commons/storage/tools)
+"bTm" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 9
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
+"bTr" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "bTu" = (
 /turf/closed/wall/r_wall,
 /area/station/security/interrogation)
@@ -8303,6 +8299,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/service/greenroom)
+"chx" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "chN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8402,6 +8402,22 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/wood/tile,
 /area/station/hallway/secondary/dock)
+"cji" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
+	},
+/obj/structure/flora/bush/sparsegrass{
+	pixel_x = 8
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "cjk" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Brig Closet"
@@ -9296,6 +9312,10 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos/lesser)
+"cwA" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "cwD" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -9992,9 +10012,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms)
-"cGV" = (
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "cGW" = (
 /obj/effect/spawner/random/entertainment/drugs,
 /turf/open/floor/plating,
@@ -10456,15 +10473,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/command/vault)
-"cMk" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/east,
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "cMm" = (
 /obj/structure/toilet{
 	pixel_y = 10
@@ -10946,6 +10954,10 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/engineering/lobby)
+"cSM" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/commons/storage/tools)
 "cST" = (
 /obj/effect/decal/cleanable/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11473,6 +11485,22 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/floor2)
+"dav" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 6
+	},
+/obj/structure/flora/bush/reed{
+	pixel_y = 5
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "daw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -11528,18 +11556,6 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
-"dbq" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Server Room"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "tcommcradlecycle"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/smooth_half,
-/area/station/tcommsat/computer)
 "dbs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12305,6 +12321,12 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"dnu" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "dnH" = (
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination/vault,
@@ -12758,10 +12780,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/lab)
-"duy" = (
-/obj/machinery/air_sensor/engine_chamber,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "duK" = (
 /obj/machinery/newscaster/directional/east,
 /obj/effect/turf_decal/tile/dark_green/full,
@@ -13224,6 +13242,11 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/cargo/sorting)
+"dBu" = (
+/obj/machinery/mining_weather_monitor/directional/east,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "dBw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13265,6 +13288,10 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"dBS" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "dCb" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -13344,19 +13371,6 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/science/server)
-"dDf" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 4
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "dDj" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
@@ -14166,19 +14180,6 @@
 "dOC" = (
 /turf/open/floor/iron/sepia,
 /area/station/cargo/lobby)
-"dOM" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/station/hallway/floor2)
 "dON" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -14223,19 +14224,6 @@
 	},
 /turf/open/floor/iron/sepia,
 /area/station/service/kitchen/diner)
-"dPe" = (
-/obj/machinery/light/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/south,
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood/tile,
-/area/station/commons/fitness/recreation)
 "dPi" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -14597,14 +14585,6 @@
 	},
 /turf/open/floor/iron/edge,
 /area/station/hallway/secondary/recreation)
-"dTR" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/engine)
 "dUa" = (
 /obj/effect/turf_decal/siding/dark/corner,
 /obj/structure/cable,
@@ -15049,6 +15029,18 @@
 	dir = 8
 	},
 /area/station/engineering/atmos/project)
+"dZm" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/station/hallway/floor2)
 "dZF" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/purple,
@@ -15124,6 +15116,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"eaF" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Server Room"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "tcommcradlecycle"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/plasticflaps/kitchen,
+/turf/open/floor/iron/dark/smooth_half,
+/area/station/tcommsat/server)
 "eaR" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 1
@@ -15183,20 +15188,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/secondary/recreation)
-"ebX" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 10
-	},
-/obj/structure/flora/bush/stalky/style_2,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "ecj" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/box,
@@ -16203,6 +16194,26 @@
 /obj/effect/turf_decal/trimline/green/line,
 /turf/open/floor/iron/dark/side,
 /area/station/commons/storage/mining)
+"epV" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
+"eqa" = (
+/obj/machinery/light/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/tile,
+/area/station/commons/fitness/recreation)
 "eqm" = (
 /obj/structure/marker_beacon/yellow,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -16463,6 +16474,25 @@
 /obj/effect/turf_decal/trimline/yellow/corner,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"etp" = (
+/obj/machinery/bouldertech/refinery{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "mining"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/cargo/miningfoundry)
 "etr" = (
 /obj/effect/turf_decal/tile/dark_green/diagonal_edge,
 /obj/effect/turf_decal/tile/green/diagonal_centre,
@@ -17366,6 +17396,11 @@
 	dir = 8
 	},
 /area/station/hallway/primary)
+"eGX" = (
+/obj/machinery/power/weather_tower,
+/obj/structure/cable,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "eHs" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/stairs/right{
@@ -17389,6 +17424,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood/large,
 /area/station/security/courtroom)
+"eHG" = (
+/obj/machinery/power/supermatter_crystal/engine,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "eHQ" = (
 /obj/effect/turf_decal/trimline/green/line,
 /obj/structure/disposalpipe/segment,
@@ -17691,6 +17730,15 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"eLX" = (
+/obj/structure/flora/ocean/seaweed,
+/obj/structure/flora/bush/sparsegrass,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "eLZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18335,14 +18383,6 @@
 /obj/structure/sign/departments/xenobio/alt/directional/west,
 /turf/open/floor/iron/stairs/left,
 /area/station/science/research)
-"eVf" = (
-/obj/structure/table/wood,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/fax/heads/nanotrasen_consultant,
-/turf/open/floor/carpet/green,
-/area/station/command/heads_quarters/nt_rep)
 "eVg" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -18782,6 +18822,19 @@
 	dir = 8
 	},
 /area/station/commons/locker)
+"faY" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "faZ" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -19019,6 +19072,16 @@
 /obj/structure/sacrificealtar,
 /turf/open/floor/cult,
 /area/station/maintenance/condemnedroom)
+"feI" = (
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/west,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/station/commons/storage/tools)
 "feK" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 10
@@ -19652,6 +19715,23 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"fmu" = (
+/obj/effect/turf_decal/trimline/yellow/line,
+/obj/item/flashlight{
+	pixel_y = 12;
+	pixel_x = -7
+	},
+/obj/item/weldingtool{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/flashlight{
+	pixel_y = 6;
+	pixel_x = -3
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/edge,
+/area/station/commons/storage/tools)
 "fmT" = (
 /turf/open/floor/carpet,
 /area/station/service/theater)
@@ -20786,13 +20866,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"fDd" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "fDh" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark/filled/line{
@@ -21139,13 +21212,6 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/science/server)
-"fGH" = (
-/obj/machinery/camera/autoname/directional/north{
-	c_tag = "Engineering - Supermatter";
-	name = "engineering camera"
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "fGK" = (
 /obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron/dark,
@@ -21540,25 +21606,6 @@
 	dir = 1
 	},
 /area/station/ai/satellite/foyer)
-"fMA" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light/directional/south,
-/obj/machinery/newscaster/directional/south,
-/obj/effect/turf_decal/trimline/yellow/line,
-/obj/item/flashlight{
-	pixel_y = 12;
-	pixel_x = -7
-	},
-/obj/item/weldingtool{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/obj/item/flashlight{
-	pixel_y = 6;
-	pixel_x = -3
-	},
-/turf/open/floor/iron/edge,
-/area/station/commons/storage/tools)
 "fMC" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -21586,6 +21633,21 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/patients_rooms)
+"fNe" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/obj/structure/sign/barber/directional/north{
+	pixel_y = 28
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/hallway/primary/starboard)
 "fNu" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/smooth_half{
@@ -21925,16 +21987,6 @@
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/ce)
-"fSt" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/closet/firecloset,
-/obj/item/clothing/mask/gas/atmos,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "fSz" = (
 /obj/structure/chair/office,
 /obj/structure/cable,
@@ -22077,19 +22129,9 @@
 	dir = 4
 	},
 /area/station/commons/fitness)
-"fUB" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Server Room"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "tcommcradlecycle"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/plasticflaps/kitchen,
-/turf/open/floor/iron/dark/smooth_half,
-/area/station/tcommsat/server)
+"fUs" = (
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "fUE" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/bot_white,
@@ -22197,6 +22239,13 @@
 	dir = 1
 	},
 /area/station/medical/virology)
+"fVI" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/firealarm/directional/north,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/commons/storage/tools)
 "fVV" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners{
 	dir = 1
@@ -23483,6 +23532,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/transit_tube)
+"gpV" = (
+/obj/machinery/power/weather_tower,
+/obj/structure/cable,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
 "gqa" = (
 /turf/open/floor/iron/smooth_edge{
 	dir = 4
@@ -23682,6 +23736,15 @@
 	dir = 1
 	},
 /area/station/science/robotics/lab)
+"gsA" = (
+/obj/structure/flora/ocean/longseaweed,
+/mob/living/basic/frog,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "gsH" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/item/reagent_containers/cup/watering_can,
@@ -23914,12 +23977,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/wood/tile,
 /area/station/service/kitchen/diner)
-"guS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "guU" = (
 /obj/effect/spawner/random/trash/crushed_can,
 /turf/open/floor/plating,
@@ -24129,15 +24186,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/purple,
 /area/station/service/barber)
-"gxj" = (
-/obj/structure/table/wood,
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/obj/machinery/fax/heads/cmo,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/cmo)
 "gxm" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -24396,6 +24444,20 @@
 	dir = 1
 	},
 /area/station/medical/chemistry)
+"gBC" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/structure/flora/bush/stalky,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "gBJ" = (
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/fore)
@@ -24604,6 +24666,10 @@
 /obj/effect/spawner/random/trash/graffiti,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/medical/morgue)
+"gDF" = (
+/obj/structure/cable,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/explored)
 "gDG" = (
 /obj/structure/curtain/cloth/fancy/mechanical{
 	icon_state = "bounty-open";
@@ -25089,6 +25155,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/supply)
+"gKg" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "gKu" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "theatshutters";
@@ -25752,6 +25827,35 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"gTD" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 9
+	},
+/obj/item/t_scanner{
+	pixel_y = 7;
+	pixel_x = 8
+	},
+/obj/item/crowbar{
+	pixel_y = 14;
+	pixel_x = -4
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -4
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/station/commons/storage/tools)
 "gTI" = (
 /obj/structure/rack/shelf,
 /obj/effect/turf_decal/tile/purple/opposingcorners{
@@ -25853,6 +25957,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
+"gUV" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/service/glass{
+	name = "Barbershop";
+	id_tag = "barberspa"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/service/barber/spa)
 "gVb" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 6
@@ -26485,6 +26603,15 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/entry)
+"heJ" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "heS" = (
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/trimline/white/line{
@@ -27221,6 +27348,15 @@
 	},
 /turf/open/floor/iron/brick,
 /area/station/hallway/primary/aft)
+"hoy" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Gas to Chamber"
+	},
+/obj/machinery/camera/autoname/directional/east{
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "hoF" = (
 /obj/machinery/door/window/right/directional/north{
 	req_access = list("cargo");
@@ -28046,6 +28182,33 @@
 /obj/item/clipboard,
 /turf/open/floor/iron/edge,
 /area/station/commons/locker)
+"hAa" = (
+/obj/structure/table,
+/obj/item/folder/yellow{
+	pixel_x = -2;
+	pixel_y = -4
+	},
+/obj/item/stamp/granted{
+	pixel_y = 11;
+	pixel_x = 9
+	},
+/obj/item/stamp/denied{
+	pixel_y = 12
+	},
+/obj/item/pen{
+	pixel_x = -3;
+	pixel_y = -1
+	},
+/obj/item/lightreplacer{
+	pixel_x = -13;
+	pixel_y = 11
+	},
+/obj/item/storage/box/shipping{
+	pixel_x = 12
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/cargo/storage)
 "hAd" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -29492,20 +29655,6 @@
 "hUc" = (
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_cafeteria/hydro)
-"hUm" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/obj/structure/flora/bush/reed/style_2,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "hUn" = (
 /turf/open/floor/iron/dark/diagonal,
 /area/station/hallway/primary/foreporthall)
@@ -30104,6 +30253,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/edge,
 /area/station/hallway/secondary/entry)
+"ibt" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "ibw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30390,6 +30548,10 @@
 	},
 /turf/open/floor/grass,
 /area/station/commons/dorms/room1)
+"ifk" = (
+/obj/machinery/air_sensor/engine_chamber,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "ifp" = (
 /turf/open/floor/iron,
 /area/station/maintenance/dorm_room)
@@ -30814,6 +30976,16 @@
 	dir = 1
 	},
 /area/station/medical/treatment_center)
+"ilk" = (
+/obj/structure/flora/ocean/seaweed{
+	pixel_y = 12
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "ilr" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/structure/sign/poster/random/directional/south,
@@ -31599,6 +31771,15 @@
 	dir = 4
 	},
 /area/station/security/office)
+"ivt" = (
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "ivA" = (
 /obj/structure/sink/kitchen/directional/west,
 /obj/machinery/light/directional/east,
@@ -31998,12 +32179,6 @@
 	dir = 4
 	},
 /area/station/medical/treatment_center)
-"iBf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "iBg" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -32318,12 +32493,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
-"iFW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "iGq" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -32393,19 +32562,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/floor2)
-"iHd" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Gas to Filter"
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/effect/mapping_helpers/airalarm/link{
-	chamber_id = "engine"
-	},
-/obj/effect/mapping_helpers/airalarm/engine_access,
-/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "iHf" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
@@ -32422,15 +32578,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms)
-"iHo" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/east,
-/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "iHp" = (
 /obj/effect/heretic_rune/big,
 /turf/open/floor/cult,
@@ -32646,10 +32793,6 @@
 /obj/machinery/computer/atmos_alert/station_only,
 /turf/open/floor/iron/white/smooth_half,
 /area/station/engineering/lobby)
-"iJV" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "iKk" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 2
@@ -32938,6 +33081,22 @@
 /obj/structure/sign/warning/cold_temp/directional/west,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"iNw" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining"
+	},
+/obj/machinery/bouldertech/refinery/smelter{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/cargo/miningfoundry)
 "iNA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -33687,22 +33846,6 @@
 	dir = 4
 	},
 /area/station/medical/chemistry)
-"iXN" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/obj/structure/flora/bush/reed{
-	pixel_y = 5
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "iXP" = (
 /obj/structure/table/wood,
 /obj/item/folder/yellow{
@@ -33803,6 +33946,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
+"iYR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/delam_scram/directional/east,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "iYV" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/green/line{
@@ -34127,15 +34277,6 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
-"jdf" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/west,
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "jdg" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
@@ -34570,6 +34711,15 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/security/medical)
+"jji" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/hallway/primary/starboard)
 "jjj" = (
 /turf/closed/wall/r_wall,
 /area/station/ai/upload/foyer)
@@ -34842,10 +34992,6 @@
 "jnH" = (
 /turf/closed/wall,
 /area/station/service/library/private)
-"jnI" = (
-/obj/machinery/power/supermatter_crystal/engine,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "jnM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/side{
@@ -36071,6 +36217,32 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
 /area/station/service/quietroom)
+"jEx" = (
+/obj/machinery/newscaster/directional/north,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 5
+	},
+/obj/item/airlock_painter/decal{
+	pixel_y = -17
+	},
+/obj/item/storage/box/lights/mixed{
+	pixel_y = 11;
+	pixel_x = 5
+	},
+/obj/item/storage/box/lights/mixed{
+	pixel_y = 2;
+	pixel_x = 5
+	},
+/obj/item/clipboard{
+	pixel_x = -12;
+	pixel_y = 5
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/corner{
+	dir = 1
+	},
+/area/station/commons/storage/tools)
 "jEA" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm4";
@@ -36576,11 +36748,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
-"jKG" = (
-/obj/structure/cable,
-/obj/machinery/light/floor,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "jKK" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/closet_maintenance,
@@ -36833,33 +37000,6 @@
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"jOd" = (
-/obj/structure/table,
-/obj/item/folder/yellow{
-	pixel_x = -2;
-	pixel_y = -4
-	},
-/obj/item/stamp/granted{
-	pixel_y = 11;
-	pixel_x = 9
-	},
-/obj/item/stamp/denied{
-	pixel_y = 12
-	},
-/obj/item/pen{
-	pixel_x = -3;
-	pixel_y = -1
-	},
-/obj/item/lightreplacer{
-	pixel_x = -13;
-	pixel_y = 11
-	},
-/obj/item/storage/box/shipping{
-	pixel_x = 12
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/cargo/storage)
 "jOr" = (
 /obj/structure/table,
 /obj/item/plate/small{
@@ -37162,15 +37302,6 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
-"jSa" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "jSw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -37221,6 +37352,22 @@
 	dir = 1
 	},
 /area/station/hallway/primary/port)
+"jSO" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
+	},
+/obj/structure/flora/bush/reed{
+	pixel_y = 5
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "jTm" = (
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -37591,17 +37738,6 @@
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
-"jYl" = (
-/obj/structure/flora/ocean/coral,
-/obj/structure/flora/bush/sparsegrass{
-	pixel_x = -6
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "jYw" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/disposal/delivery_chute{
@@ -37666,22 +37802,6 @@
 "jZY" = (
 /turf/closed/wall/r_wall,
 /area/station/security/execution/transfer)
-"kab" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 6
-	},
-/obj/structure/flora/bush/reed{
-	pixel_y = 5
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "kai" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 4
@@ -38938,19 +39058,6 @@
 	},
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
-"kqh" = (
-/obj/structure/railing{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 9
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "kqk" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 8
@@ -39028,6 +39135,16 @@
 	},
 /turf/closed/wall,
 /area/station/maintenance/department/crew_quarters/dorms)
+"krk" = (
+/obj/structure/table/wood,
+/obj/machinery/button/curtain{
+	id = "rdprivacy";
+	pixel_x = 24;
+	pixel_y = -3
+	},
+/obj/machinery/fax/heads/rd,
+/turf/open/floor/carpet/purple,
+/area/station/command/heads_quarters/rd)
 "krm" = (
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/freezer,
@@ -39939,10 +40056,6 @@
 "kCo" = (
 /turf/closed/wall,
 /area/station/service/bar/backroom)
-"kCs" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "kCC" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -41226,6 +41339,20 @@
 "kTq" = (
 /turf/closed/wall,
 /area/icemoon/underground/explored)
+"kTs" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/structure/flora/bush/reed/style_2,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "kTt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -41775,6 +41902,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/prison)
+"lbX" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/tcommsat/server)
 "lbY" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8;
@@ -41784,6 +41915,18 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood/tile,
 /area/station/hallway/secondary/dock)
+"lcd" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Server Room"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "tcommcradlecycle"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/smooth_half,
+/area/station/tcommsat/computer)
 "lce" = (
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/east,
@@ -42152,6 +42295,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/edge,
 /area/station/engineering/atmos/hallway)
+"lhn" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 4
+	},
+/obj/structure/flora/bush/sparsegrass{
+	pixel_x = -6
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "lhq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -42633,21 +42792,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/floor2)
-"lpt" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 10
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/button/door/directional/south{
-	id = "HopPrivacy";
-	name = "Privacy Shutters"
-	},
-/obj/machinery/fax/heads/hop,
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 4
-	},
-/area/station/command/heads_quarters/hop)
 "lpB" = (
 /obj/structure/fireplace,
 /obj/effect/turf_decal/siding/dark{
@@ -42819,13 +42963,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/tcommsat/server)
-"lrf" = (
-/obj/effect/turf_decal/trimline/yellow/corner{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/hallway/floor2)
 "lrp" = (
 /obj/structure/flora/tree/jungle/small/style_3,
 /turf/open/floor/grass,
@@ -42966,35 +43103,6 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
-"lsP" = (
-/obj/structure/table/reinforced,
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 9
-	},
-/obj/item/t_scanner{
-	pixel_y = 7;
-	pixel_x = 8
-	},
-/obj/item/crowbar{
-	pixel_y = 14;
-	pixel_x = -4
-	},
-/obj/item/electronics/airlock{
-	pixel_x = -4
-	},
-/obj/item/electronics/airlock{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/electronics/airlock{
-	pixel_x = -1;
-	pixel_y = 5
-	},
-/turf/open/floor/iron/edge{
-	dir = 1
-	},
-/area/station/commons/storage/tools)
 "lsX" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 1
@@ -43287,6 +43395,17 @@
 "lxf" = (
 /turf/open/floor/carpet/red,
 /area/station/command/bridge)
+"lxj" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/light/small/dim/directional/north,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/iron/edge,
+/area/station/hallway/floor2)
 "lxu" = (
 /obj/effect/turf_decal/tile/dark_green/opposingcorners,
 /obj/structure/disposalpipe/segment{
@@ -43305,6 +43424,23 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
+"lxX" = (
+/obj/machinery/newscaster/directional/east,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 13
+	},
+/obj/structure/table/wood,
+/obj/item/storage/box/gum{
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/obj/item/storage/box/sparklers{
+	pixel_x = 4
+	},
+/obj/structure/sign/calendar/directional/south,
+/obj/item/pneumatic_cannon/pie,
+/turf/open/floor/carpet/donk,
+/area/station/service/greenroom)
 "lya" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -43463,15 +43599,6 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/eighties,
 /area/station/maintenance/abandon_arcade)
-"lAG" = (
-/obj/structure/flora/ocean/seaweed,
-/obj/structure/flora/bush/sparsegrass,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "lAL" = (
 /obj/machinery/light/directional/west,
 /obj/structure/table/reinforced,
@@ -43739,13 +43866,6 @@
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/wood/large,
 /area/station/security/prison)
-"lDA" = (
-/obj/structure/cable,
-/obj/structure/table/wood,
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/fax/heads/captain,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/captain)
 "lDD" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/siding/dark{
@@ -44072,6 +44192,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos/lesser)
+"lIN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/fax/heads/hos,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/hos)
 "lIR" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -44178,22 +44306,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
-"lKp" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/obj/structure/flora/bush/sparsegrass{
-	pixel_x = 8
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "lKE" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 8
@@ -45156,6 +45268,10 @@
 	dir = 8
 	},
 /area/station/hallway/primary/primaryservicestairs)
+"lYM" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "lYN" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 6
@@ -45707,6 +45823,15 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
+"mil" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "mim" = (
 /obj/effect/turf_decal/siding/yellow,
 /obj/effect/turf_decal/siding/yellow{
@@ -45770,28 +45895,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/brick,
 /area/station/hallway/primary)
-"miX" = (
-/obj/structure/table/wood,
-/obj/machinery/camera/autoname/directional/south{
-	network = list("ss13","rd")
-	},
-/obj/item/stamp/head/rd{
-	pixel_w = -8;
-	pixel_z = 9
-	},
-/obj/item/screwdriver{
-	pixel_z = -4
-	},
-/obj/item/paper_bin{
-	pixel_w = 5;
-	pixel_z = 8
-	},
-/obj/item/pen{
-	pixel_w = 5;
-	pixel_z = 8
-	},
-/turf/open/floor/carpet/purple,
-/area/station/command/heads_quarters/rd)
 "miY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46218,15 +46321,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet/red,
 /area/station/service/chapel/funeral)
-"mnC" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 10
-	},
-/turf/open/floor/iron/corner{
-	dir = 4
-	},
-/area/station/tcommsat/computer)
 "mnE" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -46617,15 +46711,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/visit)
-"mtQ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Gas to Chamber"
-	},
-/obj/machinery/camera/autoname/directional/east{
-	network = list("ss13","engine")
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "mtU" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -46862,16 +46947,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/station/commons/dorms/room6)
-"mwI" = (
-/obj/structure/flora/ocean/seaweed{
-	pixel_y = 12
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "mwJ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
@@ -47118,19 +47193,6 @@
 	dir = 8
 	},
 /area/station/security/brig)
-"mzq" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "mzt" = (
 /turf/closed/wall/r_wall,
 /area/station/commons/dorms/room7)
@@ -47995,38 +48057,6 @@
 /obj/item/pen,
 /turf/open/floor/carpet,
 /area/station/service/library/private)
-"mMj" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 6
-	},
-/obj/machinery/firealarm/directional/east,
-/obj/item/electronics/airalarm{
-	pixel_y = 1;
-	pixel_x = 6
-	},
-/obj/item/electronics/airalarm{
-	pixel_y = 5;
-	pixel_x = 4
-	},
-/obj/item/electronics/apc{
-	pixel_x = -5
-	},
-/obj/item/electronics/apc{
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/obj/item/vending_refill/games{
-	pixel_y = 16;
-	pixel_x = 7
-	},
-/obj/item/wirecutters{
-	pixel_y = 2
-	},
-/turf/open/floor/iron/corner{
-	dir = 1
-	},
-/area/station/commons/storage/tools)
 "mMl" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -48071,6 +48101,18 @@
 	dir = 4
 	},
 /area/station/hallway/primary)
+"mMA" = (
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = -3;
+	pixel_y = 10
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron,
+/area/station/commons/storage/tools)
 "mMC" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -48279,15 +48321,12 @@
 	},
 /turf/open/floor/iron/edge,
 /area/station/engineering/atmos)
-"mRm" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/station/hallway/primary/starboard)
+"mRa" = (
+/obj/structure/table/wood,
+/obj/machinery/keycard_auth/wall_mounted/directional/north,
+/obj/machinery/fax/heads/qm,
+/turf/open/floor/wood/tile,
+/area/station/command/heads_quarters/qm)
 "mRn" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/qm)
@@ -48932,26 +48971,6 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
-"naD" = (
-/obj/structure/table/wood,
-/obj/machinery/door/window/left/directional/south,
-/obj/structure/cable,
-/obj/item/folder/yellow,
-/obj/item/stamp/head/qm{
-	pixel_y = 5;
-	pixel_x = -4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/stamp/denied{
-	pixel_y = 12
-	},
-/obj/item/stamp/granted{
-	pixel_y = 5;
-	pixel_x = 9
-	},
-/turf/open/floor/wood/tile,
-/area/station/command/heads_quarters/qm)
 "naE" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/wood{
@@ -48995,20 +49014,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/security/courtroom)
-"nbp" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/obj/structure/flora/bush/stalky/style_3,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "nbq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49127,8 +49132,13 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/barber)
-"ndU" = (
-/obj/structure/flora/bush/sparsegrass/style_3,
+"nen" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 5
+	},
 /obj/effect/spawner/liquids_spawner,
 /turf/open/floor/iron/pool{
 	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
@@ -49563,6 +49573,12 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/station/security/courtroom)
+"nlU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "nmb" = (
 /obj/structure/hedge,
 /obj/structure/window/reinforced/fulltile,
@@ -50131,15 +50147,6 @@
 /obj/machinery/rnd/experimentor,
 /turf/open/floor/engine,
 /area/station/science/explab)
-"nss" = (
-/obj/structure/flora/ocean/longseaweed,
-/mob/living/basic/frog,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "nsA" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /obj/structure/disposalpipe/segment,
@@ -50767,10 +50774,6 @@
 	dir = 6
 	},
 /area/station/cargo/storage)
-"nAO" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/tcommsat/server)
 "nBh" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/structure/closet/secure_closet/barber,
@@ -52456,14 +52459,6 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/carpet/green,
 /area/station/command/heads_quarters/nt_rep)
-"nWL" = (
-/obj/structure/flora/ocean/longseaweed,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "nWM" = (
 /turf/open/floor/iron/corner,
 /area/station/command/secure_bunker)
@@ -52618,6 +52613,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos/lesser)
+"nYE" = (
+/obj/structure/flora/ocean/longseaweed,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "nYL" = (
 /obj/structure/cable,
 /turf/open/floor/carpet/red,
@@ -53628,6 +53631,27 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms)
+"olA" = (
+/obj/structure/flora/ocean/coral,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
+"olC" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 4
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "olF" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -54972,6 +54996,12 @@
 	dir = 1
 	},
 /area/station/hallway/primary/aftporthall)
+"oHk" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/floor2)
 "oHl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -55346,14 +55376,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/grass,
 /area/station/science/genetics)
-"oMe" = (
-/obj/structure/flora/bush/sparsegrass,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "oMn" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 1
@@ -55366,6 +55388,25 @@
 /obj/effect/landmark/firealarm_sanity,
 /turf/open/floor/carpet/green,
 /area/station/commons/dorms/room7)
+"oMz" = (
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 7
+	},
+/obj/item/storage/toolbox/emergency{
+	pixel_x = 3
+	},
+/obj/item/weldingtool{
+	pixel_x = -8;
+	pixel_y = -13
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/station/commons/storage/tools)
 "oMC" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/dark,
@@ -56522,6 +56563,15 @@
 	},
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/virology)
+"pbJ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/table/wood/fancy/orange,
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/fax/heads/ce,
+/turf/open/floor/wood/tile,
+/area/station/command/heads_quarters/ce)
 "pbN" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -56557,22 +56607,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/common/pool/sauna)
-"pcf" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 4
-	},
-/obj/structure/flora/bush/sparsegrass{
-	pixel_x = -6
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "pcm" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/medbay/lobby)
@@ -57223,20 +57257,6 @@
 	dir = 4
 	},
 /area/station/science/research)
-"pkX" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/station/hallway/floor2)
 "plc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -57291,23 +57311,6 @@
 	dir = 1
 	},
 /area/station/medical/treatment_center)
-"plL" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/yellow/line,
-/obj/item/screwdriver{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/storage/toolbox/fishing{
-	pixel_y = 7;
-	pixel_x = 8
-	},
-/obj/item/wrench{
-	pixel_y = 6;
-	pixel_x = -6
-	},
-/turf/open/floor/iron/edge,
-/area/station/commons/storage/tools)
 "plN" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 9
@@ -58145,17 +58148,6 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
-"pzH" = (
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "pzI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -58177,6 +58169,15 @@
 /obj/machinery/keycard_auth/wall_mounted/directional/north,
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/rd)
+"pzX" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 10
+	},
+/turf/open/floor/iron/corner{
+	dir = 4
+	},
+/area/station/tcommsat/computer)
 "pzY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58928,20 +58929,6 @@
 "pLM" = (
 /turf/open/floor/wood/tile,
 /area/station/security/courtroom)
-"pLW" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/obj/structure/flora/bush/stalky,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "pLX" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron,
@@ -59914,6 +59901,12 @@
 "qaj" = (
 /turf/closed/wall,
 /area/station/maintenance/department/security/brig)
+"qal" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "qan" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Patient Rooms"
@@ -60297,25 +60290,6 @@
 /obj/structure/curtain/cloth,
 /turf/open/floor/iron/freezer,
 /area/station/command/heads_quarters/qm)
-"qgS" = (
-/obj/machinery/bouldertech/refinery{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "mining"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/cargo/miningfoundry)
 "qgV" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -60359,6 +60333,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/checker,
 /area/station/security/prison/mess)
+"qhK" = (
+/obj/structure/flora/bush/sparsegrass/style_3,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "qiF" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/steam_vent,
@@ -60586,32 +60568,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/freezer,
 /area/station/common/locker_room_shower)
-"qmh" = (
-/obj/structure/table/reinforced,
-/obj/machinery/newscaster/directional/north,
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 5
-	},
-/obj/item/airlock_painter/decal{
-	pixel_y = -17
-	},
-/obj/item/storage/box/lights/mixed{
-	pixel_y = 11;
-	pixel_x = 5
-	},
-/obj/item/storage/box/lights/mixed{
-	pixel_y = 2;
-	pixel_x = 5
-	},
-/obj/item/clipboard{
-	pixel_x = -12;
-	pixel_y = 5
-	},
-/turf/open/floor/iron/corner{
-	dir = 1
-	},
-/area/station/commons/storage/tools)
 "qmk" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -60841,6 +60797,19 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/exit/departure_lounge)
+"qoP" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Gas to Filter"
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/effect/mapping_helpers/airalarm/link{
+	chamber_id = "engine"
+	},
+/obj/effect/mapping_helpers/airalarm/engine_access,
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "qoU" = (
 /obj/machinery/suit_storage_unit/medical,
 /obj/effect/turf_decal/tile/blue/anticorner,
@@ -61004,6 +60973,13 @@
 "qqK" = (
 /turf/open/floor/iron,
 /area/station/maintenance/department/security)
+"qqO" = (
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/engine)
 "qqV" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plating,
@@ -61650,23 +61626,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/condemned_med)
-"qAS" = (
-/obj/machinery/newscaster/directional/east,
-/obj/item/flashlight/lamp/green{
-	pixel_y = 13
-	},
-/obj/structure/table/wood,
-/obj/item/storage/box/gum{
-	pixel_x = -10;
-	pixel_y = 5
-	},
-/obj/item/storage/box/sparklers{
-	pixel_x = 4
-	},
-/obj/structure/sign/calendar/directional/south,
-/obj/item/pneumatic_cannon/pie,
-/turf/open/floor/carpet/donk,
-/area/station/service/greenroom)
 "qAU" = (
 /obj/structure/railing,
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -61846,12 +61805,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"qCX" = (
-/obj/structure/table/wood,
-/obj/machinery/keycard_auth/wall_mounted/directional/north,
-/obj/machinery/fax/heads/qm,
-/turf/open/floor/wood/tile,
-/area/station/command/heads_quarters/qm)
 "qDi" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -61929,11 +61882,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
-"qEl" = (
-/obj/structure/cable,
-/obj/machinery/power/weather_tower,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "qEy" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
@@ -61945,6 +61893,13 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/library)
+"qED" = (
+/obj/machinery/camera/autoname/directional/north{
+	c_tag = "Engineering - Supermatter";
+	name = "engineering camera"
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "qEY" = (
 /obj/structure/stairs/south,
 /turf/open/floor/iron,
@@ -62761,6 +62716,20 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/ordnance/testlab)
+"qPJ" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 10
+	},
+/obj/structure/flora/bush/stalky/style_2,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "qPP" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -63042,6 +63011,14 @@
 /obj/machinery/status_display/supply,
 /turf/closed/wall/r_wall,
 /area/station/cargo/storage)
+"qUA" = (
+/obj/structure/flora/bush/sparsegrass,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "qUJ" = (
 /obj/machinery/space_heater,
 /turf/open/floor/iron,
@@ -63147,6 +63124,37 @@
 	dir = 8
 	},
 /area/station/engineering/storage)
+"qVK" = (
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 6
+	},
+/obj/item/electronics/airalarm{
+	pixel_y = 1;
+	pixel_x = 6
+	},
+/obj/item/electronics/airalarm{
+	pixel_y = 5;
+	pixel_x = 4
+	},
+/obj/item/electronics/apc{
+	pixel_x = -5
+	},
+/obj/item/electronics/apc{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/vending_refill/games{
+	pixel_y = 16;
+	pixel_x = 7
+	},
+/obj/item/wirecutters{
+	pixel_y = 2
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/corner{
+	dir = 1
+	},
+/area/station/commons/storage/tools)
 "qVT" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/white/line{
@@ -63539,10 +63547,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
-"rbt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "rbv" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -63633,6 +63637,17 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet/purple,
 /area/station/service/barber/spa)
+"rch" = (
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "rcp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
 	dir = 4
@@ -64602,6 +64617,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"rsE" = (
+/obj/structure/cable,
+/obj/machinery/power/weather_tower,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "rsG" = (
 /obj/structure/cable,
 /obj/structure/chair/sofa/bench/left,
@@ -64651,9 +64671,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
-"rtx" = (
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "rty" = (
 /obj/structure/closet/secure_closet/psychology,
 /turf/open/floor/plating,
@@ -64965,22 +64982,6 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/common/pool)
-"ryw" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/yellow{
-	pixel_x = -11;
-	pixel_y = 7
-	},
-/obj/item/toner,
-/obj/item/toner{
-	pixel_y = 3
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/commons/storage/tools)
 "ryA" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/machinery/light/small/directional/north,
@@ -65098,15 +65099,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/sorting)
-"rAH" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/west,
-/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "rAK" = (
 /obj/structure/table/wood,
 /obj/machinery/light/directional/north,
@@ -65857,6 +65849,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"rLR" = (
+/obj/structure/flora/ocean/coral,
+/obj/structure/flora/bush/sparsegrass{
+	pixel_x = -6
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "rLY" = (
 /obj/structure/railing/wooden_fence,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -66557,6 +66560,12 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/medical/office)
+"rUS" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "rUT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -67222,13 +67231,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/foreporthall)
-"sbG" = (
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/engine)
 "sbH" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
@@ -67471,18 +67473,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/service/janitor)
-"sfc" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = -3;
-	pixel_y = 10
-	},
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/turf/open/floor/iron,
-/area/station/commons/storage/tools)
 "sfd" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -67756,12 +67746,6 @@
 /obj/effect/turf_decal/trimline/blue/warning,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/chemistry)
-"siX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "sjb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68442,6 +68426,22 @@
 	},
 /turf/open/floor/eighties,
 /area/station/maintenance/abandon_arcade)
+"ssi" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 2;
+	pixel_y = -4
+	},
+/obj/item/storage/box/matches{
+	pixel_y = 8;
+	pixel_x = -2
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/item/megaphone/clown,
+/turf/open/floor/carpet/donk,
+/area/station/service/greenroom)
 "ssl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68580,6 +68580,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"stC" = (
+/obj/structure/table/wood,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/fax/heads/nanotrasen_consultant,
+/turf/open/floor/carpet/green,
+/area/station/command/heads_quarters/nt_rep)
 "stV" = (
 /obj/machinery/door/airlock/atmos/glass,
 /obj/structure/cable,
@@ -69098,6 +69106,22 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/law)
+"szT" = (
+/obj/item/folder/yellow{
+	pixel_x = -11;
+	pixel_y = 7
+	},
+/obj/item/toner,
+/obj/item/toner{
+	pixel_y = 3
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron,
+/area/station/commons/storage/tools)
 "sAf" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/smooth_large,
@@ -69465,6 +69489,15 @@
 /obj/structure/dresser,
 /turf/open/floor/carpet/royalblack,
 /area/station/command/heads_quarters/hos)
+"sDD" = (
+/obj/structure/table/wood,
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/fax/heads/cmo,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/cmo)
 "sDM" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -69582,20 +69615,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
-"sFo" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/service/glass{
-	name = "Barbershop";
-	id_tag = "barberspa"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/service/barber/spa)
 "sFB" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -70007,6 +70026,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/patients_rooms)
+"sLF" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/engine)
 "sLG" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -70037,10 +70064,6 @@
 	dir = 1
 	},
 /area/station/hallway/floor2)
-"sLZ" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "sMi" = (
 /obj/effect/turf_decal/trimline/green/line,
 /obj/effect/turf_decal/tile/dark_green{
@@ -70523,6 +70546,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/office)
+"sTB" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/station/hallway/floor2)
 "sTE" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -70779,14 +70817,6 @@
 "sWQ" = (
 /turf/closed/wall,
 /area/station/maintenance/abandon_wrestle)
-"sWW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/fax/heads/hos,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/hos)
 "sWY" = (
 /obj/effect/turf_decal/tile/blue/full,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -71166,15 +71196,6 @@
 /mob/living/basic/bot/secbot/beepsky/officer,
 /turf/open/floor/iron,
 /area/station/hallway/floor2)
-"tcr" = (
-/obj/structure/window/reinforced/plasma/spawner/directional/west,
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "tcu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -72336,13 +72357,6 @@
 	},
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/fore)
-"trU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/delam_scram/directional/east,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "trY" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/yellow,
@@ -72613,14 +72627,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
-"twj" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/obj/structure/fans/tiny,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "twl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -73360,22 +73366,6 @@
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/station/hallway/primary)
-"tFG" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining"
-	},
-/obj/machinery/bouldertech/refinery/smelter{
-	dir = 8
-	},
-/obj/machinery/light/directional/north,
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/cargo/miningfoundry)
 "tFK" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
@@ -73449,12 +73439,6 @@
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/brick,
 /area/station/hallway/primary)
-"tGy" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/commons/storage/tools)
 "tGB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -73713,6 +73697,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/checker,
 /area/station/commons/fitness)
+"tJC" = (
+/obj/structure/cable,
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/fax/heads/captain,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/captain)
 "tJG" = (
 /obj/structure/railing,
 /turf/open/openspace,
@@ -74080,6 +74071,12 @@
 "tNQ" = (
 /turf/open/floor/engine,
 /area/station/security/armory)
+"tNT" = (
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "tNX" = (
 /obj/machinery/modular_computer/preset/command,
 /obj/structure/window/reinforced/tinted/spawner/directional/north,
@@ -74803,6 +74800,20 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"tYg" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
+	},
+/obj/structure/flora/bush/stalky/style_random,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "tYj" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -74863,6 +74874,18 @@
 	dir = 8
 	},
 /area/station/tcommsat/computer)
+"tYI" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/siding/wideplating,
+/obj/structure/flora/bush/reed{
+	pixel_y = 5
+	},
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "tYL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -75353,12 +75376,6 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
-"ufN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "ufR" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/holopad,
@@ -76335,19 +76352,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/engineering/lobby)
-"uuy" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/item/lightreplacer{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/station/commons/storage/tools)
 "uuA" = (
 /obj/machinery/door/poddoor{
 	id = "Secure Storage";
@@ -76409,13 +76413,6 @@
 	dir = 4
 	},
 /area/station/engineering/lobby)
-"uvz" = (
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 1
-	},
-/obj/structure/sign/poster/random/directional/north,
-/turf/open/floor/iron/edge,
-/area/station/hallway/floor2)
 "uvA" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
@@ -76516,6 +76513,19 @@
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron/large,
 /area/station/cargo/storage)
+"uxy" = (
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/item/lightreplacer{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/station/commons/storage/tools)
 "uxF" = (
 /obj/structure/sign/directions/security{
 	dir = 1;
@@ -76724,6 +76734,23 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/bridge)
+"uzY" = (
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 10
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 8;
+	pixel_x = 3
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/corner{
+	dir = 4
+	},
+/area/station/commons/storage/tools)
 "uAh" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -76877,20 +76904,6 @@
 	},
 /turf/open/floor/iron/edge,
 /area/station/engineering/atmos/hallway)
-"uCk" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 4
-	},
-/obj/structure/flora/bush/stalky/style_random,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "uCv" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/machinery/light/directional/south,
@@ -77070,6 +77083,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/diagonal,
 /area/station/service/hydroponics)
+"uEU" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "uEX" = (
 /obj/structure/flora/tree/jungle/small/style_4,
 /turf/open/floor/grass,
@@ -77321,6 +77343,15 @@
 	dir = 4
 	},
 /area/station/science/robotics/lab)
+"uHL" = (
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "uHP" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Old Sci"
@@ -78648,15 +78679,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/port)
-"vbl" = (
-/obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 8
-	},
-/turf/open/floor/iron/edge{
-	dir = 8
-	},
-/area/station/commons/storage/tools)
 "vbs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -79421,6 +79443,28 @@
 	dir = 4
 	},
 /area/station/security/prison/work)
+"vml" = (
+/obj/structure/table/wood,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","rd")
+	},
+/obj/item/stamp/head/rd{
+	pixel_w = -8;
+	pixel_z = 9
+	},
+/obj/item/screwdriver{
+	pixel_z = -4
+	},
+/obj/item/paper_bin{
+	pixel_w = 5;
+	pixel_z = 8
+	},
+/obj/item/pen{
+	pixel_w = 5;
+	pixel_z = 8
+	},
+/turf/open/floor/carpet/purple,
+/area/station/command/heads_quarters/rd)
 "vmm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -79445,6 +79489,20 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/medical/office)
+"vmv" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
+	},
+/obj/structure/flora/bush/stalky/style_3,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "vmy" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -79672,11 +79730,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
-"voN" = (
-/obj/machinery/mining_weather_monitor/directional/east,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos/lesser)
 "voQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
@@ -80379,6 +80432,26 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/common/night_club)
+"vyF" = (
+/obj/structure/table/wood,
+/obj/machinery/door/window/left/directional/south,
+/obj/structure/cable,
+/obj/item/folder/yellow,
+/obj/item/stamp/head/qm{
+	pixel_y = 5;
+	pixel_x = -4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/stamp/denied{
+	pixel_y = 12
+	},
+/obj/item/stamp/granted{
+	pixel_y = 5;
+	pixel_x = 9
+	},
+/turf/open/floor/wood/tile,
+/area/station/command/heads_quarters/qm)
 "vyM" = (
 /obj/structure/marker_beacon/burgundy,
 /obj/structure/sign/warning/docking/directional/west,
@@ -80511,14 +80584,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/eighties,
 /area/station/common/arcade)
-"vAH" = (
-/obj/structure/flora/ocean/coral,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "vAK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -82164,15 +82229,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
-"vWI" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/table/wood/fancy/orange,
-/obj/item/radio/intercom/directional/west,
-/obj/machinery/fax/heads/ce,
-/turf/open/floor/wood/tile,
-/area/station/command/heads_quarters/ce)
 "vWK" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/machinery/camera/autoname/directional/east{
@@ -82426,15 +82482,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/mining)
-"vZR" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/siding/wideplating,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "wag" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
@@ -83502,11 +83549,6 @@
 	dir = 1
 	},
 /area/station/engineering/transit_tube)
-"wpd" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/hallway/floor2)
 "wpe" = (
 /obj/effect/turf_decal/trimline/yellow/line,
 /obj/item/radio/intercom/directional/south,
@@ -83709,6 +83751,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/qm)
+"wsi" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 4
+	},
+/obj/structure/flora/bush/stalky/style_random,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "wss" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -84980,11 +85036,6 @@
 /obj/machinery/netpod,
 /turf/open/floor/iron/dark/side,
 /area/station/cargo/bitrunning/den)
-"wId" = (
-/obj/machinery/power/weather_tower,
-/obj/structure/cable,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "wIh" = (
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
@@ -85057,18 +85108,6 @@
 	dir = 9
 	},
 /area/station/hallway/secondary/service)
-"wJf" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/siding/wideplating,
-/obj/structure/flora/bush/reed{
-	pixel_y = 5
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "wJt" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -85544,6 +85583,9 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/openspace/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"wOJ" = (
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "wOO" = (
 /obj/effect/turf_decal/stripes,
 /obj/structure/cable,
@@ -87993,19 +88035,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"xty" = (
-/obj/structure/railing{
-	dir = 5
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 5
-	},
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "xtT" = (
 /obj/structure/chair{
 	dir = 4
@@ -88065,21 +88094,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
-"xuM" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
-	},
-/obj/structure/sign/barber/directional/north{
-	pixel_y = 28
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/station/hallway/primary/starboard)
 "xuP" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -88117,6 +88131,15 @@
 	},
 /turf/open/floor/engine,
 /area/station/ai/satellite/hallway)
+"xvv" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/siding/wideplating,
+/obj/effect/spawner/liquids_spawner,
+/turf/open/floor/iron/pool{
+	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
+	icon_state = "cobble"
+	},
+/area/station/hallway/floor2)
 "xvB" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -88191,6 +88214,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/nt_rep)
+"xwM" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/closet/firecloset,
+/obj/item/clothing/mask/gas/atmos,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos/lesser)
 "xwV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -88674,20 +88707,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/aftstarboardhall)
-"xCD" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/obj/structure/flora/bush/stalky/style_random,
-/obj/effect/spawner/liquids_spawner,
-/turf/open/floor/iron/pool{
-	icon = 'modular_nova/modules/mapping/icons/unique/dungeon.dmi';
-	icon_state = "cobble"
-	},
-/area/station/hallway/floor2)
 "xCF" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/food_or_drink/condiment{
@@ -89020,6 +89039,10 @@
 /obj/machinery/light/floor,
 /turf/open/floor/engine,
 /area/station/ai/satellite/hallway)
+"xHm" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/engine)
 "xHu" = (
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
@@ -89498,29 +89521,6 @@
 /obj/structure/curtain/bounty/start_closed,
 /turf/open/floor/plating,
 /area/station/cargo/bitrunning/den)
-"xNF" = (
-/obj/machinery/camera/autoname/directional/south{
-	network = list("ss13","engine")
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
-"xNM" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 10
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 8;
-	pixel_x = 3
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -1;
-	pixel_y = 1
-	},
-/turf/open/floor/iron/corner{
-	dir = 4
-	},
-/area/station/commons/storage/tools)
 "xNU" = (
 /obj/structure/chair/comfy/barber_chair,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
@@ -90024,12 +90024,6 @@
 	dir = 1
 	},
 /area/station/medical/chemistry)
-"xUo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/engine)
 "xUz" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
@@ -90471,6 +90465,12 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/tcommsat/server)
+"yak" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/engine)
 "yao" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/disposalpipe/segment{
@@ -90593,10 +90593,6 @@
 /obj/item/flashlight/lantern/on,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"ybV" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "yca" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -91056,10 +91052,6 @@
 /obj/machinery/photocopier/prebuilt,
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/science/ordnance/office)
-"yhJ" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/engine)
 "yhP" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/flora/bush/generic/style_random,
@@ -91244,15 +91236,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/fore)
-"ykB" = (
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/engine)
 "ykM" = (
 /turf/closed/wall/r_wall,
 /area/station/common/nightclubbooth1)
@@ -180118,10 +180101,10 @@ tPn
 iLK
 tPn
 uuP
-aUw
-twj
-iJV
-iJV
+gDF
+aeA
+chx
+chx
 dqy
 dqy
 cSb
@@ -180180,7 +180163,7 @@ iuo
 sNw
 sKF
 gZi
-bCV
+ssi
 xpR
 lPN
 tPn
@@ -180375,7 +180358,7 @@ tPn
 hJF
 tPn
 uuP
-aUw
+gDF
 hew
 gcV
 xkN
@@ -180632,7 +180615,7 @@ tPn
 hJF
 tPn
 uuP
-aUw
+gDF
 hew
 hew
 azq
@@ -180695,7 +180678,7 @@ oUd
 sNw
 blJ
 uvm
-qAS
+lxX
 kbV
 tPn
 tPn
@@ -180889,7 +180872,7 @@ tPn
 hJF
 tPn
 uuP
-aUw
+gDF
 nFi
 tPn
 tPn
@@ -181146,7 +181129,7 @@ tKY
 hJF
 tPn
 uuP
-aUw
+gDF
 tPn
 tPn
 rGV
@@ -181403,9 +181386,9 @@ tKY
 bKB
 bIS
 uuP
-aUw
-aUw
-ahx
+gDF
+gDF
+gpV
 tPn
 tPn
 tPn
@@ -185036,8 +185019,8 @@ pon
 iPG
 pon
 pon
-lrf
-wpd
+bJt
+oHk
 hLN
 hLN
 hLN
@@ -185287,11 +185270,11 @@ sWz
 eZg
 eZg
 pon
-tGy
+fVI
 rRc
-vbl
+feI
 iUv
-xNM
+uzY
 pon
 wbq
 pnw
@@ -185546,10 +185529,10 @@ hkT
 pon
 kNn
 rBQ
-sfc
+mMA
 oEz
-fMA
-pon
+fmu
+cSM
 xCo
 lqV
 rcZ
@@ -185592,7 +185575,7 @@ qVh
 smi
 nXb
 iPX
-fSt
+xwM
 cgu
 jdO
 jdO
@@ -185803,7 +185786,7 @@ hQc
 pon
 fYC
 rBQ
-ryw
+szT
 pBQ
 faf
 elX
@@ -185849,15 +185832,15 @@ uwV
 nqV
 uhj
 iPX
-guS
-sLZ
-fDd
-sLZ
-voN
-jSa
-aUw
-aUw
-aUw
+alc
+lYM
+epV
+lYM
+dBu
+ibt
+gDF
+gDF
+gDF
 tPn
 tPn
 uuP
@@ -186114,7 +186097,7 @@ jdO
 jdO
 nFi
 tPn
-aUw
+gDF
 tPn
 tPn
 uuP
@@ -186315,13 +186298,13 @@ hLN
 tmc
 tmX
 pon
-lsP
+gTD
 boB
 uVo
 phz
-plL
-pon
-uvz
+aqI
+cSM
+xCo
 pAr
 jNr
 ncT
@@ -186371,7 +186354,7 @@ vBO
 vBO
 tPn
 tPn
-aUw
+gDF
 tPn
 tPn
 tPn
@@ -186572,13 +186555,13 @@ hLN
 hCs
 tmX
 pon
-qmh
-uuy
+jEx
+uxy
 aag
-aGZ
-mMj
-pon
-bDb
+oMz
+qVK
+cSM
+lxj
 pAr
 vXc
 sLU
@@ -186628,9 +186611,9 @@ vBO
 tPn
 tPn
 tPn
-aUw
-aUw
-ahx
+gDF
+gDF
+gpV
 tPn
 tPn
 tPn
@@ -186830,11 +186813,11 @@ xmQ
 lkx
 pon
 pon
-pon
+cSM
 muo
-pon
-pon
-pon
+cSM
+cSM
+cSM
 sws
 pAr
 tzo
@@ -187086,12 +187069,12 @@ wqG
 hIq
 afI
 iMp
-pkX
+sTB
 kWf
 kWf
-agd
+dZm
 pwM
-dOM
+dZm
 xoK
 gxp
 pZS
@@ -187602,12 +187585,12 @@ iex
 qdp
 akq
 ybB
-kqh
-nbp
-lKp
-xCD
-iXN
-ebX
+bTm
+vmv
+cji
+tYg
+jSO
+qPJ
 gbz
 cCs
 sbt
@@ -187633,7 +187616,7 @@ jdX
 oij
 azX
 lvN
-ybV
+cwA
 awt
 jth
 oYM
@@ -187859,12 +187842,12 @@ adZ
 adZ
 rbB
 oin
-hUm
-nWL
-mwI
-oMe
-nWL
-vZR
+kTs
+nYE
+ilk
+qUA
+nYE
+xvv
 gbz
 qht
 sbt
@@ -188116,12 +188099,12 @@ jIL
 adZ
 ayc
 oin
-mzq
-vAH
-nWL
-lAG
-ndU
-wJf
+faY
+olA
+nYE
+eLX
+qhK
+tYI
 gbz
 gOv
 hLN
@@ -188373,12 +188356,12 @@ xQu
 adZ
 ueM
 oin
-pLW
-mwI
-nss
-jYl
-nWL
-vZR
+gBC
+ilk
+gsA
+rLR
+nYE
+xvv
 gbz
 ecD
 hLN
@@ -188630,12 +188613,12 @@ cEj
 adZ
 sLA
 oin
-xty
-uCk
-dDf
-pcf
-dDf
-kab
+nen
+wsi
+olC
+lhn
+olC
+dav
 gbz
 geE
 hLN
@@ -188661,7 +188644,7 @@ jdX
 rXk
 kSc
 noA
-ybV
+cwA
 lsX
 jth
 oYM
@@ -189689,7 +189672,7 @@ jdX
 cVS
 wPT
 uOM
-ybV
+cwA
 wpp
 jth
 oYM
@@ -189703,7 +189686,7 @@ jth
 jth
 jth
 gKI
-ybV
+cwA
 kFB
 eWg
 cdm
@@ -190717,7 +190700,7 @@ jdX
 szM
 ouQ
 ePf
-ybV
+cwA
 rYM
 jth
 oYM
@@ -190731,7 +190714,7 @@ jth
 cGl
 jth
 bYK
-ybV
+cwA
 kQx
 hzM
 hJr
@@ -191759,7 +191742,7 @@ uBc
 nNe
 rfH
 pBC
-ybV
+cwA
 ett
 nFb
 bvg
@@ -194283,7 +194266,7 @@ wfG
 ePb
 vCs
 ofl
-dPe
+eqa
 biU
 tyb
 xvl
@@ -241048,7 +241031,7 @@ aZw
 mRn
 mRn
 hbW
-naD
+vyF
 wse
 vff
 bHE
@@ -241065,7 +241048,7 @@ gKQ
 uve
 pMZ
 tUZ
-jOd
+hAa
 vJn
 vMu
 otf
@@ -241304,7 +241287,7 @@ qgO
 gde
 wCw
 mRn
-qCX
+mRa
 vHN
 mwl
 wpv
@@ -242054,7 +242037,7 @@ lsM
 wwK
 qOa
 wwK
-sWW
+lIN
 qFv
 qUR
 xzT
@@ -246188,7 +246171,7 @@ aed
 vch
 qeX
 dzX
-tFG
+iNw
 rCp
 xyo
 wvk
@@ -246447,7 +246430,7 @@ iYL
 dzX
 ujC
 axx
-qgS
+etp
 gSt
 xjq
 gBU
@@ -247286,7 +247269,7 @@ xfD
 fws
 nwL
 nwL
-nAO
+lbX
 dyu
 jwY
 vHH
@@ -247539,11 +247522,11 @@ fws
 plG
 tHe
 mUZ
-mnC
-dbq
+pzX
+lcd
 xVp
-fUB
-nAO
+eaF
+lbX
 msO
 yaf
 plB
@@ -248553,7 +248536,7 @@ ioy
 lFT
 bDG
 inr
-vWI
+pbJ
 mBQ
 bPG
 otf
@@ -248999,7 +248982,7 @@ llx
 ubu
 tlh
 mQd
-lpt
+bLK
 llx
 iEx
 emh
@@ -253192,11 +253175,11 @@ vqy
 dKA
 gwb
 oWj
-rtx
-sbG
-dTR
-sbG
-rtx
+wOJ
+qqO
+sLF
+qqO
+wOJ
 pJb
 wTv
 bvd
@@ -253449,11 +253432,11 @@ lhS
 erm
 npn
 oWj
-rtx
-fGH
-jKG
-cGV
-rtx
+wOJ
+qED
+aZg
+fUs
+wOJ
 rSE
 rZE
 ilP
@@ -253704,13 +253687,13 @@ aRH
 aRH
 tir
 iOe
-rtx
-rtx
-xUo
-cMk
-iHo
-atR
-rtx
+wOJ
+wOJ
+bTr
+heJ
+uEU
+gKg
+wOJ
 fLd
 usK
 oks
@@ -253961,13 +253944,13 @@ ugJ
 aRH
 tir
 jec
-rbt
-iHd
-iFW
-abI
-abI
-abI
-rtx
+dBS
+qoP
+rUS
+dnu
+dnu
+dnu
+wOJ
 tOU
 uYP
 fUP
@@ -254218,13 +254201,13 @@ fOA
 aRH
 tir
 tRx
-ykB
-cGV
-pzH
-duy
-jnI
-cGV
-yhJ
+ivt
+fUs
+rch
+ifk
+eHG
+fUs
+bwc
 rVn
 jbi
 bMn
@@ -254475,13 +254458,13 @@ vNz
 aRH
 tir
 iRo
-kCs
-mtQ
-ufN
-trU
-iBf
-iBf
-rtx
+xHm
+hoy
+qal
+iYR
+yak
+yak
+wOJ
 tOU
 uYP
 bvd
@@ -254732,13 +254715,13 @@ aRH
 aRH
 tir
 bfa
-rtx
-rtx
-siX
-tcr
-rAH
-jdf
-rtx
+wOJ
+wOJ
+nlU
+uHL
+bid
+mil
+wOJ
 tSl
 usK
 oks
@@ -254991,11 +254974,11 @@ daw
 iRo
 jiM
 bEb
-rtx
-cGV
-jKG
-xNF
-rtx
+wOJ
+fUs
+aZg
+tNT
+wOJ
 gsT
 uYP
 tew
@@ -255248,11 +255231,11 @@ vqy
 iRo
 jiM
 amd
-rtx
-sbG
-dTR
-sbG
-rtx
+wOJ
+qqO
+sLF
+qqO
+wOJ
 tSl
 usK
 oiC
@@ -256688,7 +256671,7 @@ wBf
 bLo
 dPT
 ulM
-lDA
+tJC
 geG
 oXa
 ygs
@@ -260860,7 +260843,7 @@ akc
 akc
 gal
 akc
-sFo
+gUV
 akc
 akc
 iJc
@@ -262656,11 +262639,11 @@ abd
 abd
 abd
 etY
-xuM
+fNe
 bWM
 fMC
 mfF
-mRm
+jji
 etY
 wvL
 wvL
@@ -266721,7 +266704,7 @@ iUT
 jLZ
 aoi
 keS
-eVf
+stC
 sMj
 jaF
 gqZ
@@ -268830,7 +268813,7 @@ oDI
 nGx
 pzV
 bXO
-miX
+vml
 nGx
 kQP
 npQ
@@ -268865,7 +268848,7 @@ jcZ
 jcZ
 aIO
 stA
-qEl
+rsE
 jcZ
 oaq
 jcZ
@@ -269087,7 +269070,7 @@ diu
 nGx
 wgt
 kdJ
-bnl
+krk
 nKI
 ivX
 npQ
@@ -272144,7 +272127,7 @@ oVi
 oYc
 ciI
 bQg
-gxj
+sDD
 tyN
 mAE
 hFw
@@ -274743,7 +274726,7 @@ jcZ
 jcZ
 stA
 stA
-wId
+eGX
 jcZ
 jcZ
 jcZ

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -57220,7 +57220,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
@@ -82490,6 +82489,7 @@
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/floor2)
 "wbC" = (


### PR DESCRIPTION

## About The Pull Request
I decided to immerse myself in Snowglobe, and I found a handful of things that could be improved:
There was a misplaced tile decal in the chapel wall
The public pond outside of the tool storage is now a pool instead of nature tiles that disappear into nothingness when touched
The tool storage now has windows
The barber shop no longer has an access lock to the spa, the barber sign no longer floats on a tile and is mounted to a wall
Atmos now has plasma glass on each gas silo
There's no longer a plant spawner in front of the maint door in the arcade
## How This Contributes To The Nova Sector Roleplay Experience
All of these are essentially bugs.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
map: Fixed a handful of minor discrepancies within Snowglobe
/:cl:
