### PR TITLE
Fixes N2O alert typo with nitrogen breather quirk

### DIFF
--- a/modular_nova/master_files/code/datums/quirks/neutral_quirks/breather/nitrogen_breather.dm
+++ b/modular_nova/master_files/code/datums/quirks/neutral_quirks/breather/nitrogen_breather.dm
@@ -35,5 +35,5 @@
 
 /datum/quirk/item_quirk/breather/nitrogen_breather/remove()
 	. = ..()
-	quirk_holder.clear_alert(ALERT_NOT_ENOUGH_N2)
+	quirk_holder.clear_alert(ALERT_NOT_ENOUGH_NITRO)
 	quirk_holder.clear_alert(ALERT_TOO_MUCH_OXYGEN)

--- a/modular_nova/master_files/code/datums/quirks/neutral_quirks/breather/nitrogen_breather.dm
+++ b/modular_nova/master_files/code/datums/quirks/neutral_quirks/breather/nitrogen_breather.dm
@@ -35,5 +35,5 @@
 
 /datum/quirk/item_quirk/breather/nitrogen_breather/remove()
 	. = ..()
-	quirk_holder.clear_alert(ALERT_NOT_ENOUGH_N2O)
+	quirk_holder.clear_alert(ALERT_NOT_ENOUGH_N2)
 	quirk_holder.clear_alert(ALERT_TOO_MUCH_OXYGEN)


### PR DESCRIPTION
issue fix
## About The Pull Request

fixes https://github.com/NovaSector/NovaSector/issues/7651

## How This Contributes To The Nova Sector Roleplay Experience

bug fix

## Proof of Testing
<details>
Just a bug fix.
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: removing nitrogen breather quirk now clears the right alerts
/:cl:
