### PR TITLE
fixes oceanpubby in maps.txt

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -97,6 +97,7 @@ endmap
 
 map oceanpubby
     votable
+endmap
 
 map runtimestation_minimal
 endmap


### PR DESCRIPTION

## About The Pull Request

when runtimestation_minimal was added, pubby's endmap was displaced. already fixed in our config. needed for players to be able to load pubby without editing their own maps.txt



## Changelog

not player facing
