### PR TITLE
Maid'l Gear Rising: Revengeance (More maid smite options)

### DIFF
--- a/modular_nova/master_files/code/modules/admin/smites.dm
+++ b/modular_nova/master_files/code/modules/admin/smites.dm
@@ -57,7 +57,7 @@
 			/obj/item/clothing/head/costume/maid_headband = ITEM_SLOT_HEAD,
 			/obj/item/clothing/under/costume/maid = ITEM_SLOT_ICLOTHING,
 		),
-		"Maid Uniform (Colorable)" = list(
+		"Maid Uniform (Light Blue)" = list(
 			/obj/item/clothing/head/maid_headband = ITEM_SLOT_HEAD,
 			/obj/item/clothing/neck/maid_neck_cover = ITEM_SLOT_NECK,
 			/obj/item/clothing/gloves/maid_arm_covers = ITEM_SLOT_GLOVES,
@@ -70,6 +70,11 @@
 		"Maid Uniform (Alternative)" = list(
 			/obj/item/clothing/head/costume/nova/maid = ITEM_SLOT_HEAD,
 			/obj/item/clothing/under/costume/nova/maid_uniform_alt = ITEM_SLOT_ICLOTHING,
+		),
+		"Syndiemaid" = list(
+			/obj/item/clothing/head/costume/maid_headband/syndicate/loadout_headband = ITEM_SLOT_HEAD,
+			/obj/item/clothing/under/syndicate/nova/maid/loadout_maid = ITEM_SLOT_ICLOTHING,
+			/obj/item/clothing/gloves/tactical_maid = ITEM_SLOT_GLOVES,
 		),
 	)
 	var/chosen_outfit = tgui_input_list(user, "Which maid outfit should be applied?", "Maid-ification", outfit_options)
@@ -84,25 +89,3 @@
 			smite_item_protection(new_item)
 	if(!QDELETED(shamed))
 		shamed.visible_message(span_warning("A maid uniform appears on [shamed]!"))
-
-
-/*
-
-/obj/item/clothing/under/maid_costume
-/obj/item/clothing/gloves/maid_arm_covers
-/obj/item/clothing/neck/maid_neck_cover
-/obj/item/clothing/head/maid_headband
-
-
-/obj/item/clothing/head/costume/maid_headband
-/obj/item/clothing/under/costume/maid
-
-/obj/item/clothing/head/costume/maid_headband
-/obj/item/clothing/under/costume/nova/maid_uniform
-
-/obj/item/clothing/head/costume/maid_headband
-/obj/item/clothing/under/costume/nova/maid_uniform_alt
-
-
-todo - syndie
-*/

--- a/modular_nova/master_files/code/modules/admin/smites.dm
+++ b/modular_nova/master_files/code/modules/admin/smites.dm
@@ -52,16 +52,57 @@
 	if (!iscarbon(target))
 		to_chat(user, span_warning("This must be used on a carbon mob."), confidential = TRUE)
 		return
-	var/list/items = list(
-		/obj/item/clothing/head/costume/maid_headband = ITEM_SLOT_HEAD,
-		/obj/item/clothing/neck/maid_neck_cover = ITEM_SLOT_NECK,
-		/obj/item/clothing/gloves/maid_arm_covers = ITEM_SLOT_GLOVES,
-		/obj/item/clothing/under/costume/maid = ITEM_SLOT_ICLOTHING,
+	var/list/outfit_options = list(
+		"Maid Uniform - Frilly" = list(
+			/obj/item/clothing/head/costume/maid_headband = ITEM_SLOT_HEAD,
+			/obj/item/clothing/under/costume/maid = ITEM_SLOT_ICLOTHING,
+		),
+		"Maid Uniform (Colorable)" = list(
+			/obj/item/clothing/head/maid_headband = ITEM_SLOT_HEAD,
+			/obj/item/clothing/neck/maid_neck_cover = ITEM_SLOT_NECK,
+			/obj/item/clothing/gloves/maid_arm_covers = ITEM_SLOT_GLOVES,
+			/obj/item/clothing/under/maid_costume = ITEM_SLOT_ICLOTHING,
+		),
+		"Maid Uniform" = list(
+			/obj/item/clothing/head/costume/nova/maid = ITEM_SLOT_HEAD,
+			/obj/item/clothing/under/costume/nova/maid_uniform = ITEM_SLOT_ICLOTHING,
+		),
+		"Maid Uniform (Alternative)" = list(
+			/obj/item/clothing/head/costume/nova/maid = ITEM_SLOT_HEAD,
+			/obj/item/clothing/under/costume/nova/maid_uniform_alt = ITEM_SLOT_ICLOTHING,
+		),
 	)
-	var/mob/living/carbon/human/shamed = target
+	var/chosen_outfit = tgui_input_list(user, "Which maid outfit should be applied?", "Maid-ification", outfit_options)
+	if(!chosen_outfit)
+		return
+	var/list/items = outfit_options[chosen_outfit]
+	var/mob/living/carbon/shamed = target
 	for(var/path, slot in items)
 		target.dropItemToGround(target.get_item_by_slot(slot))
 		var/obj/item/clothing/new_item = new path
 		if(target.equip_to_slot_or_del(new_item, slot))
 			smite_item_protection(new_item)
-	shamed.visible_message(span_warning("A maid uniform appears on [shamed]!"))
+	if(!QDELETED(shamed))
+		shamed.visible_message(span_warning("A maid uniform appears on [shamed]!"))
+
+
+/*
+
+/obj/item/clothing/under/maid_costume
+/obj/item/clothing/gloves/maid_arm_covers
+/obj/item/clothing/neck/maid_neck_cover
+/obj/item/clothing/head/maid_headband
+
+
+/obj/item/clothing/head/costume/maid_headband
+/obj/item/clothing/under/costume/maid
+
+/obj/item/clothing/head/costume/maid_headband
+/obj/item/clothing/under/costume/nova/maid_uniform
+
+/obj/item/clothing/head/costume/maid_headband
+/obj/item/clothing/under/costume/nova/maid_uniform_alt
+
+
+todo - syndie
+*/


### PR DESCRIPTION

## About The Pull Request

Since my colorblind ass can't tell colors apart, the maid smite had mismatched light blue and black colored pieces. So I fixed that. And maybe added a few different maid outfits to the smite selection

## How This Contributes To The Nova Sector Roleplay Experience

Variety good?

## Proof of Testing
<summary>Screenshots/Videos</summary>

Frilly - 

<img width="181" height="179" alt="image" src="https://github.com/user-attachments/assets/1ecf668e-2116-4e9a-81eb-97c2c38cbc13" />
  
Light Blue - 

<img width="181" height="171" alt="image" src="https://github.com/user-attachments/assets/3a071e58-a351-469c-bbb1-aea96037480b" />

Uniform

<img width="159" height="155" alt="image" src="https://github.com/user-attachments/assets/1f08e852-6ef6-43ab-90be-3d47484762ba" />

Uniform Alt

<img width="152" height="144" alt="image" src="https://github.com/user-attachments/assets/265fda17-9610-497a-add9-9cb255456fd2" />

Syndiemaid

<img width="145" height="144" alt="image" src="https://github.com/user-attachments/assets/cc1559a6-d391-4673-b8e7-4b42bd09ff0d" />


## Changelog
:cl:
add: Maid smite gets more options.
/:cl:
