### PR TITLE
Adds a third tab to char preferences

### DIFF
--- a/code/__DEFINES/~nova_defines/preferences.dm
+++ b/code/__DEFINES/~nova_defines/preferences.dm
@@ -29,6 +29,7 @@
 #define VOICE_TYPE_BARK "Vocal Barks"
 
 #define PREFERENCE_CATEGORY_VOCALS "vocals"
+#define PREFERENCE_CATEGORY_ERP "erp"
 
 /// Max save slots for people not subscribed to BYOND and not a donator
 #define MAX_SAVE_SLOTS_NORMAL 45

--- a/modular_nova/master_files/code/modules/client/preferences/erp_preferences.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/erp_preferences.dm
@@ -119,7 +119,7 @@
 	savefile_key = "new_genitalia_growth_pref"
 
 /datum/preference/choiced/erp_status
-	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	category = PREFERENCE_CATEGORY_ERP
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "erp_status_pref"
 
@@ -176,7 +176,7 @@
 	return FALSE
 
 /datum/preference/choiced/erp_status_nc
-	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	category = PREFERENCE_CATEGORY_ERP
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "erp_status_pref_nc"
 
@@ -214,7 +214,7 @@
 	return FALSE
 
 /datum/preference/choiced/erp_status_v
-	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	category = PREFERENCE_CATEGORY_ERP
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "erp_status_pref_v"
 
@@ -252,7 +252,7 @@
 	return FALSE
 
 /datum/preference/choiced/erp_status_mechanics
-	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	category = PREFERENCE_CATEGORY_ERP
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "erp_status_pref_mechanics"
 
@@ -321,7 +321,7 @@
 	return FALSE
 
 /datum/preference/choiced/erp_status_hypno
-	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	category = PREFERENCE_CATEGORY_ERP
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "erp_status_pref_hypnosis"
 

--- a/modular_nova/master_files/code/modules/client/preferences/flavor_text.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/flavor_text.dm
@@ -8,7 +8,7 @@
 	target.dna.features[EXAMINE_DNA_FLAVOR_TEXT] = value
 
 /datum/preference/text/flavor_text_nsfw
-	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	category = PREFERENCE_CATEGORY_ERP
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "flavor_text_nsfw"
 	maximum_value_length = MAX_FLAVOR_LEN
@@ -30,7 +30,7 @@
 /// `apply_to_human` does not fire with this, this is read directly in [/mob/living/silicon/proc/get_silicon_flavortext]
 /// and given to silicon examine but *not* given to tgui—that just reads this datum
 /datum/preference/text/silicon_flavor_text_nsfw
-	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	category = PREFERENCE_CATEGORY_ERP
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "silicon_flavor_text_nsfw"
 	maximum_value_length = MAX_FLAVOR_LEN

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/MainPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/MainPage.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   Floating,
   Input,
+  Icon, // NOVA EDIT ADDITION
   LabeledList,
   Section,
   Stack,
@@ -522,15 +523,25 @@ export function MainPage(props: MainPageProps) {
     delete nonContextualPreferences.random_name;
   }
   // NOVA EDIT ADDITION BEGIN: SWAPPABLE PREF MENUS
+  const erpPreferences = {
+    ...data.character_preferences.erp,
+  };
+
   enum PrefPage {
     Visual, // The visual parts
     Profile, // Flavor Text, Age, Records, PDA ringtone, etc
+    ERP, // ERP Prefs
   }
 
   const [currentPrefPage, setCurrentPrefPage] = useState(PrefPage.Visual);
+  const erpEnabled = !!data.erp_pref;
+  const filteredCurrentPrefPage =
+    currentPrefPage === PrefPage.ERP && !erpEnabled
+      ? PrefPage.Visual
+      : currentPrefPage;
 
   let prefPageContents;
-  switch (currentPrefPage) {
+  switch (filteredCurrentPrefPage) {
     case PrefPage.Visual:
       prefPageContents = (
         <PreferenceList
@@ -557,8 +568,21 @@ export function MainPage(props: MainPageProps) {
         />
       );
       break;
+    case PrefPage.ERP:
+    prefPageContents = (
+      <PreferenceList
+        randomizations={getRandomization(
+          erpPreferences,
+          serverData,
+          randomBodyEnabled,
+        )}
+        preferences={erpPreferences}
+        maxHeight="auto"
+      />
+    );
+    break;
     default:
-      exhaustiveCheck(currentPrefPage);
+      exhaustiveCheck(filteredCurrentPrefPage);
   }
   // NOVA EDIT ADDITION END
 
@@ -755,6 +779,17 @@ export function MainPage(props: MainPageProps) {
                   Character Profile
                 </PageButton>
               </Stack.Item>
+             {erpEnabled && (
+              <Stack.Item grow={0.5}>
+                <PageButton
+                  currentPage={currentPrefPage}
+                  page={PrefPage.ERP}
+                  setPage={setCurrentPrefPage}
+                >
+                <Icon name="heart" />
+                </PageButton>
+              </Stack.Item>
+            )}
             </Stack>
             {prefPageContents}
           </Stack>

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/loadout/index.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/loadout/index.tsx
@@ -31,8 +31,7 @@ import { LoadoutModifyDimmer } from './ModifyPanel';
 export function LoadoutPage(props) {
   const serverData = useServerPrefs();
   const loadout_tabs = serverData?.loadout.loadout_tabs || [];
-  /* NOVA EDIT CHANGE - Original: const { data } = useBackend<LoadoutManagerData>();
-  const { erp_pref } = data; */
+  /* NOVA EDIT CHANGE - Original: const { data } = useBackend<LoadoutManagerData>(); */
   const erp_pref = useBackend<LoadoutManagerData>().data.erp_pref;
 
   const [searchLoadout, setSearchLoadout] = useState('');

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/types.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/types.ts
@@ -228,6 +228,7 @@ export type CharacterPreferencesData = {
 
   names: Record<string, string>;
   vocals: Record<string, string>; // NOVA EDIT ADDITION
+  erp: Record<string, unknown>; // NOVA EDIT ADDITION
 
   misc: {
     gender: Gender;


### PR DESCRIPTION
## About The Pull Request

Adds the <3 tab, if your game options are configured to show erp prefs.

## How This Contributes To The Nova Sector Roleplay Experience

The profile section is a bit cluttered, so organizing these into their own tab should help with finding things

## Proof of Testing

<details>
<summary>heart tab</summary>
  
<img width="983" height="781" alt="q0AbrYKu6U" src="https://github.com/user-attachments/assets/5631befe-ca42-4d8d-b5e3-87722f0ac39c" />

</details>

## Changelog

:cl:
qol: moves erp prefs out of the character profile tab and into the new heart tab
/:cl:
