### PR TITLE
Fully implements CPR without breathing

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -566,30 +566,30 @@
 			balloon_alert(src, "[target.p_they()] [target.p_are()] dead!")
 			return FALSE
 
+		var/can_breathe = TRUE // If FALSE, then chest compressions are the only option // NOVA EDIT ADDITION
+
 		if (is_mouth_covered())
 			balloon_alert(src, "remove your mask first!")
-			return FALSE
+			can_breathe = FALSE // NOVA EDIT, ORIGINAL: return FALSE
 
 		if (target.is_mouth_covered())
 			balloon_alert(src, "remove [target.p_their()] mask first!")
-			return FALSE
+			can_breathe = FALSE // NOVA EDIT, ORIGINAL: return FALSE
 
 		if(HAS_TRAIT_FROM(src, TRAIT_NOBREATH, DISEASE_TRAIT))
 			to_chat(src, span_warning("you can't breathe!"))
-			return FALSE
+			can_breathe = FALSE // NOVA EDIT, ORIGINAL: return FALSE
 
 		var/obj/item/organ/lungs/human_lungs = get_organ_slot(ORGAN_SLOT_LUNGS)
-		/* NOVA EDIT REMOVAL BEGIN - Allow CPR without lungs
-		if(isnull(human_lungs))
+		if(isnull(human_lungs) || istype(human_lungs, /obj/item/organ/lungs/synth)) // NOVA EDIT, ORIGINAL: if(isnull(human_lungs))
 			balloon_alert(src, "you don't have lungs!")
-			return FALSE
+			can_breathe = FALSE // NOVA EDIT, ORIGINAL: return FALSE
 		if(human_lungs.organ_flags & ORGAN_FAILING)
 			balloon_alert(src, "your lungs are too damaged!")
-			return FALSE
-		*/// NOVA EDIT REMOVAL END
+			can_breathe = FALSE // NOVA EDIT, ORIGINAL: return FALSE
 
 		visible_message(span_notice("[src] is trying to perform CPR on [target.name]!"), \
-						span_notice("You try to perform CPR on [target.name]... Hold still!"))
+						can_breathe ? span_notice("You try to perform CPR on [target.name]... Hold still!"):span_notice("You try to perform CPR on [target.name] without mouth-to-mouth... Hold still!")) // NOVA EDIT, ORIGINAL: span_notice("You try to perform CPR on [target.name]... Hold still!"))
 
 		if (!do_after(src, delay = panicking ? CPR_PANIC_SPEED : (3 SECONDS), target = target))
 			balloon_alert(src, "you fail to perform CPR!")
@@ -612,9 +612,6 @@
 			to_chat(target, span_unconscious("You feel a breath of fresh air... but you don't feel any better..."))
 		*/// NOVA EDIT REMOVAL END
 		// NOVA EDIT ADDTION BEGIN - Allow CPR without lungs
-		var/can_breathe = TRUE // If FALSE, then chest compressions are the only option
-		if(isnull(human_lungs) || istype(human_lungs, /obj/item/organ/lungs/synth) || (human_lungs.organ_flags & ORGAN_FAILING))
-			can_breathe = FALSE
 		if(issynthetic(target)) // Synthetic humanoids don't benefit from CPR
 			to_chat(target, span_unconscious("You feel someone pushing down onto your chest, but you don't feel any better..."))
 		else if(!can_breathe || (HAS_TRAIT(target, TRAIT_NOBREATH) || !target.get_organ_slot(ORGAN_SLOT_LUNGS)))


### PR DESCRIPTION

## About The Pull Request
Changes the checks that cancel CPR because you can't breathe to instead make you do CPR without rescue breaths.
Adds a notice to show when you are giving CPR without rescue breaths. The notice calls it mouth-to-mouth since that's pretty universally understood terminology as far as I'm aware.
## How This Contributes To The Nova Sector Roleplay Experience
CPR without breathing is now fully implemented. It no longer arbitrarily requires you or the target to have your mouth exposed or not have a no-breathing disease, despite not requiring rescue breaths.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="647" height="547" alt="image" src="https://github.com/user-attachments/assets/31db6524-f243-4fc2-8363-febfeda8b137" />
</details>

## Changelog
:cl:
add: You can now give CPR if you or your target has a mask on.
qol: Added a notice for when you're giving CPR without mouth-to-mouth for any reason.
fix: CPR no longer requires you or your target to have exposed mouths, despite not requiring breathing.
/:cl:
