### PR TITLE
Fixes NT/E Laevateinn Revolver reskin belt/suit sprites

### DIFF
--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/revolver.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/revolver.dm
@@ -3,59 +3,49 @@
 /datum/atom_skin/laevateinn_revolver
 	abstract_type = /datum/atom_skin/laevateinn_revolver
 	change_base_icon_state = TRUE
+	change_worn_icon_state = FALSE
 
 /datum/atom_skin/laevateinn_revolver/base
 	preview_name = "Baseline"
 	new_icon_state = "c38rail"
-	new_worn_icon = "gun"
 
 /datum/atom_skin/laevateinn_revolver/base/reflex
 	preview_name = "Reflex"
 	new_icon_state = "c38rail_sight"
-	new_worn_icon = "gun"
 
 /datum/atom_skin/laevateinn_revolver/base/hunter
 	preview_name = "Hunter"
 	new_icon_state = "c38rail_scope"
-	new_worn_icon = "gun"
 
 /datum/atom_skin/laevateinn_revolver/base/shadow
 	preview_name = "Shadow Baseline"
 	new_icon_state = "c38rail_dark"
-	new_worn_icon = "gun"
 
 /datum/atom_skin/laevateinn_revolver/base/shadow/reflex
 	preview_name = "Shadow Reflex"
 	new_icon_state = "c38rail_dark_sight"
-	new_worn_icon = "gun"
 
 /datum/atom_skin/laevateinn_revolver/base/shadow/hunter
 	preview_name = "Shadow Hunter"
 	new_icon_state = "c38rail_dark_scope"
-	new_worn_icon = "gun"
 
 /datum/atom_skin/laevateinn_revolver/midnight
 	preview_name = "Midnight Baseline"
 	new_icon_state = "c38rail_midnight"
-	new_worn_icon = "gun"
 
 /datum/atom_skin/laevateinn_revolver/midnight/reflex
 	preview_name = "Midnight Reflex"
 	new_icon_state = "c38rail_midnight_sight"
-	new_worn_icon = "gun"
 
 /datum/atom_skin/laevateinn_revolver/midnight/hunter
 	preview_name = "Midnight Hunter"
 	new_icon_state = "c38rail_midnight_scope"
-	new_worn_icon = "gun"
 
 /obj/item/gun/ballistic/revolver/c38/super
 	name = "\improper NT/E Laevateinn Revolver"
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/company_and_or_faction_based/nanotrasen_armories/ballistic.dmi'
 	icon_state = "c38rail"
 	base_icon_state = "c38rail"
-	worn_icon = 'icons/mob/clothing/belt.dmi'
-	worn_icon_state = "gun"
 	w_class = WEIGHT_CLASS_NORMAL
 	obj_flags = UNIQUE_RENAME
 	desc = "A new spin on a classic. Uses .38 Special rounds, and features both a magnified sight and a magnetic charge-shot assembly built into the barrel for precision fire."

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/revolver.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/revolver.dm
@@ -7,38 +7,47 @@
 /datum/atom_skin/laevateinn_revolver/base
 	preview_name = "Baseline"
 	new_icon_state = "c38rail"
+	new_worn_icon = "gun"
 
 /datum/atom_skin/laevateinn_revolver/base/reflex
 	preview_name = "Reflex"
 	new_icon_state = "c38rail_sight"
+	new_worn_icon = "gun"
 
 /datum/atom_skin/laevateinn_revolver/base/hunter
 	preview_name = "Hunter"
 	new_icon_state = "c38rail_scope"
+	new_worn_icon = "gun"
 
 /datum/atom_skin/laevateinn_revolver/base/shadow
 	preview_name = "Shadow Baseline"
 	new_icon_state = "c38rail_dark"
+	new_worn_icon = "gun"
 
 /datum/atom_skin/laevateinn_revolver/base/shadow/reflex
 	preview_name = "Shadow Reflex"
 	new_icon_state = "c38rail_dark_sight"
+	new_worn_icon = "gun"
 
 /datum/atom_skin/laevateinn_revolver/base/shadow/hunter
 	preview_name = "Shadow Hunter"
 	new_icon_state = "c38rail_dark_scope"
+	new_worn_icon = "gun"
 
 /datum/atom_skin/laevateinn_revolver/midnight
 	preview_name = "Midnight Baseline"
 	new_icon_state = "c38rail_midnight"
+	new_worn_icon = "gun"
 
 /datum/atom_skin/laevateinn_revolver/midnight/reflex
 	preview_name = "Midnight Reflex"
 	new_icon_state = "c38rail_midnight_sight"
+	new_worn_icon = "gun"
 
 /datum/atom_skin/laevateinn_revolver/midnight/hunter
 	preview_name = "Midnight Hunter"
 	new_icon_state = "c38rail_midnight_scope"
+	new_worn_icon = "gun"
 
 /obj/item/gun/ballistic/revolver/c38/super
 	name = "\improper NT/E Laevateinn Revolver"

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/revolver.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/revolver.dm
@@ -45,6 +45,8 @@
 	icon = 'modular_nova/modules/modular_weapons/icons/obj/company_and_or_faction_based/nanotrasen_armories/ballistic.dmi'
 	icon_state = "c38rail"
 	base_icon_state = "c38rail"
+	worn_icon = 'icons/mob/clothing/belt.dmi'
+	worn_icon_state = "gun"
 	w_class = WEIGHT_CLASS_NORMAL
 	obj_flags = UNIQUE_RENAME
 	desc = "A new spin on a classic. Uses .38 Special rounds, and features both a magnified sight and a magnetic charge-shot assembly built into the barrel for precision fire."


### PR DESCRIPTION

## About The Pull Request
Reskinning the NT/E Laevateinn Revolver broke it's belt and suit storage slot sprites, defaulting to a missing texture belt appearing when worn. This fixes that, now reskinning the revolver doesn't attempt to overwrite it's default worn sprite.

## How This Contributes To The Nova Sector Roleplay Experience
Stops a big missing texture appearing on your character if you try to wear the revolver on your hip. 

## Proof of Testing
Game builds and runs correctly, sprites appear as they should, no errors in console. 
Sprite swaps sides depending on if the belt or suit storage slot is used, as it should.

<details>
<summary>Screenshots/Videos</summary>
  
<img width="97" height="100" alt="image" src="https://github.com/user-attachments/assets/77b40442-5dd8-4a96-8c98-4b190f524b98" />
<img width="100" height="103" alt="image" src="https://github.com/user-attachments/assets/3c9078f2-3269-4e17-b1f4-83fb68345641" />

</details>

## Changelog
:cl:
fix: Reskinning the Laevateinn revolver no longer breaks its belt and suit storage slot sprite.
/:cl:

