### PR TITLE
Blacklists non oxygen species from lung augments

### DIFF
--- a/modular_nova/modules/customization/modules/client/augment/organs.dm
+++ b/modular_nova/modules/customization/modules/client/augment/organs.dm
@@ -89,6 +89,11 @@
 	abstract_type = /datum/augment_item/organ/lungs
 	slot = AUGMENT_SLOT_LUNGS
 	icon = FA_ICON_LUNGS
+	species_blacklist = list(
+		SPECIES_VOX = 1,
+		SPECIES_VOX_PRIMALIS = 1,
+		SPECIES_PLASMA = 1,
+	)
 
 /datum/augment_item/organ/lungs/normal
 	name = "Organic lungs"


### PR DESCRIPTION
## About The Pull Request

Tin.

Closes https://github.com/NovaSector/NovaSector/issues/7642

## How This Contributes To The Nova Sector Roleplay Experience

Vox and plasmamen being able to get around breathing limitations via augments was not intended.

## Changelog

:cl:
fix: Vox and plasmamen can no longer use lung augments to bypass species breathing restrictions
/:cl:
