### PR TITLE
Removes the actively detrimental CO2 filter in Void Raptor's atmospherics

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -29267,7 +29267,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/smooth_edge,
 /area/station/engineering/atmos)
@@ -45567,11 +45566,6 @@
 	},
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/fore)
-"mMw" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/open/floor/iron/smooth_large,
-/area/station/engineering/atmos)
 "mMB" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -55831,11 +55825,11 @@
 	},
 /area/station/hallway/primary/fore)
 "pzD" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/atmos)
@@ -83365,7 +83359,6 @@
 "wXg" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Atmospherics Maintenance"
 	},
@@ -112832,7 +112825,7 @@ pkR
 iXs
 jmM
 wXg
-mMw
+ace
 irQ
 pzD
 qPY


### PR DESCRIPTION
## About The Pull Request
Removes the CO2 filter in Void Raptor's atmospherics that filters CO2 out of atmos waste and puts it back into the station's waste. Replaces it with a straight pipe.
## How This Contributes To The Nova Sector Roleplay Experience
While it's normal for mapped-in atmospherics setups to be suboptimal, the filter here is actively detrimental and prevents CO2 from ever actually being cleared from waste.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="2560" height="1380" alt="image" src="https://github.com/user-attachments/assets/9f8f2ce8-3698-4aa0-a91b-b09fdafa4147" />

</details>

## Changelog
:cl:
map: Removed the actively detrimental CO2 filter in Void Raptor's atmospherics.
/:cl:
