### PR TITLE
[FIX] magazines picking up ammunition again and bullet stacks

### DIFF
--- a/modular_nova/modules/ammo_stacks/code/ammo_stack_base.dm
+++ b/modular_nova/modules/ammo_stacks/code/ammo_stack_base.dm
@@ -24,6 +24,11 @@
 	. = ..()
 	check_empty()
 
+/obj/item/ammo_box/magazine/ammo_stack/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	if(!isammocasing(interacting_with))
+		return NONE
+	return item_interaction(user, interacting_with, modifiers)
+
 /obj/item/ammo_box/magazine/ammo_stack/empty_magazine()
 	. = ..()
 	check_empty()
@@ -127,7 +132,9 @@
 
 /obj/item/ammo_casing/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	if(!istype(tool, /obj/item/ammo_casing))
-		return NONE
+		if(istype(tool, /obj/item/ammo_box/magazine/ammo_stack))
+			return NONE
+		return ..()
 
 	var/obj/item/ammo_casing/used_casing = tool
 	if(!used_casing.ammo_stack_type)


### PR DESCRIPTION

## About The Pull Request

After the recent refactor moving interactions from attackby to item_interaction in tg, this code specific to nova stopped working properly. This fixes that
## How This Contributes To The Nova Sector Roleplay Experience

Fix
## Proof of Testing

Tested locally, I can stack shotgun shells/casings again and pull all ammunition on a tile inside a magazine with one click
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: ammunition should be easily stackable again.
/:cl:
