### PR TITLE
FIX - Takron exclusive tech leaking to the station R&D

### DIFF
--- a/modular_nova/modules/tarkon/code/misc_fluff/research.dm
+++ b/modular_nova/modules/tarkon/code/misc_fluff/research.dm
@@ -31,6 +31,11 @@
 /datum/techweb_node/tarkonturret //Yes. Tarkon does not start with this unlocked.
 	display_name = "Tarkon Industries Automated Turrets"
 	description = "Tarkon Industries Blackrust Salvage division's defense designs."
+	required_items_to_unlock = list(
+		/obj/item/turret_assembly/hoplite,
+		/obj/item/turret_assembly/cerberus,
+		/obj/item/target_designator,
+	)
 	prerequisite_nodes = list(/datum/techweb_node/tarkon, /datum/techweb_node/basic_arms, /datum/techweb_node/ai)
 	unlocked_designs = list(
 		/datum/design/hoplite_assembly,

--- a/modular_nova/modules/tarkon/code/misc_fluff/research.dm
+++ b/modular_nova/modules/tarkon/code/misc_fluff/research.dm
@@ -38,6 +38,7 @@
 		/datum/design/target_designator,
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_5_POINTS)
+	node_flags = TECHWEB_NODE_HIDDEN | TECHWEB_NODE_WIKI
 
 /datum/design/mod_plating/tarkon
 	name = "MOD Tarkon Plating"
@@ -50,6 +51,7 @@
 	)
 	research_icon_state = "tarkon-plating"
 	research_icon = 'modular_nova/master_files/icons/obj/clothing/modsuit/mod_construction.dmi'
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO | DEPARTMENT_BITFLAG_SCIENCE
 
 /datum/design/arcs
 	name = "A.R.C.S Resonator"
@@ -65,6 +67,7 @@
 	category = list(
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MINING
 	)
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
 
 /datum/design/tarkonbsc
 	name = "Tarkon BSC Refinery Box"
@@ -78,7 +81,7 @@
 	category = list(
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MINING
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_CARGO
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO | DEPARTMENT_BITFLAG_SCIENCE
 
 /datum/design/tarkonrcd
 	name = "Tarkon R.C.D"
@@ -95,6 +98,7 @@
 	category = list(
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING_ADVANCED
 	)
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO | DEPARTMENT_BITFLAG_SCIENCE
 
 /datum/design/hoplite_assembly
 	name = "Hoplite Turret Assembly"
@@ -111,6 +115,7 @@
 	category = list(
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_WEAPONS_KITS
 	)
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
 
 /datum/design/cerberus_assembly
 	name = "Cerberus Turret Assembly"
@@ -127,6 +132,7 @@
 	category = list(
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_WEAPONS_KITS,
 	)
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
 
 /datum/design/target_designator
 	name = "Turret Target Designator"
@@ -144,6 +150,7 @@
 	category = list(
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_WEAPONS_KITS,
 	)
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
 
 ///// Now we make the physical server /////
 


### PR DESCRIPTION

## About The Pull Request
This pull request seeks to fix some of Takron's tech leaking into the station's lethes, allowing departments such as medical to print Takron RCD's, whilst adding department tags to Takron technology unlocked via deconstruction in R&D (so again, medical does not unlock the ability to make Takron turrents or RCDs).

<img width="250" height="250" alt="image" src="https://github.com/user-attachments/assets/2cf0f882-6491-454e-a792-ef57078d95d4" />

`/datum/techweb_node/tarkonturret` was missing, the tag `TECHWEB_NODE_HIDDEN` which allowed the station to unlock it.
I've added into this node the ability to unlock it via deconstruction instead, and once unlocked it will only show up in the secuirty lethe.

I've also added `departmental_flags` to most Takron nodes, so they get assigned to departments which it makes sense to add them into, **(Feel free to edit this yourself if you are reviewing the PR per balance needs and what not)** I just assigned them to departments it makes sense to be in.

## How This Contributes To The Nova Sector Roleplay Experience
Takron technologies should not be unlocked to the crew without effort, such as "reverse-engineering" their technology via deconstruction.

Also.. I'm quite sure medical is not supposed to have Takron RCD's and turret assembly kits in their lethe. :rofl: 

## Proof of Testing

None done, simple tag edits if something is wrong, feel free to commit changes per need.

## Changelog
:cl: Richard Blonski
fix: Tarkon items no longer show up on NanoTrasen lethes without the proper reverse engineering.
fix: Reversed-engineered Takron items show up only in the lethes of departments that should have access to them.
/:cl:
