### PR TITLE
Headshot preview when you examine a fellow crewman.

### DIFF
--- a/modular_nova/master_files/code/datums/traits/neutral.dm
+++ b/modular_nova/master_files/code/datums/traits/neutral.dm
@@ -64,8 +64,9 @@
 	else
 		set_hud_image_inactive(DNR_HUD)
 
-/mob/living/carbon/human/examine(mob/user)
-	. = ..()
+/// Examine lines warning HUD users that we're not to be revived. Called by /mob/living/carbon/human/examine().
+/mob/living/carbon/human/proc/get_dnr_examine(mob/user)
+	. = list()
 
 	if(stat != DEAD && HAS_TRAIT(src, TRAIT_DNR) && (HAS_TRAIT(user, TRAIT_SECURITY_HUD) || HAS_TRAIT(user, TRAIT_MEDICAL_HUD)))
 		. += "\n[span_boldwarning("This individual is unable to be revived, and may be permanently dead if allowed to die!")]"

--- a/modular_nova/master_files/code/modules/client/preferences/headshot.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/headshot.dm
@@ -63,3 +63,10 @@
 
 /datum/preference/text/headshot/silicon/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	return FALSE
+
+/// Whether we see other people's headshots in the chat when we examine them.
+/datum/preference/toggle/show_headshot_on_examine
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	default_value = TRUE
+	savefile_key = "show_headshot_on_examine"
+	savefile_identifier = PREFERENCE_PLAYER

--- a/modular_nova/master_files/code/modules/mob/living/examine.dm
+++ b/modular_nova/master_files/code/modules/mob/living/examine.dm
@@ -1,6 +1,10 @@
+// The single override of this proc for humans - add new examine lines here rather than overriding it again.
 /mob/living/carbon/human/examine(mob/user)
 	. = ..()
+	. += get_dnr_examine(user)
 	insert_examine_headshot(., user)
+	. += get_empath_examine(user)
+	. += get_arousal_examine(user)
 
 // Hooked per subtype rather than on /mob/living/silicon: AIs and cyborgs append their parent's lines at the
 // end of their own, so hooking the parent would bury the headshot in the middle of the examine.
@@ -31,10 +35,9 @@
 		return
 
 	// The link is validated when it's set, but make sure nothing can break out of the src attribute anyway.
-	var/static/list/forbidden_characters = list("'", "\"", "<", ">", " ")
-	for(var/character in forbidden_characters)
-		if(findtext(headshot_url, character))
-			return
+	var/static/regex/forbidden_characters = regex(@{"['"<> ]"})
+	if(forbidden_characters.Find(headshot_url))
+		return
 
 	examine_list.Insert(1, "<span class='examine_headshot'><img src='[headshot_url]'></span>")
 

--- a/modular_nova/master_files/code/modules/mob/living/examine.dm
+++ b/modular_nova/master_files/code/modules/mob/living/examine.dm
@@ -3,8 +3,8 @@
 	. = ..()
 	. += get_dnr_examine(user)
 	insert_examine_headshot(., user)
-	. += get_empath_examine(user)
 	. += get_arousal_examine(user)
+	. += get_empath_examine(user)
 
 // Hooked per subtype rather than on /mob/living/silicon: AIs and cyborgs append their parent's lines at the
 // end of their own, so hooking the parent would bury the headshot in the middle of the examine.

--- a/modular_nova/master_files/code/modules/mob/living/examine.dm
+++ b/modular_nova/master_files/code/modules/mob/living/examine.dm
@@ -1,0 +1,51 @@
+/mob/living/carbon/human/examine(mob/user)
+	. = ..()
+	insert_examine_headshot(., user)
+
+// Hooked per subtype rather than on /mob/living/silicon: AIs and cyborgs append their parent's lines at the
+// end of their own, so hooking the parent would bury the headshot in the middle of the examine.
+/mob/living/silicon/ai/examine(mob/user)
+	. = ..()
+	insert_examine_headshot(., user)
+
+/mob/living/silicon/robot/examine(mob/user)
+	. = ..()
+	insert_examine_headshot(., user)
+
+/mob/living/silicon/pai/examine(mob/user)
+	. = ..()
+	insert_examine_headshot(., user)
+
+/// Puts our headshot thumbnail at the top of [examine_list], if [user] should be shown one.
+/mob/living/proc/insert_examine_headshot(list/examine_list, mob/user)
+	if(!user?.client?.prefs?.read_preference(/datum/preference/toggle/show_headshot_on_examine))
+		return
+
+	if(isliving(user))
+		var/mob/living/living_user = user
+		if(living_user.is_blind())
+			return
+
+	var/headshot_url = get_headshot_url()
+	if(!headshot_url)
+		return
+
+	// The link is validated when it's set, but make sure nothing can break out of the src attribute anyway.
+	var/static/list/forbidden_characters = list("'", "\"", "<", ">", " ")
+	for(var/character in forbidden_characters)
+		if(findtext(headshot_url, character))
+			return
+
+	examine_list.Insert(1, "<span class='examine_headshot'><img src='[headshot_url]'></span>")
+
+/// Returns the image link to use as our headshot, if we have one to show.
+/mob/living/proc/get_headshot_url()
+	return null
+
+/mob/living/carbon/human/get_headshot_url()
+	if(is_face_obscured())
+		return null
+	return dna?.features?[EXAMINE_DNA_HEADSHOT]
+
+/mob/living/silicon/get_headshot_url()
+	return client?.prefs?.read_preference(/datum/preference/text/headshot/silicon)

--- a/modular_nova/master_files/code/modules/mob/living/examine.dm
+++ b/modular_nova/master_files/code/modules/mob/living/examine.dm
@@ -31,10 +31,9 @@
 		return
 
 	// The link is validated when it's set, but make sure nothing can break out of the src attribute anyway.
-	var/static/list/forbidden_characters = list("'", "\"", "<", ">", " ")
-	for(var/character in forbidden_characters)
-		if(findtext(headshot_url, character))
-			return
+	var/static/regex/forbidden_characters = regex("['\"<> ]")
+	if(forbidden_characters.Find(headshot_url))
+		return
 
 	examine_list.Insert(1, "<span class='examine_headshot'><img src='[headshot_url]'></span>")
 

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_arousal/status_effects/spank_related.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_arousal/status_effects/spank_related.dm
@@ -26,8 +26,9 @@
 	duration = 300 SECONDS
 	alert_type = null
 
-/mob/living/carbon/human/examine(mob/user)
-	. = ..()
+/// Examine lines for our arousal flavor text and a freshly spanked rear. Called by /mob/living/carbon/human/examine().
+/mob/living/carbon/human/proc/get_arousal_examine(mob/user)
+	. = list()
 	if(arousal && ishuman(user))
 		var/mob/living/carbon/human/examiner = user
 		if(examiner.can_see_erp_flavor(src))

--- a/modular_nova/modules/modular_items/lewd_items/code/lewd_quirks.dm
+++ b/modular_nova/modules/modular_items/lewd_items/code/lewd_quirks.dm
@@ -338,8 +338,9 @@
 *	EMPATH BONUS
 */
 
-/mob/living/carbon/human/examine(mob/user)
-	. = ..()
+/// Examine lines letting empaths read how aroused we are. Called by /mob/living/carbon/human/examine().
+/mob/living/carbon/human/proc/get_empath_examine(mob/user)
+	. = list()
 	var/mob/living/examiner = user
 	if(stat >= DEAD || HAS_TRAIT(src, TRAIT_FAKEDEATH) || src == examiner || !HAS_TRAIT(examiner, TRAIT_SEE_MASK_WHISPER)) // See mask whisper is for the empath quirk. This is more performant than GetComponent()...
 		return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7625,6 +7625,7 @@
 #include "modular_nova\master_files\code\modules\mob\living\blood_types.dm"
 #include "modular_nova\master_files\code\modules\mob\living\damage_procs.dm"
 #include "modular_nova\master_files\code\modules\mob\living\emote_popup.dm"
+#include "modular_nova\master_files\code\modules\mob\living\examine.dm"
 #include "modular_nova\master_files\code\modules\mob\living\examine_tgui.dm"
 #include "modular_nova\master_files\code\modules\mob\living\init_signals.dm"
 #include "modular_nova\master_files\code\modules\mob\living\living.dm"

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1200,6 +1200,37 @@ em {
   flex-grow: 1;
 }
 
+// NOVA EDIT ADDITION BEGIN - Headshot thumbnail in the examine block, expands on hover
+.examine_headshot {
+  position: relative;
+  display: block;
+  width: 96px;
+  height: 96px;
+  margin: 0.25em 0;
+}
+
+.examine_headshot img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 96px;
+  height: 96px;
+  object-fit: cover;
+  border: 1px solid hsla(220, 40%, 75%, 0.35);
+  border-radius: 2px;
+  image-rendering: auto;
+  transition:
+    width 120ms ease-out,
+    height 120ms ease-out;
+}
+
+.examine_headshot:hover img {
+  width: 250px;
+  height: 250px;
+  z-index: 50;
+}
+// NOVA EDIT ADDITION END
+
 // NOVA EDIT CHANGE BEGIN - Remove neon colors, replaced with less saturated
 /*
 $alert-stripe-colors: (

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1200,37 +1200,6 @@ em {
   flex-grow: 1;
 }
 
-// NOVA EDIT ADDITION BEGIN - Headshot thumbnail in the examine block, expands on hover
-.examine_headshot {
-  position: relative;
-  display: block;
-  width: 96px;
-  height: 96px;
-  margin: 0.25em 0;
-}
-
-.examine_headshot img {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 96px;
-  height: 96px;
-  object-fit: cover;
-  border: 1px solid hsla(220, 40%, 75%, 0.35);
-  border-radius: 2px;
-  image-rendering: auto;
-  transition:
-    width 120ms ease-out,
-    height 120ms ease-out;
-}
-
-.examine_headshot:hover img {
-  width: 250px;
-  height: 250px;
-  z-index: 50;
-}
-// NOVA EDIT ADDITION END
-
 // NOVA EDIT CHANGE BEGIN - Remove neon colors, replaced with less saturated
 /*
 $alert-stripe-colors: (
@@ -1553,5 +1522,35 @@ $border-width-px: $border-width * 1px;
   color: #6e001a;
   font-weight: bold;
   font-style: italic;
+}
+
+// Headshot thumbnail in the examine block, expands on hover
+.examine_headshot {
+  position: relative;
+  display: block;
+  width: 96px;
+  height: 96px;
+  margin: 0.25em 0;
+}
+
+.examine_headshot img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 96px;
+  height: 96px;
+  object-fit: cover;
+  border: 1px solid hsla(220, 40%, 75%, 0.35);
+  border-radius: 2px;
+  image-rendering: auto;
+  transition:
+    width 120ms ease-out,
+    height 120ms ease-out;
+}
+
+.examine_headshot:hover img {
+  width: 250px;
+  height: 250px;
+  z-index: 50;
 }
 // NOVA EDIT ADDITION END

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -1093,6 +1093,13 @@ h2.alert {
   flex-grow: 1;
 }
 
+// NOVA EDIT ADDITION BEGIN - Headshots are photos, not sprites, so undo the pixelated `img` rule above
+.examine_headshot img {
+  image-rendering: auto;
+  border-color: hsla(220, 40%, 25%, 0.35);
+}
+// NOVA EDIT ADDITION END
+
 // NOVA EDIT CHANGE BEGIN - Remove neon colors, replaced with less saturated
 /*
 $alert-stripe-colors: (

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -1093,13 +1093,6 @@ h2.alert {
   flex-grow: 1;
 }
 
-// NOVA EDIT ADDITION BEGIN - Headshots are photos, not sprites, so undo the pixelated `img` rule above
-.examine_headshot img {
-  image-rendering: auto;
-  border-color: hsla(220, 40%, 25%, 0.35);
-}
-// NOVA EDIT ADDITION END
-
 // NOVA EDIT CHANGE BEGIN - Remove neon colors, replaced with less saturated
 /*
 $alert-stripe-colors: (
@@ -1441,5 +1434,11 @@ $border-width-px: $border-width * 1px;
   100% {
     color: #9b6000;
   }
+}
+
+// Headshots are photos, not sprites, so undo the pixelated `img` rule from earlier in this file
+.examine_headshot img {
+  image-rendering: auto;
+  border-color: hsla(220, 40%, 25%, 0.35);
 }
 // NOVA EDIT ADDITION END

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/nova/show_headshot_on_examine.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/nova/show_headshot_on_examine.tsx
@@ -1,0 +1,10 @@
+// THIS IS A NOVA SECTOR UI FILE
+import { CheckboxInput, type FeatureToggle } from '../../base';
+
+export const show_headshot_on_examine: FeatureToggle = {
+  name: 'Show headshot on examine',
+  category: 'UI',
+  description: `When enabled, examining someone whose face isn't covered shows
+    their headshot in the chat, if they have one set. Hover over it to enlarge it.`,
+  component: CheckboxInput,
+};


### PR DESCRIPTION

## About The Pull Request

Tin. Short and sweet PR that lets you see the face of who you're talking with just by examining them IF they don't have their face covered. Works for silicon headshots too. Gated behind an UI preference in case you don't want to see them.
## How This Contributes To The Nova Sector Roleplay Experience

Makes sense to see the face of who you're talking with at a glance
## Proof of Testing


https://github.com/user-attachments/assets/67dc1d02-9a08-4f82-9f8f-17e7e96e67fb
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
add: Examine preview headshots are now available.
/:cl:
