### PR TITLE
Adds a toggle ability for holosynths to pass through tables

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -569,7 +569,7 @@
 /obj/structure/table/glass/proc/check_break(mob/living/M)
 	if(is_flipped)
 		return FALSE
-	if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL && !(M.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) && (!isteshari(M)) && (!isholosynth(M)) && !HAS_TRAIT(M, TRAIT_PRONE)) //NOVA EDIT CHANGE - Original: if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL && !(M.movement_type & MOVETYPES_NOT_TOUCHING_GROUND))
+	if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL && !(M.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) && (!isteshari(M)) && (!(isholosynth(M) && HAS_TRAIT(M, TRAIT_PASSTABLE))) && !HAS_TRAIT(M, TRAIT_PRONE)) //NOVA EDIT CHANGE - Original: if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL && !(M.movement_type & MOVETYPES_NOT_TOUCHING_GROUND))
 		table_shatter(M)
 
 /obj/structure/table/glass/proc/table_shatter(mob/living/victim)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -569,7 +569,7 @@
 /obj/structure/table/glass/proc/check_break(mob/living/M)
 	if(is_flipped)
 		return FALSE
-	if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL && !(M.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) && (!isteshari(M)) && !HAS_TRAIT(M, TRAIT_PRONE)) //NOVA EDIT CHANGE - Original: if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL && !(M.movement_type & MOVETYPES_NOT_TOUCHING_GROUND))
+	if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL && !(M.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) && (!isteshari(M)) && (!isholosynth(M)) && !HAS_TRAIT(M, TRAIT_PRONE)) //NOVA EDIT CHANGE - Original: if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL && !(M.movement_type & MOVETYPES_NOT_TOUCHING_GROUND))
 		table_shatter(M)
 
 /obj/structure/table/glass/proc/table_shatter(mob/living/victim)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -569,7 +569,7 @@
 /obj/structure/table/glass/proc/check_break(mob/living/M)
 	if(is_flipped)
 		return FALSE
-	if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL && !(M.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) && (!isteshari(M)) && (!(isholosynth(M) && HAS_TRAIT(M, TRAIT_PASSTABLE))) && !HAS_TRAIT(M, TRAIT_PRONE)) //NOVA EDIT CHANGE - Original: if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL && !(M.movement_type & MOVETYPES_NOT_TOUCHING_GROUND))
+	if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL && !(M.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) && (!isteshari(M)) && !HAS_TRAIT(M, TRAIT_PRONE) && (!(isholosynth(M) && HAS_TRAIT(M, TRAIT_PASSTABLE)))) //NOVA EDIT CHANGE - Original: if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL && !(M.movement_type & MOVETYPES_NOT_TOUCHING_GROUND))
 		table_shatter(M)
 
 /obj/structure/table/glass/proc/table_shatter(mob/living/victim)

--- a/modular_nova/modules/holosynth/code/holosynth.dm
+++ b/modular_nova/modules/holosynth/code/holosynth.dm
@@ -92,7 +92,9 @@
 			species_holder.cut_overlay(chest.glow)
 		chest.glow = makeHologramHolosynth(species_holder)
 	var/datum/action/innate/holosynth_toggle_phase/phase_toggle = new(species_holder)
+	var/datum/action/innate/holosynth_toggle_passtable/table_toggle = new(species_holder)
 	phase_toggle.Grant(species_holder)
+	table_toggle.Grant(species_holder)
 	if(!isdummy(species_holder))
 		RegisterSignal(species_holder, COMSIG_HUMAN_CHARACTER_SETUP_FINISHED, PROC_REF(attach_scanline), override = TRUE)
 	RegisterSignal(species_holder, COMSIG_MOB_APPLY_DAMAGE, PROC_REF(on_mob_disrupted))
@@ -105,6 +107,7 @@
 		var/obj/item/holosynth_pen/owner_projector = new /obj/item/holosynth_pen(get_turf(species_holder), species_holder)
 		if(chest)
 			chest.owner_projector_ref = WEAKREF(owner_projector)
+		//RegisterSignal(owner_projector, COMSIG_ITEM_PICKUP, PROC_REF(pen_picked_up))
 		species_holder.put_in_hands(owner_projector)
 
 /datum/species/synthetic/holosynth/on_species_loss(mob/living/carbon/target, datum/species/new_species, pref_load)
@@ -121,6 +124,8 @@
 		species_holder.cut_overlay(chest.glow)
 		chest.glow = null
 	for(var/datum/action/innate/holosynth_toggle_phase/phase_toggle in species_holder.actions)
+		qdel(phase_toggle)
+	for(var/datum/action/innate/holosynth_toggle_passtable/phase_toggle in species_holder.actions)
 		qdel(phase_toggle)
 	UNASSIGN_GAME_VERB(species_holder, /mob/living/carbon/human, holosynth_adjust_transparency)
 	UNASSIGN_GAME_VERB(species_holder, /mob/living/carbon/human, holosynth_toggle_scanline)

--- a/modular_nova/modules/holosynth/code/holosynth.dm
+++ b/modular_nova/modules/holosynth/code/holosynth.dm
@@ -107,7 +107,6 @@
 		var/obj/item/holosynth_pen/owner_projector = new /obj/item/holosynth_pen(get_turf(species_holder), species_holder)
 		if(chest)
 			chest.owner_projector_ref = WEAKREF(owner_projector)
-		//RegisterSignal(owner_projector, COMSIG_ITEM_PICKUP, PROC_REF(pen_picked_up))
 		species_holder.put_in_hands(owner_projector)
 
 /datum/species/synthetic/holosynth/on_species_loss(mob/living/carbon/target, datum/species/new_species, pref_load)

--- a/modular_nova/modules/holosynth/code/holosynth_passtable.dm
+++ b/modular_nova/modules/holosynth/code/holosynth_passtable.dm
@@ -1,0 +1,30 @@
+#define HOLOSYNTH_TABLE_PASS_TRAIT
+
+/datum/movespeed_modifier/holosynth_passtable
+	multiplicative_slowdown = 1.5
+
+/datum/action/innate/holosynth_toggle_passtable
+	name = "Toggle Table Phasing"
+	desc = "Toggle phasing through tables freely"
+	button_icon = 'icons/hud/radial.dmi'
+	button_icon_state = "table"
+	var/table_toggle = FALSE
+
+/datum/action/innate/holosynth_toggle_passtable/Activate()
+	if(!table_toggle)
+		owner.add_traits(list(TRAIT_PASSTABLE, TRAIT_IGNORE_ELEVATION), HOLOSYNTH_TABLE_PASS_TRAIT)
+		owner.add_movespeed_modifier(/datum/movespeed_modifier/holosynth_passtable)
+	else
+		owner.remove_traits(list(TRAIT_PASSTABLE, TRAIT_IGNORE_ELEVATION), HOLOSYNTH_TABLE_PASS_TRAIT)
+		owner.remove_movespeed_modifier(/datum/movespeed_modifier/holosynth_passtable)
+	table_toggle = !table_toggle
+	to_chat(owner, span_notice("Table phasing [table_toggle ? "enabled" : "disabled"]."))
+	build_all_button_icons(UPDATE_BUTTON_BACKGROUND)
+
+/datum/action/innate/holosynth_toggle_passtable/Destroy()
+	owner.remove_traits(list(TRAIT_PASSTABLE, TRAIT_IGNORE_ELEVATION), HOLOSYNTH_TABLE_PASS_TRAIT)
+	owner.remove_movespeed_modifier(/datum/movespeed_modifier/holosynth_passtable)
+	return ..()
+
+/datum/action/innate/holosynth_toggle_passtable/is_action_active(atom/movable/screen/movable/action_button/current_button)
+	return table_toggle

--- a/modular_nova/modules/holosynth/code/holosynth_passtable.dm
+++ b/modular_nova/modules/holosynth/code/holosynth_passtable.dm
@@ -23,7 +23,7 @@
 /datum/action/innate/holosynth_toggle_passtable/Destroy(force)
 	if(owner)
 		owner.remove_traits(list(TRAIT_PASSTABLE, TRAIT_IGNORE_ELEVATION), type)
-	owner.remove_movespeed_modifier(/datum/movespeed_modifier/holosynth_passtable)
+		owner.remove_movespeed_modifier(/datum/movespeed_modifier/holosynth_passtable)
 	return ..()
 
 /datum/action/innate/holosynth_toggle_passtable/is_action_active(atom/movable/screen/movable/action_button/current_button)

--- a/modular_nova/modules/holosynth/code/holosynth_passtable.dm
+++ b/modular_nova/modules/holosynth/code/holosynth_passtable.dm
@@ -20,8 +20,9 @@
 	to_chat(owner, span_notice("Table phasing [table_toggle ? "enabled" : "disabled"]."))
 	build_all_button_icons(UPDATE_BUTTON_BACKGROUND)
 
-/datum/action/innate/holosynth_toggle_passtable/Destroy()
-	owner.remove_traits(list(TRAIT_PASSTABLE, TRAIT_IGNORE_ELEVATION), type)
+/datum/action/innate/holosynth_toggle_passtable/Destroy(force)
+	if(owner)
+		owner.remove_traits(list(TRAIT_PASSTABLE, TRAIT_IGNORE_ELEVATION), type)
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/holosynth_passtable)
 	return ..()
 

--- a/modular_nova/modules/holosynth/code/holosynth_passtable.dm
+++ b/modular_nova/modules/holosynth/code/holosynth_passtable.dm
@@ -1,5 +1,3 @@
-#define HOLOSYNTH_TABLE_PASS_TRAIT
-
 /datum/movespeed_modifier/holosynth_passtable
 	multiplicative_slowdown = 1.5
 
@@ -8,21 +6,22 @@
 	desc = "Toggle phasing through tables freely"
 	button_icon = 'icons/hud/radial.dmi'
 	button_icon_state = "table"
+	//Variable to keep track of toggle state
 	var/table_toggle = FALSE
 
 /datum/action/innate/holosynth_toggle_passtable/Activate()
 	if(!table_toggle)
-		owner.add_traits(list(TRAIT_PASSTABLE, TRAIT_IGNORE_ELEVATION), HOLOSYNTH_TABLE_PASS_TRAIT)
+		owner.add_traits(list(TRAIT_PASSTABLE, TRAIT_IGNORE_ELEVATION), type)
 		owner.add_movespeed_modifier(/datum/movespeed_modifier/holosynth_passtable)
 	else
-		owner.remove_traits(list(TRAIT_PASSTABLE, TRAIT_IGNORE_ELEVATION), HOLOSYNTH_TABLE_PASS_TRAIT)
+		owner.remove_traits(list(TRAIT_PASSTABLE, TRAIT_IGNORE_ELEVATION), type)
 		owner.remove_movespeed_modifier(/datum/movespeed_modifier/holosynth_passtable)
 	table_toggle = !table_toggle
 	to_chat(owner, span_notice("Table phasing [table_toggle ? "enabled" : "disabled"]."))
 	build_all_button_icons(UPDATE_BUTTON_BACKGROUND)
 
 /datum/action/innate/holosynth_toggle_passtable/Destroy()
-	owner.remove_traits(list(TRAIT_PASSTABLE, TRAIT_IGNORE_ELEVATION), HOLOSYNTH_TABLE_PASS_TRAIT)
+	owner.remove_traits(list(TRAIT_PASSTABLE, TRAIT_IGNORE_ELEVATION), type)
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/holosynth_passtable)
 	return ..()
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8788,6 +8788,7 @@
 #include "modular_nova\modules\holosynth\code\holopassthrough.dm"
 #include "modular_nova\modules\holosynth\code\holoray_trail.dm"
 #include "modular_nova\modules\holosynth\code\holosynth.dm"
+#include "modular_nova\modules\holosynth\code\holosynth_passtable.dm"
 #include "modular_nova\modules\holosynth\code\holosynth_prefs.dm"
 #include "modular_nova\modules\holosynth\code\holosynth_projector.dm"
 #include "modular_nova\modules\holosynth\code\holosynth_wounds.dm"


### PR DESCRIPTION
## About The Pull Request

Adds simple toggle ability for holosynths, while it's on it offers freedom to walk through tables (sprites don't shift like they would when you climb them). You don't break glass tables if this is on. While active, 1.5 slowdown modifier is applied.

## How This Contributes To The Nova Sector Roleplay Experience

Lets holosynths pass through tables which adds to the flavor of being a projection. Walking over them is for material beings. It's basically a teshari passive table walking but with slowdown to balance it out.

## Proof of Testing

<img width="345" height="152" alt="image" src="https://github.com/user-attachments/assets/7189f71f-d4ee-4e1a-b2ce-f8313367b310" />
<img width="195" height="198" alt="image" src="https://github.com/user-attachments/assets/24335e3c-514a-4fe9-b994-37efea62bb7f" />

## Changelog

:cl:
add: Added a toggle ability for holosynths to pass through tables (at cost of a slowdown)
/:cl: