### PR TITLE
Automapper templates are no longer overwritten by modular map modules

### DIFF
--- a/modular_nova/modules/automapper/code/automapper_subsystem.dm
+++ b/modular_nova/modules/automapper/code/automapper_subsystem.dm
@@ -22,6 +22,9 @@ SUBSYSTEM_DEF(automapper)
 	var/loaded_config
 	/// Our preloaded map templates
 	var/list/preloaded_map_templates = list()
+	/// Every turf our preloaded templates have laid claim to, kept for the whole round.
+	/// Anything that loads maps after LoadGroup() has run (modular map modules, for example) must not write over these.
+	var/list/reserved_turfs = list()
 
 /datum/controller/subsystem/automapper/Initialize()
 	loaded_config = rustg_read_toml_file(config_file)
@@ -161,4 +164,5 @@ SUBSYSTEM_DEF(automapper)
 				continue
 
 			blacklisted_turfs[blacklisted_turf] = TRUE
+			reserved_turfs[blacklisted_turf] = TRUE
 	return blacklisted_turfs

--- a/modular_nova/modules/automapper/code/modular_map_loader.dm
+++ b/modular_nova/modules/automapper/code/modular_map_loader.dm
@@ -1,0 +1,16 @@
+/**
+ * Maps like Tramstation build themselves out of map modules, which are loaded from
+ * /obj/modular_map_root. Those roots are INITIALIZE_IMMEDIATE and load their module through
+ * INVOKE_ASYNC, so a module (and any attachment root nested inside it) finishes loading at an
+ * arbitrary point after the base map has been parsed - frequently after LoadGroup() has already
+ * asked SSautomapper to place its templates. Whichever load lands last wins the turf, so the
+ * automapper's templates end up buried under the modules.
+ *
+ * Rather than trying to force an order onto two loaders that both yield mid-load, we make the
+ * modules honour the same turf blacklist the base map does. The automapper's footprint is then
+ * carved out of every module too, and the template can be placed whenever it likes.
+ */
+/datum/map_template/map_module/update_blacklist(turf/placement, list/input_blacklist)
+	. = ..()
+	for(var/turf/reserved_turf as anything in SSautomapper.reserved_turfs)
+		input_blacklist[reserved_turf] = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8064,6 +8064,7 @@
 #include "modular_nova\modules\automapper\code\area_spawn_subsystem.dm"
 #include "modular_nova\modules\automapper\code\automap_template.dm"
 #include "modular_nova\modules\automapper\code\automapper_subsystem.dm"
+#include "modular_nova\modules\automapper\code\modular_map_loader.dm"
 #include "modular_nova\modules\autotransfer\code\autotransfer.dm"
 #include "modular_nova\modules\autotransfer\code\autotransfer_config.dm"
 #include "modular_nova\modules\autotransfer\code\shuttle.dm"


### PR DESCRIPTION

## About The Pull Request

Tramstation builds its maints out of random modules and connectors, and those modules load on their own schedule which sometimes completes after the automapper has placed its template. This tweak tells the module loader to leave the automapper's footprint alone, the same way the base map already does.

<details>
<summary>Screenshots/Videos</summary>
before: modular tram connector writes over part of a new automapper template

<img width="1753" height="1790" alt="image" src="https://github.com/user-attachments/assets/d41659f7-14bc-4f30-9026-6c18f28e9e31" />

after: both templates run, but the automapper's spaces are left untouched

<img width="1700" height="1223" alt="image" src="https://github.com/user-attachments/assets/2dd47750-8d5a-4466-b0ad-514cc32e5a33" />

</details>

## Changelog
:cl:
code: Automapper templates are no longer overwritten by modular map modules
/:cl:
