### PR TITLE
The LOOC button in the OOC tab now encodes messages properly.

### DIFF
--- a/modular_nova/modules/admin/code/aooc.dm
+++ b/modular_nova/modules/admin/code/aooc.dm
@@ -30,7 +30,7 @@ GAME_VERB(/client, aooc, "AOOC", "OOC")
 	if(QDELETED(src))
 		return
 
-	msg = copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN)
+	msg = copytext_char(sanitize(html_decode(msg)), 1, MAX_MESSAGE_LEN)
 	var/raw_msg = msg
 
 	if(!msg)

--- a/modular_nova/modules/admin/code/sooc.dm
+++ b/modular_nova/modules/admin/code/sooc.dm
@@ -32,7 +32,7 @@ GAME_VERB(/client, sooc, "SOOC", "OOC")
 	if(QDELETED(src))
 		return
 
-	msg = copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN)
+	msg = copytext_char(sanitize(html_decode(msg)), 1, MAX_MESSAGE_LEN)
 	var/raw_msg = msg
 
 	if(!msg)

--- a/modular_nova/modules/verbs/code/looc.dm
+++ b/modular_nova/modules/verbs/code/looc.dm
@@ -14,7 +14,7 @@ GAME_VERB_DESC(/client, looc_wallpierce, "LOOC(Wallpierce)", "Local OOC, seen by
 	if(!mob)
 		return
 
-	msg = copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN)
+	msg = copytext_char(sanitize(html_decode(msg)), 1, MAX_MESSAGE_LEN)
 	if(!msg)
 		return
 


### PR DESCRIPTION

## About The Pull Request

This fixes LOOC (as well as AOOC and SOOC) so that it doesn't double sanitize when used from the LOOC/AOOC/SOOC buttons in the OOC tab, meaning that certain characters, like double and single quotes, actually display properly.

I did test both the button and the hotkey to make sure everything worked as it should and was sanitized properly, and i haven't noticed any problems.

Fixes #7810.

## How This Contributes To The Nova Sector Roleplay Experience

The LOOC button spitting out unprocessed HTML entities instead of the characters they're supposed to represent is a bad thing.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="333" height="145" alt="Screenshot_579" src="https://github.com/user-attachments/assets/1ef05baf-0456-4a19-8d5f-e9a361d4874a" />
<br>
<img width="394" height="17" alt="Screenshot_580" src="https://github.com/user-attachments/assets/b7d3aaa4-5452-427a-8339-e76d47405a78" />

</details>

## Changelog
:cl:
fix: When sending messages in LOOC, AOOC, or SOOC using their respective buttons in the OOC tab, certain characters, such as single and double quotes, should no longer display as unprocessed HTML entities instead of their proper characters.
/:cl:
