### PR TITLE
Interlink Hotfix

### DIFF
--- a/_maps/map_files/generic/CentCom_nova_z2.dmm
+++ b/_maps/map_files/generic/CentCom_nova_z2.dmm
@@ -9813,6 +9813,11 @@
 "iKR" = (
 /turf/open/floor/iron/large,
 /area/centcom/interlink)
+"iLh" = (
+/obj/machinery/door/poddoor/ert,
+/obj/machinery/nova/fan/self_powered,
+/turf/open/floor/iron/smooth_large,
+/area/centcom/interlink)
 "iLp" = (
 /obj/structure/chair/sofa/bench{
 	dir = 1
@@ -15002,6 +15007,7 @@
 /obj/machinery/door/poddoor{
 	id = "interlink_shuttles"
 	},
+/obj/machinery/nova/fan/self_powered,
 /turf/open/floor/plating,
 /area/centcom/interlink)
 "pLm" = (
@@ -39557,11 +39563,11 @@ vLx
 vLx
 wTk
 wTk
-fkf
-fkf
-fkf
-fkf
-fkf
+iLh
+iLh
+iLh
+iLh
+iLh
 wTk
 wTk
 gRu

--- a/_maps/map_files/generic/CentCom_nova_z2.dmm
+++ b/_maps/map_files/generic/CentCom_nova_z2.dmm
@@ -39557,11 +39557,11 @@ vLx
 vLx
 wTk
 wTk
-llq
-llq
-llq
-llq
-llq
+fkf
+fkf
+fkf
+fkf
+fkf
 wTk
 wTk
 gRu


### PR DESCRIPTION

## About The Pull Request

Somehow the blast doors (intended to be entirely cosmetic) at the end of the shuttle track were opened on the current round. Still researching on how that happened, but in the meantime, assuming there's no CI/linter complaints, just going to shove some tiny fans underneath them, so even if they get opened again in the future we don't vent the interlink.

## How This Contributes To The Nova Sector Roleplay Experience

Interlink should not be a dangerous zone.


## Changelog

:cl:
map: minor adjustments to cosmetic areas of the interlink to prevent further atmos issues.
/:cl:

