### PR TITLE
Removes Wormspeak and Adds Chimpanzee from/to Language Shop

### DIFF
--- a/code/modules/language/wormspeak.dm
+++ b/code/modules/language/wormspeak.dm
@@ -6,3 +6,4 @@
 	icon_state = "wormspeak"
 	default_priority = 90
 	always_use_default_namelist = TRUE
+	secret = TRUE // NOVA ADDITION - We don't have blood worms, and it barely makes sense even if we did.

--- a/code/modules/language/wormspeak.dm
+++ b/code/modules/language/wormspeak.dm
@@ -6,4 +6,3 @@
 	icon_state = "wormspeak"
 	default_priority = 90
 	always_use_default_namelist = TRUE
-	secret = TRUE // NOVA ADDITION - We don't have blood worms, and it barely makes sense even if we did.

--- a/modular_nova/master_files/code/modules/language/_language.dm
+++ b/modular_nova/master_files/code/modules/language/_language.dm
@@ -22,7 +22,7 @@
 	secret = TRUE
 
 /datum/language/monkey
-	secret = TRUE
+	secret = FALSE //NOVA EDIT -  Monkey language for all! Original: `secret = TRUE`
 
 /datum/language/mushroom
 	secret = TRUE

--- a/modular_nova/master_files/code/modules/language/_language.dm
+++ b/modular_nova/master_files/code/modules/language/_language.dm
@@ -22,7 +22,10 @@
 	secret = TRUE
 
 /datum/language/monkey
-	secret = FALSE //NOVA EDIT -  Monkey language for all! Original: `secret = TRUE`
+	secret = FALSE
+	
+/datum/language/wormspeak
+	secret = TRUE
 
 /datum/language/mushroom
 	secret = TRUE


### PR DESCRIPTION

## About The Pull Request
<img width="809" height="214" alt="Discord_czIr41ChI7" src="https://github.com/user-attachments/assets/9b2505e8-9d7a-4f76-870f-12fd90a22c8d" />


Removes wormspeak from the round start language choices (We haven’t had blood worms for a long time, and even if we did, this hardly makes sense for a language for basically anyone to have.) and adds Chimpanzee (For our simians and anyone who likes to talk to pun pun or other monkeys that might be sentient.)
## How This Contributes To The Nova Sector Roleplay Experience
Lets our simian players speak to their smaller kin in their tongue if any of them happen to be sentient. Plus I just feel like this fits much better than wormtongue.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="920" height="780" alt="RLNmy4HWcA" src="https://github.com/user-attachments/assets/41af438b-d574-4697-95ad-78c89a549031" />

</details>

## Changelog
:cl:
add: Chimpanzee (Monkey) language is now a round start choice.
del: Wormtongue language is no longer a round start choice.
/:cl:
