### PR TITLE
Really Specific SAD Change That Allows For Biosynthetic AI Shells

### DIFF
--- a/modular_nova/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_nova/modules/self_actualization_device/code/self_actualization_device.dm
@@ -230,6 +230,7 @@
 			return
 		old_ai_brain.undeploy()
 		real_ai_player.client?.prefs?.safe_transfer_prefs_to_with_damage(patient)
+		attempt_appendix_removal(patient, check_prefs)
 	else
 		patient.client?.prefs?.safe_transfer_prefs_to_with_damage(patient)
 
@@ -322,6 +323,7 @@
 /obj/machinery/self_actualization_device/proc/is_augmented_enough(datum/preferences/player_prefs)
 	var/mob/living/carbon/human/nullspace_dummy = new(null)
 	player_prefs?.apply_prefs_to(nullspace_dummy, icon_updates = FALSE)
+	attempt_appendix_removal(nullspace_dummy, player_prefs)
 	var/obj/item/organ/brain/cybernetic/ai/dummy_ai_brain = new
 	if(!dummy_ai_brain.Insert(nullspace_dummy, movement_flags = DELETE_IF_REPLACED))
 		QDEL_NULL(dummy_ai_brain)
@@ -332,6 +334,23 @@
 	QDEL_NULL(dummy_ai_brain)
 	QDEL_NULL(nullspace_dummy)
 	return result
+
+/*
+ * Helper function for the removal of appendices from a mob.
+ * Shamelessly stolen from /datum/quirk/no_appendix/post_add().
+ * If you have a better idea on how to handle this, i'd like to hear it,
+ * because add_quirk() isn't working.
+ */
+/obj/machinery/self_actualization_device/proc/attempt_appendix_removal(mob/living/carbon/human/shell, datum/preferences/player_prefs)
+	if (!(/datum/quirk/no_appendix::name in player_prefs?.all_quirks))
+		return FALSE // don't bother
+
+	var/obj/item/organ/appendix/old_appendix = shell.get_organ_slot(ORGAN_SLOT_APPENDIX)
+	if(isnull(old_appendix))
+		return FALSE // no appendix, no worries
+
+	old_appendix.Remove(shell, special = TRUE)
+	QDEL_NULL(old_appendix)
 
 #undef NO_CONSENT
 #undef CONSENT_GRANTED


### PR DESCRIPTION

## About The Pull Request

Adds a check to the SAD which will attempt to remove the appendix in the instance that the occupant has an AI uplink brain and the desired resultant character has the "Appendicitis Survivor" quirk taken. This allows for a shell that is otherwise organic, so long as all of the organs are cybernetic.
## How This Contributes To The Nova Sector Roleplay Experience

uhhhh more options for AI players i guess idk
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  

https://github.com/user-attachments/assets/384af4ae-eba3-4233-9620-996f70c5f82f


</details>

## Changelog
:cl:
code: Adds a function to attempt the removal of an appendix if one is present in an AI uplink shell going through the SAD, allowing for biosynthetic shells
/:cl:
