### PR TITLE
[NON-MODULAR] Neckerchiefs no longer look wonky if you have a snout.

### DIFF
--- a/code/modules/clothing/masks/bandana.dm
+++ b/code/modules/clothing/masks/bandana.dm
@@ -81,6 +81,7 @@
 		user.visible_message(span_notice("[user] ties [src] up like a neckerchief."), span_notice("You tie [src] up like a neckerchief."))
 		flags_inv = NONE
 		flags_cover = NONE
+		supports_variations_flags = NONE //NOVA EDIT ADDITION - Needed so that it doesn't use the snout sprite for the neckerchief.
 		return CLICK_ACTION_SUCCESS
 
 	undyeable = initial(undyeable)
@@ -90,6 +91,7 @@
 	user.visible_message(span_notice("[user] unties the neckerchief."), span_notice("You untie the neckerchief."))
 	flags_inv = initial(flags_inv)
 	flags_cover = initial(flags_cover)
+	supports_variations_flags = initial(supports_variations_flags) //NOVA EDIT ADDITION - See above.
 	return CLICK_ACTION_SUCCESS
 
 /obj/item/clothing/mask/bandana/red


### PR DESCRIPTION

## About The Pull Request

For some reason, when you turned a bandana into a neckerchief, it didn't take off the variation flags when you did. This meant that, if you had a snout, it still used the snout variant of the bandana in neckerchief form, causing it to look wonky. This fixes that.

Before and after pictures are in the testing section.

## How This Contributes To The Nova Sector Roleplay Experience

I don't think i need to explain why fixing this is a good thing.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
 Before:
<br>
<img width="99" height="96" alt="Screenshot_566" src="https://github.com/user-attachments/assets/2d57fb0a-add0-46b9-9076-aebb7284d7cf" />
<br>
After:
<br>
<img width="133" height="131" alt="Screenshot_567" src="https://github.com/user-attachments/assets/00f8acd7-47b8-4572-91eb-67ce51e30e71" />

</details>

## Changelog
:cl:
fix: Neckerchiefs should no longer look wonky if you have a snout.
/:cl:
