### PR TITLE
Ports Doppler's Nervous Aim quirk PR

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -46,6 +46,7 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/psionic_dampener, /datum/quirk/telepathic),
 	list(/datum/quirk/hydrophobia, /datum/quirk/item_quirk/breather/water_breather),
 	list(/datum/quirk/unblinking, /datum/quirk/item_quirk/fluoride_stare),
+	list(/datum/quirk/poor_aim, /datum/quirk/nervous_aim),
 	// NOVA EDIT ADDITION END
 ))
 

--- a/modular_nova/modules/quirk_nervous_tremble/nervous_tremble.dm
+++ b/modular_nova/modules/quirk_nervous_tremble/nervous_tremble.dm
@@ -1,0 +1,25 @@
+/datum/quirk/nervous_aim
+	name = "Nervous Tremble"
+	desc = "When you're not in peak mental condition your aim has a funny habit of becoming catastrophic."
+	icon = FA_ICON_FACE_SURPRISE
+	value = -6
+	gain_text = ("Your hands feel a little shakier.")
+	lose_text = ("The tremble in your hands seems to have disappeared.")
+	medical_record_text = "Patient has a documented nervous tremble in their hands that worsens with stress."
+
+/datum/quirk/nervous_aim/add(client/client_source)
+	RegisterSignal(quirk_holder, COMSIG_MOB_FIRED_GUN, PROC_REF(on_mob_fired_gun))
+
+/datum/quirk/nervous_aim/remove(client/client_source)
+	UnregisterSignal(quirk_holder, COMSIG_MOB_FIRED_GUN)
+
+/datum/quirk/nervous_aim/proc/on_mob_fired_gun(mob/user, obj/item/gun/gun_fired, target, params, zone_override, list/bonus_spread_values)
+	SIGNAL_HANDLER
+	var/mob/living/carbon/human/shooter = user
+	switch(shooter.mob_mood.sanity_level)
+		if (SANITY_LEVEL_GREAT to SANITY_LEVEL_NEUTRAL)
+			return
+		if (SANITY_LEVEL_DISTURBED to SANITY_LEVEL_UNSTABLE)
+			bonus_spread_values[MAX_BONUS_SPREAD_INDEX] += 10
+		if (SANITY_LEVEL_CRAZY to SANITY_LEVEL_INSANE)
+			bonus_spread_values[MAX_BONUS_SPREAD_INDEX] += 45

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9472,6 +9472,7 @@
 #include "modular_nova\modules\quirk_heavyset\heavyset.dm"
 #include "modular_nova\modules\quirk_hydrophobia\hydrophobia.dm"
 #include "modular_nova\modules\quirk_masquerade\masquerade.dm"
+#include "modular_nova\modules\quirk_nervous_tremble\nervous_tremble.dm"
 #include "modular_nova\modules\quirk_skilled\skilled.dm"
 #include "modular_nova\modules\quirk_unsteady\unsteady.dm"
 #include "modular_nova\modules\radiosound\code\radio.dm"


### PR DESCRIPTION

## About The Pull Request
Ports [this](https://github.com/DopplerShift13/DopplerShift/pull/1094) PR.
Adds a Nervous Tremble quirk. The worse your mood gets, the worse your aim is.
<img width="423" height="246" alt="изображение" src="https://github.com/user-attachments/assets/b1fad55f-72e9-476f-9d95-15e0137e31b1" />


https://github.com/user-attachments/assets/3640826b-b851-4421-a17a-9c123eacd19b
## How This Contributes To The Nova Sector Roleplay Experience
It's a pretty cool roleplaying quirk that might come in handy for any allegedly inexperienced fighter characters.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  Video and screenshot above.
</details>

## Changelog
:cl: Stalkeros, NewyearnewmeUwu for the original PR
add: Added Nervous Tremble, a quirk that makes aim worse when sanity is low.
/:cl:
