### PR TITLE
Rounds down the .27-54 ammo box (and the Miecz magazine by extension) to make the Alacran more convenient to load from ammo boxes.

### DIFF
--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/ammo/pistol.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/ammo/pistol.dm
@@ -26,7 +26,7 @@
 
 /obj/item/ammo_box/c27_54cesarzowa
 	name = "ammo box (.27-54 Cesarzowa piercing)"
-	desc = "A box of .27-54 Cesarzowa piercing pistol rounds, holds twenty eight cartridges."
+	desc = "A box of .27-54 Cesarzowa piercing pistol rounds, holds twenty four cartridges."
 
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/company_and_or_faction_based/szot_dynamica/ammo.dmi'
 	icon_state = "27-54cesarzowa_box"
@@ -37,7 +37,7 @@
 
 	caliber = CALIBER_CESARZOWA
 	ammo_type = /obj/item/ammo_casing/c27_54cesarzowa
-	max_ammo = 28
+	max_ammo = 24
 
 // .27-54 Cesarzowa rubber
 // Small caliber pistol round meant to be fired out of something that shoots real quick like, this one is less lethal
@@ -61,7 +61,7 @@
 
 /obj/item/ammo_box/c27_54cesarzowa/rubber
 	name = "ammo box (.27-54 Cesarzowa rubber)"
-	desc = "A box of .27-54 Cesarzowa rubber pistol rounds, holds twenty eight cartridges."
+	desc = "A box of .27-54 Cesarzowa rubber pistol rounds, holds twenty four cartridges."
 
 	icon_state = "27-54cesarzowa_box_rubber"
 

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/magazines.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/magazines.dm
@@ -20,7 +20,7 @@
 
 /obj/item/ammo_box/magazine/miecz
 	name = "\improper Miecz submachinegun magazine"
-	desc = "A standard size magazine for Miecz submachineguns, holds twenty eight rounds."
+	desc = "A standard size magazine for Miecz submachineguns, holds twenty four rounds."
 
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/company_and_or_faction_based/szot_dynamica/ammo.dmi'
 	icon_state = "miecz_mag"
@@ -29,7 +29,7 @@
 
 	ammo_type = /obj/item/ammo_casing/c27_54cesarzowa
 	caliber = CALIBER_CESARZOWA
-	max_ammo = 28
+	max_ammo = 24
 
 /obj/item/ammo_box/magazine/miecz/spawns_empty
 	start_empty = TRUE


### PR DESCRIPTION

## About The Pull Request

This, as the title says, rounds the .27-54 ammo boxes, and the Miecz magazines by extension, down to 24 rounds. This is so that you can load up a Alacran magazine, which is 48 rounds, without having extra rounds knocking around, meaning that the Miecz still takes 1 box as before, and the Alacran takes an even two boxes.

This is a quasi-sequel to #7131, where i did something similar with the Zashch and Napad magazines.

## How This Contributes To The Nova Sector Roleplay Experience

Currently, loading up a Alacran magazine is going to leave 8 extra rounds, because two boxes of .27-54 total up to 56 rounds, while the magazine only holds 48. This fixes that.

While 24 rounds is a bit of a decrease from 28, i don't think that this will be enough to make a significant difference. I did think about instead upping the Alacran's capacity to 56, but i feel like that would be too much.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="557" height="149" alt="Screenshot_541" src="https://github.com/user-attachments/assets/fdc505f6-c0dd-43b5-b7d9-4e4efccbdb6d" />
<img width="557" height="125" alt="Screenshot_542" src="https://github.com/user-attachments/assets/79f58617-e682-49dc-b6c3-df4cae514e9e" />

</details>

## Changelog
:cl:
qol: The .27-54 ammo box has been reduced to 24 rounds to facilitate more convenient loading of Alacran magazines, As a consequence, Miecz magazines have also been reduced to 24 rounds.
/:cl:
