### PR TITLE
Fixes taur blood overlays

### DIFF
--- a/code/datums/components/bloodysoles.dm
+++ b/code/datums/components/bloodysoles.dm
@@ -312,7 +312,12 @@
 		return
 
 	wielder.remove_overlay(SHOES_LAYER)
-	if(!total_bloodiness || is_obscured())
+	//if(!total_bloodiness || is_obscured()) // NOVA EDIT REMOVAL - See below
+	// NOVA EDIT ADDITION START
+	var/mob/living/carbon/human/human_wielder = wielder
+	// Taurs (and anything else that hides its shoes) have nothing to smear shoeblood onto
+	if(!total_bloodiness || is_obscured() || (human_wielder.bodyshape & BODYSHAPE_HIDE_SHOES))
+	// NOVA EDIT ADDITION END
 		wielder.update_worn_shoes()
 		return
 

--- a/modular_nova/master_files/code/modules/clothing/suits/_suits.dm
+++ b/modular_nova/master_files/code/modules/clothing/suits/_suits.dm
@@ -1,6 +1,9 @@
 // taur suit blood overlays
 /obj/item/clothing/suit/get_blood_overlay(blood_state, bodyshape)
-	if(!(bodyshape & BODYSHAPE_TAUR))
+	// worn_x_offset is only set to -16 when we're actually drawing a taur-fitted (64x32) worn icon.
+	// Suits without a taur-specific sprite fall back to the cropped generic icon and stay at offset 0,
+	// so using the wide blood overlay for them makes the blood render shifted off to the side.
+	if(!(bodyshape & BODYSHAPE_TAUR) || !worn_x_offset)
 		return ..()
 	if(!GET_ATOM_BLOOD_DNA_LENGTH(src))
 		return


### PR DESCRIPTION
## About The Pull Request

These were being offset to the right, and also shoe blood overlays shouldn't be a thing for taurs

## Changelog


:cl:
fix: fixes taur blood overlays being offset incorrectly
fix: fixes taur getting blood shoe overlays
/:cl:
