### PR TITLE
Undo undocumented nova deletion causing blood to accumulate as a reagent in the bloodstream

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -519,6 +519,7 @@
 
 	var/blood_transfusion_cap = (MONKEY_ORIGINS in chem.data) && chem.data[MONKEY_ORIGINS] ? BLOOD_VOLUME_NORMAL : BLOOD_VOLUME_MAXIMUM // NOVA EDIT ADDITION - Clamp the value so that being injected with monkey blood when you're past 560u doesn't do anything
 	var/blood_added = adjust_blood_volume(round(reac_volume, CHEMICAL_VOLUME_ROUNDING), maximum = blood_transfusion_cap) // NOVA EDIT CHANGE - ORIGINAL: var/blood_added = adjust_blood_volume(round(reac_volume, CHEMICAL_VOLUME_ROUNDING))
+	reagents.remove_reagent(chem.type, blood_added)
 
 	if(chem.data?[BLOOD_DATA_SYNTH_CONTENT] && !IS_BLOOD_ALWAYS_SYNTHETIC(src))
 		var/added_synth_volume = blood_added * chem.data[BLOOD_DATA_SYNTH_CONTENT]

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -1,13 +1,12 @@
 /mob/living/carbon/Life(seconds_per_tick = SSMOBS_DT)
 	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
-
-	//NOVA EDIT ADDITION
+	//NOVA EDIT ADDITION START
 	if(isopenturf(loc))
 		var/turf/open/my_our_turf = loc
 		if(my_our_turf.pollution)
 			my_our_turf.pollution.touch_act(src)
-	//NOVA EDIT END
+	//NOVA EDIT ADDITION END
 
 	if(damageoverlaytemp)
 		damageoverlaytemp = 0


### PR DESCRIPTION

## About The Pull Request
Undoes the undocumented removal of `reagents.remove_reagent(chem.type, blood_added)` in `code\modules\mob\living\carbon\life.dm`. This fixes blood accumulating as a reagent in the bloodstream, as it shouldn't be doing so, and was causing issues such as pushing other reagents like formaldehyde out when attempting to resanguinate bodies. 
## How This Contributes To The Nova Sector Roleplay Experience
Fixes a bug, better code.
## Proof of Testing
Tested putting blood in a dead body, they didn't accumulate blood as a reagent.
<details>
<summary>Screenshots/Videos</summary>
<img width="641" height="369" alt="image" src="https://github.com/user-attachments/assets/d636b6b3-dacb-4153-983f-db246bd4b947" />
</details>

## Changelog
:cl:
fix: Fixed blood accumulating as a reagent in the bloodstream.
code: Undid the undocumented removal of the code that removes blood as a reagent from the bloodstream.
/:cl:
