### PR TITLE
Add a corridor between Medical and Science on oceanpubby

### DIFF
--- a/_maps/map_files/oceanpubby/oceanpubby.dmm
+++ b/_maps/map_files/oceanpubby/oceanpubby.dmm
@@ -33221,6 +33221,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/corner,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/aft)
 "hsc" = (

--- a/_maps/map_files/oceanpubby/oceanpubby.dmm
+++ b/_maps/map_files/oceanpubby/oceanpubby.dmm
@@ -6382,6 +6382,9 @@
 /obj/structure/chair/greyscale{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -14439,17 +14442,6 @@
 	dir = 8
 	},
 /area/station/medical/medbay/lobby)
-"bmB" = (
-/obj/item/kirbyplants/organic/plant21{
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/station/hallway/primary/aft)
 "bmD" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
@@ -17426,11 +17418,6 @@
 /obj/machinery/smoke_machine,
 /turf/open/floor/engine,
 /area/station/medical/chemistry)
-"bAl" = (
-/turf/open/floor/iron/dark/corner{
-	dir = 4
-	},
-/area/station/hallway/primary/aft)
 "bAm" = (
 /obj/structure/sign/warning/no_smoking/circle,
 /turf/closed/wall/r_wall,
@@ -18009,6 +17996,9 @@
 /area/station/medical/chemistry)
 "bDA" = (
 /obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -18372,6 +18362,13 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Eng2";
+	location = "Kitchen"
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -19050,6 +19047,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "bJr" = (
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -19109,6 +19109,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -26636,6 +26639,9 @@
 /area/station/service/chapel/funeral)
 "cIe" = (
 /obj/structure/chair/greyscale,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -28485,6 +28491,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -28522,7 +28531,7 @@
 	},
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/effect/turf_decal/trimline/purple/line{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 6
@@ -29508,6 +29517,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -30414,9 +30426,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "fpt" = (
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
+/obj/effect/spawner/random/trash/cigpack,
+/turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "fpT" = (
 /obj/structure/lattice,
@@ -32653,6 +32664,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -34420,6 +34434,9 @@
 /area/station/hallway/primary/fore)
 "ipu" = (
 /obj/structure/chair/greyscale,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 9
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 9
 	},
@@ -35049,11 +35066,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/large,
 /area/station/security/warden)
-"iNc" = (
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/station/hallway/primary/aft)
 "iNf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/warning{
@@ -36019,15 +36031,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
-"jCv" = (
-/obj/structure/sign/poster/official/random/directional/west,
-/obj/effect/turf_decal/trimline/yellow/filled/warning/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/station/hallway/primary/aft)
 "jCw" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/chem_dispenser,
@@ -36405,6 +36408,9 @@
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "jSA" = (
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/corner{
 	dir = 8
 	},
@@ -40553,6 +40559,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "mOt" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -41304,6 +41313,9 @@
 /area/station/service/hydroponics)
 "nmV" = (
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -41575,8 +41587,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "nyN" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/vending/snack,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 6
+	},
+/obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron/dark/side{
 	dir = 6
 	},
@@ -41898,6 +41912,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "nOr" = (
+/obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/primary/aft)
 "nOt" = (
@@ -42916,7 +42931,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 10
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 10
 	},
@@ -43381,7 +43398,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "oQi" = (
-/obj/machinery/vending/snack/orange,
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -43911,6 +43932,9 @@
 "phx" = (
 /obj/machinery/light/directional/west,
 /obj/structure/table,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -44380,6 +44404,7 @@
 /turf/open/floor/plastic,
 /area/station/security/mechbay)
 "pzj" = (
+/obj/effect/turf_decal/trimline/purple/corner,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/aft)
 "pzm" = (
@@ -48299,6 +48324,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/purple/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/corner{
 	dir = 4
 	},
@@ -51131,8 +51159,10 @@
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "uaY" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/vending/snack/teal,
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 5
+	},
+/obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/dark/side{
 	dir = 5
 	},
@@ -89878,21 +89908,21 @@ pyh
 fWg
 eCs
 dhy
-bmB
-iNc
-iNc
+fWg
+fWg
+fWg
 nmV
-iNc
+fWg
 eNd
-nmV
-iNc
+fWg
+fWg
 bJr
 bmD
 bmD
 hop
 jSA
-iNc
-jCv
+fWg
+bEN
 bGd
 bRV
 ery
@@ -90403,10 +90433,10 @@ bAy
 bAm
 mOt
 bmD
-bmD
-pzj
 fpt
-bAl
+pzj
+gRb
+boW
 bIu
 beH
 bKK

--- a/_maps/map_files/oceanpubby/oceanpubby.dmm
+++ b/_maps/map_files/oceanpubby/oceanpubby.dmm
@@ -6379,15 +6379,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "azR" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
+/obj/structure/chair/greyscale{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/welded,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/hallway/primary/aft)
 "azS" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Port Solar Access"
@@ -8462,7 +8460,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/area/station/hallway/primary/central/aft)
+/area/station/hallway/primary/aft)
 "aKb" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitory"
@@ -14445,14 +14443,13 @@
 /obj/item/kirbyplants/organic/plant21{
 	pixel_y = 3
 	},
-/obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
-/area/station/hallway/primary/central/aft)
+/area/station/hallway/primary/aft)
 "bmD" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
@@ -15435,8 +15432,11 @@
 "bro" = (
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/bot,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/maintenance/department/medical)
+/area/station/hallway/primary/aft)
 "brq" = (
 /obj/machinery/modular_computer/preset/cargochat/science,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -16614,7 +16614,7 @@
 /area/station/science/research)
 "bxc" = (
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
@@ -17054,34 +17054,14 @@
 /turf/open/floor/engine,
 /area/station/medical/chemistry)
 "byD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = -11
 	},
-/obj/structure/cable,
-/obj/item/radio/intercom/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "byE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/white,
@@ -17447,29 +17427,14 @@
 /turf/open/floor/engine,
 /area/station/medical/chemistry)
 "bAl" = (
-/obj/structure/sign/poster/random/directional/north,
-/obj/effect/turf_decal/trimline/purple/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 1
+/turf/open/floor/iron/dark/corner{
+	dir = 4
 	},
 /area/station/hallway/primary/aft)
 "bAm" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Research Lab Maintenance"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/general,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/structure/sign/warning/no_smoking/circle,
+/turf/closed/wall/r_wall,
+/area/station/hallway/primary/aft)
 "bAo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -18044,9 +18009,10 @@
 /area/station/medical/chemistry)
 "bDA" = (
 /obj/machinery/vending/cigarette,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/hallway/primary/aft)
 "bDB" = (
 /obj/machinery/computer/rdconsole{
 	dir = 4
@@ -18400,14 +18366,17 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "bFq" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/hallway/primary/aft)
 "bFr" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -19080,6 +19049,11 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/psychology,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
+"bJr" = (
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/hallway/primary/aft)
 "bJB" = (
 /obj/structure/sign/warning/pods/directional/north,
 /turf/open/floor/engine,
@@ -19128,18 +19102,17 @@
 	},
 /area/station/hallway/primary/aft)
 "bJN" = (
-/obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/hallway/primary/aft)
 "bJO" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -26662,11 +26635,11 @@
 /turf/open/floor/plating,
 /area/station/service/chapel/funeral)
 "cIe" = (
-/obj/machinery/computer/records/medical/laptop,
-/obj/structure/table/glass,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/medical)
+/obj/structure/chair/greyscale,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/hallway/primary/aft)
 "cIE" = (
 /turf/closed/mineral/random/stationside/ocean,
 /area/ocean)
@@ -26721,8 +26694,8 @@
 /area/station/command/heads_quarters/captain/private)
 "cLB" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "cMa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -26919,6 +26892,9 @@
 	location = "Research Division"
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "cTq" = (
@@ -27091,7 +27067,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/area/station/hallway/primary/central/aft)
+/area/station/hallway/primary/aft)
 "dcQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -27226,7 +27202,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
-/area/station/hallway/primary/central/aft)
+/area/station/hallway/primary/aft)
 "diM" = (
 /obj/machinery/light/directional/west,
 /obj/effect/landmark/start/hangover,
@@ -28498,6 +28474,21 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"ede" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/hallway/primary/aft)
 "edJ" = (
 /obj/structure/chair/office/light,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -28534,9 +28525,9 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/side{
-	dir = 4
+	dir = 6
 	},
-/area/station/hallway/primary/central/aft)
+/area/station/hallway/primary/aft)
 "efu" = (
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/dark,
@@ -29199,7 +29190,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
-/area/station/hallway/primary/central/aft)
+/area/station/hallway/primary/aft)
 "eCB" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -29511,6 +29502,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"eNd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/hallway/primary/aft)
 "eNh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -30020,11 +30021,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "fby" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/medical)
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "fbW" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
@@ -30414,6 +30413,11 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"fpt" = (
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/hallway/primary/aft)
 "fpT" = (
 /obj/structure/lattice,
 /turf/open/water/deep_beach/lethal/planet_surface,
@@ -30967,6 +30971,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
+"fJl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "fJw" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -31281,7 +31295,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
-/area/station/hallway/primary/central/aft)
+/area/station/hallway/primary/aft)
 "fWh" = (
 /obj/structure/table/wood/fancy,
 /turf/open/floor/iron/dark,
@@ -32067,6 +32081,9 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "gzf" = (
@@ -32530,19 +32547,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "gRb" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/trimline/purple/line{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/hallway/primary/aft)
 "gRv" = (
 /obj/item/toy/basketball,
 /turf/open/misc/beach/sand/nofishy,
@@ -32639,8 +32650,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/hallway/primary/aft)
 "gVy" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -33119,12 +33135,11 @@
 "hop" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/sign/poster/official/random/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "hoR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -33184,6 +33199,16 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"hqu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner,
+/area/station/hallway/primary/aft)
 "hsc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -34394,18 +34419,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "ipu" = (
-/obj/machinery/vending/wallmed{
-	pixel_y = 28
+/obj/structure/chair/greyscale,
+/turf/open/floor/iron/dark/side{
+	dir = 9
 	},
-/obj/structure/table_frame,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/folder/white,
-/obj/effect/decal/cleanable/cobweb,
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/medical)
+/area/station/hallway/primary/aft)
 "ipE" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -35032,9 +35050,10 @@
 /turf/open/floor/iron/large,
 /area/station/security/warden)
 "iNc" = (
-/obj/effect/spawner/random/trash/box,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/hallway/primary/aft)
 "iNf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/warning{
@@ -36001,18 +36020,12 @@
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "jCv" = (
-/obj/structure/sign/poster/random/directional/north,
-/obj/item/kirbyplants/organic/plant17,
 /obj/structure/sign/poster/official/random/directional/west,
-/obj/effect/turf_decal/trimline/purple/filled/warning/corner{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/warning/corner{
 	dir = 8
 	},
-/obj/structure/table/glass,
 /turf/open/floor/iron/dark/side{
-	dir = 9
+	dir = 8
 	},
 /area/station/hallway/primary/aft)
 "jCw" = (
@@ -36392,9 +36405,10 @@
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "jSA" = (
-/obj/structure/sign/departments/science,
-/turf/closed/wall,
-/area/station/maintenance/department/medical)
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/station/hallway/primary/aft)
 "jSF" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/command)
@@ -37297,6 +37311,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
+"kvS" = (
+/obj/item/poster,
+/turf/closed/wall/r_wall,
+/area/station/hallway/primary/aft)
 "kvY" = (
 /obj/structure/chair/wood,
 /obj/machinery/requests_console/directional/north{
@@ -40535,15 +40553,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "mOt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/turf/open/floor/iron/dark/side{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/hallway/primary/aft)
 "mOx" = (
 /obj/machinery/light/directional/west,
 /obj/structure/cable,
@@ -41290,16 +41303,11 @@
 /turf/open/floor/iron/large,
 /area/station/service/hydroponics)
 "nmV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/side{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/spawner/random/structure/steam_vent,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/hallway/primary/aft)
 "nnh" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron/dark/diagonal,
@@ -41315,7 +41323,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/area/station/hallway/primary/central/aft)
+/area/station/hallway/primary/aft)
 "nnX" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/line{
@@ -41567,9 +41575,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "nyN" = (
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/machinery/light/directional/east,
+/obj/machinery/vending/snack,
+/turf/open/floor/iron/dark/side{
+	dir = 6
+	},
+/area/station/hallway/primary/aft)
 "nyO" = (
 /obj/item/kirbyplants/organic/plant22,
 /obj/machinery/light/small/directional/north,
@@ -41770,16 +41781,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "nIU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/science/research)
@@ -41895,6 +41897,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"nOr" = (
+/turf/open/floor/iron/dark/side,
+/area/station/hallway/primary/aft)
 "nOt" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -42163,6 +42168,14 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"nXS" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "nYb" = (
 /obj/structure/table_frame/wood,
 /turf/open/floor/wood,
@@ -42897,6 +42910,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"oxV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/side{
+	dir = 10
+	},
+/area/station/hallway/primary/aft)
 "oya" = (
 /obj/machinery/camera/autoname/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -43357,18 +43381,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "oQi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/machinery/vending/snack/orange,
+/turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/hallway/primary/aft)
 "oQn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -43603,8 +43620,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "oXc" = (
 /turf/closed/wall,
 /area/station/security/prison/mess)
@@ -43889,9 +43909,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "phx" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/medical)
+/obj/machinery/light/directional/west,
+/obj/structure/table,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/hallway/primary/aft)
 "pif" = (
 /obj/structure/hoop{
 	dir = 8
@@ -44320,7 +44343,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
-/area/station/hallway/primary/central/aft)
+/area/station/hallway/primary/aft)
 "pyA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -44356,6 +44379,9 @@
 /obj/structure/cable,
 /turf/open/floor/plastic,
 /area/station/security/mechbay)
+"pzj" = (
+/turf/open/floor/iron/dark/corner,
+/area/station/hallway/primary/aft)
 "pzm" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -47260,6 +47286,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"rwj" = (
+/obj/structure/chair/greyscale{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "rxa" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -48256,6 +48288,21 @@
 /obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
+"siE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/aft)
 "siF" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
@@ -51084,16 +51131,12 @@
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "uaY" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/light/directional/east,
+/obj/machinery/vending/snack/teal,
+/turf/open/floor/iron/dark/side{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/area/station/hallway/primary/aft)
 "ubq" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/white{
@@ -52381,9 +52424,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "uQB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -52391,8 +52431,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical)
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "uQR" = (
 /obj/item/ammo_casing/shotgun/beanbag,
 /turf/open/floor/plating,
@@ -53100,7 +53143,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/area/station/hallway/primary/aft)
 "vsn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -53907,7 +53950,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/maintenance/department/medical)
+/area/station/hallway/primary/aft)
 "vTg" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -54314,6 +54357,13 @@
 /obj/structure/cable/layer3,
 /turf/open/water/deep_beach/lethal/planet_surface,
 /area/ocean)
+"wgL" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "wha" = (
 /obj/structure/table/glass,
 /obj/item/folder/white{
@@ -57501,7 +57551,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
+/area/station/hallway/primary/aft)
 "yjt" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron/dark,
@@ -89064,12 +89114,12 @@ bwT
 qHa
 pxw
 dRj
-lRN
-lRN
-lRN
-lRN
-lRN
-lRN
+bAy
+bAy
+kvS
+bAy
+bAy
+bAy
 lRN
 lRN
 lRN
@@ -89321,13 +89371,13 @@ lmA
 bun
 lnl
 fEU
-lRN
+bAy
 ipu
 phx
 azR
-eMp
-eMp
-eMp
+eNd
+oxV
+bVZ
 eMp
 eMp
 eMp
@@ -89572,18 +89622,18 @@ cQN
 xOq
 bmA
 cQN
-oJj
-lRN
-lRN
-lRN
+bBo
+bAy
+bAy
+bAy
 vSL
-lRN
-lRN
+bAy
+bAy
 cIe
 fby
-oJj
-eMp
-oXV
+rwj
+dpA
+nOr
 oJj
 oJj
 oJj
@@ -89829,19 +89879,19 @@ fWg
 eCs
 dhy
 bmB
-oJj
 iNc
-oPH
-oPH
-eMp
-upW
-oJj
-oJj
-oJj
-oJj
+iNc
+nmV
+iNc
+eNd
+nmV
+iNc
+bJr
+bmD
+bmD
 hop
-oJj
-oJj
+jSA
+iNc
 jCv
 bGd
 bRV
@@ -90083,23 +90133,23 @@ bio
 sMg
 yiR
 vsm
-sMg
-sMg
-sMg
+fJl
+fJl
+hqu
 bJN
-mOt
+bJN
+bFq
+ede
 gVk
 gVk
 gVk
 gVk
-gVk
-nmV
-gVk
+siE
 uQB
 oWN
 cLB
-bFq
-tWh
+cLB
+cLB
 bIt
 xbB
 xbB
@@ -90339,23 +90389,23 @@ cpK
 cpQ
 lYE
 aKa
-lYE
+gRb
 nnr
 dcN
 eeF
-lRN
-lRN
-lRN
+bAy
+bAy
+bAy
 bro
-lRN
-lRN
-lRN
-lRN
-oJj
-gRb
-oPH
-oPH
-oJj
+bAy
+bAy
+bAy
+bAm
+mOt
+bmD
+bmD
+pzj
+fpt
 bAl
 bIu
 beH
@@ -90607,12 +90657,12 @@ cSK
 duF
 bxa
 byD
-bAm
+bAy
 uaY
 oQi
 bDA
 nyN
-jSA
+bGa
 bcX
 voL
 bJD
@@ -90861,15 +90911,15 @@ bqb
 pov
 byF
 gyP
-byF
-tiI
+nXS
+wgL
 byE
-lRN
-lRN
-lRN
-lRN
-lRN
-lRN
+bAy
+bAy
+bAy
+bAy
+bAy
+bAy
 bvD
 bIx
 bJF


### PR DESCRIPTION

## About The Pull Request
Removed part of the Medical Maintenance and added a corridor, connecting Aft Hallway to Central Hallway
Because it was deemed unnecessary and every time Engineering removed those walls, making it a direct hallway without having to cut corners through science
## How This Contributes To The Nova Sector Roleplay Experience
You get to engineering faster and you don't have to go through Science.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="347" height="603" alt="image" src="https://github.com/user-attachments/assets/82a00f8b-fb86-4f59-811e-a66ddb44c72a" />

</details>

## Changelog
:cl:
map: Engineering Department Team has deemed that the time to translocate between Central Hallway to the Aft Hallway reaching Engineering took too long, in simple terms, we added a corridor heading to Engineering.
/:cl:
