### PR TITLE
[FIX] opium and heroin should metabolize now

### DIFF
--- a/modular_nova/modules/morenarcotics/code/opium.dm
+++ b/modular_nova/modules/morenarcotics/code/opium.dm
@@ -107,7 +107,6 @@
 	ph = 8
 	taste_description = "flowers"
 	addiction_types = list(/datum/addiction/opioids = 30)
-	metabolization_rate = 0
 
 /datum/reagent/drug/opium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	var/high_message = pick("You feel euphoric.", "You feel on top of the world.")


### PR DESCRIPTION

## About The Pull Request

The recent addiction refactor from tg somehow set metabolization rate for opium to 0, causing it to permanently remain in the stomach/bloodstream without ever processing
## How This Contributes To The Nova Sector Roleplay Experience

Bugfix
## Proof of Testing

Tested locally, reagents get processed now
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: opium and heroin should metabolize now
/:cl:
