### PR TITLE
Fixes Loadout Enabled Deathmatch modifier

### DIFF
--- a/modular_nova/modules/deathmatch/deathmatch_modifier.dm
+++ b/modular_nova/modules/deathmatch/deathmatch_modifier.dm
@@ -12,6 +12,8 @@
 	if(!preferences)
 		return
 	var/mob/living/carbon/human/human_player = player
-	var/datum/outfit/deathmatch_loadout/dm_outfit = lobby.players[human_player.ckey]["loadout"]
+	var/datum/outfit/deathmatch_loadout/dm_outfit
+	if(human_player.ckey)
+		dm_outfit = lobby.players[human_player.ckey]["loadout"]
 	human_player.equip_outfit_and_loadout(dm_outfit || new /datum/outfit, preferences)
 

--- a/modular_nova/modules/deathmatch/deathmatch_modifier.dm
+++ b/modular_nova/modules/deathmatch/deathmatch_modifier.dm
@@ -12,6 +12,6 @@
 	if(!preferences)
 		return
 	var/mob/living/carbon/human/human_player = player
-	var/outfit = lobby.players[human_player.ckey]["loadout"]
-	human_player.equip_outfit_and_loadout(outfit || new /datum/outfit, preferences)
+	var/datum/outfit/deathmatch_loadout/dm_outfit = lobby.players[human_player.ckey]["loadout"]
+	human_player.equip_outfit_and_loadout(dm_outfit || new /datum/outfit, preferences)
 

--- a/modular_nova/modules/deathmatch/deathmatch_modifier.dm
+++ b/modular_nova/modules/deathmatch/deathmatch_modifier.dm
@@ -4,26 +4,14 @@
 
 /datum/deathmatch_modifier/loadout_enabled/apply(mob/living/carbon/player, datum/deathmatch_lobby/lobby)
 	. = ..()
-
-	var/datum/preferences/preference_source = player.client?.prefs
-	if (!preference_source)
+	if(!player.client)
 		return
+	if(!ishuman(player))
+		return
+	var/datum/preferences/preferences = player.client.prefs
+	if(!preferences)
+		return
+	var/mob/living/carbon/human/human_player = player
+	var/outfit = lobby.players[human_player.ckey]["loadout"]
+	human_player.equip_outfit_and_loadout(outfit || new /datum/outfit, preferences)
 
-	// using briefcase since im gonna be fuckin honest i tried to refactor the loadout helper code to not depend on outfits
-	// and i failed so womp womp
-	var/list/loadout_entries = preference_source.read_preference(/datum/preference/loadout)
-	var/list/loadout_datums = loadout_list_to_datums(loadout_entries[preference_source.read_preference(/datum/preference/loadout_index)])
-
-	var/obj/item/storage/briefcase/empty/briefcase = new(get_turf(player))
-
-	for(var/datum/loadout_item/item as anything in loadout_datums)
-		// NO CAN BE APPLIED TO CHECK. WE GO WILD. WE GO HARD
-		var/obj/item/new_item = new item.item_path(get_turf(player))
-		if (!new_item.equip_to_best_slot(player))
-			new_item.forceMove(briefcase)
-
-	if (!length(briefcase.contents))
-		qdel(briefcase)
-	else
-		briefcase.name = "[preference_source.read_preference(/datum/preference/name/real_name)]'s travel suitcase"
-		player.put_in_hands(briefcase)


### PR DESCRIPTION

## About The Pull Request
This modifier shitcodes its own logic for applying loadout items, likely because the original author just didn't know how to provide an outfit to `equip_outfit_and_loadout` in this situation. Because this logic for applying loadout items is *novel* and not using `equip_outfit_and_loadout`, it doesn't apply colors to greyscale loadout items.

So instead of doing all that, we'll just get the player's Deathmatch loadout using the lobby datum and pass that outfit to `equip_outfit_and_loadout`. And if their Deathmatch outfit is unavailable for some reason, we'll just fall back to an empty outfit datum.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

**Move job to backpack/Delete job items** with Unarmed loadout:
In these modes, preference loadout items will be deleted if their slot is taken by an item from your current Deathmatch loadout, which is fine.
<img width="1121" height="620" alt="image" src="https://github.com/user-attachments/assets/73b913ba-8a0b-4a65-b5e0-1e305bd16053" />

**Place all in case** with any loadout:
<img width="723" height="595" alt="image" src="https://github.com/user-attachments/assets/4528d5b7-b426-44c9-bd71-8339b9cae2df" />

</details>

## Changelog
:cl:
fix: [NOVA] Loadout Enabled Deathmatch modifier now applies colors to recolorable loadout items.
/:cl:
