### PR TITLE
fixes hi-cap .38 speedloaders

### DIFF
--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/conversion_kits.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/conversion_kits.dm
@@ -104,7 +104,7 @@
 
 /datum/crafting_recipe/c38_speedloader_plus
 	name = ".38 Speedloader Expansion"
-	crafting_flags = parent_type::crafting_flags | CRAFT_COLLECT_REQUIREMENTS
+	crafting_flags = parent_type::crafting_flags | CRAFT_COLLECT_REQUIREMENTS | CRAFT_SKIP_MATERIALS_PARITY
 	desc = "Six rounds is two less than eight, which makes reloading an eight-round cylinder with a six-round speedloader both annoying and suboptimal. \
 		This, however, is a fixable problem."
 	result = /obj/item/ammo_box/speedloader/c38/hicap/empty
@@ -120,7 +120,6 @@
 	tool_behaviors = list(TOOL_SCREWDRIVER)
 	time = 10 SECONDS
 	category = CAT_WEAPON_RANGED
-	crafting_flags = parent_type::crafting_flags | CRAFT_SKIP_MATERIALS_PARITY
 
 /datum/crafting_recipe/c38_speedloader_plus/New()
 	..()


### PR DESCRIPTION
## About The Pull Request

tin

## How This Contributes To The Nova Sector Roleplay Experience

probably a good thing that your eight-shot revolver can use speedloaders with eight shots

## Proof of Testing

<img width="470" height="296" alt="2026-08-18_02-41-22-PM-Tuesday" src="https://github.com/user-attachments/assets/b07e2f5a-dba6-4e66-a66c-dfdcb728f676" />

## Changelog

:cl:
fix: .38 speedloader widening kits work again.
/:cl:
