### PR TITLE
Removing the First Responder, Orange Satchel, and Pink Kit from unrestricted access in cargo

### DIFF
--- a/modular_nova/master_files/code/modules/cargo/packs/companies/medical.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/medical.dm
@@ -31,9 +31,6 @@
 	contains = list(/obj/item/storage/medkit/robotic_repair/preemo/stocked)
 	cost = CARGO_CRATE_VALUE * 4
 
-//datum/supply_pack/companies/medical/first_aid_kit/first_responder
-	//contains = list(/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked)
-	//cost = CARGO_CRATE_VALUE * 5.25
 
 //datum/supply_pack/companies/medical/first_aid_kit/orange_satchel
 	//contains = list(/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked)

--- a/modular_nova/master_files/code/modules/cargo/packs/companies/medical.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/medical.dm
@@ -36,9 +36,6 @@
 	//contains = list(/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked)
 	//cost = CARGO_CRATE_VALUE * 4.75
 
-//datum/supply_pack/companies/medical/first_aid_kit/technician_satchel
-	//contains = list(/obj/item/storage/backpack/duffelbag/deforest_paramedic/stocked)
-	//cost = CARGO_CRATE_VALUE * 8
 
 // Basic first aid supplies like gauze, sutures, mesh, so on
 /datum/supply_pack/companies/medical/first_aid

--- a/modular_nova/master_files/code/modules/cargo/packs/companies/medical.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/medical.dm
@@ -32,9 +32,6 @@
 	cost = CARGO_CRATE_VALUE * 4
 
 
-//datum/supply_pack/companies/medical/first_aid_kit/orange_satchel
-	//contains = list(/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked)
-	//cost = CARGO_CRATE_VALUE * 4.75
 
 
 // Basic first aid supplies like gauze, sutures, mesh, so on

--- a/modular_nova/master_files/code/modules/cargo/packs/companies/medical.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/medical.dm
@@ -31,17 +31,17 @@
 	contains = list(/obj/item/storage/medkit/robotic_repair/preemo/stocked)
 	cost = CARGO_CRATE_VALUE * 4
 
-/datum/supply_pack/companies/medical/first_aid_kit/first_responder
-	contains = list(/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked)
-	cost = CARGO_CRATE_VALUE * 5.25
+//datum/supply_pack/companies/medical/first_aid_kit/first_responder
+	//contains = list(/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked)
+	//cost = CARGO_CRATE_VALUE * 5.25
 
-/datum/supply_pack/companies/medical/first_aid_kit/orange_satchel
-	contains = list(/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked)
-	cost = CARGO_CRATE_VALUE * 4.75
+//datum/supply_pack/companies/medical/first_aid_kit/orange_satchel
+	//contains = list(/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked)
+	//cost = CARGO_CRATE_VALUE * 4.75
 
-/datum/supply_pack/companies/medical/first_aid_kit/technician_satchel
-	contains = list(/obj/item/storage/backpack/duffelbag/deforest_paramedic/stocked)
-	cost = CARGO_CRATE_VALUE * 8
+//datum/supply_pack/companies/medical/first_aid_kit/technician_satchel
+	//contains = list(/obj/item/storage/backpack/duffelbag/deforest_paramedic/stocked)
+	//cost = CARGO_CRATE_VALUE * 8
 
 // Basic first aid supplies like gauze, sutures, mesh, so on
 /datum/supply_pack/companies/medical/first_aid


### PR DESCRIPTION

## About The Pull Request
removes what I would consider to be the biggest three pre-pack medical kits from unrestricted purchasing in cargo, that's it really.
## How This Contributes To The Nova Sector Roleplay Experience
I don't really think being able to get the best pre-packaged medical equipment in the dedicated carrying cases for it as non-Medical staff is necessarily a good thing. Leave the Medical'ing to Medical or get your items piece-meal, IMO.

This is mostly a bandaid fix for a problem I've seen and heard people complaining about of security officers buying the tech kit to just have a healing hypospray without any interaction from medical. After taking a look at it there was the opportunity for more than one 'problem kit' they could get their hands on to trivialize wounds and damage.
## Proof of Testing
<img width="794" height="365" alt="image" src="https://github.com/user-attachments/assets/d14c4c1a-3615-4c9c-9d23-47c8cbd89976" />
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
del: Removed First Responder, Orange, And Pink medical kits from unrestricted access in cargo.
/:cl:
