### PR TITLE
[NON-MODULAR] The supply shuttle will not spawn crates on turfs occupied by conveyor belts and other objects

### DIFF
--- a/code/modules/shuttle/mobile_port/variants/supply.dm
+++ b/code/modules/shuttle/mobile_port/variants/supply.dm
@@ -149,8 +149,13 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 				continue
 			empty_turfs += shuttle_turf
 
-	if (!length(empty_turfs)) { announce_all_turfs_blocked(); return; } // NOVA EDIT ADDITION - Feedback + safety
-	if (length(empty_turfs) < 11) { announce_many_turfs_blocked(); } // NOVA EDIT ADDITION - Feedback
+	// NOVA EDIT ADDITION START - Providing feedback, and safety
+	if(!length(empty_turfs))
+		announce_rejection()
+		return // there can now be zero empty turfs to go around
+	if(length(empty_turfs) < 11)
+		announce_overcrowding()
+	// NOVA EDIT ADDITION END
 	//quickly and greedily handle chef's grocery runs first, there are a few reasons why this isn't attached to the rest of cargo...
 	//but the biggest reason is that the chef requires produce to cook and do their job, and if they are using this system they
 	//already got let down by the botanists. So to open a new chance for cargo to also screw them over any more than is necessary is bad.
@@ -347,7 +352,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 				continue
 			empty_turfs += shuttle_floor
 
-	if (!length(empty_turfs)) { return } // NOVA EDIT ADDITION - Because there can genuinely be no empty turfs
+	if (!length(empty_turfs)) { return } // NOVA EDIT ADDITION - There can now be zero empty turfs to go around
 	new /obj/structure/closet/crate/mail/economy(pick(empty_turfs))
 
 /// Takes a supply pack, returns the amount we currently have on order (or OVER_ORDER_LIMIT if we are over the hardcap on orders of this type)

--- a/code/modules/shuttle/mobile_port/variants/supply.dm
+++ b/code/modules/shuttle/mobile_port/variants/supply.dm
@@ -149,8 +149,8 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 				continue
 			empty_turfs += shuttle_turf
 
-	if(!length(empty_turfs)) { announce_all_turfs_blocked(); return; } // NOVA EDIT ADDITION - Feedback + safety
-	else if(length(empty_turfs) < 11) { announce_many_turfs_blocked(); } // NOVA EDIT ADDITION - Feedback
+	if (!length(empty_turfs)) { announce_all_turfs_blocked(); return; } // NOVA EDIT ADDITION - Feedback + safety
+	else if (length(empty_turfs) < 11) { announce_many_turfs_blocked(); } // NOVA EDIT ADDITION - Feedback
 	//quickly and greedily handle chef's grocery runs first, there are a few reasons why this isn't attached to the rest of cargo...
 	//but the biggest reason is that the chef requires produce to cook and do their job, and if they are using this system they
 	//already got let down by the botanists. So to open a new chance for cargo to also screw them over any more than is necessary is bad.

--- a/code/modules/shuttle/mobile_port/variants/supply.dm
+++ b/code/modules/shuttle/mobile_port/variants/supply.dm
@@ -149,7 +149,8 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 				continue
 			empty_turfs += shuttle_turf
 
-	if (!length(empty_turfs)) { return } // NOVA EDIT ADDITION - Because there can genuinely be no empty turfs
+	if(!length(empty_turfs)) { announce_all_turfs_blocked(); return; } // NOVA EDIT ADDITION - Feedback + safety
+	else if(length(empty_turfs) < 11) { announce_many_turfs_blocked(); } // NOVA EDIT ADDITION - Feedback
 	//quickly and greedily handle chef's grocery runs first, there are a few reasons why this isn't attached to the rest of cargo...
 	//but the biggest reason is that the chef requires produce to cook and do their job, and if they are using this system they
 	//already got let down by the botanists. So to open a new chance for cargo to also screw them over any more than is necessary is bad.

--- a/code/modules/shuttle/mobile_port/variants/supply.dm
+++ b/code/modules/shuttle/mobile_port/variants/supply.dm
@@ -150,7 +150,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 			empty_turfs += shuttle_turf
 
 	if (!length(empty_turfs)) { announce_all_turfs_blocked(); return; } // NOVA EDIT ADDITION - Feedback + safety
-	else if (length(empty_turfs) < 11) { announce_many_turfs_blocked(); } // NOVA EDIT ADDITION - Feedback
+	if (length(empty_turfs) < 11) { announce_many_turfs_blocked(); } // NOVA EDIT ADDITION - Feedback
 	//quickly and greedily handle chef's grocery runs first, there are a few reasons why this isn't attached to the rest of cargo...
 	//but the biggest reason is that the chef requires produce to cook and do their job, and if they are using this system they
 	//already got let down by the botanists. So to open a new chance for cargo to also screw them over any more than is necessary is bad.

--- a/code/modules/shuttle/mobile_port/variants/supply.dm
+++ b/code/modules/shuttle/mobile_port/variants/supply.dm
@@ -343,7 +343,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	var/list/empty_turfs = list()
 	for(var/area/shuttle/shuttle_area as anything in shuttle_areas)
 		for(var/turf/open/floor/shuttle_floor in shuttle_area.get_turfs_from_all_zlevels())
-			if(turf_is_occupied(shuttle_floor)) // NOVA EDIT CHANGE - Enhanced checks that a turf is unavailable - if(shuttle_floor.is_blocked_turf())
+			if(turf_is_occupied(shuttle_floor)) // NOVA EDIT CHANGE - Enhanced checks that a turf is unavailable - ORIGINAL: if(shuttle_floor.is_blocked_turf())
 				continue
 			empty_turfs += shuttle_floor
 

--- a/code/modules/shuttle/mobile_port/variants/supply.dm
+++ b/code/modules/shuttle/mobile_port/variants/supply.dm
@@ -145,10 +145,11 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	var/list/empty_turfs = list()
 	for(var/area/shuttle/shuttle_area as anything in shuttle_areas)
 		for(var/turf/open/floor/shuttle_turf in shuttle_area.get_turfs_from_all_zlevels())
-			if(shuttle_turf.is_blocked_turf())
+			if(turf_is_occupied(shuttle_turf)) // NOVA EDIT CHANGE - Enhanced checks that a turf is unavailable - ORIGINAL: if(shuttle_turf.is_blocked_turf())
 				continue
 			empty_turfs += shuttle_turf
 
+	if (!length(empty_turfs)) { return } // NOVA EDIT ADDITION - Because there can genuinely be no empty turfs
 	//quickly and greedily handle chef's grocery runs first, there are a few reasons why this isn't attached to the rest of cargo...
 	//but the biggest reason is that the chef requires produce to cook and do their job, and if they are using this system they
 	//already got let down by the botanists. So to open a new chance for cargo to also screw them over any more than is necessary is bad.
@@ -341,10 +342,11 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	var/list/empty_turfs = list()
 	for(var/area/shuttle/shuttle_area as anything in shuttle_areas)
 		for(var/turf/open/floor/shuttle_floor in shuttle_area.get_turfs_from_all_zlevels())
-			if(shuttle_floor.is_blocked_turf())
+			if(turf_is_occupied(shuttle_floor)) // NOVA EDIT CHANGE - Enhanced checks that a turf is unavailable - if(shuttle_floor.is_blocked_turf())
 				continue
 			empty_turfs += shuttle_floor
 
+	if (!length(empty_turfs)) { return } // NOVA EDIT ADDITION - Because there can genuinely be no empty turfs
 	new /obj/structure/closet/crate/mail/economy(pick(empty_turfs))
 
 /// Takes a supply pack, returns the amount we currently have on order (or OVER_ORDER_LIMIT if we are over the hardcap on orders of this type)

--- a/modular_nova/master_files/code/modules/shuttle/shuttle.dm
+++ b/modular_nova/master_files/code/modules/shuttle/shuttle.dm
@@ -88,6 +88,7 @@
 		/obj/effect,
 		/obj/machinery/light,
 		/obj/machinery/button,
+		/obj/structure/railing,
 	))
 
 /// Returns FALSE if a turf is blocked by a dense object

--- a/modular_nova/master_files/code/modules/shuttle/shuttle.dm
+++ b/modular_nova/master_files/code/modules/shuttle/shuttle.dm
@@ -81,8 +81,8 @@
 			hearing_mob.playsound_local(distant_source, takeoff ? takeoff_sound : landing_sound, vol)
 
 /obj/docking_port/mobile/supply
-	/// Number of times there's been an announcement for there being a lot of blocking objects on the shuttle
-	var/static/many_turfs_blocked_warnings = 0
+	/// Number of times there's been an announcement for overcrowding on the shuttle
+	var/static/overcrowding_announcements = 0
 	/// These *objects* will not be considered as blocking a tile
 	var/static/list/ignored_objects = typecacheof(list(
 		/obj/effect,
@@ -91,7 +91,7 @@
 	))
 
 /// Returns FALSE if a turf is blocked by a dense object
-/// or has objects in its contents that aren't whitelisted
+/// or has objects in its contents that aren't ignored
 /obj/docking_port/mobile/supply/proc/turf_is_occupied(turf/open/shuttle_turf)
 	for(var/obj/object in shuttle_turf.contents)
 		if(object.density)
@@ -100,7 +100,7 @@
 			return TRUE
 
 /// Announces that all turfs are blocked and orders aren't being confirmed
-/obj/docking_port/mobile/supply/proc/announce_all_turfs_blocked()
+/obj/docking_port/mobile/supply/proc/announce_rejection()
 	// I thought of having a cooldown for this, but the station is
 	// being deprived of orders at this stage so it's whatever
 	aas_config_announce(
@@ -113,14 +113,14 @@
 	)
 
 /// Announces that many turfs are blocked and some orders may not be confirmed
-/obj/docking_port/mobile/supply/proc/announce_many_turfs_blocked()
-	if(many_turfs_blocked_warnings >= 2)
+/obj/docking_port/mobile/supply/proc/announce_overcrowding()
+	if(overcrowding_announcements >= 2)
 		return // if you really want the shuttle to be full of shit and know the downsides...
-	many_turfs_blocked_warnings++
+	overcrowding_announcements++
 	aas_config_announce(
 		/datum/aas_config_entry/supply_shuttle_overcrowding,
 		variables_map = list(),
 		source = null,
 		channels = list(RADIO_CHANNEL_SUPPLY),
-		announcement_line = many_turfs_blocked_warnings < 2 ? "First Notice" : "Second Notice",
+		announcement_line = overcrowding_announcements < 2 ? "First Notice" : "Second Notice",
 	)

--- a/modular_nova/master_files/code/modules/shuttle/shuttle.dm
+++ b/modular_nova/master_files/code/modules/shuttle/shuttle.dm
@@ -71,3 +71,18 @@
 			var/dist = get_dist(hearing_mob.loc, distant_source.loc)
 			var/vol = clamp(40 - ((dist - 3) * 5) * volume_pref_modifier, 0, 40) // Every tile decreases sound volume by 5
 			hearing_mob.playsound_local(distant_source, takeoff ? takeoff_sound : landing_sound, vol)
+
+/// Returns FALSE if a turf is blocked by a dense object
+/// or has objects in its contents that aren't whitelisted
+/obj/docking_port/mobile/supply/proc/turf_is_occupied(turf/open/shuttle_turf)
+	var/static/list/ignored_objects = typecacheof(list(
+		/obj/effect,
+		/obj/machinery/light,
+		/obj/machinery/button,
+		/obj/machinery/conveyor_switch,
+	))
+	for(var/obj/object in shuttle_turf.contents)
+		if(object.density)
+			return TRUE
+		if(!is_type_in_typecache(object, ignored_objects))
+			return TRUE

--- a/modular_nova/master_files/code/modules/shuttle/shuttle.dm
+++ b/modular_nova/master_files/code/modules/shuttle/shuttle.dm
@@ -80,24 +80,25 @@
 			var/vol = clamp(40 - ((dist - 3) * 5) * volume_pref_modifier, 0, 40) // Every tile decreases sound volume by 5
 			hearing_mob.playsound_local(distant_source, takeoff ? takeoff_sound : landing_sound, vol)
 
-/// Returns FALSE if a turf is blocked by a dense object
-/// or has objects in its contents that aren't whitelisted
-/obj/docking_port/mobile/supply/proc/turf_is_occupied(turf/open/shuttle_turf)
+/obj/docking_port/mobile/supply
+	/// Number of times there's been an announcement for there being a lot of blocking objects on the shuttle
+	var/static/many_turfs_blocked_warnings = 0
+	/// These *objects* will not be considered as blocking a tile
 	var/static/list/ignored_objects = typecacheof(list(
 		/obj/effect,
 		/obj/machinery/light,
 		/obj/machinery/button,
 		/obj/machinery/conveyor_switch,
 	))
+
+/// Returns FALSE if a turf is blocked by a dense object
+/// or has objects in its contents that aren't whitelisted
+/obj/docking_port/mobile/supply/proc/turf_is_occupied(turf/open/shuttle_turf)
 	for(var/obj/object in shuttle_turf.contents)
 		if(object.density)
 			return TRUE
 		if(!is_type_in_typecache(object, ignored_objects))
 			return TRUE
-
-/obj/docking_port/mobile/supply
-	/// Number of times there's been an announcement for there being a lot of blocking objects on the shuttle
-	var/static/many_turfs_blocked_warnings = 0
 
 /// Announces that all turfs are blocked and orders aren't being confirmed
 /obj/docking_port/mobile/supply/proc/announce_all_turfs_blocked()

--- a/modular_nova/master_files/code/modules/shuttle/shuttle.dm
+++ b/modular_nova/master_files/code/modules/shuttle/shuttle.dm
@@ -1,9 +1,9 @@
 /datum/aas_config_entry/supply_shuttle_overcrowding
-	name = "Cargo Alert: Shuttle Overcrowding"
+	name = "Cargo Alert: Supply Shuttle Overcrowding"
 	announcement_lines_map = list(
-		"First Notice" = "NOTICE: The supply shuttle has low free space. Some orders may not be confirmed. Consider removing objects from the shuttle.",
-		"Second Notice" = "NOTICE: The supply shuttle still has low free space. Consider removing objects from the shuttle.",
-		"Blocked" = "The supply shuttle has no free space for Central Command to load cargo onto. Orders are not being confirmed. Consider removing objects from the shuttle.",
+		"First Notice" = "The supply shuttle has low free space. Some orders may not be confirmed. Consider removing objects from the shuttle.",
+		"Second Notice" = "The supply shuttle still has low free space. Consider removing objects from the shuttle.",
+		"Blocked" = "The supply shuttle has no free space for Central Command to load cargo onto. Orders are not being confirmed. Clear the shuttle of blockages to start receiving orders again.",
 	)
 
 /obj/docking_port/mobile

--- a/modular_nova/master_files/code/modules/shuttle/shuttle.dm
+++ b/modular_nova/master_files/code/modules/shuttle/shuttle.dm
@@ -3,7 +3,7 @@
 	announcement_lines_map = list(
 		"First Notice" = "The supply shuttle has low free space. Some orders may not be confirmed. Consider removing objects from the shuttle.",
 		"Second Notice" = "The supply shuttle still has low free space. Consider removing objects from the shuttle.",
-		"Blocked" = "The supply shuttle has no free space for Central Command to load cargo onto. Orders are not being confirmed. Clear the shuttle of blockages to start receiving orders again.",
+		"Blocked" = "The supply shuttle has no free space for cargo to be loaded onto. Orders are not being confirmed. Clear the shuttle of blockages to start receiving orders again.",
 	)
 
 /obj/docking_port/mobile

--- a/modular_nova/master_files/code/modules/shuttle/shuttle.dm
+++ b/modular_nova/master_files/code/modules/shuttle/shuttle.dm
@@ -88,7 +88,6 @@
 		/obj/effect,
 		/obj/machinery/light,
 		/obj/machinery/button,
-		/obj/machinery/conveyor_switch,
 	))
 
 /// Returns FALSE if a turf is blocked by a dense object

--- a/modular_nova/master_files/code/modules/shuttle/shuttle.dm
+++ b/modular_nova/master_files/code/modules/shuttle/shuttle.dm
@@ -1,3 +1,11 @@
+/datum/aas_config_entry/supply_shuttle_overcrowding
+	name = "Cargo Alert: Shuttle Overcrowding"
+	announcement_lines_map = list(
+		"First Notice" = "NOTICE: The supply shuttle has low free space. Some orders may not be confirmed. Consider removing objects from the shuttle.",
+		"Second Notice" = "NOTICE: The supply shuttle still has low free space. Consider removing objects from the shuttle.",
+		"Blocked" = "The supply shuttle has no free space for Central Command to load cargo onto. Orders are not being confirmed. Consider removing objects from the shuttle.",
+	)
+
 /obj/docking_port/mobile
 	/// Does this shuttle play sounds upon landing and takeoff?
 	var/shuttle_sounds = TRUE
@@ -86,3 +94,33 @@
 			return TRUE
 		if(!is_type_in_typecache(object, ignored_objects))
 			return TRUE
+
+/obj/docking_port/mobile/supply
+	/// Number of times there's been an announcement for there being a lot of blocking objects on the shuttle
+	var/static/many_turfs_blocked_warnings = 0
+
+/// Announces that all turfs are blocked and orders aren't being confirmed
+/obj/docking_port/mobile/supply/proc/announce_all_turfs_blocked()
+	// I thought of having a cooldown for this, but the station is
+	// being deprived of orders at this stage so it's whatever
+	aas_config_announce(
+		/datum/aas_config_entry/supply_shuttle_overcrowding,
+		variables_map = list(),
+		source = null,
+		channels = list(RADIO_CHANNEL_SUPPLY),
+		announcement_line = "Blocked",
+		command_span = TRUE,
+	)
+
+/// Announces that many turfs are blocked and some orders may not be confirmed
+/obj/docking_port/mobile/supply/proc/announce_many_turfs_blocked()
+	if(many_turfs_blocked_warnings >= 2)
+		return // if you really want the shuttle to be full of shit and know the downsides...
+	many_turfs_blocked_warnings++
+	aas_config_announce(
+		/datum/aas_config_entry/supply_shuttle_overcrowding,
+		variables_map = list(),
+		source = null,
+		channels = list(RADIO_CHANNEL_SUPPLY),
+		announcement_line = many_turfs_blocked_warnings < 2 ? "First Notice" : "Second Notice",
+	)


### PR DESCRIPTION
## About The Pull Request
The supply shuttle when spawning crates and mail will not populate turfs that have non-whitelisted objects, in addition to not populating turfs taken up by dense objects. Lights, buttons and ambient effects are whitelisted objects and will not prevent a turf from being populated.

In practice, this means that **crates will never spawn on turfs occupied by non-whitelisted objects like conveyor belts, conveyor switches, and sorters.** If the shuttle has fewer available turfs than the number of unique items that need to be spawned, random orders may be skipped. **If the shuttle has no available turfs, no orders will be delivered.**

Feedback is provided in the form of a Supply channel announcement. Up to two announcements will be provided if the number of available turfs is problematically low, then there will be no further announcements. If there are no available turfs, a loud-mode announcement warns the active Supply staff every time the shuttle is called to the station.

<details><summary>More in-depth explanations of how this really affects the game</summary>

*This uses the term "belts", but any non-dense anchored object that isn't already blacklisted works the same.*

**Fully belted shuttles will be completely unusable for receiving orders.** This is completely intentional and there's no way around this but to remove some belts. This creates a loud-mode announcement in the Supply channel every time it happens.

**Heavily belted shuttles will be harder to work with as some orders may not be delivered.** The orders that *were delivered* will need to be moved onto an unloading belt or off of the shuttle, still making the shuttle harder to use than one with less or no belts, and requiring Supply staff to enter the shuttle at all.

**Shuttles with very few belts won't be affected very much, if at all.** For example, if you only put belts along the edges of your shuttle, you already had to move *some* crates onto the unloading belt. Now, you simply have to move *all of them,* instead of only having to move the crates that didn't spawn on the unloading belt.

</details>

This adds multiple lines of non-modular additions. I resent that. This could be a good candidate for creation on TG, but I'm not completely certain about if that crowd will react better or worse than here, so I'm making it here.

## How This Contributes To The Nova Sector Roleplay Experience
The intent of this PR is to make it much harder to move crates in the supply shuttle unattended. I want to put pressure on Cargo Technicians to do a little bit more *consistent* work throughout the whole round and would like to see how the easiest form of automation receiving a major nerf changes how Cargo Technicians play their game.

It's certainly still possible and valid to modify the supply shuttle, but people will have to work around this PR's new requirements while doing so and ideally will have to enter the shuttle to make significant progress unloading crates, unless they find some new method to move crates in the shuttle unattended (which I'll just go out of my way to remove tbh).

<details><summary>It should be stated that I'm very partial to disliking automated cargo as a whole.</summary>

I am a Cargo Technician main on TG and every TG-derived server I have ever played, including Nova. I have always resented the ability to fully automate a shuttle (and to an extent, the bay it docks to) and having to work in a cargo bay or with a shuttle that is automated.

I would rather see methods of automating supply labor permanently removed or nerfed so Cargo Technicians have to choose between joining the game to actually do their job or just opening Factorio instead of SS13, and maybe one day I'll remove more automation methods or change them to not work unattended, but this is a good alternative with very few immediate design complications to deal with. 

</details>

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

### Partially belted shuttle (slightly outdated, conveyor switches will now also block spawning)
<img width="497" height="752" alt="Screenshot_3529" src="https://github.com/user-attachments/assets/9790eb98-0349-4056-935f-1fef6e8f326b" />

### Fully belted shuttle—useless
<img width="461" height="751" alt="Screenshot_3530" src="https://github.com/user-attachments/assets/2580fde4-2341-4d2d-ad10-2325a6ed19f3" />

### Overcrowding warnings—two are provided, then there are no more warnings if you really know what you're doing
<img width="484" height="249" alt="Screenshot_3533" src="https://github.com/user-attachments/assets/10e9ea73-78d2-4afa-9206-3e52043db27a" />

### Blocking warnings—these have no cooldown (slightly outdated, this announcement received better phrasing)
<img width="490" height="195" alt="Screenshot_3534" src="https://github.com/user-attachments/assets/4d664251-ec51-4192-b85a-1b85c79b4f9d" />

</details>

## Changelog
:cl:
balance: [NOVA] The supply shuttle will not spawn crates on tiles occupied by conveyor belts, conveyor switches, sorters, and other machinery. This can prevent orders from being confirmed if there are fewer un-occupied tiles in the shuttle than unique items that need to be spawned.
/:cl:
