### PR TITLE
[NON-MODULAR] Drops the cooldown on the door buzz sound down to the length of the sound, as door buzzing is an intended feature to get the attention of people beyond the door.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -682,7 +682,7 @@
 		if(DOOR_DENY_ANIMATION)
 			if(feedback && COOLDOWN_FINISHED(src, denied_sound_cd)) // NOVA EDIT CHANGE - ORIGINAL: if(feedback)
 				playsound(src, soundin = doorDeni, vol = 50, vary = FALSE, extrarange = 3)
-				COOLDOWN_START(src, denied_sound_cd, 4 SECONDS) // NOVA EDIT ADDITION - No spamming this sound, sorry
+				COOLDOWN_START(src, denied_sound_cd, 0.49 SECONDS) // NOVA EDIT ADDITION - Ensures the door buzz sound can't be overlapped.
 			addtimer(CALLBACK(src, PROC_REF(handle_deny_end)), AIRLOCK_DENY_ANIMATION_TIME)
 
 /obj/machinery/door/airlock/proc/handle_deny_end()


### PR DESCRIPTION
## About The Pull Request

Drops the cooldown on the door buzz sound down to the length of the sound, as door buzzing is an intended feature to get the attention of people beyond the door.

## How This Contributes To The Nova Sector Roleplay Experience

The purpose of the door buzz sound is to get the attention of people on the other side of the door, akin to a doorbell, which is why it has an extended range of an additional 3 tiles. It is annoying because it is to get your attention, especially in emergencies. I've dropped the cooldown of the sound down to the minimum length of the sound itself instead of deleting it entirely to ensure it can't be overlapped but is still able to be annoying for attention, as that is the purpose of it.

Since this original PR went in, I have, at least 5 times now since the change went in, had issues getting Medbay's attention while I've got a dead/dying in crit person at their front doors because I don't have a way to make a loud enough noise to get the treatment center's attention and have had to start banging on the windows or smashing the doors with something with a loud enough attack sound to get a doctor to come from treatment to see the dying person/dead body. The cooldown of 4 seconds is too damn long.

## Proof of Testing

Numbers tweak. Length of deniedbeep.ogg is 0.486 seconds. I rounded it to 0.49 for clarity.

## Changelog

:cl:
qol: Drops the cooldown on the door buzz sound down to the length of the sound, as door buzzing is an intended feature to get the attention of people beyond the door.
/:cl:
