### PR TITLE
Remove antimagic spell from syndicate anti-runner

### DIFF
--- a/modular_nova/modules/bitrunning/code/virtual_domains/syndicate_assault/ghost_spawner.dm
+++ b/modular_nova/modules/bitrunning/code/virtual_domains/syndicate_assault/ghost_spawner.dm
@@ -20,35 +20,8 @@
 
 /obj/effect/mob_spawn/ghost_role/human/virtual_domain/syndie/special(mob/living/carbon/human/spawned_human, mob/mob_possessor, apply_prefs)
 	. = ..()
-	var/datum/action/cooldown/spell/home_network/norton = new(spawned_human)
-	norton.Grant(spawned_human)
 	apply_random_alias(spawned_human)
 
 /obj/effect/mob_spawn/ghost_role/human/virtual_domain/syndie/post_transfer_prefs(mob/living/carbon/human/spawned_human)
 	. = ..()
 	apply_pref_alias(spawned_human)
-
-/datum/action/cooldown/spell/home_network
-	name = "Home Network"
-	desc = "Makes the caster immune to many forms of practical hacks, backing themselves to the home network."
-
-	button_icon = 'icons/mob/actions/actions_items.dmi'
-	button_icon_state = "bci_shield"
-	sound = 'sound/effects/magic/staff_animation.ogg'
-	cooldown_time = 10 SECONDS
-	spell_requirements = SPELL_REQUIRES_HUMAN
-
-	invocation = "NOR TON"
-	invocation_type = INVOCATION_SHOUT
-
-/datum/action/cooldown/spell/home_network/is_valid_target(atom/cast_on)
-	return isliving(cast_on)
-
-/datum/action/cooldown/spell/home_network/cast(mob/living/cast_on)
-	. = ..()
-	cast_on.visible_message(
-		span_warning("Numerous loading bars and nano-scale hexagonal energy shields briefly cover [cast_on]!"),
-		span_notice("You protect yourself from foreign intrusion!"),
-	)
-	ADD_TRAIT(cast_on, TRAIT_ANTIMAGIC, REF(src))
-	Remove(cast_on)


### PR DESCRIPTION
Removed Home Network spell and its associated functionality.
## About The Pull Request
Removes the "home network" spell from the syndicate assault anti-runners

## How This Contributes To The Nova Sector Roleplay Experience

Bitrunning is supposed to be a power fantasy experience for the bitrunning players. Rendering most of their purchased utilities useless in a domain against antirunners goes against the spirit of being able to buy and build a loadout in the first place. On top of this, there is often only one bitrunning player, putting the antirunners in a numbers advantage

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: Bitrunner anti-runners no longer have wholesale antimagic in the Cybersun domain.
/:cl:
