### PR TITLE
Removes the Jitter Effect on Athletics Examines

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -3108,7 +3108,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	var/comparative_fitness = their_fitness_level ? our_fitness_level / their_fitness_level : 1
 
 	if (comparative_fitness > 2)
-		scouter.set_jitter_if_lower(comparative_fitness SECONDS)
+		//scouter.set_jitter_if_lower(comparative_fitness SECONDS) // NOVA EDIT REMOVAL
 		return "[span_notice("You'd estimate [p_their()] fitness level at about...")] [span_boldwarning("What?!? [our_fitness_level]???")]"
 
 	return span_notice("You'd estimate [p_their()] fitness level at about [our_fitness_level]. [comparative_fitness <= 0.33 ? "Pathetic." : ""]")


### PR DESCRIPTION

## About The Pull Request

Salt PR time?

I really, really hate the fact that going up and down ladders raises your athletics level, which in turn lets you see people's fitness levels, which... in turn makes everyone SO STRONK in comparison?! Time to jitter every time I examine someone!

It stems from the fact that a baseline human has 1249 fitness just by existing, and paraplegics start out at ~507 which means that everyone who's able bodied triggers the jitter from having >2x more fitness rating.

Bleh. Paraplegic problems. Just removing the jitter, nothing more.

:cl:
del: removed the jitter when you examine someone who has a much higher athletics skill than you.
/:cl:

