### PR TITLE
Fixes biglegs getting cropped when they shouldn't be

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -813,7 +813,8 @@ generate/load female uniform sprites matching all previously decided variables
 )
 
 	// NOVA EDIT ADDITION START - Taur-friendly uniforms and suits
-	var/is_for_taur = !isinhands && (bodyshape & BODYSHAPE_TAUR)
+	var/is_for_big_legs = !isinhands && (bodyshape & BODYSHAPE_TAUR_BIG_LEGS_ALL)
+	var/is_for_taur = !isinhands && (bodyshape & BODYSHAPE_TAUR) && !is_for_big_legs
 	var/using_taur_variant
 	if(is_for_taur)
 		using_taur_variant = !gets_cropped_on_taurs
@@ -855,7 +856,7 @@ generate/load female uniform sprites matching all previously decided variables
 	// NOVA EDIT ADDITION START - Taur-friendly uniforms and suits
 	if(is_for_taur && !using_taur_variant)
 		building_icon = wear_taur_version(t_state, building_icon || icon(file2use, t_state), female_uniform, greyscale_colors)
-	else if((bodyshape & BODYSHAPE_TAUR_BIG_LEGS_ALL) && (supports_variations_flags & CLOTHING_BIG_LEGS_MASK) && !(supports_variations_flags & CLOTHING_BIG_LEGS_VARIATION))
+	else if(is_for_big_legs && (supports_variations_flags & CLOTHING_BIG_LEGS_MASK) && !(supports_variations_flags & CLOTHING_BIG_LEGS_VARIATION))
 		building_icon = wear_big_legs_version(building_icon || icon(file2use, t_state), src, "[t_state]-[building_icon]-[female_uniform]", greyscale_colors, bodyshape)
 	// NOVA EDIT ADDITION END
 	if(building_icon)

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/synthliz.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/synthliz.dm
@@ -197,11 +197,12 @@
 /datum/sprite_accessory/taur/synthliz/biglegs
 	name = "Synthetic Big Legs"
 	icon_state = "biglegs"
-	taur_mode = BODYSHAPE_TAUR_PAW
+	taur_mode = BODYSHAPE_TAUR_BIG_LEGS
 	organ_type = /obj/item/organ/taur_body/anthro/synth
 
 /datum/sprite_accessory/taur/synthliz/biglegs/stanced
 	name = "Synthetic Big Legs (Stanced)"
+	taur_mode = BODYSHAPE_TAUR_BIG_LEGS_STANCED
 	icon_state = "biglegs_stanced"
 
 /datum/sprite_accessory/taur/synthliz/biglegs/bird


### PR DESCRIPTION
## About The Pull Request

This is a rough patch for now pending a later refactor so people aren't deprived in the meantime

## How This Contributes To The Nova Sector Roleplay Experience

stuff that actually works is nice

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
 
<img width="130" height="122" alt="image" src="https://github.com/user-attachments/assets/b1650040-a1fa-4cda-b616-320f5328c0e9" />

<img width="94" height="78" alt="image" src="https://github.com/user-attachments/assets/287f6d8f-7915-49ae-8c8f-d73f1fd118c0" />

 
</details>

## Changelog

:cl:
fix: fixes an issue where biglegs clothing sprites were being cropped when they weren't supposed to be
/:cl:
