### PR TITLE
Adds a syndicate encryption key to the posibrain option for marauders

### DIFF
--- a/modular_nova/modules/marauders/voucher_lists/supplies/science.dm
+++ b/modular_nova/modules/marauders/voucher_lists/supplies/science.dm
@@ -7,6 +7,7 @@
 	icon_state = /obj/item/mmi/posibrain/circuit/disk/syndie::icon_state
 	set_items = list(
 		/obj/item/mmi/posibrain/circuit/disk/syndie,
+		/obj/item/encryptionkey/syndicate,
 	)
 
 /datum/voucher_set/traitor/supplies/science/concealed_bay


### PR DESCRIPTION

## About The Pull Request
At the moment the marauder borgs can only use binary and common, which seems a little iffy. Being able to coordinate over the radio without the whole station listening in would be a great change in my opinion.
## How This Contributes To The Nova Sector Roleplay Experience
It would let Marauders coordinate better with their borg that they get if they wish to choose one.
## Proof of Testing
I personally don't have the marauder ruleset on my localhost for some reason, and the vouchers working seem to be tied with the z-level spawn. I can't personally test it but it is just adding one item to a voucher option
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
add: Following up on heightened interest in combat capable silicon units, Gorlex Marauders now supply their operatives with a paired encryption key with every posibrain requisition.
/:cl:
