### PR TITLE
Underwear in the Interaction Menu

### DIFF
--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/human.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/human.dm
@@ -92,18 +92,65 @@
 /mob/living/carbon/human/species/shadekin
 	race = /datum/species/shadekin
 
+/// Every toggleable underwear slot, by menu label, mapped to the flag that hides it.
+GLOBAL_LIST_INIT(underwear_visibility_slots, list(
+	"Underwear" = UNDERWEAR_HIDE_UNDIES,
+	"Bra" = UNDERWEAR_HIDE_BRA,
+	"Undershirt" = UNDERWEAR_HIDE_SHIRT,
+	"Socks" = UNDERWEAR_HIDE_SOCKS,
+))
+
+/// Shows or hides a single underwear slot by its menu label.
+/mob/living/carbon/human/proc/set_underwear_visibility(label, hidden)
+	var/flag = GLOB.underwear_visibility_slots[label]
+	if(isnull(flag))
+		return FALSE
+	if(hidden)
+		underwear_visibility |= flag
+	else
+		underwear_visibility &= ~flag
+	update_body()
+	return TRUE
+
+/// Shows or hides every underwear slot at once.
+/mob/living/carbon/human/proc/set_all_underwear_visibility(hidden)
+	underwear_visibility = hidden ? UNDERWEAR_HIDE_ALL : NONE
+	update_body()
+	return TRUE
+
+/// The per-slot underwear entries every configuring UI sends to tgui.
+/mob/living/carbon/human/proc/get_underwear_ui_entries()
+	var/list/entries = list()
+	for(var/label in GLOB.underwear_visibility_slots)
+		var/flag = GLOB.underwear_visibility_slots[label]
+		var/worn
+		switch(flag)
+			if(UNDERWEAR_HIDE_UNDIES)
+				worn = (underwear && underwear != "Nude")
+			if(UNDERWEAR_HIDE_BRA)
+				worn = (bra && bra != "Nude")
+			if(UNDERWEAR_HIDE_SHIRT)
+				worn = (undershirt && undershirt != "Nude")
+			if(UNDERWEAR_HIDE_SOCKS)
+				worn = (socks && socks != "Nude")
+		entries += list(list(
+			"name" = label,
+			"hidden" = !!(underwear_visibility & flag),
+			"worn" = !!worn,
+		))
+	return entries
+
 GAME_VERB_DESC(/mob/living/carbon/human, toggle_undies, "Toggle underwear visibility", "Allows you to toggle which underwear should show or be hidden. Underwear will obscure genitals.", "IC")
 
 	if(IS_UNCONSCIOUS_OR_CRIT(src))
 		to_chat(usr, span_warning("You can't toggle underwear visibility right now..."))
 		return
 
-	var/underwear_button = underwear_visibility & UNDERWEAR_HIDE_UNDIES ? "Show underwear" : "Hide underwear"
-	var/undershirt_button = underwear_visibility & UNDERWEAR_HIDE_SHIRT ? "Show shirt" : "Hide shirt"
-	var/socks_button = underwear_visibility & UNDERWEAR_HIDE_SOCKS ? "Show socks" : "Hide socks"
-	var/bra_button = underwear_visibility & UNDERWEAR_HIDE_BRA ? "Show bra" : "Hide bra"
+	var/list/choice_list = list()
 
-	var/list/choice_list = list("[underwear_button]" = "underwear", "[bra_button]" = "bra", "[undershirt_button]" = "shirt", "[socks_button]" = "socks")
+	for(var/label in GLOB.underwear_visibility_slots)
+		var/hidden = underwear_visibility & GLOB.underwear_visibility_slots[label]
+		choice_list["[hidden ? "Show" : "Hide"] [LOWER_TEXT(label)]"] = label
 
 	if(underwear_visibility != NONE)
 		choice_list += list("Show all" = "show")
@@ -119,20 +166,12 @@ GAME_VERB_DESC(/mob/living/carbon/human, toggle_undies, "Toggle underwear visibi
 	var/picked_choice = choice_list[picked_visibility]
 
 	switch(picked_choice)
-		if("underwear")
-			underwear_visibility ^= UNDERWEAR_HIDE_UNDIES
-		if("bra")
-			underwear_visibility ^= UNDERWEAR_HIDE_BRA
-		if("shirt")
-			underwear_visibility ^= UNDERWEAR_HIDE_SHIRT
-		if("socks")
-			underwear_visibility ^= UNDERWEAR_HIDE_SOCKS
 		if("show")
-			underwear_visibility = NONE
+			set_all_underwear_visibility(FALSE)
 		if("hide")
-			underwear_visibility = UNDERWEAR_HIDE_ALL
-
-	update_body()
+			set_all_underwear_visibility(TRUE)
+		else
+			set_underwear_visibility(picked_choice, !(underwear_visibility & GLOB.underwear_visibility_slots[picked_choice]))
 
 /mob/living/carbon/human/revive(full_heal_flags = NONE, excess_healing = 0, force_grab_ghost = FALSE)
 	. = ..()

--- a/modular_nova/modules/interaction_menu/code/interaction_component.dm
+++ b/modular_nova/modules/interaction_menu/code/interaction_component.dm
@@ -193,6 +193,9 @@
 			genital_config += list(genital.get_layering_ui_entry())
 	data["genital_config"] = genital_config
 
+	// Underwear visibility, same deal.
+	data["underwear_config"] = (user == self) ? self.get_underwear_ui_entries() : list()
+
 	return data
 
 /**
@@ -240,6 +243,18 @@
 			if("set_genital_arousal")
 				success = organ.apply_arousal_label(params["option"])
 		return success
+
+	if(action == "set_underwear_visibility" || action == "set_all_underwear_visibility")
+		var/mob/living/carbon/human/actor = ui.user
+		if(actor != self)
+			return
+		if(IS_UNCONSCIOUS_OR_CRIT(actor))
+			to_chat(actor, span_warning("You can't toggle underwear visibility right now..."))
+			return
+		var/hidden = !!params["hidden"]
+		if(action == "set_all_underwear_visibility")
+			return actor.set_all_underwear_visibility(hidden)
+		return actor.set_underwear_visibility(params["slot"], hidden)
 
 	if(params["interaction"])
 		var/interaction_id = params["interaction"]

--- a/tgui/packages/tgui/interfaces/InteractionPanel/MainContent.tsx
+++ b/tgui/packages/tgui/interfaces/InteractionPanel/MainContent.tsx
@@ -15,19 +15,26 @@ enum InteractionTab {
   Interactions = 0,
   GenitalOptions = 1,
   LewdItems = 2,
+  Underwear = 3,
 }
 type Interaction = {
   erp_interaction: BooleanLike;
   genital_config: { name: string; ref: string }[];
+  underwear_config: { name: string }[];
 };
 
-import { GenitalLayeringTab, InteractionsTab, LewdItemsTab } from './tabs';
+import {
+  GenitalLayeringTab,
+  InteractionsTab,
+  LewdItemsTab,
+  UnderwearTab,
+} from './tabs';
 export const MainContent = () => {
   const [searchText, setSearchText] = useState('');
   const [tabIndex, setTabIndex] = useState(InteractionTab.Interactions);
   const [showCategories, setShowCategories] = useState(true);
   const { data } = useBackend<Interaction>();
-  const { erp_interaction, genital_config = [] } = data;
+  const { erp_interaction, genital_config = [], underwear_config = [] } = data;
   const placeholder =
     tabIndex === InteractionTab.Interactions
       ? 'Search for an interaction'
@@ -45,6 +52,14 @@ export const MainContent = () => {
             >
               Interactions
             </Tabs.Tab>
+            {underwear_config.length > 0 && (
+              <Tabs.Tab
+                selected={tabIndex === InteractionTab.Underwear}
+                onClick={() => setTabIndex(InteractionTab.Underwear)}
+              >
+                Underwear
+              </Tabs.Tab>
+            )}
             {genital_config.length > 0 && (
               <Tabs.Tab
                 selected={tabIndex === InteractionTab.LewdItems}
@@ -95,6 +110,8 @@ export const MainContent = () => {
           <Section fill>
             {tabIndex === InteractionTab.LewdItems ? (
               <GenitalLayeringTab />
+            ) : tabIndex === InteractionTab.Underwear ? (
+              <UnderwearTab />
             ) : tabIndex === InteractionTab.GenitalOptions ? (
               <LewdItemsTab searchText={searchText} />
             ) : (

--- a/tgui/packages/tgui/interfaces/InteractionPanel/tabs/UnderwearTab.tsx
+++ b/tgui/packages/tgui/interfaces/InteractionPanel/tabs/UnderwearTab.tsx
@@ -1,0 +1,105 @@
+// THIS IS A NOVA SECTOR UI FILE
+import { Button, NoticeBox, Section, Stack, Table } from 'tgui-core/components';
+import type { BooleanLike } from 'tgui-core/react';
+import { useBackend } from '../../../backend';
+
+type UnderwearConfigEntry = {
+  name: string;
+  hidden: BooleanLike;
+  worn: BooleanLike;
+};
+
+type UnderwearConfig = {
+  underwear_config: UnderwearConfigEntry[];
+};
+
+export const UnderwearTab = () => {
+  const { act, data } = useBackend<UnderwearConfig>();
+  const { underwear_config = [] } = data;
+
+  const anyHidden = underwear_config.some((slot) => !!slot.hidden);
+  const anyShown = underwear_config.some((slot) => !slot.hidden);
+
+  return (
+    <Stack fill vertical>
+      <NoticeBox>
+        {underwear_config.length > 0
+          ? 'Configure how your underwear renders.'
+          : 'Nothing to configure'}
+      </NoticeBox>
+      <Stack.Item>
+        <Button
+          icon="eye"
+          disabled={!anyHidden}
+          tooltip="Show every underwear slot."
+          onClick={() => act('set_all_underwear_visibility', { hidden: 0 })}
+        >
+          Show all
+        </Button>
+        <Button
+          icon="eye-slash"
+          disabled={!anyShown}
+          tooltip="Hide every underwear slot."
+          onClick={() => act('set_all_underwear_visibility', { hidden: 1 })}
+        >
+          Hide all
+        </Button>
+      </Stack.Item>
+      <Stack.Item grow>
+        <Section scrollable>
+          <Table>
+            <Table.Row header>
+              <Table.Cell />
+              <Table.Cell collapsing textAlign="center" color="label" pl={2}>
+                Visibility
+              </Table.Cell>
+            </Table.Row>
+            {underwear_config.map((slot) => (
+              <Table.Row key={slot.name} className="candystripe">
+                <Table.Cell
+                  bold
+                  verticalAlign="middle"
+                  color={slot.worn ? undefined : 'label'}
+                >
+                  {slot.name}
+                </Table.Cell>
+                <Table.Cell collapsing textAlign="center" pl={2}>
+                  <Button
+                    icon="eye"
+                    selected={!slot.hidden}
+                    tooltip={
+                      slot.worn
+                        ? `Show your ${slot.name.toLowerCase()}.`
+                        : `You aren't wearing any ${slot.name.toLowerCase()}.`
+                    }
+                    onClick={() =>
+                      act('set_underwear_visibility', {
+                        slot: slot.name,
+                        hidden: 0,
+                      })
+                    }
+                  />
+                  <Button
+                    icon="eye-slash"
+                    selected={!!slot.hidden}
+                    tooltip={
+                      slot.worn
+                        ? `Hide your ${slot.name.toLowerCase()}.`
+                        : `You aren't wearing any ${slot.name.toLowerCase()}.`
+                    }
+                    onClick={() =>
+                      act('set_underwear_visibility', {
+                        slot: slot.name,
+                        hidden: 1,
+                      })
+                    }
+                  />
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table>
+        </Section>
+      </Stack.Item>
+    </Stack>
+  );
+};

--- a/tgui/packages/tgui/interfaces/InteractionPanel/tabs/index.tsx
+++ b/tgui/packages/tgui/interfaces/InteractionPanel/tabs/index.tsx
@@ -2,3 +2,4 @@
 export { InteractionsTab } from './InteractionsTab';
 export { LewdItemsTab } from './LewdItemsTab';
 export { GenitalLayeringTab } from './GenitalLayeringTab';
+export { UnderwearTab } from './UnderwearTab';


### PR DESCRIPTION

## About The Pull Request

Adds underwear options to the interaction menu.  

## How This Contributes To The Nova Sector Roleplay Experience

Faster, easier than hunting the verb in the panel.

## Proof of Testing

<img width="492" height="311" alt="image" src="https://github.com/user-attachments/assets/b75dcded-a75c-495e-baf9-0ea156891b35" />



## Changelog
:cl:
add: Underwear can now be adjusted via the ctrl-shift-click interaction menu.
/:cl:
