### PR TITLE
Removes adaptation mutations visual cues once again.

### DIFF
--- a/code/datums/mutations/adaptation.dm
+++ b/code/datums/mutations/adaptation.dm
@@ -10,12 +10,9 @@
 	mutation_traits = list(TRAIT_WADDLING)
 	mutation_icon = 'icons/mob/effects/genetics.dmi'
 
-/* // NOVA EDIT REMOVAL START - Removes the visual indicators.
 /datum/mutation/adaptation/New(datum/mutation/copymut)
 	. = ..()
 	conflicts = typesof(/datum/mutation/adaptation)
-
-*/ // NOVA EDIT REMOVAL END
 
 /datum/mutation/adaptation/cold
 	name = "Cold Adaptation"

--- a/modular_nova/master_files/code/datums/mutations/_mutations.dm
+++ b/modular_nova/master_files/code/datums/mutations/_mutations.dm
@@ -1,2 +1,0 @@
-/datum/mutation/thermal
-	locked = TRUE

--- a/modular_nova/master_files/code/datums/mutations/adaptation.dm
+++ b/modular_nova/master_files/code/datums/mutations/adaptation.dm
@@ -1,0 +1,11 @@
+/datum/mutation/adaptation/cold
+	mutation_icon_state = ""
+
+/datum/mutation/adaptation/heat
+	mutation_icon_state = ""
+
+/datum/mutation/adaptation/thermal
+	mutation_icon_state = ""
+
+/datum/mutation/adaptation/pressure
+	mutation_icon_state = ""

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7189,7 +7189,7 @@
 #include "modular_nova\master_files\code\datums\mood_events\drink_events.dm"
 #include "modular_nova\master_files\code\datums\mood_events\generic_negative_events.dm"
 #include "modular_nova\master_files\code\datums\mood_events\needs_events.dm"
-#include "modular_nova\master_files\code\datums\mutations\_mutations.dm"
+#include "modular_nova\master_files\code\datums\mutations\adaptation.dm"
 #include "modular_nova\master_files\code\datums\mutations\antenna.dm"
 #include "modular_nova\master_files\code\datums\mutations\chameleon.dm"
 #include "modular_nova\master_files\code\datums\mutations\reach.dm"


### PR DESCRIPTION

## About The Pull Request
TG changed  how it was rendered and Orbis' edit became irrelevant here. Also there was an undocumented (but a good one) change that allowed different adaptations to overlap. Since it was undocumented, i removed it only to add in another PR, *blep.
## How This Contributes To The Nova Sector Roleplay Experience
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="605" height="271" alt="изображение" src="https://github.com/user-attachments/assets/f065dcbd-493e-479b-a09e-e78b755cba9c" />

</details>

## Changelog
:cl:
fix: adaptation mutations are invisible once again
/:cl:
