### PR TITLE
Fixes height filters not applying to certain bodypart overlays

### DIFF
--- a/modular_nova/modules/customization/modules/surgery/organs/fluff.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/fluff.dm
@@ -14,6 +14,7 @@
 	feature_key = FEATURE_FLUFF
 	layers = EXTERNAL_FRONT | EXTERNAL_ADJACENT
 	color_source = ORGAN_COLOR_OVERRIDE
+	offset_location = UPPER_BODY
 
 /datum/bodypart_overlay/mutant/fluff/override_color(rgb_value)
 	return draw_color

--- a/modular_nova/modules/customization/modules/surgery/organs/head_accessory.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/head_accessory.dm
@@ -14,6 +14,7 @@
 	feature_key = FEATURE_HEAD_ACCESSORY
 	layers = EXTERNAL_FRONT | EXTERNAL_ADJACENT | EXTERNAL_BEHIND
 	color_source = ORGAN_COLOR_OVERRIDE
+	offset_location = UPPER_BODY
 
 /datum/bodypart_overlay/mutant/head_accessory/override_color(rgb_value)
 	return draw_color

--- a/modular_nova/modules/customization/modules/surgery/organs/moth_markings.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/moth_markings.dm
@@ -15,6 +15,7 @@
 	feature_key = FEATURE_MOTH_MARKINGS
 	layers = EXTERNAL_FRONT | EXTERNAL_ADJACENT | EXTERNAL_BEHIND
 	color_source = ORGAN_COLOR_OVERRIDE
+	offset_location = ENTIRE_BODY
 
 /datum/bodypart_overlay/mutant/moth_markings/override_color(rgb_value)
 	return draw_color

--- a/modular_nova/modules/customization/modules/surgery/organs/neck_accessory.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/neck_accessory.dm
@@ -14,6 +14,7 @@
 	feature_key = FEATURE_NECK_ACCESSORY
 	layers = EXTERNAL_FRONT | EXTERNAL_ADJACENT
 	color_source = ORGAN_COLOR_OVERRIDE
+	offset_location = UPPER_BODY
 
 /datum/bodypart_overlay/mutant/neck_accessory/override_color(rgb_value)
 	return draw_color

--- a/modular_nova/modules/customization/modules/surgery/organs/pod.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/pod.dm
@@ -13,6 +13,7 @@
 	layers = EXTERNAL_FRONT_OVER|EXTERNAL_FRONT_ABOVE_HAIR
 	color_swapped_layer = EXTERNAL_FRONT_OVER
 	color_source = ORGAN_COLOR_OVERRIDE
+	offset_location = ENTIRE_BODY
 
 /datum/bodypart_overlay/mutant/pod_hair/override_color(rgb_value)
 	return draw_color

--- a/modular_nova/modules/customization/modules/surgery/organs/skrell_hair.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/skrell_hair.dm
@@ -17,6 +17,7 @@
 	feature_key = FEATURE_SKRELL_HAIR
 	layers = EXTERNAL_FRONT | EXTERNAL_ADJACENT
 	color_source = ORGAN_COLOR_OVERRIDE
+	offset_location = ENTIRE_BODY
 
 /datum/bodypart_overlay/mutant/skrell_hair/override_color(rgb_value)
 	return draw_color

--- a/modular_nova/modules/customization/modules/surgery/organs/synth_antenna.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/synth_antenna.dm
@@ -14,6 +14,7 @@
 	feature_key = FEATURE_SYNTH_ANTENNA
 	layers = EXTERNAL_ADJACENT
 	color_source = ORGAN_COLOR_OVERRIDE
+	offset_location = UPPER_BODY
 
 /datum/bodypart_overlay/mutant/synth_antenna/override_color(rgb_value)
 	return draw_color

--- a/modular_nova/modules/customization/modules/surgery/organs/synth_screen.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/synth_screen.dm
@@ -15,6 +15,7 @@
 	feature_key = FEATURE_SYNTH_SCREEN
 	layers = EXTERNAL_FRONT_UNDER_CLOTHES
 	color_source = ORGAN_COLOR_OVERRIDE
+	offset_location = UPPER_BODY
 
 /datum/bodypart_overlay/mutant/synth_screen/override_color(rgb_value)
 	return draw_color

--- a/modular_nova/modules/customization/modules/surgery/organs/taur_body.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/taur_body.dm
@@ -212,6 +212,7 @@
 	feature_key = FEATURE_TAUR
 	layers = EXTERNAL_FRONT | EXTERNAL_ADJACENT | EXTERNAL_BEHIND | EXTERNAL_FRONT_UNDER_CLOTHES | EXTERNAL_FRONT_OVER
 	color_source = ORGAN_COLOR_OVERRIDE
+	offset_location = ENTIRE_BODY
 
 	/// If this taur body can lay down
 	var/can_lay_down = FALSE

--- a/modular_nova/modules/customization/modules/surgery/organs/xenodorsal.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/xenodorsal.dm
@@ -14,6 +14,7 @@
 	feature_key = FEATURE_XENODORSAL
 	layers = EXTERNAL_FRONT | EXTERNAL_BEHIND
 	color_source = ORGAN_COLOR_OVERRIDE
+	offset_location = ENTIRE_BODY
 
 /datum/bodypart_overlay/mutant/xenodorsal/override_color(rgb_value)
 	return draw_color

--- a/modular_nova/modules/customization/modules/surgery/organs/xenohead.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/xenohead.dm
@@ -16,6 +16,7 @@
 	feature_key = FEATURE_XENOHEAD
 	layers = EXTERNAL_ADJACENT
 	color_source = ORGAN_COLOR_OVERRIDE
+	offset_location = UPPER_BODY
 
 /datum/bodypart_overlay/mutant/xenohead/override_color(rgb_value)
 	return draw_color

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_organs/_genital.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_organs/_genital.dm
@@ -146,6 +146,8 @@
 /datum/bodypart_overlay/mutant/genital
 	layers = EXTERNAL_FRONT_UNDER_CLOTHES
 	color_source = ORGAN_COLOR_OVERRIDE
+	offset_location = LOWER_BODY
+	draw_on_husks = FALSE
 	/// The suffix appended to the feature_key for the overlays.
 	var/sprite_suffix
 	/// Owning human.  Used to adjust layers depending on underwear
@@ -159,7 +161,6 @@
 	var/layer_above_undies = -(UNIFORM_LAYER - 0.06)
 	/// Ditto, but for BELOW UNDERWEAR
 	var/layer_below_undies = -(UNIFORM_LAYER + 0.06)
-	draw_on_husks = FALSE
 
 /datum/bodypart_overlay/mutant/genital/override_color(rgb_value)
 	return draw_color

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_organs/breasts.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_organs/breasts.dm
@@ -17,6 +17,7 @@
 /datum/bodypart_overlay/mutant/genital/breasts
 	feature_key = ORGAN_SLOT_BREASTS
 	layers = EXTERNAL_FRONT_UNDER_CLOTHES | EXTERNAL_BEHIND
+	offset_location = ENTIRE_BODY
 
 /datum/bodypart_overlay/mutant/genital/breasts/underwear_check()
 	if(!istype(owner))

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_organs/womb.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_organs/womb.dm
@@ -15,6 +15,7 @@
 /datum/bodypart_overlay/mutant/genital/womb
 	feature_key = ORGAN_SLOT_WOMB
 	layers = NONE
+	offset_location = NO_MODIFY
 
 /datum/bodypart_overlay/mutant/genital/womb/get_global_feature_list()
 	return SSaccessories.sprite_accessories[ORGAN_SLOT_WOMB]


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/NovaSector/NovaSector/issues/7558

Height filters weren't actually being applied to most of the non-tg parts in live, but were to the dummy by coincidence.

## Changelog

:cl:
fix: fixes an issue where height filters would not be applied to many bodypart overlays
/:cl: