### PR TITLE
[NON-MODULAR] Command jobs now mandate your Security and Medical records be filled out before you can qualify for them, as per Server Policy

### DIFF
--- a/code/__DEFINES/~nova_defines/jobs.dm
+++ b/code/__DEFINES/~nova_defines/jobs.dm
@@ -5,6 +5,8 @@
 #define JOB_UNAVAILABLE_LANGUAGE (JOB_UNAVAILABLE_SPECIES + 1)
 #define JOB_UNAVAILABLE_FLAVOUR (JOB_UNAVAILABLE_LANGUAGE + 1)
 #define JOB_UNAVAILABLE_AUGMENT (JOB_UNAVAILABLE_FLAVOUR + 1)
+#define JOB_UNAVAILABLE_MEDREC (JOB_UNAVAILABLE_AUGMENT + 1)
+#define JOB_UNAVAILABLE_SECREC (JOB_UNAVAILABLE_MEDREC + 1)
 
 #define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Hemiplegic" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "No Guns" = TRUE, "Illiterate" = TRUE, "Nerve Stapled" = TRUE, "Underworld Connections" = TRUE
 #define HEAD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Brain Tumor" = TRUE, "Illiterate" = TRUE, "Underworld Connections" = TRUE

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -1010,8 +1010,8 @@ SUBSYSTEM_DEF(job)
 		if(length_char(player.client.prefs.read_preference(/datum/preference/text/flavor_text)) <= CONFIG_GET(number/flavor_text_character_requirement))
 			job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_FLAVOUR)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
 			return JOB_UNAVAILABLE_FLAVOUR
-	if(CONFIG_GET(flag/min_records_text))
-		if(possible_job.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND) // Is it a head of staff?
+	if(possible_job.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND) // Is it a head of staff?
+		if(CONFIG_GET(flag/min_records_text))
 			if(length_char(player.client.prefs.read_preference(/datum/preference/text/medical)) <= CONFIG_GET(number/records_text_character_requirement))
 				job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_MEDREC)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
 				return JOB_UNAVAILABLE_MEDREC

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -1019,7 +1019,6 @@ SUBSYSTEM_DEF(job)
 				job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_SECREC)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
 				return JOB_UNAVAILABLE_SECREC
 
-
 	if(possible_job.has_banned_augment(player.client.prefs))
 		job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_AUGMENT)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
 		return JOB_UNAVAILABLE_AUGMENT

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -1011,6 +1011,15 @@ SUBSYSTEM_DEF(job)
 			job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_FLAVOUR)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
 			return JOB_UNAVAILABLE_FLAVOUR
 
+		if(possible_job.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND) // Is it a head of staff?
+			if(length_char(player.client.prefs.read_preference(/datum/preference/text/medical)) <= CONFIG_GET(number/flavor_text_character_requirement))
+				job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_MEDREC)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
+				return JOB_UNAVAILABLE_MEDREC
+			if(length_char(player.client.prefs.read_preference(/datum/preference/text/security)) <= CONFIG_GET(number/flavor_text_character_requirement))
+				job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_SECREC)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
+				return JOB_UNAVAILABLE_SECREC
+
+
 	if(possible_job.has_banned_augment(player.client.prefs))
 		job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_AUGMENT)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
 		return JOB_UNAVAILABLE_AUGMENT

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -1010,12 +1010,12 @@ SUBSYSTEM_DEF(job)
 		if(length_char(player.client.prefs.read_preference(/datum/preference/text/flavor_text)) <= CONFIG_GET(number/flavor_text_character_requirement))
 			job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_FLAVOUR)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
 			return JOB_UNAVAILABLE_FLAVOUR
-
+	if(CONFIG_GET(flag/min_records_text))
 		if(possible_job.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND) // Is it a head of staff?
-			if(length_char(player.client.prefs.read_preference(/datum/preference/text/medical)) <= CONFIG_GET(number/flavor_text_character_requirement))
+			if(length_char(player.client.prefs.read_preference(/datum/preference/text/medical)) <= CONFIG_GET(number/records_text_character_requirement))
 				job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_MEDREC)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
 				return JOB_UNAVAILABLE_MEDREC
-			if(length_char(player.client.prefs.read_preference(/datum/preference/text/security)) <= CONFIG_GET(number/flavor_text_character_requirement))
+			if(length_char(player.client.prefs.read_preference(/datum/preference/text/security)) <= CONFIG_GET(number/records_text_character_requirement))
 				job_debug("[debug_prefix] Error: [get_job_unavailable_error_message(JOB_UNAVAILABLE_SECREC)], Player: [player][add_job_to_log ? ", Job: [possible_job]" : ""]")
 				return JOB_UNAVAILABLE_SECREC
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -143,6 +143,10 @@
 			return "[jobtitle] requires you to have flavour text for your character."
 		if(JOB_UNAVAILABLE_AUGMENT)
 			return "[jobtitle] is restricted due to your selected body augments."
+		if(JOB_UNAVAILABLE_MEDREC)
+			return "[jobtitle] requires you to have medical records text for your character."
+		if(JOB_UNAVAILABLE_SECREC)
+			return "[jobtitle] requires you to have security records text for your character."
 		//NOVA EDIT END
 		if(JOB_UNAVAILABLE_ANTAG_INCOMPAT)
 			return "[jobtitle] is not compatible with some antagonist role assigned to you."

--- a/config/nova/config_nova.txt
+++ b/config/nova/config_nova.txt
@@ -142,7 +142,7 @@ SIZE_COLLAR_MAXIMUM 400
 SIZE_COLLAR_MINIMUM 15
 
 ## Uncomment to enable minimum flavor text requirements for joining the round
-#MIN_FLAVOR_TEXT
+MIN_FLAVOR_TEXT 300
 
 ## Minimum flavor text number needed to enter the game
 ## YOU MUST HAVE MIN_FLAVOR_TEXT ENABLED FOR THIS TO WORK.

--- a/config/nova/config_nova.txt
+++ b/config/nova/config_nova.txt
@@ -142,7 +142,7 @@ SIZE_COLLAR_MAXIMUM 400
 SIZE_COLLAR_MINIMUM 15
 
 ## Uncomment to enable minimum flavor text requirements for joining the round
-MIN_FLAVOR_TEXT 300
+#MIN_FLAVOR_TEXT 300
 
 ## Minimum flavor text number needed to enter the game
 ## YOU MUST HAVE MIN_FLAVOR_TEXT ENABLED FOR THIS TO WORK.

--- a/config/nova/config_nova.txt
+++ b/config/nova/config_nova.txt
@@ -142,12 +142,20 @@ SIZE_COLLAR_MAXIMUM 400
 SIZE_COLLAR_MINIMUM 15
 
 ## Uncomment to enable minimum flavor text requirements for joining the round
-#MIN_FLAVOR_TEXT 300
+#MIN_FLAVOR_TEXT
+
+## Uncomment to enable minimum records text requirements for joining the round as command staff
+#MIN_RECORDS_TEXT
 
 ## Minimum flavor text number needed to enter the game
 ## YOU MUST HAVE MIN_FLAVOR_TEXT ENABLED FOR THIS TO WORK.
 ## Don't ever set this to 0, just disable MIN_FLAVOR_TEXT
 #FLAVOR_TEXT_CHARACTER_REQUIREMENT 150
+
+## Minimum records text number needed to enter the game as command staff
+## YOU MUST HAVE MIN_RECORDS_TEXT ENABLED FOR THIS TO WORK.
+## Don't ever set this to 0, just disable MIN_RECORDS_TEXT
+#RECORDS_TEXT_CHARACTER_REQUIREMENT 150
 
 ## Comment these out if you want to use the SQL-based player rank system, the
 ## legacy system uses the .txt files in the data folder instead.

--- a/modular_nova/master_files/code/controllers/configuration/entries/config_entries.dm
+++ b/modular_nova/master_files/code/controllers/configuration/entries/config_entries.dm
@@ -82,6 +82,12 @@
 /datum/config_entry/number/flavor_text_character_requirement
 	default = 150
 
+/datum/config_entry/flag/min_records_text
+	default = FALSE
+
+/datum/config_entry/number/records_text_character_requirement
+	default = 150
+
 /// Defines whether or not mentors can see ckeys alongside mobnames.
 /datum/config_entry/flag/mentors_mobname_only
 


### PR DESCRIPTION
## About The Pull Request

Command jobs now mandate your Security and Medical records be filled out before you can qualify for them, as per Server Policy.

## How This Contributes To The Nova Sector Roleplay Experience

This is already against the rules to not have, so I'm just making it a hard mechanical restriction like Flavor Text because I keep forgetting to fill these out and keep getting bwoinked.

## Proof of Testing

<img width="1012" height="900" alt="K78DV2AeVO" src="https://github.com/user-attachments/assets/6f96acbf-a5c1-491f-a5be-abfd9ee3c81c" />

## Changelog

:cl:
fix: Command jobs now mandate your Security and Medical records be filled out before you can qualify for them, as per Server Policy
/:cl:
