### PR TITLE
fixes crafting-based conversion items (gun conversions, holster charger upgrades)

### DIFF
--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/archon_combat_systems/conversion_kits.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/archon_combat_systems/conversion_kits.dm
@@ -17,6 +17,7 @@
 	AddElement(/datum/element/manufacturer_examine, COMPANY_ARCHON)
 
 /datum/crafting_recipe/riot_sol_super
+	crafting_flags = parent_type::crafting_flags | CRAFT_COLLECT_REQUIREMENTS
 	name = "M64 to KOLBEN/NACHTREIHER Shotgun Conversion"
 	desc = "Bring order to chaos."
 	result = /obj/item/gun/ballistic/shotgun/riot/sol/super/empty
@@ -65,6 +66,7 @@
 
 /datum/crafting_recipe/doublebarrel_super
 	name = "Double-Barrel Shotgun to Lammergeier O/U Conversion"
+	crafting_flags = parent_type::crafting_flags | CRAFT_COLLECT_REQUIREMENTS
 	desc = "Sighting correction A-OK. 90... 95... I won't miss."
 	result = /obj/item/gun/ballistic/shotgun/doublebarrel/super/empty
 	reqs = list(

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/conversion_kits.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/conversion_kits.dm
@@ -20,6 +20,7 @@
 
 /datum/crafting_recipe/reclaimer_reverse
 	name = "rC-20 'Reclaimer' to NT20 Conversion"
+	crafting_flags = parent_type::crafting_flags | CRAFT_COLLECT_REQUIREMENTS
 	desc = "Do you care about honor, or do you use honor as an excuse? An excuse to exist in a violent world."
 	result = /obj/item/gun/ballistic/automatic/nt20/empty
 	reqs = list(
@@ -62,6 +63,7 @@
 
 /datum/crafting_recipe/c38_super
 	name = ".38 Revolver to NT/E Laevateinn Conversion"
+	crafting_flags = parent_type::crafting_flags | CRAFT_COLLECT_REQUIREMENTS
 	desc = "Under what circumstances would you need to carry around a .38 revolver converted into a railgun? Whatever circumstances you're in, apparently."
 	result = /obj/item/gun/ballistic/revolver/c38/super/empty
 	reqs = list(
@@ -102,6 +104,7 @@
 
 /datum/crafting_recipe/c38_speedloader_plus
 	name = ".38 Speedloader Expansion"
+	crafting_flags = parent_type::crafting_flags | CRAFT_COLLECT_REQUIREMENTS
 	desc = "Six rounds is two less than eight, which makes reloading an eight-round cylinder with a six-round speedloader both annoying and suboptimal. \
 		This, however, is a fixable problem."
 	result = /obj/item/ammo_box/speedloader/c38/hicap/empty

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/scarborough_arms/conversion_kits.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/scarborough_arms/conversion_kits.dm
@@ -21,6 +21,7 @@
 
 /datum/crafting_recipe/reclaimer_c20r
 	name = "NT20 to rC-20 'Reclaimer' Conversion"
+	crafting_flags = parent_type::crafting_flags | CRAFT_COLLECT_REQUIREMENTS
 	desc = "Unlike you, I have no physical or social restraints. The candles burn out for you; I am free."
 	result = /obj/item/gun/ballistic/automatic/c20r/reclaimed/empty
 	reqs = list(

--- a/modular_nova/modules/modular_weapons/code/conversion_kits.dm
+++ b/modular_nova/modules/modular_weapons/code/conversion_kits.dm
@@ -39,6 +39,7 @@
 
 /datum/crafting_recipe/mosin_pro
 	name = "Sakhno to Xhihao 'Rengo' Conversion"
+	crafting_flags = parent_type::crafting_flags | CRAFT_COLLECT_REQUIREMENTS
 	desc = "It's actually really easy to change the stock on your Sakhno. Anyone can do it. It takes roughly thirty seconds and a screwdriver."
 	result = /obj/item/gun/ballistic/rifle/sporterized/empty
 	reqs = list(

--- a/modular_nova/modules/modular_weapons/code/holster_conversions.dm
+++ b/modular_nova/modules/modular_weapons/code/holster_conversions.dm
@@ -1,5 +1,6 @@
 /datum/crafting_recipe/charge_holster
 	name = "Energy Shoulder Holster Conversion"
+	crafting_flags = parent_type::crafting_flags | CRAFT_COLLECT_REQUIREMENTS
 	desc = "Retool a regular shoulder holster into one that can't hold regular sidearms, but can recharge energy weapons."
 	result = /obj/item/storage/belt/holster/energy
 	reqs = list(
@@ -27,6 +28,7 @@
 
 /datum/crafting_recipe/supercharge_holster
 	name = "High-Output Energy Shoulder Holster Conversion"
+	crafting_flags = parent_type::crafting_flags | CRAFT_COLLECT_REQUIREMENTS
 	desc = "Sacrifice the second holster in return for extra charging throughput on your energy holster. \
 		Do you lose the ability to have two guns? Yes. Do you have a faster wearable recharger? Also yes."
 	result = /obj/item/storage/belt/holster/energy/onegun


### PR DESCRIPTION
## About The Pull Request

Adds `CRAFT_COLLECT_REQUIREMENTS` flags to a bunch of Nova-specific crafting conversions so that the conditionals can be checked and satisfied.

## How This Contributes To The Nova Sector Roleplay Experience

Whoa, cool crafting!

## Changelog

:cl:
fix: Crafting recipes for Nova-specific gun conversion kits and shoulder holsters should work again.
/:cl: