### PR TITLE
fixes tarkon carp ore vent

### DIFF
--- a/code/controllers/subsystem/ore_generation.dm
+++ b/code/controllers/subsystem/ore_generation.dm
@@ -149,7 +149,7 @@ SUBSYSTEM_DEF(ore_generation)
 		var/local_vent_count = 0
 		for(var/obj/item/boulder/old_rock in current_vent.loc)
 			available_boulders += old_rock
-			local_vent_count++ 
+			local_vent_count++
 		*/ // NOVA EDIT REMOVAL END
 		// NOVA EDIT ADDITION START
 
@@ -175,6 +175,6 @@ SUBSYSTEM_DEF(ore_generation)
 			var/obj/structure/ore_vent/ghost_mining/crystal_check = current_vent
 			if(crystal_check.ghost_mining == TRUE)
 				current_vent.produce_boulder()
-				return
+				continue
 		// NOVA EDIT ADDITION END
 		available_boulders += current_vent.produce_boulder()


### PR DESCRIPTION

## About The Pull Request

Turns out the code for the ore_generation subsystem would only run a single ore vent if it was a ghost mining type at a time before returning.

Fixes #7613

now it continues. 

## Proof of Testing
<details>
 i know this image shows like nothing but trust me it works now see they all have crystals on them
<img width="268" height="293" alt="image" src="https://github.com/user-attachments/assets/731a54cc-17b9-41d3-a933-5e615644ee37" />
  
</details>

## Changelog
:cl:
fix: ore generation subsystem will now not stop after one ghost_mining ore vent and instead will continue for them all.
/:cl:
