### PR TITLE
Taking the hypospray out of the Heavy-Duty Medical Technician kit

### DIFF
--- a/modular_nova/modules/deforest_medical_items/code/storage_items.dm
+++ b/modular_nova/modules/deforest_medical_items/code/storage_items.dm
@@ -397,7 +397,7 @@
 		/obj/item/bodybag,
 	))
 
-// Midrange bag for paramedics, hypospray and more flexible item wise than surgical, but restricted to small items only
+// Midrange bag for paramedics, more flexible item wise than surgical, but restricted to small items only
 /obj/item/storage/backpack/duffelbag/deforest_paramedic
 	name = "medical technician kit"
 	desc = "Compared to its sibling the first responder surgical kit, this variant is equipped with a hypospray hit for roving paramedics. Featuring rapid access pockets that are lightweight, it can however only hold smaller items."
@@ -430,15 +430,12 @@
 		/obj/item/stack/medical/bone_gel = 1,
 		/obj/item/stack/medical/wound_recovery = 1,
 		/obj/item/stack/medical/wound_recovery/rapid_coagulant = 1,
-		/obj/item/stack/medical/mesh/advanced = 2,
-		/obj/item/stack/medical/suture/medicated = 2,
+		/obj/item/stack/medical/mesh/advanced = 3,
+		/obj/item/stack/medical/suture/medicated = 3,
 		/obj/item/stack/medical/wrap/gauze/sterilized = 1,
 		/obj/item/storage/pill_bottle/painkiller = 1,
-		/obj/item/hypospray/mkii/piercing/atropine = 1,
-		/obj/item/reagent_containers/cup/vial/small/libital = 1,
-		/obj/item/reagent_containers/cup/vial/small/lenturi = 1,
-		/obj/item/reagent_containers/cup/vial/small/seiver = 1,
 		/obj/item/healthanalyzer/advanced = 1,
+		/obj/item/holosign_creator/medical/treatment_zone = 1,
 	)
 	generate_items_inside(items_inside,src)
 

--- a/modular_nova/modules/deforest_medical_items/code/storage_items.dm
+++ b/modular_nova/modules/deforest_medical_items/code/storage_items.dm
@@ -400,7 +400,7 @@
 // Midrange bag for paramedics, more flexible item wise than surgical, but restricted to small items only
 /obj/item/storage/backpack/duffelbag/deforest_paramedic
 	name = "medical technician kit"
-	desc = "Compared to its sibling the first responder surgical kit, this variant is equipped with a hypospray hit for roving paramedics. Featuring rapid access pockets that are lightweight, it can however only hold smaller items."
+	desc = "Features rapid access pockets that are lightweight, it can however only hold smaller items."
 	icon = 'modular_nova/modules/deforest_medical_items/icons/storage.dmi'
 	icon_state = "technician"
 	lefthand_file = 'modular_nova/modules/deforest_medical_items/icons/inhands/cases_lefthand.dmi'


### PR DESCRIPTION

## About The Pull Request
As it says on the tin, removes the hypospray from the ever ubiquitous pink kit. I put in another suture, mesh, and a treatment zone projector to sortof fill out the slots that were opened.
## How This Contributes To The Nova Sector Roleplay Experience
I see this thing picked way too much, exclusively for the hypospray. Alot of the times even left on the floor after pilfering just the hypospray it. Removing the hypospray will actually have the orange kit give it some competition, putting all 3 Heavy-Duty kits into the same sort of level without one being objectively better than the rest. And maybe people won't ignore their chemist anymore, god willing.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="744" height="445" alt="image" src="https://github.com/user-attachments/assets/a9b0fc14-4b67-40f0-aa1f-75644e86ad4d" />

</details>

## Changelog
:cl:
Balance: Due to the loss of a DeForest brand chemical production facility in a chain reaction chemical detonation, Heavy-Duty Technician kits are no longer being shipped with included hyposprays.
/:cl:
