### PR TITLE
Fixes Medical Records Bluescreening

### DIFF
--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/insectoid.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/insectoid.dm
@@ -14,7 +14,7 @@
 		TRAIT_WEB_SURFER,
 	)
 	meat = /obj/item/food/meat/slab/spider
-	exotic_bloodtype = "Chlorocruorin" // awkwardly not a define
+	exotic_bloodtype = /datum/blood_type/chlorocruorin
 	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID|MOB_BUG
 	payday_modifier = 1.0
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT


### PR DESCRIPTION

## About The Pull Request
See title.

Insectoids didn't have their blood type set as a define previously, for.... reasons? which is why I failed to notice when the blood types were undefined recently.

## Changelog

:cl:
fix: medical records shouldn't be bluescreening now
/:cl:

