### PR TITLE
[MODULAR] Removes the junkiness from fried chicken.

### DIFF
--- a/modular_nova/master_files/code/modules/food_and_drinks/food/meatdish.dm
+++ b/modular_nova/master_files/code/modules/food_and_drinks/food/meatdish.dm
@@ -1,0 +1,2 @@
+/obj/item/food/fried_chicken
+	junkiness = 0 // "You don't feel like eating any more junk food at the moment!", begone.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7516,6 +7516,7 @@
 #include "modular_nova\master_files\code\modules\events\_event.dm"
 #include "modular_nova\master_files\code\modules\events\vent_clog.dm"
 #include "modular_nova\master_files\code\modules\experisci\experiment.dm"
+#include "modular_nova\master_files\code\modules\food_and_drinks\food\meatdish.dm"
 #include "modular_nova\master_files\code\modules\food_and_drinks\recipes\food_mixtures.dm"
 #include "modular_nova\master_files\code\modules\jobs\landmarks.dm"
 #include "modular_nova\master_files\code\modules\jobs\off_duty_check.dm"


### PR DESCRIPTION

## About The Pull Request

This sets the junkiness value of fried chicken to 0, putting it in line with most of the other food items you can craft.

## How This Contributes To The Nova Sector Roleplay Experience

I've always found it incredibly bizarre that fried chicken had junkiness. Junkiness, as far as i know, was only meant for stuff out of junk food vendors, like chips and space twinkies, to make it harder to subsist off of vendor junk instead of going to the kitchen. I'm pretty sure that fried chicken is one of the only, if not the only, food item you can craft that is saddled with this. The fact that the game declares "You don't feel like eating any more junk food at the moment!" when you eat more than a couple of pieces of chicken at a time makes it not worth the chicken meat and corn starch you need to go out of your way to get to make it, and it's probably why i hardly ever see it made. With the junkiness gone, fried chicken is now a lot less unappealing as a food option, and you can now eat as much as you want of it until you get full, like everything else you can cook.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

I didn't really know how to demonstrate this in screenshot form, so i made a video. I spawned in 10 pieces of chicken, and ate through 9 of them without the junk food message showing up.


https://github.com/user-attachments/assets/2344d175-a350-4fe9-909a-d700cb5f8a38


</details>

## Changelog
:cl:
qol: Fried chicken no longer has junkiness, meaning that the game no longer declares you don't feel like eating any more after two or so pieces.
/:cl:
