### PR TITLE
Soft-spoken signers can go non verbal and speak at full volume

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -158,7 +158,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	if(IS_UNCONSCIOUS(src) && (stat != HARD_CRIT || !message_mods[WHISPER_MODE]))
 		return
 
-	if(HAS_TRAIT(src, TRAIT_FORCE_WHISPER))
+	if(HAS_TRAIT(src, TRAIT_FORCE_WHISPER) && !HAS_TRAIT(src, TRAIT_SIGN_LANG)) // NOVA EDIT CHANGE - Soft-spoken signers can go non verbal and speak at full volume - ORIGINAL: if(HAS_TRAIT(src, TRAIT_FORCE_WHISPER))
 		message_mods[WHISPER_MODE] = MODE_WHISPER
 
 	if(client && SSlag_switch.measures[SLOWMODE_SAY] && !HAS_TRAIT(src, TRAIT_BYPASS_MEASURES) && !forced && src == usr)


### PR DESCRIPTION
## About The Pull Request
https://github.com/tgstation/tgstation/pull/97041, along with its 5 refactors and other gameplay change spanning across 500 files (dick move), removed the ability for Signers to bypass whispering. It's really easy to add the interaction back after spending a few minutes finding where it was in the codebase.

It's probably possible to improve this code for modularity. However, I *want* this to be more likely to conflict in the event that someone on TG changes this again.
## How This Contributes To The Nova Sector Roleplay Experience
Soft-spoken signers can go non-verbal and speak at full volume again. This is a mundane thing to have on our server.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="381" height="64" alt="Screenshot_3614" src="https://github.com/user-attachments/assets/5f7023a2-f4ab-40bd-97db-b3f5db3b7d18" />

</details>

## Changelog
:cl:
qol: [NOVA] Signer will once again bypass forced whispering from Soft-Spoken or other states.
/:cl:
