### PR TITLE
fix: misc radios

### DIFF
--- a/code/__DEFINES/~nova_defines/radio.dm
+++ b/code/__DEFINES/~nova_defines/radio.dm
@@ -11,8 +11,8 @@
 #define FREQ_INTERDYNE 1209
 
 #define RADIO_CHANNEL_GUILD "Guild"
-#define RADIO_KEY_GUILD ","
-#define RADIO_TOKEN_GUILD ":,"
+#define RADIO_KEY_GUILD "1"
+#define RADIO_TOKEN_GUILD ":1"
 
 #define FREQ_GUILD 1214
 

--- a/code/__DEFINES/~nova_defines/radio.dm
+++ b/code/__DEFINES/~nova_defines/radio.dm
@@ -2,7 +2,7 @@
 #define RADIO_KEY_CYBERSUN "q"
 #define RADIO_TOKEN_CYBERSUN ":q"
 
-#define FREQ_CYBERSUN 1211
+#define FREQ_CYBERSUN 1207
 
 #define RADIO_CHANNEL_INTERDYNE "Interdyne"
 #define RADIO_KEY_INTERDYNE "w"
@@ -11,8 +11,8 @@
 #define FREQ_INTERDYNE 1209
 
 #define RADIO_CHANNEL_GUILD "Guild"
-#define RADIO_KEY_GUILD "d"
-#define RADIO_TOKEN_GUILD ":d"
+#define RADIO_KEY_GUILD ","
+#define RADIO_TOKEN_GUILD ":,"
 
 #define FREQ_GUILD 1214
 

--- a/code/__DEFINES/~nova_defines/solfed.dm
+++ b/code/__DEFINES/~nova_defines/solfed.dm
@@ -1,5 +1,5 @@
 #define RADIO_CHANNEL_SOLFED "SolFed"
-#define RADIO_KEY_SOLFED "."
-#define RADIO_TOKEN_SOLFED ":."
+#define RADIO_KEY_SOLFED "2"
+#define RADIO_TOKEN_SOLFED ":2"
 
 #define FREQ_SOLFED 1377

--- a/code/__DEFINES/~nova_defines/solfed.dm
+++ b/code/__DEFINES/~nova_defines/solfed.dm
@@ -1,5 +1,5 @@
 #define RADIO_CHANNEL_SOLFED "SolFed"
-#define RADIO_KEY_SOLFED "f"
-#define RADIO_TOKEN_SOLFED ":f"
+#define RADIO_KEY_SOLFED "."
+#define RADIO_TOKEN_SOLFED ":."
 
 #define FREQ_SOLFED 1377

--- a/modular_nova/modules/advanced_engineering/readme.md
+++ b/modular_nova/modules/advanced_engineering/readme.md
@@ -15,8 +15,8 @@ None
 ### Defines
 
 #define RADIO_CHANNEL_SOLFED "SolFed"
-#define RADIO_KEY_SOLFED "."
-#define RADIO_TOKEN_SOLFED ":."
+#define RADIO_KEY_SOLFED "2"
+#define RADIO_TOKEN_SOLFED ":2"
 
 #define FREQ_SOLFED 1377
 

--- a/modular_nova/modules/advanced_engineering/readme.md
+++ b/modular_nova/modules/advanced_engineering/readme.md
@@ -15,8 +15,8 @@ None
 ### Defines
 
 #define RADIO_CHANNEL_SOLFED "SolFed"
-#define RADIO_KEY_SOLFED "f"
-#define RADIO_TOKEN_SOLFED ":f"
+#define RADIO_KEY_SOLFED "."
+#define RADIO_TOKEN_SOLFED ":."
 
 #define FREQ_SOLFED 1377
 

--- a/tgui/packages/tgui-say/constants.ts
+++ b/tgui/packages/tgui-say/constants.ts
@@ -36,7 +36,7 @@ export const RADIO_PREFIXES = {
   ':w ': 'Dyne',
   ':k ': 'Tark',
   ':q ': 'Csun',
-  ':, ': 'Guild',
-  ':. ': 'SolFed',
+  ':1 ': 'Guild',
+  ':2 ': 'SolFed',
   // NOVA EDIT ADDITION END
 } as const;

--- a/tgui/packages/tgui-say/constants.ts
+++ b/tgui/packages/tgui-say/constants.ts
@@ -36,7 +36,7 @@ export const RADIO_PREFIXES = {
   ':w ': 'Dyne',
   ':k ': 'Tark',
   ':q ': 'Csun',
-  ':i ': 'Guild',
-  ':l ': 'SolFed',
+  ':, ': 'Guild',
+  ':. ': 'SolFed',
   // NOVA EDIT ADDITION END
 } as const;


### PR DESCRIPTION
## About The Pull Request

we are replacing FREQ_CYBERSUN 1211 since it uses same freq as FREQ_UPLINK(tg, probably this is should be removed by them)
aslo replacing "d" for guild since d is "deadchat"
also "f" for solfed, since it used by faction(misc ghostroles, and bitrunning headset)

## Changelog

:cl:
fix: fixed a misc radio channels(cybersun, guild, faction/solfed)
/:cl:
