### PR TITLE
Cleans Up Loadout Issues Relating to Sec Gags

### DIFF
--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_heads.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_heads.dm
@@ -715,13 +715,13 @@
 /datum/loadout_item/head/officerberet
 	name = "Guard Beret"
 	item_path = /obj/item/clothing/head/beret/sec/depgag
-	restricted_roles = list(ALL_JOBS_SEC)
+	restricted_roles = list(ALL_JOBS_SEC, ALL_JOBS_DEPTGUARD)
 	group = "Guard"
 
 /datum/loadout_item/head/navyblueofficerberet
 	name = "Guard Beret (Navy Blue)"
 	item_path = /obj/item/clothing/head/beret/sec/navyofficer
-	restricted_roles = list(ALL_JOBS_SEC)
+	restricted_roles = list(ALL_JOBS_SEC, ALL_JOBS_DEPTGUARD)
 	group = "Guard"
 
 /datum/loadout_item/head/officergarrisoncap
@@ -733,19 +733,19 @@
 /datum/loadout_item/head/officerpatrolcap
 	name = "Guard Cap - Patrol"
 	item_path = /obj/item/clothing/head/hats/warden/police/patrol
-	restricted_roles = list(ALL_JOBS_SEC)
+	restricted_roles = list(ALL_JOBS_SEC, ALL_JOBS_DEPTGUARD)
 	group = "Guard"
 
 /datum/loadout_item/head/cowboyhat_sec
 	name = "Guard Cattleman Hat"
 	item_path = /obj/item/clothing/head/cowboy/nova/cattleman/sec
-	restricted_roles = list(ALL_JOBS_SEC)
+	restricted_roles = list(ALL_JOBS_SEC, ALL_JOBS_DEPTGUARD)
 	group = "Guard"
 
 /datum/loadout_item/head/cowboyhat_secwide
 	name = "Guard Cattleman Hat - Wide-Brimmed"
 	item_path = /obj/item/clothing/head/cowboy/nova/cattleman/wide/sec
-	restricted_roles = list(ALL_JOBS_SEC)
+	restricted_roles = list(ALL_JOBS_SEC, ALL_JOBS_DEPTGUARD)
 	group = "Guard"
 
 /datum/loadout_item/head/ushanka/sec

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_suit.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_suit.dm
@@ -1057,13 +1057,13 @@
 /datum/loadout_item/suit/armorvest
 	name = "Armor Vest (Colorable)"
 	item_path = /obj/item/clothing/suit/armor/vest/alt/sec/depgag_vest
-	restricted_roles = list(ALL_JOBS_SEC)
+	restricted_roles = list(ALL_JOBS_SEC, ALL_JOBS_DEPTGUARD)
 	group = "Guard"
 
 /datum/loadout_item/suit/flakvest
 	name = "Flak Vest (Colorable)"
 	item_path = /obj/item/clothing/suit/armor/vest/alt/sec/depgag_vest_slim
-	restricted_roles = list(ALL_JOBS_SEC)
+	restricted_roles = list(ALL_JOBS_SEC, ALL_JOBS_DEPTGUARD)
 	group = "Guard"
 
 /datum/loadout_item/suit/hazardvest
@@ -1087,7 +1087,7 @@
 /datum/loadout_item/suit/secbomber
 	name = "Guard Bomber Jacket (Colorable)"
 	item_path = /obj/item/clothing/suit/hooded/wintercoat/security/depgag/bomber
-	restricted_roles = list(ALL_JOBS_SEC)
+	restricted_roles = list(ALL_JOBS_SEC, ALL_JOBS_DEPTGUARD)
 	group = "Guard"
 
 /datum/loadout_item/suit/vestedjacket
@@ -1123,13 +1123,13 @@
 /datum/loadout_item/suit/british_jacket
 	name = "Guard British Coat"
 	item_path = /obj/item/clothing/suit/british_officer
-	restricted_roles = list(ALL_JOBS_SEC)
+	restricted_roles = list(ALL_JOBS_SEC, ALL_JOBS_DEPTGUARD)
 	group = "Guard"
 
 /datum/loadout_item/suit/navybluejacketofficer
 	name = "Guard Formal Jacket (Navy Blue)"
 	item_path = /obj/item/clothing/suit/jacket/officer/blue
-	restricted_roles = list(ALL_JOBS_SEC)
+	restricted_roles = list(ALL_JOBS_SEC, ALL_JOBS_DEPTGUARD)
 	group = "Guard"
 
 /datum/loadout_item/suit/security_wintercoat
@@ -1147,19 +1147,19 @@
 /datum/loadout_item/suit/tailcoatsec
 	name = "Guard's Tailcoat"
 	item_path = /obj/item/clothing/suit/armor/security_tailcoat
-	restricted_roles = list(ALL_JOBS_SEC)
+	restricted_roles = list(ALL_JOBS_SEC, ALL_JOBS_DEPTGUARD)
 	group = "Guard"
 
 /datum/loadout_item/suit/tailcoatsecdept
 	name = "Guard's Deputy Tailcoat"
 	item_path = /obj/item/clothing/suit/armor/security_tailcoat/assistant
-	restricted_roles = list(ALL_JOBS_SEC)
+	restricted_roles = list(ALL_JOBS_SEC, ALL_JOBS_DEPTGUARD)
 	group = "Guard"
 
 /datum/loadout_item/suit/tailcoatsecmedic
 	name = "Guard's Medicated Tailcoat"
 	item_path = /obj/item/clothing/suit/toggle/labcoat/nova/security_medic/doctor_tailcoat
-	restricted_roles = list(ALL_JOBS_SEC)
+	restricted_roles = list(ALL_JOBS_SEC, ALL_JOBS_DEPTGUARD)
 	group = "Guard"
 
 //Detective

--- a/modular_nova/modules/loadouts/loadout_items/under/loadout_datum_under.dm
+++ b/modular_nova/modules/loadouts/loadout_items/under/loadout_datum_under.dm
@@ -616,13 +616,13 @@
 	name = "Guard M.O.D. Skinsuit (Colorable)"
 	item_path = /obj/item/clothing/under/rank/security/nova/modskin
 	group = "Guard"
-	restricted_roles = list(ALL_JOBS_SEC)
+	restricted_roles = list(ALL_JOBS_SEC, ALL_JOBS_DEPTGUARD)
 
 /datum/loadout_item/under/secpantsuit
 	name = "Guard Pantsuit (Colorable)"
 	item_path = /obj/item/clothing/under/rank/security/nova/depgag_pantsuit
 	group = "Guard"
-	restricted_roles = list(ALL_JOBS_SEC)
+	restricted_roles = list(ALL_JOBS_SEC, ALL_JOBS_DEPTGUARD)
 
 /datum/loadout_item/under/secshorts
 	name = "Guard Shorts (Colorable)"


### PR DESCRIPTION

## About The Pull Request
It was an afterthought to think that people wouldn't want the entirety of security greyscales available in the loadout menu compared to just the selection available in game. This PR addresses that.
## How This Contributes To The Nova Sector Roleplay Experience
It's a bug fix.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: All gags related security items are now available in the loadout menu.
/:cl:
