### PR TITLE
Removes CSL language number requirements

### DIFF
--- a/code/datums/quirks/negative_quirks/csl.dm
+++ b/code/datums/quirks/negative_quirks/csl.dm
@@ -43,11 +43,13 @@
 		quirk_holder.grant_language(/datum/language/common, UNDERSTOOD_LANGUAGE, LANGUAGE_ATOM)
 
 /datum/quirk/csl/is_species_appropriate(datum/species/mob_species)
+	/* // NOVA EDIT REMOVAL START - We only care about the languages menu - but we can't check from in here because there's no access to preferences.
 	var/datum/language_holder/species_holder = GLOB.prototype_language_holders[mob_species.species_language_holder]
 	if(isnull(species_holder))
 		return FALSE
 	if(length(species_holder.spoken_languages) < 2)
 		return FALSE
+	*/ // NOVA EDIT REMOVAL END - Not the end of the world honestly if they don't actually know a second language.
 	return ..()
 
 /// Gets our native language from our list of spoken languages


### PR DESCRIPTION
## About The Pull Request

On TG they base whether or not you can speak 2 languages on your species' languages, but here we have the languages menu.

Since you can change those out and customize those restrictions should be ignored.

## How This Contributes To The Nova Sector Roleplay Experience

CSL quirk can be selected by people who should be able to select it, and regardless of how many languages they know.

## Changelog

:cl:
del: CSL quirk species restrictions are lifted
/:cl:
