### PR TITLE
[FIX] .38 Mags reload .38 revolvers with a delay

### DIFF
--- a/modular_nova/modules/modular_weapons/code/overrides/ballistic_master.dm
+++ b/modular_nova/modules/modular_weapons/code/overrides/ballistic_master.dm
@@ -20,6 +20,9 @@
 /obj/item/ammo_box/magazine/shitzu
 	reload_delay = CLICK_CD_MELEE
 
+/obj/item/ammo_box/magazine/m38
+	reload_delay = CLICK_CD_SLOW // battle rifle mags shouldn't outclass actual .38 speedloaders at reloading revolvers
+
 /// Reloading with ammo box can incur penalty with some guns
 /obj/item/gun/ballistic/proc/handle_box_reload(mob/user, obj/item/ammo, num_loaded)
 	SEND_SIGNAL(src, COMSIG_UPDATE_AMMO_HUD)


### PR DESCRIPTION

## About The Pull Request

Right now you could reload .38 revolvers with a .38 mag. Since reloading from boxes in other guns was slower already, I consider this an oversight rather than an actual balance since it should've never been instant in the first place as with the other ammunition boxes.
## How This Contributes To The Nova Sector Roleplay Experience

Make speedloaders for .38 relevant.
## Proof of Testing

Works locally, takes 1s to push ammo into the revolver from the .38 mag. Speedloader is instant as usual
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: Loading .38 revolver with .38 BR mag has a cooldown now.
/:cl:
