### PR TITLE
[FIX] bug with ammo stacks

### DIFF
--- a/modular_nova/modules/ammo_stacks/code/ammo_stack_base.dm
+++ b/modular_nova/modules/ammo_stacks/code/ammo_stack_base.dm
@@ -29,6 +29,11 @@
 		return NONE
 	return item_interaction(user, interacting_with, modifiers) || ITEM_INTERACT_BLOCKING
 
+/obj/item/ammo_box/magazine/ammo_stack/give_round(obj/item/ammo_casing/new_round, replace_spent = 0)
+	if(new_round in stored_ammo)
+		return FALSE
+	return ..()
+
 /obj/item/ammo_box/magazine/ammo_stack/empty_magazine()
 	. = ..()
 	check_empty()
@@ -150,9 +155,10 @@
 		balloon_alert(user, "can't stack empty casings!")
 		return ITEM_INTERACT_BLOCKING
 
+	// try_load rather than give_round, so casings held by the user are properly unequipped instead of forceMoved out of their hands
 	var/obj/item/ammo_box/magazine/ammo_stack = new ammo_stack_type(drop_location())
-	ammo_stack.give_round(src)
-	ammo_stack.give_round(used_casing)
+	ammo_stack.try_load(user, src, silent = TRUE)
+	ammo_stack.try_load(user, used_casing, silent = TRUE)
 	user.put_in_hands(ammo_stack)
 	ammo_stack.update_appearance()
 	return ITEM_INTERACT_SUCCESS


### PR DESCRIPTION

## About The Pull Request

I noticed when you click a stack of shells with another shell quickly, you can spawn bullets out of thin air. This should hopefully address that moving to try_load().
## How This Contributes To The Nova Sector Roleplay Experience
Bugdix.
## Proof of Testing
Tested locally with some round types and shells. Clicking fast no longer creates new shells
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: ammo stacks should stop creating new bullets when clicked on them very fast.
/:cl:
