### PR TITLE
Adds katana sheath to curator bundle

### DIFF
--- a/modular_nova/modules/curatorbundle/ronin.dm
+++ b/modular_nova/modules/curatorbundle/ronin.dm
@@ -7,3 +7,4 @@
 	new /obj/item/clothing/head/costume/rice_hat(src)
 	new /obj/item/katana/weak/curator(src)
 	new /obj/item/clothing/shoes/sandal(src)
+	new /obj/item/storage/belt/sheath/katana/empty(src)


### PR DESCRIPTION

## About The Pull Request

Adds the katana sheath to the curator bundle with the katana, allowing the curator to actually store it on their person (belt or back). 

## How This Contributes To The Nova Sector Roleplay Experience

There is a MINOR balance effect, since the scabbard allows the use of the parry ability, but this is Nova and everyone has a gun.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
<img width="576" height="353" alt="Screenshot 2026-07-21 192035" src="https://github.com/user-attachments/assets/8a99dda3-0803-4c4d-b553-bc8c38678245" />
<img width="303" height="195" alt="Screenshot 2026-07-21 192047" src="https://github.com/user-attachments/assets/b448951f-5d39-41f0-9eda-995a90e26929" />

</details>

## Changelog

:cl:
add: katana sheath to "ronin" curator bundle.
/:cl:
