### PR TITLE
Croptop bomber jacket works with digitigrade characters

### DIFF
--- a/modular_nova/master_files/code/modules/clothing/suits/jackets.dm
+++ b/modular_nova/master_files/code/modules/clothing/suits/jackets.dm
@@ -13,6 +13,7 @@
 	greyscale_config_worn = /datum/greyscale_config/croptop_bomber_jacket/worn
 	greyscale_colors = "#227EFE#E5F0EA#B8BB59#FF0000"
 	flags_1 = IS_PLAYER_COLORABLE_1
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
 /obj/item/clothing/suit/toggle/jacket/croptop_bomber_jacket/setup_reskins()
 	AddComponent(/datum/component/reskinable_item, /datum/atom_skin/croptop_bomber_jacket)


### PR DESCRIPTION

## About The Pull Request
Allows the croptop bomber jacket to work on digitigrade characters instead of displaying an error sprite.
## How This Contributes To The Nova Sector Roleplay Experience
It's literally not even long enough to be affected by the presence of digitigrade legs.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="138" height="142" alt="Screenshot_3205" src="https://github.com/user-attachments/assets/a7cfba9e-484e-4027-9d2e-1bc552dd060b" />

</details>

## Changelog
:cl:
fix: Croptop bomber jacket works on characters with digitigrade legs.
/:cl:
