### PR TITLE
Nova Star restrictions defaults to false

### DIFF
--- a/modular_nova/master_files/code/controllers/configuration/entries/config_entries.dm
+++ b/modular_nova/master_files/code/controllers/configuration/entries/config_entries.dm
@@ -149,7 +149,7 @@
 	default = 2000
 
 /datum/config_entry/flag/enable_nova_star_restrictions
-	default = TRUE
+	default = FALSE
 
 /// Whether the supermatter dusts consumed mobs outright (FALSE) or superheats and blasts them away instead (TRUE).
 /datum/config_entry/flag/disable_sm_dusting


### PR DESCRIPTION

## About The Pull Request

Quick config flip to make the entry in nova_config.txt make sense, so that uncommenting it actually enables the restriction.
