### PR TITLE
Boxers and long johns now use their proper digitigrade sprites.

### DIFF
--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/underwear/underwear.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/underwear/underwear.dm
@@ -8,40 +8,42 @@
 	return icon_state
 
 /*
-	Adding has_custom_digi_sprite to TG stuff
+	Adding has_custom_digi_sprite to TG stuff, as well as setting digi_icon_state to null on the boxers, because we have dedicated digi sprites for those
 */
-/datum/sprite_accessory/clothing/underwear/female_kinky
-	name = "Panties - Lingerie"
-	icon_state = "panties_kinky"
-	gender = FEMALE
-	has_custom_digi_sprite = TRUE
-
 /datum/sprite_accessory/clothing/underwear/male_briefs
 	has_custom_digi_sprite = TRUE
 
 /datum/sprite_accessory/clothing/underwear/male_boxers
 	has_custom_digi_sprite = TRUE
+	digi_icon_state = null
 
 /datum/sprite_accessory/clothing/underwear/male_stripe
 	has_custom_digi_sprite = TRUE
+	digi_icon_state = null
 
 /datum/sprite_accessory/clothing/underwear/male_midway
 	has_custom_digi_sprite = TRUE
+	digi_icon_state = null
 
 /datum/sprite_accessory/clothing/underwear/male_longjohns
 	has_custom_digi_sprite = TRUE
+	digi_icon_state = null
 
 /datum/sprite_accessory/clothing/underwear/male_hearts
 	has_custom_digi_sprite = TRUE
+	digi_icon_state = null
 
 /datum/sprite_accessory/clothing/underwear/male_commie
 	has_custom_digi_sprite = TRUE
+	digi_icon_state = null
 
 /datum/sprite_accessory/clothing/underwear/male_usastripe
 	has_custom_digi_sprite = TRUE
+	digi_icon_state = null
 
 /datum/sprite_accessory/clothing/underwear/male_uk
 	has_custom_digi_sprite = TRUE
+	digi_icon_state = null
 
 /*
 	Modular Underwear past here
@@ -72,6 +74,12 @@
 	name = "Panties"
 	icon_state = "panties"
 	gender = FEMALE
+	
+/datum/sprite_accessory/clothing/underwear/female_kinky
+	name = "Panties - Lingerie"
+	icon_state = "panties_kinky"
+	gender = FEMALE
+	has_custom_digi_sprite = TRUE
 
 /datum/sprite_accessory/clothing/underwear/panties_slim
 	name = "Panties - Slim"

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/underwear/underwear.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/underwear/underwear.dm
@@ -10,6 +10,12 @@
 /*
 	Adding has_custom_digi_sprite to TG stuff, as well as setting digi_icon_state to null on the boxers, because we have dedicated digi sprites for those
 */
+/datum/sprite_accessory/clothing/underwear/female_kinky
+	name = "Panties - Lingerie"
+	icon_state = "panties_kinky"
+	gender = FEMALE
+	has_custom_digi_sprite = TRUE
+
 /datum/sprite_accessory/clothing/underwear/male_briefs
 	has_custom_digi_sprite = TRUE
 
@@ -74,12 +80,6 @@
 	name = "Panties"
 	icon_state = "panties"
 	gender = FEMALE
-	
-/datum/sprite_accessory/clothing/underwear/female_kinky
-	name = "Panties - Lingerie"
-	icon_state = "panties_kinky"
-	gender = FEMALE
-	has_custom_digi_sprite = TRUE
 
 /datum/sprite_accessory/clothing/underwear/panties_slim
 	name = "Panties - Slim"


### PR DESCRIPTION

## About The Pull Request

This sets digi_icon_state to null on all the boxers and the long johns, so that they use Nova's digi sprites instead of trying to use /tg/'s.

Fixes #7758.

## How This Contributes To The Nova Sector Roleplay Experience

Having certain kinds of underwear not display properly on digitigrade legs because of a bug is bad.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="232" height="343" alt="Screenshot_564" src="https://github.com/user-attachments/assets/bff6b9bc-eab7-49ca-8967-5c1ca7acbb43" />
<br>
<img width="233" height="300" alt="Screenshot_565" src="https://github.com/user-attachments/assets/7f882df6-04af-4532-8f7c-e8f239187ebe" />

</details>

## Changelog
:cl:
fix: The regular, midway, hearts, commie, freedom, and UK boxers, as well as the long johns, should all now use their proper digitigrade sprites.
/:cl:
