### PR TITLE
Refactors ERP sense/arousal text to use DNA

### DIFF
--- a/code/__DEFINES/~nova_defines/DNA.dm
+++ b/code/__DEFINES/~nova_defines/DNA.dm
@@ -9,6 +9,17 @@
 /// Examine Panel NSFW ooc notes—requires you to click a tab to see
 #define EXAMINE_DNA_OOC_NOTES_NSFW "ooc_notes_nsfw"
 
+/// Examine text when a person has low arousal
+#define ERP_FLAVOR_DNA_LOW_AROUSAL "erp_low_arousal_text"
+/// Examine text when a person has medium arousal
+#define ERP_FLAVOR_DNA_MEDIUM_AROUSAL "erp_medium_arousal_text"
+/// Examine text when a person has high arousal
+#define ERP_FLAVOR_DNA_HIGH_AROUSAL "erp_high_arousal_text"
+/// Flavor text when licking someone
+#define ERP_FLAVOR_DNA_TASTE "erp_taste"
+/// Flavor text when smelling someone
+#define ERP_FLAVOR_DNA_SCENT "erp_scent"
+
 //We start from 30 to not interfere with TG species defines, should they add more
 /// We're using all three mutcolor features for our skin coloration
 #define MUTCOLOR_MATRIXED	30

--- a/modular_nova/master_files/code/modules/client/preferences/arousal_flavor_text.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/arousal_flavor_text.dm
@@ -24,18 +24,18 @@
 	savefile_key = "low_arousal_text"
 
 /datum/preference/text/erp_flavor/low_arousal/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
-	return
+	target.dna.features[ERP_FLAVOR_DNA_LOW_AROUSAL] = value
 
 /datum/preference/text/erp_flavor/medium_arousal
 	savefile_key = "medium_arousal_text"
 
 /datum/preference/text/erp_flavor/medium_arousal/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
-	return
+	target.dna.features[ERP_FLAVOR_DNA_MEDIUM_AROUSAL] = value
 
 /datum/preference/text/erp_flavor/high_arousal
 	savefile_key = "high_arousal_text"
 
 /datum/preference/text/erp_flavor/high_arousal/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
-	return
+	target.dna.features[ERP_FLAVOR_DNA_HIGH_AROUSAL] = value
 
 #undef MAX_FLAVOR_ERP_TEXT_LEN

--- a/modular_nova/master_files/code/modules/client/preferences/scent_taste.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/scent_taste.dm
@@ -2,10 +2,10 @@
 	savefile_key = "custom_taste"
 
 /datum/preference/text/erp_flavor/taste/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
-	return
+	target.dna.features[ERP_FLAVOR_DNA_TASTE] = value
 
 /datum/preference/text/erp_flavor/smell
 	savefile_key = "custom_smell"
 
 /datum/preference/text/erp_flavor/smell/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
-	return
+	target.dna.features[ERP_FLAVOR_DNA_SCENT] = value

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_arousal/status_effects/spank_related.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_arousal/status_effects/spank_related.dm
@@ -45,13 +45,13 @@
 		return ""
 
 	if(arousal >= AROUSAL_HIGH)
-		var/high_flavor = client.prefs.read_preference(/datum/preference/text/erp_flavor/high_arousal)
+		var/high_flavor = dna.features[ERP_FLAVOR_DNA_HIGH_AROUSAL]
 		return high_flavor ? span_userlove(high_flavor) + "\n" : ""
 	if(arousal >= AROUSAL_MEDIUM)
-		var/medium_flavor = client.prefs.read_preference(/datum/preference/text/erp_flavor/medium_arousal)
+		var/medium_flavor = dna.features[ERP_FLAVOR_DNA_MEDIUM_AROUSAL]
 		return medium_flavor ? span_userlove(medium_flavor) + "\n" : ""
 	if(arousal >= AROUSAL_LOW)
-		var/low_flavor = client.prefs.read_preference(/datum/preference/text/erp_flavor/low_arousal)
+		var/low_flavor = dna.features[ERP_FLAVOR_DNA_LOW_AROUSAL]
 		return low_flavor ? span_purple(low_flavor) + "\n" : ""
 	return ""
 

--- a/modular_nova/modules/modular_items/lewd_items/code/scent_taste_verbs.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/scent_taste_verbs.dm
@@ -10,7 +10,7 @@
 	if(!can_use_erp_flavor_verb(target, "doesn't feel like being touched right now."))
 		return FALSE
 
-	var/taste = target.client?.prefs?.read_preference(/datum/preference/text/erp_flavor/taste)
+	var/taste = target.dna.features[ERP_FLAVOR_DNA_TASTE]
 	if(!taste)
 		to_chat(src, span_warning("[target] doesn't seem to have a taste."))
 		return FALSE
@@ -28,7 +28,7 @@
 	if(!can_use_erp_flavor_verb(target, "doesn't feel like being approached that close right now."))
 		return FALSE
 
-	var/scent = target.client?.prefs?.read_preference(/datum/preference/text/erp_flavor/smell)
+	var/scent = target.dna.features[ERP_FLAVOR_DNA_SCENT]
 	if(!scent)
 		to_chat(src, span_warning("[target] doesn't seem to have a smell."))
 		return FALSE


### PR DESCRIPTION

## About The Pull Request
These features read directly from your preferences instead of using something semi-constant and unique to your mob (DNA), so if you switch character slots when playing, these features will show text from whatever character slot is active and not your mob.

So let's make these use DNA to avoid that.
## How This Contributes To The Nova Sector Roleplay Experience
I'm *very* confident these have no reason not to use DNA.
## Proof of Testing
<details>
<summary>Tested by spawning in, gaining arousal, editing preferences and ensuring arousal flavor text did not change.</summary>

<img width="320" height="34" alt="Screenshot_3241" src="https://github.com/user-attachments/assets/9d475e84-2020-45a9-90a6-2f5e3018c2b6" />
<img width="262" height="53" alt="Screenshot_3242" src="https://github.com/user-attachments/assets/067200a4-f293-46a8-9c47-a91b87d2fd1b" />
<img width="409" height="51" alt="Screenshot_3243" src="https://github.com/user-attachments/assets/22a0bc3f-7f1b-4b75-8c3a-747d4e7ce1f1" />

</details>

## Changelog
:cl:
code: ERP taste/scent descriptions and arousal flavor texts now use DNA instead of reading directly from preferences.
/:cl:
