### PR TITLE
adds stamina shield and attaches it to Drifting Contractor's default loadout.

### DIFF
--- a/modular_nova/modules/contractor/code/datums/midround/outfit.dm
+++ b/modular_nova/modules/contractor/code/datums/midround/outfit.dm
@@ -59,6 +59,11 @@
 	if(visuals_only)
 		return
 	handlebank(user)
+	var/obj/item/clothing/under/uniform = user.w_uniform
+	if(istype(uniform))
+		var/obj/item/clothing/accessory/energy_shield/syndicate/stamina/shield = new(uniform)
+		shield.enabled = TRUE
+		uniform.attach_accessory(shield, attach_message = FALSE)
 	var/obj/item/mod/control/mod = user.back
 	if(!istype(mod))
 		return

--- a/modular_nova/modules/energy_shield/code/energy_shield.dm
+++ b/modular_nova/modules/energy_shield/code/energy_shield.dm
@@ -54,10 +54,12 @@
 	var/enabled = FALSE
 	/// Fraction of shield health retained after an EMP (0 = full wipe, 0.5 = halved)
 	var/emp_retention = 0
-	/// Whether the shield blocks projectile damage
+	/// Whether the shield blocks physical projectile damage
 	var/blocks_projectiles = TRUE
-	/// Whether the shield blocks melee damage
+	/// Whether the shield blocks physical melee damage
 	var/blocks_melee = TRUE
+	/// Whether the shield absorbs stamina damage, from any source
+	var/blocks_stamina = TRUE
 	/// Whether shield visuals stay on continuously while active (until collapse)
 	var/persistent_visuals = FALSE
 	/// Damage absorbed in the current hit, pending application in on_after_damage
@@ -227,41 +229,34 @@
 /obj/item/clothing/accessory/energy_shield/proc/on_pre_bullet(mob/living/carbon/source, obj/projectile/proj, def_zone, piercing_hit)
 	SIGNAL_HANDLER
 
-	if(!blocks_projectiles)
-		return
 	if(shield_health <= 0 || !shield_active)
 		return
 	//Special case for ammunition with secondary damage (pulse/plasma ammo)
-	var/secondary_damage = 0
-	var/obj/projectile/bullet/pulse/pulse_proj
-	if(istype(proj, /obj/projectile/bullet/pulse))
-		pulse_proj = proj
-		secondary_damage = pulse_proj.secondary_damage
+	var/obj/projectile/bullet/pulse/pulse_proj = istype(proj, /obj/projectile/bullet/pulse) ? proj : null
+	var/secondary_damage = pulse_proj?.secondary_damage || 0
 	var/total_damage = proj.damage + proj.stamina + secondary_damage
 	if(total_damage <= 0)
 		return
 
-	var/remaining_shield = shield_health
-	// Absorb brute first
-	var/brute_absorbed = min(proj.damage, remaining_shield)
-	remaining_shield -= brute_absorbed
-	// Then secondary damage with whatever shield is left
-	var/secondary_absorbed = min(secondary_damage, remaining_shield)
-	remaining_shield -= secondary_absorbed
-	// Then stamina with whatever shield is left
-	var/stamina_absorbed = min(proj.stamina, remaining_shield)
+	// The main damage pool counts as stamina or physical based on the projectile's damage type
+	var/main_blocked = (proj.damage_type == STAMINA) ? blocks_stamina : blocks_projectiles
+	var/remaining = shield_health
+	var/main_absorbed = main_blocked ? min(proj.damage, remaining) : 0
+	remaining -= main_absorbed
+	var/secondary_absorbed = blocks_projectiles ? min(secondary_damage, remaining) : 0
+	remaining -= secondary_absorbed
+	var/stamina_absorbed = blocks_stamina ? min(proj.stamina, remaining) : 0
 
-	var/total_absorbed = brute_absorbed + secondary_absorbed + stamina_absorbed
-	var/obj/item/bodypart/limb = wearer.get_bodypart(check_zone(def_zone))
-	apply_shield_hit(total_absorbed, limb)
+	var/total_absorbed = main_absorbed + secondary_absorbed + stamina_absorbed
+	if(total_absorbed <= 0)
+		return
+	apply_shield_hit(total_absorbed, wearer.get_bodypart(check_zone(def_zone)))
 
-	// Reduce the projectile's damage for whatever passes through
-	proj.damage -= brute_absorbed
-	if(secondary_damage && secondary_absorbed)
+	proj.damage -= main_absorbed
+	if(secondary_absorbed)
 		pulse_proj.secondary_damage -= secondary_absorbed
 	proj.stamina -= stamina_absorbed
 
-	// Fully absorbed — block the bullet entirely
 	if(total_absorbed >= total_damage)
 		return COMPONENT_BULLET_BLOCKED
 
@@ -270,7 +265,7 @@
 /obj/item/clothing/accessory/energy_shield/proc/on_check_block(mob/living/carbon/source, atom/hit_by, damage, attack_text, attack_type, armour_penetration, damage_type)
 	SIGNAL_HANDLER
 
-	if(!blocks_melee)
+	if(!(damage_type == STAMINA ? blocks_stamina : blocks_melee))
 		return FAILED_BLOCK
 	if(shield_health <= 0 || !shield_active)
 		return FAILED_BLOCK
@@ -298,14 +293,14 @@
 		return
 	if(damage <= 0)
 		return
-	// Projectiles are handled entirely by on_pre_bullet (brute + stamina absorption)
+	if(!(damagetype == STAMINA ? blocks_stamina : blocks_melee))
+		return
+	// Projectiles are handled entirely by on_pre_bullet
 	if(isprojectile(attacking_item))
 		return
 	// Only absorb external attacks (melee, thrown) — not embeds, wounds, or reagent damage.
 	// External attacks have an attack_direction or an attacking_item; internal sources have neither.
 	if(isnull(attack_direction) && isnull(attacking_item))
-		return
-	if(!blocks_melee)
 		return
 
 	var/absorbed = min(damage, shield_health)

--- a/modular_nova/modules/energy_shield/code/energy_shield_variants.dm
+++ b/modular_nova/modules/energy_shield/code/energy_shield_variants.dm
@@ -34,6 +34,17 @@
 	emp_retention = 0.5
 	max_armor_class = 100
 
+/// Stamina-only shield
+/obj/item/clothing/accessory/energy_shield/syndicate/stamina
+	name = "\improper Low energy shield projector"
+	desc = "A specialist barrier fine-tuned to wavelengths typically associated disabler beams, incidentally also stopping low-energy projectiles like rubber shot; lethal rounds will pass through unhindered. The low intensity emitters conform to any body armor. Typically used by those who confront the law."
+	max_shield_health = 100
+	recharge_delay = 20 SECONDS
+	recharge_rate = 10
+	shield_color = "#ffaa33"
+	blocks_projectiles = FALSE
+	blocks_melee = FALSE
+
 /// Syndicate shield tuned for projectile interception only. Transparent to melee.
 /obj/item/clothing/accessory/energy_shield/syndicate/phasic
 	name = "\improper Gorlex phasic deflector"

--- a/modular_nova/modules/energy_shield/code/energy_shield_variants.dm
+++ b/modular_nova/modules/energy_shield/code/energy_shield_variants.dm
@@ -45,6 +45,10 @@
 	blocks_projectiles = FALSE
 	blocks_melee = FALSE
 
+/obj/item/clothing/accessory/energy_shield/syndicate/stamina/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/manufacturer_examine, COMPANY_SCARBOROUGH)
+
 /// Syndicate shield tuned for projectile interception only. Transparent to melee.
 /obj/item/clothing/accessory/energy_shield/syndicate/phasic
 	name = "\improper Gorlex phasic deflector"

--- a/modular_nova/modules/energy_shield/code/energy_shield_variants.dm
+++ b/modular_nova/modules/energy_shield/code/energy_shield_variants.dm
@@ -37,7 +37,8 @@
 /// Stamina-only shield
 /obj/item/clothing/accessory/energy_shield/syndicate/stamina
 	name = "\improper Low energy shield projector"
-	desc = "A specialist barrier fine-tuned to wavelengths typically associated disabler beams, incidentally also stopping low-energy projectiles like rubber shot; lethal rounds will pass through unhindered. The low intensity emitters conform to any body armor. Typically used by those who confront the law."
+	desc = "A specialist barrier fine-tuned to wavelengths typically associated disabler beams, incidentally also stopping low-energy projectiles like rubber shot; lethal rounds will pass through unhindered. 
+		The low intensity emitters conform to any body armor. Typically used by those who confront the law."
 	max_shield_health = 100
 	recharge_delay = 20 SECONDS
 	recharge_rate = 10

--- a/modular_nova/modules/energy_shield/code/energy_shield_variants.dm
+++ b/modular_nova/modules/energy_shield/code/energy_shield_variants.dm
@@ -37,7 +37,7 @@
 /// Stamina-only shield
 /obj/item/clothing/accessory/energy_shield/syndicate/stamina
 	name = "\improper Low energy shield projector"
-	desc = "A specialist barrier fine-tuned to wavelengths typically associated disabler beams, incidentally also stopping low-energy projectiles like rubber shot; lethal rounds will pass through unhindered. 
+	desc = "A specialist barrier fine-tuned to wavelengths typically associated disabler beams, incidentally also stopping low-energy projectiles like rubber shot; lethal rounds will pass through unhindered. \
 		The low intensity emitters conform to any body armor. Typically used by those who confront the law."
 	max_shield_health = 100
 	recharge_delay = 20 SECONDS


### PR DESCRIPTION

## About The Pull Request

Current position of DC's is not good, as a heavy roll they loose too easily to recently buffed up SMG's and disablers. My solution to this problem is giving them a shield that only stops stamina damage. Also serves me as a slow introduction of shields in the antagonist/security roster and it's a novel thing for DC's to have.
## How This Contributes To The Nova Sector Roleplay Experience

Stamcrit'ing someone with this shield is still possible, however it becomes more challenging versus just using lethals, which is a reasonable tradeoff. You won't get a slowdown a couple shots in as it working now. 
## Proof of Testing

Tested it locally, the shield works as expected.
<details>
<summary>Screenshots/Videos</summary>
  

https://github.com/user-attachments/assets/69790fa4-3894-41f8-90ad-ca7263d9157b


</details>

## Changelog
:cl:
add: Stamina-only shield and drifting contractors get it by default with their loadout.
/:cl:
