### PR TITLE
Ports Monkestation's revenant naming PR

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
@@ -114,7 +114,6 @@
 		SIGNAL_REMOVETRAIT(TRAIT_NO_TRANSFORM),
 	), PROC_REF(update_revenant_appearance))
 	name = generate_random_mob_name()
-	real_name = name // NOVA EDIT ADDITION
 
 	GLOB.revenant_relay_mobs |= src
 

--- a/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
@@ -114,6 +114,7 @@
 		SIGNAL_REMOVETRAIT(TRAIT_NO_TRANSFORM),
 	), PROC_REF(update_revenant_appearance))
 	name = generate_random_mob_name()
+	real_name = name // NOVA EDIT ADDITION
 
 	GLOB.revenant_relay_mobs |= src
 

--- a/modular_nova/modules/revenant_buffs/revenant_antag.dm
+++ b/modular_nova/modules/revenant_buffs/revenant_antag.dm
@@ -1,0 +1,27 @@
+// revenant antag datum is given on login, so this should be fine
+/datum/antagonist/revenant/on_gain()
+	. = ..()
+	INVOKE_ASYNC(src, PROC_REF(pick_name), owner.current)
+
+/datum/antagonist/revenant/proc/pick_name(mob/living/basic/revenant/revenant)
+	if(!istype(revenant))
+		CRASH("Somehow a non-revenant got a revenant antag datum?")
+	while(revenant?.client)
+		var/new_name = reject_bad_text(tgui_input_text(revenant, "Would you like to change your ghostly name to something else?", "Spooky Identity", revenant.name, MAX_NAME_LEN, encode = FALSE))
+		if(!new_name || new_name == revenant.name)
+			if(tgui_alert(revenant, "Are you sure you would like to keep your default name of \"[revenant.name]\"?", "Spooky Identity", list("Yes", "No")) == "Yes")
+				return
+			else
+				continue
+		new_name = sanitize_name(new_name, allow_numbers = TRUE)
+		if(!new_name)
+			if(tgui_alert(revenant, "Invalid name, please pick another!", "Spooky Identity", list("Try Again", "Keep Default Name")) == "Try Again")
+				continue
+			else
+				return
+
+		revenant.log_message("set their revenant name to [new_name]", LOG_OWNERSHIP)
+		message_admins("[ADMIN_LOOKUPFLW(revenant)] has changed their revenant name to \"[span_name(new_name)]\"")
+		revenant.fully_replace_character_name(null, new_name)
+		to_chat(revenant, span_revennotice("Your name is now \"[span_name(new_name)]\"."), type = MESSAGE_TYPE_INFO)
+		return

--- a/modular_nova/modules/revenant_buffs/revenant_antag.dm
+++ b/modular_nova/modules/revenant_buffs/revenant_antag.dm
@@ -11,12 +11,11 @@
 		if(tgui_alert(revenant, "Are you sure you would like to keep your default name of \"[revenant.name]\"?", "Spooky Identity", list("Yes", "No")) == "Yes")
 			return
 
-	new_name = sanitize_name(reject_bad_text(tgui_input_text "What would you like your ghostly name to be?", "Spooky Identity", revenant.name, MAX_NAME_LEN, encode = FALSE)), allow_numbers = TRUE)
+	new_name = sanitize_name(reject_bad_text(tgui_input_text(revenant, "What would you like your ghostly name to be?", "Spooky Identity", revenant.name, MAX_NAME_LEN, encode = FALSE)), allow_numbers = TRUE)
 	if(!new_name)
 		return
 
-		revenant.log_message("set their revenant name to [new_name]", LOG_OWNERSHIP)
-		message_admins("[ADMIN_LOOKUPFLW(revenant)] has changed their revenant name to \"[span_name(new_name)]\"")
-		revenant.fully_replace_character_name(null, new_name)
-		to_chat(revenant, span_revennotice("Your name is now \"[span_name(new_name)]\"."), type = MESSAGE_TYPE_INFO)
-		return
+	revenant.log_message("set their revenant name to [new_name]", LOG_OWNERSHIP)
+	revenant.fully_replace_character_name(null, new_name)
+	to_chat(revenant, span_revennotice("Your name is now \"[span_name(new_name)]\"."), type = MESSAGE_TYPE_INFO)
+	return

--- a/modular_nova/modules/revenant_buffs/revenant_antag.dm
+++ b/modular_nova/modules/revenant_buffs/revenant_antag.dm
@@ -6,19 +6,14 @@
 /datum/antagonist/revenant/proc/pick_name(mob/living/basic/revenant/revenant)
 	if(!istype(revenant))
 		CRASH("Somehow a non-revenant got a revenant antag datum?")
-	while(revenant?.client)
-		var/new_name = reject_bad_text(tgui_input_text(revenant, "Would you like to change your ghostly name to something else?", "Spooky Identity", revenant.name, MAX_NAME_LEN, encode = FALSE))
-		if(!new_name || new_name == revenant.name)
-			if(tgui_alert(revenant, "Are you sure you would like to keep your default name of \"[revenant.name]\"?", "Spooky Identity", list("Yes", "No")) == "Yes")
-				return
-			else
-				continue
-		new_name = sanitize_name(new_name, allow_numbers = TRUE)
-		if(!new_name)
-			if(tgui_alert(revenant, "Invalid name, please pick another!", "Spooky Identity", list("Try Again", "Keep Default Name")) == "Try Again")
-				continue
-			else
-				return
+	var/new_name = sanitize_name(reject_bad_text(tgui_input_text(revenant, "Would you like to change your ghostly name to something else?", "Spooky Identity", revenant.name, MAX_NAME_LEN, encode = FALSE)), allow_numbers = TRUE)
+	if(!new_name || new_name == revenant.name)
+		if(tgui_alert(revenant, "Are you sure you would like to keep your default name of \"[revenant.name]\"?", "Spooky Identity", list("Yes", "No")) == "Yes")
+			return
+
+	new_name = sanitize_name(reject_bad_text(tgui_input_text "What would you like your ghostly name to be?", "Spooky Identity", revenant.name, MAX_NAME_LEN, encode = FALSE)), allow_numbers = TRUE)
+	if(!new_name)
+		return
 
 		revenant.log_message("set their revenant name to [new_name]", LOG_OWNERSHIP)
 		message_admins("[ADMIN_LOOKUPFLW(revenant)] has changed their revenant name to \"[span_name(new_name)]\"")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9534,6 +9534,7 @@
 #include "modular_nova\modules\research\techweb\nodes\disabled-experiments.dm"
 #include "modular_nova\modules\resleeving\code\rsd_interface.dm"
 #include "modular_nova\modules\resleeving\code\research\resleeving_research.dm"
+#include "modular_nova\modules\revenant_buffs\revenant_antag.dm"
 #include "modular_nova\modules\robot_limb_detach\code\robot_limb_detach_quirk.dm"
 #include "modular_nova\modules\rod-stopper\code\immovable_nova.dm"
 #include "modular_nova\modules\rod-stopper\code\rodstopper.dm"


### PR DESCRIPTION

## About The Pull Request
Ports [this](https://github.com/Monkestation/OculisStation/pull/129) PR.
Revenants now can name themselves as they please.
<img width="790" height="524" alt="изображение" src="https://github.com/user-attachments/assets/0cbee7d5-5f0e-4bce-8bde-00a06074afed" />
<img width="491" height="58" alt="изображение" src="https://github.com/user-attachments/assets/9a179b82-47ef-4942-90c8-29ac2c214b67" />
<img width="191" height="133" alt="изображение" src="https://github.com/user-attachments/assets/59b3011c-11d3-4a3d-841c-d4eff362efc0" />
## How This Contributes To The Nova Sector Roleplay Experience
Reciting the original PR's point, the naming schemes are quite goofy; and it should allow people to pull off any of the ideas they could have envisioned more easily.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
Screenshots above.  
</details>

## Changelog
:cl: Stalkeros, Absolucy for original PR
add: Revenants can now pick their own name!
/:cl:
