### PR TITLE
[NON-MODULAR] Restores the half-removed Clown Cytology which was a casualty of the Xyel era.

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -328,7 +328,7 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 		"The Rainbow Color" = image(icon = src.icon, icon_state = "rainbow"),
 		"The Dealer" = image(icon = src.icon, icon_state = "cards"),
 		)
-	//AddElement(/datum/element/swabable, CELL_LINE_TABLE_CLOWN, CELL_VIRUS_TABLE_GENERIC, rand(2,3), 0) //NOVA EDIT REMOVAL
+	AddElement(/datum/element/swabable, CELL_LINE_TABLE_CLOWN, CELL_VIRUS_TABLE_GENERIC, rand(2,3), 0)
 
 /obj/item/clothing/mask/gas/clown_hat/ui_action_click(mob/user)
 	if(!istype(user) || user.incapacitated)

--- a/code/modules/clothing/under/jobs/civilian/clown_mime.dm
+++ b/code/modules/clothing/under/jobs/civilian/clown_mime.dm
@@ -33,14 +33,11 @@
 	can_adjust = FALSE
 	supports_variations_flags = NONE
 
-//NOVA EDIT REMOVAL BEGIN
-/*
+
 /obj/item/clothing/under/rank/civilian/clown/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/squeak, list('sound/items/bikehorn.ogg'=1), 50, falloff_exponent = 20) //die off quick please
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_CLOWN, CELL_VIRUS_TABLE_GENERIC, rand(2,3), 0)
-*/
-//NOVA EDIT REMOVAL END
 
 /obj/item/clothing/under/rank/civilian/clown/blue
 	name = "blue clown suit"

--- a/code/modules/clothing/under/jobs/civilian/clown_mime.dm
+++ b/code/modules/clothing/under/jobs/civilian/clown_mime.dm
@@ -33,7 +33,6 @@
 	can_adjust = FALSE
 	supports_variations_flags = NONE
 
-
 /obj/item/clothing/under/rank/civilian/clown/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/squeak, list('sound/items/bikehorn.ogg'=1), 50, falloff_exponent = 20) //die off quick please

--- a/modular_nova/master_files/code/modules/clothing/shoes/clown.dm
+++ b/modular_nova/master_files/code/modules/clothing/shoes/clown.dm
@@ -1,5 +1,0 @@
-// NO CLOWN CYTOLOGY
-/obj/item/clothing/shoes/clown_shoes/Initialize(mapload)
-	. = ..()
-
-	RemoveElement(/datum/element/swabable, CELL_LINE_TABLE_CLOWN, CELL_VIRUS_TABLE_GENERIC, rand(2,3), 0)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7480,7 +7480,6 @@
 #include "modular_nova\master_files\code\modules\clothing\outfits\standard.dm"
 #include "modular_nova\master_files\code\modules\clothing\shoes\bananashoes.dm"
 #include "modular_nova\master_files\code\modules\clothing\shoes\boots.dm"
-#include "modular_nova\master_files\code\modules\clothing\shoes\clown.dm"
 #include "modular_nova\master_files\code\modules\clothing\shoes\costume.dm"
 #include "modular_nova\master_files\code\modules\clothing\shoes\sneakers.dm"
 #include "modular_nova\master_files\code\modules\clothing\shoes\wheelys.dm"


### PR DESCRIPTION
## About The Pull Request

Restores the half-removed Clown Cytology which was a casualty of the Xyel era.

## How This Contributes To The Nova Sector Roleplay Experience

This was only half-removed and was a relic of the Xyel era when they were mad and removed clowns for being not-serious, someone did the "but what about X" thing at him and it got removed as a result.

The new supreme leader, Moonridden, has restored Clowns to their former glory, and as such clown content is BACK.

## Proof of Testing

I just uncommented stock /tg/ code and removed an override element removal.

## Changelog

:cl:
add: Restores the half-removed Clown Cytology which was a casualty of the Xyel era.
/:cl: