### PR TITLE
makes crusher trophies droppable *and* craftable, watcher wing diamond reduction

### DIFF
--- a/modular_nova/modules/crusher_trophies/trophy_crafts.dm
+++ b/modular_nova/modules/crusher_trophies/trophy_crafts.dm
@@ -1,4 +1,5 @@
 /datum/crafting_recipe/crusher_trophy
+	tool_paths = null
 	time = 2 SECONDS
 
 /datum/crafting_recipe/crusher_trophy/watcher_wing

--- a/modular_nova/modules/crusher_trophies/trophy_crafts.dm
+++ b/modular_nova/modules/crusher_trophies/trophy_crafts.dm
@@ -1,13 +1,11 @@
 /datum/crafting_recipe/crusher_trophy
 	tool_paths = null
-	time = 2 SECONDS
+	time = 2 SECONDS // originally 5 seconds. this... doesn't feel like it changes much for some reason, though
 
 /datum/crafting_recipe/crusher_trophy/watcher_wing
-	name = "Watcher Wing Trophy"
-	result = /obj/item/crusher_trophy/watcher_wing
 	reqs = list(
 		/obj/item/stack/sheet/sinew = 7,
-		/obj/item/stack/ore/diamond = 4,
+		/obj/item/stack/ore/diamond = 4, // originally 10
 		/obj/item/stack/sheet/bone = 5,
 	)
 
@@ -16,11 +14,9 @@
 	custom_materials = list(/datum/material/diamond = SHEET_MATERIAL_AMOUNT * 4, /datum/material/bone = SHEET_MATERIAL_AMOUNT * 5)
 
 /datum/crafting_recipe/crusher_trophy/icewing_watcher_wing
-	name = "Icewing Watcher Wing Trophy"
-	result = /obj/item/crusher_trophy/ice_wing
 	reqs = list(
 		/obj/item/stack/sheet/sinew/icewing = 3,
-		/obj/item/stack/ore/diamond = 2,
+		/obj/item/stack/ore/diamond = 2, // originally 6
 		/obj/item/stack/sheet/bone = 3,
 	)
 
@@ -29,11 +25,9 @@
 	custom_materials = list(/datum/material/diamond = SHEET_MATERIAL_AMOUNT * 2, /datum/material/bone = SHEET_MATERIAL_AMOUNT * 3)
 
 /datum/crafting_recipe/crusher_trophy/magmawing_watcher_wing
-	name = "Magmawing Watcher Wing Trophy"
-	result = /obj/item/crusher_trophy/magma_wing
 	reqs = list(
 		/obj/item/stack/sheet/sinew/magmawing = 3,
-		/obj/item/stack/ore/diamond = 2,
+		/obj/item/stack/ore/diamond = 2, // originally 6
 		/obj/item/stack/sheet/bone = 3,
 	)
 

--- a/modular_nova/modules/crusher_trophies/trophy_crafts.dm
+++ b/modular_nova/modules/crusher_trophies/trophy_crafts.dm
@@ -1,5 +1,5 @@
 /datum/crafting_recipe/crusher_trophy
-	tool_paths = null
+	tool_paths = null // originally: tool_paths = list(/obj/item/kinetic_crusher)
 	time = 2 SECONDS // originally 5 seconds. this... doesn't feel like it changes much for some reason, though
 
 /datum/crafting_recipe/crusher_trophy/watcher_wing

--- a/modular_nova/modules/crusher_trophies/trophy_crafts.dm
+++ b/modular_nova/modules/crusher_trophies/trophy_crafts.dm
@@ -1,0 +1,42 @@
+/datum/crafting_recipe/crusher_trophy
+	time = 2 SECONDS
+
+/datum/crafting_recipe/crusher_trophy/watcher_wing
+	name = "Watcher Wing Trophy"
+	result = /obj/item/crusher_trophy/watcher_wing
+	reqs = list(
+		/obj/item/stack/sheet/sinew = 7,
+		/obj/item/stack/ore/diamond = 4,
+		/obj/item/stack/sheet/bone = 5,
+	)
+
+/obj/item/crusher_trophy/watcher_wing
+	// reduced diamond count to match recipe
+	custom_materials = list(/datum/material/diamond = SHEET_MATERIAL_AMOUNT * 4, /datum/material/bone = SHEET_MATERIAL_AMOUNT * 5)
+
+/datum/crafting_recipe/crusher_trophy/icewing_watcher_wing
+	name = "Icewing Watcher Wing Trophy"
+	result = /obj/item/crusher_trophy/ice_wing
+	reqs = list(
+		/obj/item/stack/sheet/sinew/icewing = 3,
+		/obj/item/stack/ore/diamond = 2,
+		/obj/item/stack/sheet/bone = 3,
+	)
+
+/obj/item/crusher_trophy/ice_wing
+	// reduced diamond count to match new recipe
+	custom_materials = list(/datum/material/diamond = SHEET_MATERIAL_AMOUNT * 2, /datum/material/bone = SHEET_MATERIAL_AMOUNT * 3)
+
+/datum/crafting_recipe/crusher_trophy/magmawing_watcher_wing
+	name = "Magmawing Watcher Wing Trophy"
+	result = /obj/item/crusher_trophy/magma_wing
+	reqs = list(
+		/obj/item/stack/sheet/sinew/magmawing = 3,
+		/obj/item/stack/ore/diamond = 2,
+		/obj/item/stack/sheet/bone = 3,
+	)
+
+/obj/item/crusher_trophy/magma_wing
+	// reduced diamond count to match new recipe
+	custom_materials = list(/datum/material/diamond = SHEET_MATERIAL_AMOUNT * 2, /datum/material/bone = SHEET_MATERIAL_AMOUNT * 3)
+

--- a/modular_nova/modules/crusher_trophies/trophy_drops.dm
+++ b/modular_nova/modules/crusher_trophies/trophy_drops.dm
@@ -1,0 +1,31 @@
+// goliath
+/mob/living/basic/mining/goliath
+	crusher_loot = /obj/item/crusher_trophy/goliath_tentacle
+
+// legion
+/mob/living/basic/mining/legion
+	crusher_loot = /obj/item/crusher_trophy/legion_skull
+
+// watchers
+/mob/living/basic/mining/watcher
+	crusher_loot = /obj/item/crusher_trophy/watcher_wing
+
+/mob/living/basic/mining/watcher/magmawing
+	crusher_loot = /obj/item/crusher_trophy/magma_wing
+	crusher_drop_chance = 100
+
+/mob/living/basic/mining/watcher/icewing
+	crusher_loot = /obj/item/crusher_trophy/ice_wing
+	crusher_drop_chance = 100
+
+// lobster
+/mob/living/basic/mining/lobstrosity
+	crusher_loot = /obj/item/crusher_trophy/lobster_claw
+
+// worm
+/mob/living/basic/mining/bileworm
+	crusher_loot = /obj/item/crusher_trophy/bileworm_spewlet
+
+// brim
+/mob/living/basic/mining/brimdemon
+	crusher_loot = /obj/item/crusher_trophy/brimdemon_fang

--- a/modular_nova/modules/crusher_trophies/trophy_drops.dm
+++ b/modular_nova/modules/crusher_trophies/trophy_drops.dm
@@ -12,11 +12,9 @@
 
 /mob/living/basic/mining/watcher/magmawing
 	crusher_loot = /obj/item/crusher_trophy/magma_wing
-	crusher_drop_chance = 100
 
 /mob/living/basic/mining/watcher/icewing
 	crusher_loot = /obj/item/crusher_trophy/ice_wing
-	crusher_drop_chance = 100
 
 // lobster
 /mob/living/basic/mining/lobstrosity

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8236,6 +8236,8 @@
 #include "modular_nova\modules\cortical_borer\code\evolution\evolution_symbiote.dm"
 #include "modular_nova\modules\cortical_borer\code\evolution\evolution_things\empowered_egg.dm"
 #include "modular_nova\modules\crafting\crafting.dm"
+#include "modular_nova\modules\crusher_trophies\trophy_crafts.dm"
+#include "modular_nova\modules\crusher_trophies\trophy_drops.dm"
 #include "modular_nova\modules\cryosleep\code\admin.dm"
 #include "modular_nova\modules\cryosleep\code\ai.dm"
 #include "modular_nova\modules\cryosleep\code\config.dm"


### PR DESCRIPTION
## About The Pull Request

Crusher trophies off regular Lavaland fauna (goliaths, watchers, legions, brimdemons, bileworms, lobstrosities) can now be dropped via RNG again. The crafting recipes from existing drops still exists, though, in case your RNG sucks.

Watcher wing trophies cost less diamond ore to make, as well.

After thirty seconds of consideration, trophies no longer need a crusher to craft.

## How This Contributes To The Nova Sector Roleplay Experience

The diamond costs were annoying to me. The random droprate idea was kinda funny so I figured we could give it a shot.

## Proof of Testing

<img width="453" height="211" alt="image" src="https://github.com/user-attachments/assets/65412005-124a-4176-ba88-6b71585b7342" />

## Changelog

:cl:
balance: Trophies can drop from regular Lavaland fauna again. Watcher wings now cost less diamonds to make. Crusher trophies no longer require a crusher to craft.
/:cl: