### PR TITLE
Fixes Plexagon trying to show job icons

### DIFF
--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -46,7 +46,11 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 			misc_list[++misc_list.len] = list(
 				"name" = name,
 				"rank" = rank,
-				"trim" = job.tgui_icon,
+				// NOVA EDIT CHANGE BEGIN
+				// ORIGINAL: "trim" = job.tgui_icon,
+				"trim" = trim,
+				"icon" = job?.tgui_icon,
+				// NOVA EDIT CHANGE END
 				)
 			continue
 		for(var/department_type in job.departments_list)
@@ -60,7 +64,11 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 			var/list/entry = list(
 				"name" = name,
 				"rank" = rank,
-				"trim" = job.tgui_icon,
+				// NOVA EDIT CHANGE BEGIN
+				// ORIGINAL: "trim" = job.tgui_icon,
+				"trim" = trim,
+				"icon" = job.tgui_icon,
+				// NOVA EDIT CHANGE END
 				)
 			var/list/department_list = manifest_out[department.department_name]
 			if(istype(job, department.department_head))


### PR DESCRIPTION

## About The Pull Request

Fixes this.

<img width="450" height="347" alt="image" src="https://github.com/user-attachments/assets/2128cf6e-9473-43b0-b4fb-98d7bb2bee86" />

Small issue discovered by our use of alt titles.

## How This Contributes To The Nova Sector Roleplay Experience

Bug bad.
## Proof of Testing

<img width="480" height="133" alt="image" src="https://github.com/user-attachments/assets/9285fb11-2ad4-47ec-97e5-5d40da97c368" />


## Changelog
:cl:
fix: plexagon no longer tries to draw a job icon after the name.
/:cl:
