### PR TITLE
Fixes delayed airlock access

### DIFF
--- a/modular_nova/modules/airlock_override/code/airlock_override.dm
+++ b/modular_nova/modules/airlock_override/code/airlock_override.dm
@@ -81,14 +81,10 @@
 	RegisterSignal(door_area, COMSIG_AREA_FIRE_CHANGED, PROC_REF(update_fire_status))
 	RegisterSignal(SSdcs, COMSIG_GLOB_FORCE_ENG_OVERRIDE, PROC_REF(force_eng_override))
 
-///Check for the three states of open access. Emergency, Unrestricted, and Engineering Override
+/// If the station has the engineering override set, or
+/// the area has a fire alarm, allows peoples with [ACCESS_ENGINEERING]
+/// to open the airlock anyway (falls back to TG behavior otherwise)
 /obj/machinery/door/airlock/allowed(mob/user)
-	if(emergency)
-		return TRUE
-
-	if(unrestricted_side(user))
-		return TRUE
-
 	if(engineering_override || fire_active)
 		var/mob/living/carbon/human/interacting_human = user
 		if(!istype(interacting_human))


### PR DESCRIPTION
## About The Pull Request

While debugging NorthStar, I discovered we've had an override preventing delayed airlock access from working [since it was added to the game.](https://github.com/tgstation/tgstation/pull/94040) I've removed that override so it will fall back to TG behavior and let delayed access work.

## How This Contributes To The Nova Sector Roleplay Experience

This is more of a fix than a balance change. And to be honest, this change is good for the game regardless.

I want delayed airlock access working before it's NorthStar time, and I might tweak other Nova maps to make use of delayed airlock access too.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/9545bfa2-7eb8-4c2e-a77c-226599300a32

</details>

## Changelog

:cl:
fix: [NOVA] Delayed unrestricted access on airlocks now works on TG maps, and any Nova maps that may implement it.
/:cl:
