### PR TITLE
FIX: Fixes Slime Death/Revival issues from #7490

### DIFF
--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -231,7 +231,7 @@
 /obj/item/organ/brain/slime/on_mob_remove(mob/living/carbon/organ_owner)
 	. = ..()
 	UnregisterSignal(organ_owner, COMSIG_LIVING_DEATH)
-	UnregisterSignal(source, COMSIG_MOB_LOGIN)
+	UnregisterSignal(organ_owner, COMSIG_MOB_LOGIN)
 
 /**
 * Colors the slime's core (their brain) the same as their first mutant color.

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -231,6 +231,7 @@
 /obj/item/organ/brain/slime/on_mob_remove(mob/living/carbon/organ_owner)
 	. = ..()
 	UnregisterSignal(organ_owner, COMSIG_LIVING_DEATH)
+	UnregisterSignal(source, COMSIG_MOB_LOGIN)
 
 /**
 * Colors the slime's core (their brain) the same as their first mutant color.

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -186,20 +186,11 @@
 	throw_range = 9 //Oh! That's a baseball!
 	throw_speed = 0.5
 	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | LAVA_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
-	/// This tracks the Slime's body, we use this to send them to Nullspace when they die, and to regenerate them when they are revived.
-	var/mob/living/carbon/human/body
 
 /obj/item/organ/brain/slime/Initialize(mapload, mob/living/carbon/organ_owner, list/examine_list)
 	. = ..()
 	AddComponent(/datum/component/bubble_icon_override, "slime", BUBBLE_ICON_PRIORITY_ORGAN)
 	colorize()
-
-// Handle the slime core being destroyed, and if it has a body in nullspace, delete it as well.
-/obj/item/organ/brain/slime/Destroy(force)
-	if(body)
-		UnregisterSignal(body, COMSIG_MOB_LOGIN)
-		QDEL_NULL(body)
-	return ..()
 
 /obj/item/organ/brain/slime/examine()
 	. = ..()
@@ -271,10 +262,6 @@
 		return
 	core_ejected = TRUE
 
-	// Cache the body refrence inside the Core/Brain.
-	if(!src.body)
-		src.body = victim
-
 	var/atom/death_loc = victim.drop_location()
 	if(!death_loc)
 		death_loc = get_turf(victim) // Fallback to avoid the Slime core showing up in Nullspace.
@@ -307,7 +294,7 @@
 
 	// Message the victim and the surrounding area that they have died.
 	victim.visible_message(span_warning("[victim]'s body completely dissolves, collapsing outwards!"), span_notice("Your body completely dissolves, collapsing outwards!"), span_notice("You hear liquid splattering."))
-	victim.moveToNullspace() // Move the body to nullspace.
+	qdel(victim) // Remove the Body.
 	UnregisterSignal(victim, COMSIG_LIVING_DEATH)
 
 /**
@@ -352,6 +339,10 @@
 	regenerate()
 	return TRUE
 
+/**
+* SLIME REVIVE PROC
+* This heals the core/brain, and creates a new body which we move the player/client into.
+*/
 /obj/item/organ/brain/slime/proc/regenerate()
 	//we have the plasma. we can rebuild them.
 	set_organ_damage(-maxHealth) //fully heals the brain
@@ -359,43 +350,55 @@
 		gps_active = FALSE
 		qdel(GetComponent(/datum/component/gps))
 
-	// If the Slime player has a body use that, otherwise create a new one for them and try to apply their prefrences to it.
-	if(!body || QDELETED(body))
-		var/mob/living/carbon/human/new_body = new(src.drop_location())
-		body = new_body
-		var/datum/preferences/prefs = brainmob?.client?.prefs || brainmob?.mind?.current?.client?.prefs
-		if(prefs)
-			prefs.apply_prefs_to(body)
-		// ISSUE: The new body gets no quirks, TODO: Add them
+	// Create a new body and spawn it on the Brain/Core, than register the signal for the player to be inserted into the new body.
+	var/mob/living/carbon/human/body = new(src.drop_location())
+	RegisterSignal(body, COMSIG_MOB_LOGIN, PROC_REF(on_gained_client))
 
-	else
-		// Retrieve, and revive our original body that we moved to Nullspace.
-		RegisterSignal(body, COMSIG_LIVING_DEATH)
-		body.revive(HEAL_ALL)
-		body.forceMove(src.drop_location())
-
-	// Ensure they appear fully nude when revived, since slimes don't regrow clothes.
-	body.underwear = "Nude"
-	body.bra = "Nude"
-	body.undershirt = "Nude"
-	body.socks = "Nude"
-
-	// Handle Blood
-	body.set_blood_volume(BLOOD_VOLUME_SAFE + 60)
-
-	// Remove non-chest limbs.
-	for(var/obj/item/bodypart/part in body.bodyparts)
-		if(part.body_zone == BODY_ZONE_CHEST)
-			continue
-		part.drop_limb(TRUE)
-
-	// Move the brain/core back into our body.
+	// Move the brain/core back into the body.
 	src.replace_into(body)
 
 	// Notify the player that their body has been rebuilt
 	body.visible_message(span_warning("[body]'s torso \"forms\" from [body.p_their()] core, yet to form the rest."))
 	to_chat(owner, span_purple("Your torso fully forms out of your core, yet to form the rest."))
 	return TRUE
+
+/**
+* APPLY PREFRENCES & QUIRKS AND OTHER EDITS
+* When we gain a client, apply the prefrences, and apply quirks without spawning items.
+* In addition Remove their underwear, their non-chest limbs, and give them some extra blood for slime limb regen.
+*/
+/obj/item/organ/brain/slime/proc/on_gained_client(mob/living/source)
+	SIGNAL_HANDLER
+	if(!source.client)
+		return
+
+	// Handle Prefrences & Quirks.
+	var/datum/preferences/prefs = source.client.prefs || source.mind?.current?.client.prefs
+	if(prefs)
+		prefs.apply_prefs_to(source)
+		// Handle Quirks without spawning items.
+		for(var/quirks in prefs.all_quirks)
+			var/datum/quirk/quirk_path = SSquirks.quirks[quirks]
+			if(quirk_path)
+				source.add_quirk(quirk_path, add_unique = FALSE)
+
+	var/mob/living/carbon/human/body = source
+	// Ensure they appear fully nude when revived, since slimes don't regrow clothes.
+	body.underwear = "Nude"
+	body.bra = "Nude"
+	body.undershirt = "Nude"
+	body.socks = "Nude"
+
+	// Handle Blood, We give them extra blood so they can regenerate their limbs as soon as they are revived.
+	body.set_blood_volume(BLOOD_VOLUME_SAFE + 60)
+
+	// Remove non-chest limbs, they can use their regenerate ability to regain their limbs.
+	for(var/obj/item/bodypart/part in body.bodyparts)
+		if(part.body_zone == BODY_ZONE_CHEST)
+			continue
+		part.drop_limb(TRUE)
+
+	UnregisterSignal(source, COMSIG_MOB_LOGIN)
 
 // HEALING SECTION
 // Handles passive healing and water damage for slimes and water-breathing variants.

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -188,7 +188,7 @@
 	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | LAVA_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 	/// This tracks a new body that is created when a slime core is killed, and is used to safely trasnfer quirks and prefrences to this body and than summon it upon revival.
 	var/mob/living/carbon/human/new_body
-	/// This caches the mob's prefrences/quirks for revival.
+	/// This caches the mob's prefrences for revival.
 	var/datum/preferences/cached_prefs
 
 /obj/item/organ/brain/slime/Initialize(mapload, mob/living/carbon/organ_owner, list/examine_list)
@@ -275,8 +275,6 @@
 
 	// Create a new body in nullspace, and transfer their prefrences and quirks into it.
 	new_body = new(null)
-	//victim.client?.prefs.safe_transfer_prefs_to(new_body)
-	//victim.transfer_quirk_datums(new_body)
 
 	// Cache the victim's prefrences in the Brain/Core, and transfer them and their quirks to the new body.
 	if(victim.client?.prefs)

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -368,7 +368,7 @@
 		// ISSUE: The new body gets no quirks, TODO: Add them
 
 	else
-		// Retreive, and revive our original body that we moved to Nullspace.
+		// Retrieve, and revive our original body that we moved to Nullspace.
 		RegisterSignal(body, COMSIG_LIVING_DEATH)
 		body.revive(HEAL_ALL)
 		body.forceMove(src.drop_location())

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -230,8 +230,7 @@
 
 /obj/item/organ/brain/slime/on_mob_remove(mob/living/carbon/organ_owner)
 	. = ..()
-	UnregisterSignal(organ_owner, COMSIG_LIVING_DEATH)
-	UnregisterSignal(organ_owner, COMSIG_MOB_LOGIN)
+	UnregisterSignal(organ_owner, list(COMSIG_LIVING_DEATH, COMSIG_MOB_LOGIN))
 
 /**
 * Colors the slime's core (their brain) the same as their first mutant color.

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -197,6 +197,7 @@
 // Handle the slime core being destroyed, and if it has a body in nullspace, delete it as well.
 /obj/item/organ/brain/slime/Destroy(force)
 	if(body)
+		UnregisterSignal(body, COMSIG_MOB_LOGIN)
 		QDEL_NULL(body)
 	return ..()
 

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -256,8 +256,7 @@
 	UnregisterSignal(victim, COMSIG_LIVING_DEATH)
 
 	if(gibbed)
-		qdel(src)
-		UnregisterSignal(victim, COMSIG_LIVING_DEATH)
+		core_ejection(victim)
 		return
 
 	addtimer(CALLBACK(src, PROC_REF(core_ejection), victim), 0) // explode them after the current proc chain ends, to avoid weirdness
@@ -359,10 +358,20 @@
 		gps_active = FALSE
 		qdel(GetComponent(/datum/component/gps))
 
-	// Retreive, and revive our original body that we moved to Nullspace.
-	RegisterSignal(body, COMSIG_LIVING_DEATH)
-	body.revive(HEAL_ALL)
-	body.forceMove(src.drop_location())
+	// If the Slime player has a body use that, otherwise create a new one for them and try to apply their prefrences to it.
+	if(!body || QDELETED(body))
+		var/mob/living/carbon/human/new_body = new(src.drop_location())
+		body = new_body
+		var/datum/preferences/prefs = brainmob?.client?.prefs || brainmob?.mind?.current?.client?.prefs
+		if(prefs)
+			prefs.apply_prefs_to(body)
+		// ISSUE: The new body gets no quirks, TODO: Add them
+
+	else
+		// Retreive, and revive our original body that we moved to Nullspace.
+		RegisterSignal(body, COMSIG_LIVING_DEATH)
+		body.revive(HEAL_ALL)
+		body.forceMove(src.drop_location())
 
 	// Ensure they appear fully nude when revived, since slimes don't regrow clothes.
 	body.underwear = "Nude"

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -188,6 +188,8 @@
 	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | LAVA_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 	/// This tracks a new body that is created when a slime core is killed, and is used to safely trasnfer quirks and prefrences to this body and than summon it upon revival.
 	var/mob/living/carbon/human/new_body
+	/// This caches the mob's prefrences/quirks for revival.
+	var/datum/preferences/cached_prefs
 
 /obj/item/organ/brain/slime/Initialize(mapload, mob/living/carbon/organ_owner, list/examine_list)
 	. = ..()
@@ -270,34 +272,51 @@
 	if(core_ejected)
 		return
 	core_ejected = TRUE
-	victim.visible_message(span_warning("[victim]'s body completely dissolves, collapsing outwards!"), span_notice("Your body completely dissolves, collapsing outwards!"), span_notice("You hear liquid splattering."))
-	var/atom/death_loc = victim.drop_location()
 
 	// Create a new body in nullspace, and transfer their prefrences and quirks into it.
 	new_body = new(null)
-	victim.client?.prefs.safe_transfer_prefs_to(new_body)
+	//victim.client?.prefs.safe_transfer_prefs_to(new_body)
+	//victim.transfer_quirk_datums(new_body)
+
+	// Cache the victim's prefrences in the Brain/Core, and transfer them and their quirks to the new body.
+	if(victim.client?.prefs)
+		src.cached_prefs = victim.client.prefs
+	if(src.cached_prefs)
+		src.cached_prefs.safe_transfer_prefs_to(new_body)
 	victim.transfer_quirk_datums(new_body)
 
-	// Drop the Brain/Core, and implants to the floor.
-	for(var/obj/item/organ/organs in victim)
-		if(istype(organs, /obj/item/organ/brain) || istype(organs, /obj/item/implant))
-			Remove(organs, special = TRUE)
+	var/atom/death_loc = victim.drop_location()
+	if(!death_loc)
+		death_loc = get_turf(victim) // Fallback to avoid the Slime core showing up in Nullspace.
+
+	// Drop their equipment, Brain/Core, and implants to the floor.
+	victim.unequip_everything()
+	src.Remove(victim, special = TRUE) // Brain/Core
+	for(var/obj/item/implant/implants in victim) // Implants
+		implants.forceMove(death_loc)
+
+	// Move the Brain/Core, and implants to the death location.
 	if(death_loc)
 		forceMove(death_loc)
-		// Cleans up spilled organs - When a mob is attacked, it has a chance to spill all its organs on the ground upon death, for slime people we do not need their organs as they regain them when they get revived.
-		for(var/obj/item/organ/spilled_organ in death_loc)
-			if(istype(spilled_organ, /obj/item/organ/brain) || istype(spilled_organ, /obj/item/implant))
-				continue
-			else
-				qdel(spilled_organ)
+
+	// Cleans up spilled organs - When a mob is attacked, it has a chance to spill all its organs on the ground upon death, for slime people we do not need their organs as they regain them when they get revived.
+	for(var/obj/item/organ/spilled_organ in death_loc)
+		if(istype(spilled_organ, /obj/item/organ/brain) || istype(spilled_organ, /obj/item/implant))
+			continue
+		else
+			qdel(spilled_organ)
+
 	src.wash(CLEAN_WASH)
 	new death_melt_type(death_loc, victim.dir)
 
-	do_steam_effects(get_turf(victim))
-	playsound(victim, 'sound/effects/blob/blobattack.ogg', 80, TRUE)
+	do_steam_effects(death_loc)
+	playsound(death_loc, 'sound/effects/blob/blobattack.ogg', 80, TRUE)
 
 	if(gps_active) // adding the gps signal if they have activated the ability
 		AddComponent(/datum/component/gps, "[victim]'s Core")
+
+	// Message the victim and the surrounding area that they have died.
+	victim.visible_message(span_warning("[victim]'s body completely dissolves, collapsing outwards!"), span_notice("Your body completely dissolves, collapsing outwards!"), span_notice("You hear liquid splattering."))
 
 	qdel(victim) // Remove the body.
 	UnregisterSignal(victim, COMSIG_LIVING_DEATH)
@@ -350,6 +369,10 @@
 	if(gps_active) // making sure the gps signal is removed if it's active on revival
 		gps_active = FALSE
 		qdel(GetComponent(/datum/component/gps))
+
+	// Reapply prefrences from the Brain/Core in-case it failed in the Core Eject Proc.
+	if(src.cached_prefs)
+		src.cached_prefs.safe_transfer_prefs_to(new_body)
 
 	// Retreive the new body we created from nullspace.
 	new_body.forceMove(src.drop_location())

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -186,20 +186,18 @@
 	throw_range = 9 //Oh! That's a baseball!
 	throw_speed = 0.5
 	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | LAVA_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
-	/// This tracks a new body that is created when a slime core is killed, and is used to safely trasnfer quirks and prefrences to this body and than summon it upon revival.
-	var/mob/living/carbon/human/new_body
-	/// This caches the mob's prefrences for revival.
-	var/datum/preferences/cached_prefs
+	/// This tracks the Slime's body, we use this to send them to Nullspace when they die, and to regenerate them when they are revived.
+	var/mob/living/carbon/human/body
 
 /obj/item/organ/brain/slime/Initialize(mapload, mob/living/carbon/organ_owner, list/examine_list)
 	. = ..()
 	AddComponent(/datum/component/bubble_icon_override, "slime", BUBBLE_ICON_PRIORITY_ORGAN)
 	colorize()
 
-// Handle the slime core being destroyed, and if it has a new body, delete it as well.
+// Handle the slime core being destroyed, and if it has a body in nullspace, delete it as well.
 /obj/item/organ/brain/slime/Destroy(force)
-	if(new_body)
-		QDEL_NULL(new_body)
+	if(body)
+		QDEL_NULL(body)
 	return ..()
 
 /obj/item/organ/brain/slime/examine()
@@ -273,15 +271,9 @@
 		return
 	core_ejected = TRUE
 
-	// Create a new body in nullspace, and transfer their prefrences and quirks into it.
-	new_body = new(null)
-
-	// Cache the victim's prefrences in the Brain/Core, and transfer them and their quirks to the new body.
-	if(victim.client?.prefs)
-		src.cached_prefs = victim.client.prefs
-	if(src.cached_prefs)
-		src.cached_prefs.safe_transfer_prefs_to(new_body)
-	victim.transfer_quirk_datums(new_body)
+	// Cache the body refrence inside the Core/Brain.
+	if(!src.body)
+		src.body = victim
 
 	var/atom/death_loc = victim.drop_location()
 	if(!death_loc)
@@ -315,8 +307,7 @@
 
 	// Message the victim and the surrounding area that they have died.
 	victim.visible_message(span_warning("[victim]'s body completely dissolves, collapsing outwards!"), span_notice("Your body completely dissolves, collapsing outwards!"), span_notice("You hear liquid splattering."))
-
-	qdel(victim) // Remove the body.
+	victim.moveToNullspace() // Move the body to nullspace.
 	UnregisterSignal(victim, COMSIG_LIVING_DEATH)
 
 /**
@@ -368,35 +359,32 @@
 		gps_active = FALSE
 		qdel(GetComponent(/datum/component/gps))
 
-	// Reapply prefrences from the Brain/Core in-case it failed in the Core Eject Proc.
-	if(src.cached_prefs)
-		src.cached_prefs.safe_transfer_prefs_to(new_body)
-
-	// Retreive the new body we created from nullspace.
-	new_body.forceMove(src.drop_location())
+	// Retreive, and revive our original body that we moved to Nullspace.
+	RegisterSignal(body, COMSIG_LIVING_DEATH)
+	body.revive(HEAL_ALL)
+	body.forceMove(src.drop_location())
 
 	// Ensure they appear fully nude when revived, since slimes don't regrow clothes.
-	new_body.underwear = "Nude"
-	new_body.bra = "Nude"
-	new_body.undershirt = "Nude"
-	new_body.socks = "Nude"
+	body.underwear = "Nude"
+	body.bra = "Nude"
+	body.undershirt = "Nude"
+	body.socks = "Nude"
 
 	// Handle Blood
-	new_body.set_blood_volume(BLOOD_VOLUME_SAFE + 60)
+	body.set_blood_volume(BLOOD_VOLUME_SAFE + 60)
 
 	// Remove non-chest limbs.
-	for(var/obj/item/bodypart/part in new_body.bodyparts)
+	for(var/obj/item/bodypart/part in body.bodyparts)
 		if(part.body_zone == BODY_ZONE_CHEST)
 			continue
 		part.drop_limb(TRUE)
 
-	// Move the brain/core into the new body
-	src.replace_into(new_body)
+	// Move the brain/core back into our body.
+	src.replace_into(body)
 
 	// Notify the player that their body has been rebuilt
-	new_body.visible_message(span_warning("[new_body]'s torso \"forms\" from [new_body.p_their()] core, yet to form the rest."))
+	body.visible_message(span_warning("[body]'s torso \"forms\" from [body.p_their()] core, yet to form the rest."))
 	to_chat(owner, span_purple("Your torso fully forms out of your core, yet to form the rest."))
-	new_body = null // Clear the new_body variable to avoid dangling references
 	return TRUE
 
 // HEALING SECTION


### PR DESCRIPTION

## About The Pull Request

This Pull Request is a follow-up for #7490
It fixes major issues with that Pull Request which made slimes **unplayable** if they die.
- [x] Slimes get most of their equipment deleted upon death.
- [x] Slimes Brain/Core teleporting into **nullspace**.
- [x] After the first revival, slimes won't any more be able to get their preferences.  
- [x] When Slimes Gib they get removed. 
- [x] Slimes not getting quirks if they got gibbed. 

### What this PR Changed.
So the main two issues I came from playing on the server we're **Equipment being deleted** and **Cores appearing in Nullspace**, after debugging I eventually found that in #7490 I've removed `victim.unequip_everything()` in the eject proc which was what dropped all the equipment the player had on them.

As for the core appearing in nullspace, I'd figured out that the for loop that was checking that we are dropping the brain and implants along cleaning up spilled organs and ensuring the core drops in the death location was all inside the same loop, so you could get the game trying 20 times to teleport the core to the same location (fun!).

As well as I figured out our `Remove(organs` is a function for mostly.. organs, and implants are items not organs, so trying to by running Remove on a for loop for implants and the brain/core we could try to twice remove the brain/core which won't work, so I've changed it to remove the brain and force move the implants onto the death location.

In addition, I added an extra safety check in-case for some reason we don't have the death location to get it from the victim's body, and while I'm at it, I changed some messages or effects to show up on the death location to avoid errors.

### So How does Slime Revive work now?

Once the Slime core accepts the plasma it runs the Revive Proc,
This Proc **Spawns a new body** on the location of the core and moves the player into the body, which than it runs the `on_gained_client` which handles the following:
- Preferences (Character appearance & species).
- Quirks (Things like blind, deaf, etc...)
- Removing Underwear from the new body (Slimes don't grow underwear).
- Removing all limbs apart from the chest, to simulate a slime growing out their limbs.
- Extra blood so they can instantly regrow **some** of their limbs. 



Next whilst testing I found that for whatever reason when we try to revive the slime player for the 2nd time their preferences don't transfer over.

After code reviews and more debugging eventually I've figured out a way to get quirks applied to a character without spawning items. 

## How This Contributes To The Nova Sector Roleplay Experience

Bug Fixes.
<img width="112" height="112" alt="2" src="https://github.com/user-attachments/assets/a6e729df-ee43-49f6-910f-2a21b6ab7cda" />


## Proof of Testing

**This is outdated look at the end of discussion**

https://github.com/user-attachments/assets/cadaf930-7b31-4480-a7a0-b8490d5eacb7



## Changelog
:cl: Richard Blonski
fix: Fixed Slime Players cores being teleported into nullspace upon death.
fix: Fixed Slime Players equipment getting deleted upon death.
fix: Fixed Slime Players not getting their preferences or quirks upon revival.
fix: Fixed Slime Players getting removed when gibbed.
/:cl:
