### PR TITLE
Bitrunning objectives can't be thrown (by explosions)

### DIFF
--- a/modular_nova/modules/bitrunning/code/bitrunning_objective.dm
+++ b/modular_nova/modules/bitrunning/code/bitrunning_objective.dm
@@ -1,5 +1,5 @@
-/// Prevents an atom from being interacted with by bitrunning threats.
-/// Cannot pull it, cannot push it, cannot interact with it (unarmed or with an item).
+/// Prevents an atom from being directly interacted with by bitrunning threats,
+/// and tries to prevent methods of indirectly moving it (such as throwing)
 /datum/element/bitrunning_objective
 	var/static/list/restricted_from = list(/datum/antagonist/domain_ghost_actor, /datum/antagonist/bitrunning_glitch)
 
@@ -14,6 +14,7 @@
 	RegisterSignals(objective, list(COMSIG_ATOM_ATTACK_HAND, COMSIG_ATOM_ATTACK_HAND_SECONDARY), PROC_REF(on_attack_hand))
 	RegisterSignal(objective, COMSIG_TRY_USE_MACHINE, PROC_REF(on_try_use_machine))
 	RegisterSignals(objective, list(COMSIG_ATOM_ITEM_INTERACTION, COMSIG_ATOM_ITEM_INTERACTION_SECONDARY), PROC_REF(on_item_interaction))
+	RegisterSignal(objective, COMSIG_MOVABLE_PRE_THROW, PROC_REF(on_pre_throw))
 
 /datum/element/bitrunning_objective/Detach(atom/movable/objective, ...)
 	. = ..()
@@ -25,6 +26,7 @@
 		COMSIG_TRY_USE_MACHINE,
 		COMSIG_ATOM_ITEM_INTERACTION,
 		COMSIG_ATOM_ITEM_INTERACTION_SECONDARY,
+		COMSIG_MOVABLE_PRE_THROW,
 	))
 
 /// When you try to pull it
@@ -51,6 +53,17 @@
 /datum/element/bitrunning_objective/proc/on_item_interaction(atom/movable/source, mob/living/user, obj/item/tool, list/modifiers)
 	SIGNAL_HANDLER
 	return should_interaction_fail(source, user) ? ITEM_INTERACT_BLOCKING : NONE
+
+/// When something tries to throw it
+/datum/element/bitrunning_objective/proc/on_pre_throw(atom/movable/source, list/throw_args)
+	SIGNAL_HANDLER
+	var/mob/living/thrower = throw_args[4]
+	if(istype(thrower))
+		// If they somehow have a datum. I won't judge
+		return should_interaction_fail(source, thrower) ? COMPONENT_CANCEL_THROW : NONE
+	// If the thrower isn't a mob, just block it here. It's probably an explosion
+	source.visible_message(span_warning("\The [source] resists being thrown!"))
+	return COMPONENT_CANCEL_THROW
 
 /// Returns FALSE if we don't have a bitrunning threat antag datum, TRUE + balloon alert otherwise
 /datum/element/bitrunning_objective/proc/should_interaction_fail(atom/movable/objective, mob/user)

--- a/modular_nova/modules/bitrunning/code/bitrunning_objective.dm
+++ b/modular_nova/modules/bitrunning/code/bitrunning_objective.dm
@@ -61,7 +61,7 @@
 	if(istype(thrower))
 		// If they somehow have a datum. I won't judge
 		return should_interaction_fail(source, thrower) ? COMPONENT_CANCEL_THROW : NONE
-	// If the thrower isn't a mob, just block it here. It's probably an explosion
+	// If the thrower isn't a mob, just block it. It could be anything, but it's probably an explosion
 	source.visible_message(span_warning("\The [source] resists being thrown!"))
 	return COMPONENT_CANCEL_THROW
 


### PR DESCRIPTION

## About The Pull Request
The bitrunning objective element now intercepts throwing attempts. This prevents explosions and other non-mob sources from throwing objectives, and if someone with a restricted datum is somehow trying to throw an item (like a cache), it blocks that too.
## How This Contributes To The Nova Sector Roleplay Experience
It's not super ideal to have explosions (or whatever else that isn't a bitrunner) moving these protected objects around.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/384650cf-fcc0-41c6-a4a8-2c38d8ee7e99

</details>

## Changelog
:cl:
fix: [NOVA] Bitrunning objectives can't be thrown by explosions.
/:cl:
