### PR TITLE
ghost cafe qol: more parts! comically large beakers! a random bugfix!

### DIFF
--- a/_maps/map_files/generic/CentCom_nova_z2.dmm
+++ b/_maps/map_files/generic/CentCom_nova_z2.dmm
@@ -764,8 +764,12 @@
 /obj/item/choice_beacon/ingredient,
 /obj/item/reagent_containers/condiment/red_bay,
 /obj/item/reagent_containers/condiment/curry_powder,
-/obj/item/storage/box/stockparts/deluxe,
-/obj/item/storage/part_replacer/bluespace/tier4,
+/obj/item/storage/part_replacer/bluespace/tier4/cafe,
+/obj/item/storage/portable_chem_mixer,
+/obj/item/storage/box/beakers/cafe,
+/obj/item/storage/box/beakers/cafe,
+/obj/item/storage/box/beakers/cafe,
+/obj/item/storage/box/beakers/cafe,
 /turf/open/indestructible/kitchen,
 /area/centcom/holding/cafe)
 "amT" = (
@@ -1177,7 +1181,7 @@
 /obj/machinery/reagentgrinder{
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/storage/box/beakers/cafe,
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
@@ -2644,6 +2648,8 @@
 /obj/item/seeds/starfruit,
 /obj/item/seeds/starfruit,
 /obj/item/seeds/starfruit,
+/obj/item/seeds/honeysuckle,
+/obj/item/seeds/gelthi,
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
@@ -3232,6 +3238,7 @@
 	},
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
+/obj/item/airlock_painter/decal,
 /turf/open/floor/plating/vox,
 /area/centcom/holding/cafevox)
 "aOI" = (
@@ -3437,6 +3444,7 @@
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 3
 	},
+/obj/item/airlock_painter/decal,
 /turf/open/floor/wood/wood_7,
 /area/centcom/holding/cafe)
 "aQM" = (
@@ -9978,10 +9986,6 @@
 /area/centcom/holding/cafe)
 "iZr" = (
 /obj/structure/table/wood,
-/obj/machinery/reagentgrinder{
-	pixel_x = -2;
-	pixel_y = 8
-	},
 /obj/item/reagent_containers/cup/soda_cans/nova/welding_fizz{
 	pixel_x = 14;
 	pixel_y = 12
@@ -9993,6 +9997,7 @@
 /obj/item/reagent_containers/cup/soda_cans/nova/welding_fizz{
 	pixel_x = 14
 	},
+/obj/machinery/reagentgrinder,
 /turf/open/floor/wood/wood_1,
 /area/centcom/holding/cafe)
 "iZu" = (
@@ -15896,6 +15901,7 @@
 /area/centcom/holding/cafepark)
 "qNc" = (
 /obj/structure/table/wood,
+/obj/item/storage/portable_chem_mixer,
 /turf/open/floor/iron/checker,
 /area/centcom/holding/cafe)
 "qNu" = (
@@ -15982,9 +15988,7 @@
 /area/centcom/interlink)
 "qTu" = (
 /obj/structure/table/wood,
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
-	},
+/obj/machinery/reagentgrinder,
 /turf/open/floor/wood/wood_3,
 /area/centcom/holding/cafe)
 "qUb" = (
@@ -16042,6 +16046,9 @@
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder{
 	pixel_x = 6
+	},
+/obj/item/storage/box/beakers/cafe{
+	pixel_x = -14
 	},
 /turf/open/floor/wood/large,
 /area/centcom/holding/cafe)
@@ -17109,33 +17116,10 @@
 	pixel_x = 7;
 	pixel_y = 12
 	},
-/obj/item/reagent_containers/cup/beaker/bluespace{
-	luminosity = 3;
-	name = "floofmagic beaker";
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,150,200,250,500);
-	volume = 500
-	},
-/obj/item/reagent_containers/cup/beaker/bluespace{
-	luminosity = 3;
-	name = "floofmagic beaker";
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,150,200,250,500);
-	volume = 500
-	},
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
-/obj/item/reagent_containers/cup/beaker/bluespace{
-	luminosity = 3;
-	name = "floofmagic beaker";
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,150,200,250,500);
-	volume = 500
-	},
-/obj/item/reagent_containers/cup/beaker/bluespace{
-	luminosity = 3;
-	name = "floofmagic beaker";
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,150,200,250,500);
-	volume = 500
-	},
+/obj/item/storage/portable_chem_mixer,
 /turf/open/floor/iron/white,
 /area/centcom/holding/cafe)
 "skr" = (
@@ -17720,6 +17704,14 @@
 /obj/machinery/reagentgrinder,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 1
+	},
+/obj/item/storage/box/beakers/cafe{
+	pixel_x = -13;
+	pixel_y = 9
+	},
+/obj/item/storage/box/beakers/cafe{
+	pixel_x = -13;
+	pixel_y = 1
 	},
 /turf/open/floor/iron/white,
 /area/centcom/holding/cafe)
@@ -18592,6 +18584,7 @@
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 1
 	},
+/obj/item/airlock_painter/decal,
 /turf/open/floor/wood/wood_7,
 /area/centcom/holding/cafe)
 "ubQ" = (
@@ -18689,18 +18682,6 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/condiment/enzyme,
 /obj/machinery/light/directional/south,
-/obj/item/reagent_containers/cup/beaker/bluespace{
-	luminosity = 3;
-	name = "floofmagic beaker";
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,150,200,250,500);
-	volume = 500
-	},
-/obj/item/reagent_containers/cup/beaker/bluespace{
-	luminosity = 3;
-	name = "floofmagic beaker";
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,150,200,250,500);
-	volume = 500
-	},
 /turf/open/floor/wood/large,
 /area/centcom/holding/cafe)
 "ueR" = (
@@ -18717,40 +18698,11 @@
 	pixel_x = -1;
 	pixel_y = 16
 	},
-/obj/item/reagent_containers/cup/beaker/bluespace{
-	luminosity = 3;
-	name = "floofmagic beaker";
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,150,200,250,500);
-	volume = 500
-	},
-/obj/item/reagent_containers/cup/beaker/bluespace{
-	luminosity = 3;
-	name = "floofmagic beaker";
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,150,200,250,500);
-	volume = 500;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/cup/beaker/bluespace{
-	luminosity = 3;
-	name = "floofmagic beaker";
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,150,200,250,500);
-	volume = 500;
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/cup/beaker/bluespace{
-	luminosity = 3;
-	name = "floofmagic beaker";
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,150,200,250,500);
-	volume = 500;
-	pixel_x = 7;
-	pixel_y = 1
-	},
 /obj/item/reagent_containers/dropper{
 	pixel_x = 0;
 	pixel_y = -9
 	},
+/obj/item/storage/box/beakers/cafe,
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 8
 	},
@@ -21455,24 +21407,6 @@
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "xYA" = (
-/obj/item/reagent_containers/cup/beaker/bluespace{
-	luminosity = 3;
-	name = "floofmagic beaker";
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,150,200,250,500);
-	volume = 500
-	},
-/obj/item/reagent_containers/cup/beaker/bluespace{
-	luminosity = 3;
-	name = "floofmagic beaker";
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,150,200,250,500);
-	volume = 500
-	},
-/obj/item/reagent_containers/cup/beaker/bluespace{
-	luminosity = 3;
-	name = "floofmagic beaker";
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,150,200,250,500);
-	volume = 500
-	},
 /obj/structure/table/wood,
 /obj/item/reagent_containers/condiment/saltshaker{
 	pixel_x = 11;
@@ -21485,6 +21419,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
+/obj/item/storage/box/beakers/cafe,
 /turf/open/floor/iron/dark/brick,
 /area/centcom/holding/cafe)
 "xZe" = (

--- a/modular_nova/modules/ghostcafe/code/ghost_cafe_items.dm
+++ b/modular_nova/modules/ghostcafe/code/ghost_cafe_items.dm
@@ -13,3 +13,29 @@
 	add_overlay("rdcomp")
 	add_overlay("rd_key")
 
+// more parts. no megacells. moderate amount of cables
+/obj/item/storage/part_replacer/bluespace/tier4/cafe/PopulateContents()
+	for(var/i in 1 to 30)
+		new /obj/item/stock_parts/servo/femto(src)
+		new /obj/item/stock_parts/micro_laser/quadultra(src)
+		new /obj/item/stock_parts/matter_bin/bluespace(src)
+		new /obj/item/stock_parts/capacitor/quadratic(src)
+		new /obj/item/stock_parts/scanning_module/triphasic(src)
+		new /obj/item/stock_parts/power_store/cell/bluespace(src)
+	new /obj/item/stack/cable_coil/thirty(src)
+
+// concerningly high capacity. listen there were varedited 500u beakers but they were hard to read because they were bluespace beakers
+// this is like. logical conclusion
+/obj/item/reagent_containers/cup/beaker/large/cafe
+	name = "quantum beaker"
+	desc = "A beaker that's, inexplicably, much bigger on the inside. Can hold up to 600 units."
+	possible_transfer_amounts = list(5,10,20,30,50,100,300,600)
+	volume = 600
+
+/obj/item/storage/box/beakers/cafe
+	name = "box of quantum beakers"
+	desc = "Don't worry, we're not sure how they hold that much either."
+
+/obj/item/storage/box/beakers/cafe/PopulateContents()
+	for(var/i in 1 to 7)
+		new /obj/item/reagent_containers/cup/beaker/large/cafe(src)

--- a/modular_nova/modules/xenoarch/code/modules/hydroponics/telriis.dm
+++ b/modular_nova/modules/xenoarch/code/modules/hydroponics/telriis.dm
@@ -14,7 +14,7 @@
 	growthstages = 4
 	plant_icon_offset = 7
 	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/invasive)
-	reagents_add = list(/datum/reagent/consumable/milk = 0.1, /datum/reagent/consumable/soymilk = 0.1, /datum/reagent/consumable/korta_milk)
+	reagents_add = list(/datum/reagent/consumable/milk = 0.1, /datum/reagent/consumable/soymilk = 0.1, /datum/reagent/consumable/korta_milk = 0.1)
 
 /obj/item/food/grown/telriis
 	seed = /obj/item/seeds/telriis


### PR DESCRIPTION
## About The Pull Request
Parts:
The ghost cafe's parts exchangers now have three times the stock parts (from 10 to 30) and no longer have megacells, as they were unneeded.

Beakers:
Every varedited "floofmagic" bluespace beaker is now a "quantum beaker" with 600u capacity (up from 500u) and uses large beaker sprites for slightly improved visibility at a glance.

Plants:
Added honeysuckle and gelthi to the botany section for a source of honey in recipes.
Properly sets the korta milk gene in telriis to match the other milk genes in it.

## How This Contributes To The Nova Sector Roleplay Experience

Upgrading the ghost cafe kitchen is pretty nice. Being able to glance at beakers is also pretty nice.

## Proof of Testing

give me a second

## Changelog

:cl:
qol: The ghost cafe now has honeysuckle and gelthi seeds lying around, along with comically large quantum beakers and a slightly more full BRPED for all your machinery-upgrading needs.
/:cl: