### PR TITLE
Sprite accessory visibility and hardlight overlay refactors

### DIFF
--- a/code/__DEFINES/~nova_defines/sprite_accessories.dm
+++ b/code/__DEFINES/~nova_defines/sprite_accessories.dm
@@ -6,3 +6,13 @@
 #define SPRITE_ACCESSORY_HIDE_SHOES (1<<2)
 /// The flag to that controls whether or not this sprite accessory should force worn facewear to use layers 5 (for glasses) and 4 (for masks and hats).
 #define SPRITE_ACCESSORY_USE_ALT_FACEWEAR_LAYER (1<<3)
+
+// Flags for rendering hardlight overlays
+/// Must have boots active to render hardlight overlays
+#define MOD_ACCESSORY_BOOTS (1 << 0)
+/// Must have gauntlets active to render hardlight overlays
+#define MOD_ACCESSORY_GAUNTLETS (1 << 1)
+/// Must have a chestplate active to render hardlight overlays
+#define MOD_ACCESSORY_CHESTPLATE (1 << 2)
+/// Must have a helmet active to render hardlight overlays
+#define MOD_ACCESSORY_HELMET (1 << 3)

--- a/code/modules/mod/mod_clothes.dm
+++ b/code/modules/mod/mod_clothes.dm
@@ -15,7 +15,7 @@
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NO_SPEED_POTION, INNATE_TRAIT)
 	AddComponent(/datum/component/hat_stabilizer, loose_hat = TRUE)
-	AddElement(/datum/element/equipment_bodypart_texture, BODY_ZONE_HEAD, /datum/bodypart_texture/mesh/space)
+	//AddElement(/datum/element/equipment_bodypart_texture, BODY_ZONE_HEAD, /datum/bodypart_texture/mesh/space) // NOVA EDIT REMOVAL
 
 /obj/item/clothing/suit/mod
 	name = "\improper MOD chestplate"
@@ -39,7 +39,7 @@
 /obj/item/clothing/suit/mod/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NO_SPEED_POTION, INNATE_TRAIT)
-	AddElement(/datum/element/equipment_bodypart_texture, BODY_ZONE_CHEST, /datum/bodypart_texture/mesh/space)
+	//AddElement(/datum/element/equipment_bodypart_texture, BODY_ZONE_CHEST, /datum/bodypart_texture/mesh/space) // NOVA EDIT REMOVAL
 
 /obj/item/clothing/gloves/mod
 	name = "\improper MOD gauntlets"

--- a/modular_nova/master_files/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
+++ b/modular_nova/master_files/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
@@ -36,7 +36,7 @@
 		return FALSE
 	var/datum/mutant_bodypart/mutant_part = mutantparts_list[feature_key]
 	sprite_datum = fetch_sprite_datum_from_name(accessory_name ? accessory_name : mutant_part.name)
-	modsuit_affected = sprite_datum.use_custom_mod_icon
+	modsuit_affected = sprite_datum.flags_custom_mod_icon
 	draw_color = mutant_part.get_colors()
 	emissive_eligibility_by_color_index = mutant_part.get_emissive_tri_bool_list()
 	return TRUE

--- a/modular_nova/master_files/code/modules/mod/mod_activation.dm
+++ b/modular_nova/master_files/code/modules/mod/mod_activation.dm
@@ -2,5 +2,19 @@
 	. = ..()
 	if(!. || !theme?.hardlight)
 		return
-	// make sure our parts update their overlays when we deactivate
+	// make sure parts update their overlays when the suit activates/deactivates
+	wearer.update_body_parts()
+
+/obj/item/mod/control/deploy(mob/user, obj/item/part, instant)
+	. = ..()
+	if(!. || !theme?.hardlight)
+		return
+	// make sure parts update their overlays when a part is deployed
+	wearer.update_body_parts()
+
+/obj/item/mod/control/retract(mob/user, obj/item/part, instant)
+	. = ..()
+	if(!. || !theme?.hardlight)
+		return
+	// make sure parts update their overlays when a part is retracted
 	wearer.update_body_parts()

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories.dm
@@ -29,8 +29,9 @@
 	var/always_color_customizable
 	///Special case of whether the accessory should be shifted in the X dimension, check taur genitals for example
 	var/special_x_dimension
-	///Special case for MODsuit overlays
-	var/use_custom_mod_icon
+	/// Flags that decide if this will have hardlight overlays applied when a MODsuit is active and
+	/// what parts of the MOD need to be deployed for the overlay to be applied or force visibility.
+	var/flags_custom_mod_icon = NONE
 	var/uses_emissives = FALSE
 	var/color_layer_names
 	/// If this sprite accessory will be inaccessable if ERP config is disabled
@@ -75,7 +76,26 @@
 /datum/sprite_accessory/proc/get_sprite_suffix()
 	return icon_state
 
+/// Decides if this accessory will be rendered on a body part.
+/// If this accessory works with [/mob/living/carbon/human/proc/mutant_part_visibility]
+/// and/or uses [flags_custom_mod_icon], you should call parent and return if it is truthy.
 /datum/sprite_accessory/proc/is_hidden(mob/living/carbon/human/owner, datum/bodypart_overlay/mutant/bodypart_overlay)
+	SHOULD_CALL_PARENT(TRUE)
+
+	if(key in owner.try_hide_mutant_parts)
+		return TRUE
+
+	if(flags_custom_mod_icon != NONE && wearing_active_mod(owner))
+		// having any matching MOD piece with MOD hardlight icon flags will check that any piece is there, and force visibility
+		if((flags_custom_mod_icon & MOD_ACCESSORY_HELMET) && istype(owner.head, /obj/item/clothing/head/mod))
+			return FALSE
+		if((flags_custom_mod_icon & MOD_ACCESSORY_CHESTPLATE) && istype(owner.wear_suit, /obj/item/clothing/suit/mod))
+			return FALSE
+		if((flags_custom_mod_icon & MOD_ACCESSORY_GAUNTLETS) && istype(owner.gloves, /obj/item/clothing/gloves/mod))
+			return FALSE
+		if((flags_custom_mod_icon & MOD_ACCESSORY_BOOTS) && istype(owner.shoes, /obj/item/clothing/shoes/mod))
+			return FALSE
+
 	return FALSE
 
 /datum/sprite_accessory/proc/get_special_icon(mob/living/carbon/human/H, passed_state)
@@ -113,9 +133,6 @@
 	key = FEATURE_MOTH_MARKINGS
 	// organ_type = /obj/item/organ/moth_markings // UNCOMMENT THIS IF THEY EVER FIX IT UPSTREAM, CAN'T BE BOTHERED TO FIX IT MYSELF
 
-/datum/sprite_accessory/moth_markings/is_hidden(mob/living/carbon/human/owner, datum/bodypart_overlay/mutant/bodypart_overlay)
-	return FALSE
-
 /datum/sprite_accessory/moth_markings/none
 	name = SPRITE_ACCESSORY_NONE
 	icon_state = "none"
@@ -144,10 +161,12 @@
 	organ_type = /obj/item/organ/mushroom_cap
 
 /datum/sprite_accessory/caps/is_hidden(mob/living/carbon/human/human, datum/bodypart_overlay/mutant/bodypart_overlay)
-	if(((human.head?.flags_inv & HIDEHAIR) || (human.wear_mask?.flags_inv & HIDEHAIR)) || (key in human.try_hide_mutant_parts))
-		return TRUE
+	. = ..()
+	if(.)
+		return
 
-	return FALSE
+	if(human.obscured_slots & HIDEHAIR)
+		return TRUE
 
 /datum/sprite_accessory/caps/none
 	name = SPRITE_ACCESSORY_NONE

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories.dm
@@ -78,7 +78,7 @@
 
 /// Decides if this accessory will be rendered on a body part.
 /// If this accessory works with [/mob/living/carbon/human/proc/mutant_part_visibility]
-/// and/or uses [flags_custom_mod_icon], you should call parent and return if it is truthy.
+/// and/or uses [flags_custom_mod_icon], you should call `..()` and return if it is already true.
 /datum/sprite_accessory/proc/is_hidden(mob/living/carbon/human/owner, datum/bodypart_overlay/mutant/bodypart_overlay)
 	SHOULD_CALL_PARENT(TRUE)
 
@@ -86,7 +86,7 @@
 		return TRUE
 
 	if(flags_custom_mod_icon != NONE && wearing_active_mod(owner))
-		// having any matching MOD piece with MOD hardlight icon flags will check that any piece is there, and force visibility
+		// forced visibility if the owner has a matching MOD piece
 		if((flags_custom_mod_icon & MOD_ACCESSORY_HELMET) && istype(owner.head, /obj/item/clothing/head/mod))
 			return FALSE
 		if((flags_custom_mod_icon & MOD_ACCESSORY_CHESTPLATE) && istype(owner.wear_suit, /obj/item/clothing/suit/mod))

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/ears.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/ears.dm
@@ -2,23 +2,19 @@
 	key = FEATURE_EARS
 	organ_type = /obj/item/organ/ears_external
 	color_src = USE_MATRIXED_COLORS
-	use_custom_mod_icon = TRUE
+	flags_custom_mod_icon = MOD_ACCESSORY_HELMET
 
 /datum/sprite_accessory/ears/is_hidden(mob/living/carbon/human/wearer, datum/bodypart_overlay/mutant/bodypart_overlay)
-	if(!(wearer.obscured_slots & HIDEHAIR))
-		return (key in wearer.try_hide_mutant_parts)
-	if(key in wearer.try_hide_mutant_parts)
+	. = ..()
+	if(.)
+		return
+
+	if(wearer.obscured_slots & HIDEHAIR)
+		if(istype(wearer.head, /obj/item/clothing/head/mod))
+			return FALSE // i'm so sorry, this is still required
+		if(wearer.obscured_slots & SHOWSPRITEEARS)
+			return FALSE
 		return TRUE
-	var/obj/item/worn_head = wearer.head
-	if(istype(worn_head, /obj/item/clothing/head/mod))
-		return FALSE
-	// Items with earholes (balaclavas, luchador masks) force ears to show
-	if(worn_head && (worn_head.flags_inv & (HIDEHAIR|SHOWSPRITEEARS)) == (HIDEHAIR|SHOWSPRITEEARS))
-		return FALSE
-	var/obj/item/worn_mask = wearer.wear_mask
-	if(worn_mask && (worn_mask.flags_inv & (HIDEHAIR|SHOWSPRITEEARS)) == (HIDEHAIR|SHOWSPRITEEARS))
-		return FALSE
-	return TRUE
 
 /datum/sprite_accessory/ears/cat
 	recommended_species = list(

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/fluff.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/fluff.dm
@@ -16,10 +16,12 @@
 	natural_spawn = FALSE
 
 /datum/sprite_accessory/fluff/moth/is_hidden(mob/living/carbon/human/human, datum/bodypart_overlay/mutant/bodypart_overlay)
-	if((human.head?.flags_inv & HIDEHAIR) || (human.wear_mask?.flags_inv & HIDEHAIR))
-		return TRUE
+	. = ..()
+	if(.)
+		return
 
-	return FALSE
+	if((human.obscured_slots & HIDEHAIR))
+		return TRUE
 
 /datum/sprite_accessory/fluff/moth/plain
 	name = "Plain"

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/fluff.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/fluff.dm
@@ -20,8 +20,7 @@
 	if(.)
 		return
 
-	if((human.obscured_slots & HIDEHAIR))
-		return TRUE
+	return !!(human.obscured_slots & HIDEHAIR)
 
 /datum/sprite_accessory/fluff/moth/plain
 	name = "Plain"

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/frills.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/frills.dm
@@ -9,8 +9,7 @@
 	if(.)
 		return
 
-	if((human.obscured_slots & HIDEEARS))
-		return TRUE
+	return !!(human.obscured_slots & HIDEEARS)
 
 /datum/sprite_accessory/frills/none
 	name = SPRITE_ACCESSORY_NONE

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/frills.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/frills.dm
@@ -2,12 +2,15 @@
 	key = FEATURE_FRILLS
 	default_color = DEFAULT_SECONDARY
 	organ_type = /obj/item/organ/frills
+	flags_custom_mod_icon = MOD_ACCESSORY_HELMET
 
 /datum/sprite_accessory/frills/is_hidden(mob/living/carbon/human/human, datum/bodypart_overlay/mutant/bodypart_overlay)
-	if((human.head?.flags_inv & HIDEEARS) || (key in human.try_hide_mutant_parts))
-		return TRUE
+	. = ..()
+	if(.)
+		return
 
-	return FALSE
+	if((human.obscured_slots & HIDEEARS))
+		return TRUE
 
 /datum/sprite_accessory/frills/none
 	name = SPRITE_ACCESSORY_NONE

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/genitals.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/genitals.dm
@@ -15,6 +15,8 @@
 	var/skintone_max_sprite_size_affix
 
 /datum/sprite_accessory/genital/is_hidden(mob/living/carbon/human/target_mob, datum/bodypart_overlay/mutant/bodypart_overlay)
+	SHOULD_CALL_PARENT(FALSE) // doesn't use standard code, and you probably shouldn't make it use it lmao
+
 	var/obj/item/organ/genital/badonkers = target_mob?.get_organ_slot(associated_organ_slot)
 	if(!badonkers)
 		return TRUE

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/head_accessory.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/head_accessory.dm
@@ -17,13 +17,17 @@
 	natural_spawn = FALSE
 	factual = FALSE
 
-/datum/sprite_accessory/head_accessory/is_hidden(mob/living/carbon/human/owner, datum/bodypart_overlay/mutant/bodypart_overlay)
-	var/obj/item/clothing/head/worn_head = owner.head
-	var/obj/item/clothing/mask/worn_mask = owner.wear_mask
-	if((worn_head?.flags_inv & HIDEHAIR || worn_mask?.flags_inv & HIDEHAIR) \
-		&& !(worn_mask && worn_mask.flags_inv & SHOWSPRITEEARS))
+/datum/sprite_accessory/head_accessory/is_hidden(mob/living/carbon/human/wearer, datum/bodypart_overlay/mutant/bodypart_overlay)
+	. = ..()
+	if(.)
+		return
+
+	if(wearer.obscured_slots & HIDEHAIR)
+		if(istype(wearer.head, /obj/item/clothing/head/mod))
+			return FALSE // i'm so sorry, this is still required
+		if(wearer.obscured_slots & SHOWSPRITEEARS)
+			return FALSE
 		return TRUE
-	return FALSE
 
 /datum/sprite_accessory/head_accessory/sylveon_bow
 	name = "Sylveon Bow"

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/horns.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/horns.dm
@@ -3,28 +3,19 @@
 	icon = 'modular_nova/master_files/icons/mob/sprite_accessory/horns.dmi'
 	default_color = "#555555"
 	organ_type = /obj/item/organ/horns
-	use_custom_mod_icon = TRUE
+	flags_custom_mod_icon = MOD_ACCESSORY_HELMET
 
 /datum/sprite_accessory/horns/is_hidden(mob/living/carbon/human/wearer, datum/bodypart_overlay/mutant/bodypart_overlay)
-	var/obj/item/clothing/head/worn_head = wearer.head
-	var/obj/item/clothing/mask/worn_mask = wearer.wear_mask
-	if(isnull(worn_head) && isnull(worn_mask))
-		return FALSE
+	. = ..()
+	if(.)
+		return
 
-	// Can hide if wearing hat
-	if(key in wearer.try_hide_mutant_parts)
+	if(wearer.obscured_slots & HIDEHAIR)
+		if(istype(wearer.head, /obj/item/clothing/head/mod))
+			return FALSE // i'm so sorry, this is still required
+		if(wearer.obscured_slots & SHOWSPRITEEARS)
+			return FALSE
 		return TRUE
-
-	// Exception for MODs
-	if(istype(wearer.head, /obj/item/clothing/head/mod))
-		return FALSE
-
-	// Hide accessory if flagged to do so
-	if((worn_head?.flags_inv & HIDEHAIR || worn_mask?.flags_inv & HIDEHAIR) \
-		&& !(worn_mask && worn_mask.flags_inv & SHOWSPRITEEARS))
-		return TRUE
-
-	return FALSE
 
 /datum/sprite_accessory/horns/none
 	name = SPRITE_ACCESSORY_NONE

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/ipc.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/ipc.dm
@@ -149,22 +149,18 @@
 	recommended_species = list(SPECIES_SYNTH = 1)
 	key = FEATURE_SYNTH_ANTENNA
 	organ_type = /obj/item/organ/synth_antenna
-	use_custom_mod_icon = TRUE
+	flags_custom_mod_icon = MOD_ACCESSORY_HELMET
 
 /datum/sprite_accessory/antenna/is_hidden(mob/living/carbon/human/wearer, datum/bodypart_overlay/mutant/bodypart_overlay)
-	var/obj/item/clothing/head/mod/worn_head = wearer.head
-	if(isnull(worn_head))
-		return FALSE
-	if(key in wearer.try_hide_mutant_parts)
-		return TRUE
-//	Exception for MODs
-	if(istype(worn_head))
-		return FALSE
-//	Hide accessory if flagged to do so
-	var/obj/item/clothing/mask/worn_mask = wearer.wear_mask
-	if((worn_head?.flags_inv & HIDEHAIR || worn_mask?.flags_inv & HIDEHAIR) \
-		// This line basically checks if we FORCE accessory-ears to show, for items with earholes like Balaclavas and Luchador masks
-		&& ((worn_head && !(worn_head.flags_inv & SHOWSPRITEEARS)) || (worn_mask && !(worn_mask.flags_inv & SHOWSPRITEEARS))))
+	. = ..()
+	if(.)
+		return
+
+	if(wearer.obscured_slots & HIDEHAIR)
+		if(istype(wearer.head, /obj/item/clothing/head/mod))
+			return FALSE // i'm so sorry, this is still required
+		if(wearer.obscured_slots & SHOWSPRITEEARS)
+			return FALSE
 		return TRUE
 
 /datum/sprite_accessory/antenna/none

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/moth_antennae.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/moth_antennae.dm
@@ -1,26 +1,18 @@
 /datum/sprite_accessory/moth_antennae
 	key = FEATURE_MOTH_ANTENNAE
 	organ_type = /obj/item/organ/antennae
-	use_custom_mod_icon = TRUE
+	flags_custom_mod_icon = MOD_ACCESSORY_HELMET
 
 /datum/sprite_accessory/moth_antennae/is_hidden(mob/living/carbon/human/wearer, datum/bodypart_overlay/mutant/bodypart_overlay)
-	var/obj/item/clothing/head/mod/worn_head = wearer.head
-	if(isnull(worn_head))
-		return FALSE
+	. = ..()
+	if(.)
+		return
 
-	// Can hide if wearing hat
-	if(key in wearer.try_hide_mutant_parts)
-		return TRUE
-
-	// Exception for MODs
-	if(istype(worn_head))
-		return FALSE
-
-	// Hide accessory if flagged to do so
-	var/obj/item/clothing/mask/worn_mask = wearer.wear_mask
-	if((worn_head?.flags_inv & HIDEHAIR || worn_mask?.flags_inv & HIDEHAIR) \
-		// This line basically checks if we FORCE accessory-ears to show, for items with earholes like Balaclavas and Luchador masks
-		&& ((worn_head && !(worn_head.flags_inv & SHOWSPRITEEARS)) || (worn_mask && !(wearer.wear_mask?.flags_inv & SHOWSPRITEEARS))))
+	if(wearer.obscured_slots & HIDEHAIR)
+		if(istype(wearer.head, /obj/item/clothing/head/mod))
+			return FALSE // i'm so sorry, this is still required
+		if(wearer.obscured_slots & SHOWSPRITEEARS)
+			return FALSE
 		return TRUE
 
 /datum/sprite_accessory/moth_antennae/none

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/neck_accessory.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/neck_accessory.dm
@@ -23,8 +23,9 @@
 	icon_state = "sylveon_bow"
 
 /datum/sprite_accessory/neck_accessory/is_hidden(mob/living/carbon/human/wearer, datum/bodypart_overlay/mutant/bodypart_overlay)
-	var/obj/item/clothing/head/worn_neck = wearer.wear_neck
-	var/obj/item/clothing/mask/worn_mask = wearer.wear_mask
-	if((worn_neck?.flags_inv & HIDEHAIR || worn_mask?.flags_inv & HIDEHAIR))
+	. = ..()
+	if(.)
+		return
+
+	if(wearer.obscured_slots & HIDEHAIR)
 		return TRUE
-	return FALSE

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/neck_accessory.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/neck_accessory.dm
@@ -27,5 +27,4 @@
 	if(.)
 		return
 
-	if(wearer.obscured_slots & HIDEHAIR)
-		return TRUE
+	return !!(wearer.obscured_slots & HIDEHAIR)

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/skrell_hair.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/skrell_hair.dm
@@ -3,17 +3,15 @@
 	key = FEATURE_SKRELL_HAIR
 	color_src = USE_ONE_COLOR
 	organ_type = /obj/item/organ/skrell_hair
-	use_custom_mod_icon = TRUE
+	flags_custom_mod_icon = MOD_ACCESSORY_HELMET
 
 /datum/sprite_accessory/skrell_hair/is_hidden(mob/living/carbon/human/wearer, datum/bodypart_overlay/mutant/bodypart_overlay)
-	// Exception for MODs
-	if(istype(wearer.head, /obj/item/clothing/head/mod))
-		return FALSE
+	. = ..()
+	if(.)
+		return
 
-	if((wearer.head?.flags_inv & HIDEHAIR) || (wearer.wear_mask?.flags_inv & HIDEHAIR))
+	if(wearer.obscured_slots & HIDEHAIR)
 		return TRUE
-
-	return FALSE
 
 /datum/sprite_accessory/skrell_hair/none
 	name = SPRITE_ACCESSORY_NONE

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/skrell_hair.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/skrell_hair.dm
@@ -10,8 +10,7 @@
 	if(.)
 		return
 
-	if(wearer.obscured_slots & HIDEHAIR)
-		return TRUE
+	return !!(wearer.obscured_slots & HIDEHAIR)
 
 /datum/sprite_accessory/skrell_hair/none
 	name = SPRITE_ACCESSORY_NONE

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/snout.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/snout.dm
@@ -13,6 +13,10 @@
 	)
 
 /datum/sprite_accessory/snouts/is_hidden(mob/living/carbon/human/human, datum/bodypart_overlay/mutant/bodypart_overlay)
+	. = ..()
+	if(.)
+		return
+
 	return !!(human.obscured_slots & HIDESNOUT)
 
 /obj/item/organ/snout

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/species/harpy.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/species/harpy.dm
@@ -8,6 +8,7 @@
 	icon = 'modular_nova/master_files/icons/mob/sprite_accessory/species/harpy_wings.dmi'
 	icon_state = "arfelharpy"
 	color_src = USE_ONE_COLOR
+	flags_custom_mod_icon = MOD_ACCESSORY_GAUNTLETS
 
 /datum/sprite_accessory/wings/mammal/harpy/alt/polish
 	name = "Harpy (Alt) Reshade"

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/spines.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/spines.dm
@@ -19,10 +19,7 @@
 	if(.)
 		return
 
-	if(wearer.obscured_slots & HIDESPINE)
-		return TRUE
-
-	return FALSE
+	return !!(wearer.obscured_slots & HIDESPINE)
 
 /datum/sprite_accessory/tail_spines
 	key = FEATURE_TAILSPINES

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/spines.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/spines.dm
@@ -8,20 +8,18 @@
 		SPECIES_LIZARD_SILVER = 1,
 	)
 	organ_type = /obj/item/organ/spines
-	use_custom_mod_icon = TRUE
+	flags_custom_mod_icon = MOD_ACCESSORY_CHESTPLATE|MOD_ACCESSORY_HELMET
 
 /datum/sprite_accessory/spines/none
 	name = SPRITE_ACCESSORY_NONE
 	icon_state = "none"
 
 /datum/sprite_accessory/spines/is_hidden(mob/living/carbon/human/wearer, datum/bodypart_overlay/mutant/bodypart_overlay)
-	var/obj/item/clothing/worn_uniform = wearer.w_uniform
-	var/obj/item/clothing/suit/mod/worn_suit = wearer.wear_suit
-	if(worn_uniform?.flags_inv & HIDESPINE)
-		return TRUE
-	if(worn_suit?.flags_inv & HIDESPINE)
-		return TRUE
-	if(key in wearer.try_hide_mutant_parts)
+	. = ..()
+	if(.)
+		return
+
+	if(wearer.obscured_slots & HIDESPINE)
 		return TRUE
 
 	return FALSE
@@ -37,24 +35,20 @@
 	natural_spawn = FALSE
 
 /datum/sprite_accessory/tail_spines/is_hidden(mob/living/carbon/human/wearer, datum/bodypart_overlay/mutant/bodypart_overlay)
+	. = ..()
+	if(.)
+		return
+
 	if(wearer.owned_turf?.name == "tail")
 	// Emote exception
 		return TRUE
 
-	var/obj/item/clothing/suit/mod/worn_suit = wearer.wear_suit
-	if(isnull(wearer.w_uniform) && isnull(worn_suit))
-		return FALSE
-	if("spines" in wearer.try_hide_mutant_parts)
+	if(FEATURE_SPINES in wearer.try_hide_mutant_parts)
 		return TRUE
-	if("tail" in wearer.try_hide_mutant_parts)
+	if(FEATURE_TAIL in wearer.try_hide_mutant_parts)
 		return TRUE
 
-	if(worn_suit)
-		// Exception for MODs
-		if(istype(worn_suit))
-			return FALSE
-		// Hide accessory if flagged to do so
-		if(worn_suit.flags_inv & HIDETAIL)
-			return TRUE
+	if(wearer.obscured_slots & HIDETAIL)
+		return TRUE
 
 	return FALSE

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/tails.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/tails.dm
@@ -2,28 +2,21 @@
 	key = FEATURE_TAIL
 	organ_type = /obj/item/organ/tail
 	icon = 'modular_nova/master_files/icons/mob/sprite_accessory/tails.dmi'
-	use_custom_mod_icon = TRUE
+	flags_custom_mod_icon = MOD_ACCESSORY_CHESTPLATE
 	/// Can we use this tail for the fluffy tail turf emote?
 	var/fluffy = FALSE
 
 /datum/sprite_accessory/tails/is_hidden(mob/living/carbon/human/wearer, datum/bodypart_overlay/mutant/bodypart_overlay)
+	. = ..()
+	if(.)
+		return
+
 	// Emote exception
-	if(wearer.owned_turf?.name == FEATURE_TAIL)
+	if(wearer.owned_turf?.name == "tail")
 		return TRUE
 
-	var/obj/item/clothing/suit/mod/worn_suit = wearer.wear_suit
-	if(isnull(wearer.w_uniform) && isnull(worn_suit))
-		return FALSE
-	if(key in wearer.try_hide_mutant_parts)
+	if(wearer.obscured_slots & HIDETAIL)
 		return TRUE
-
-	if(worn_suit)
-		// Exception for MODs
-		if(istype(worn_suit))
-			return FALSE
-		// Hide accessory if flagged to do so
-		else if(worn_suit.flags_inv & HIDETAIL)
-			return TRUE
 
 /datum/sprite_accessory/tails/none
 	name = SPRITE_ACCESSORY_NONE

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/taur_types.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/taur_types.dm
@@ -22,7 +22,7 @@
 	center = TRUE
 	organ_type = /obj/item/organ/taur_body/horselike // horselike by default, dont forget to override if you make another bodytype
 	flags_for_organ = SPRITE_ACCESSORY_HIDE_SHOES
-	use_custom_mod_icon = TRUE
+	flags_custom_mod_icon = MOD_ACCESSORY_CHESTPLATE
 	/// Must be a single specific tauric suit variation bitflag. Don't do FLAG_1|FLAG_2
 	var/taur_mode = NONE
 	taur_mode = BODYSHAPE_TAUR_GENERIC /// So that every taur would crop clothes
@@ -35,6 +35,10 @@
 	var/laydown_offset = 0
 
 /datum/sprite_accessory/taur/is_hidden(mob/living/carbon/human/target, datum/bodypart_overlay/mutant/bodypart_overlay)
+	. = ..()
+	if(.)
+		return
+
 	var/obj/item/organ/taur_body/taur_body = target.get_organ_slot(ORGAN_SLOT_EXTERNAL_TAUR)
 	if (taur_body?.hide_self)
 		return TRUE

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/wings.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/wings.dm
@@ -24,7 +24,7 @@
 	if(.)
 		return
 
-	return (wearer.obscured_slots & bodypart_overlay?.slot_blocker)
+	return !!(wearer.obscured_slots & bodypart_overlay?.slot_blocker)
 
 /datum/sprite_accessory/wings/none
 	name = SPRITE_ACCESSORY_NONE

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/wings.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/wings.dm
@@ -17,19 +17,13 @@
 		SPECIES_MAMMAL = 1,
 	)
 	organ_type = /obj/item/organ/wings/custom
-	use_custom_mod_icon = TRUE
+	flags_custom_mod_icon = MOD_ACCESSORY_CHESTPLATE
 
 /datum/sprite_accessory/wings/is_hidden(mob/living/carbon/human/wearer, datum/bodypart_overlay/mutant/wings/bodypart_overlay)
-	var/obj/item/clothing/suit/mod/worn_suit = wearer.wear_suit
-	if(isnull(wearer.w_uniform) && isnull(worn_suit))
-		return FALSE
-	// Can hide if wearing uniform
-	if(initial(key) in wearer.try_hide_mutant_parts) // initial because some of the wing types have different keys (wings_functional, wings_open, etc)
-		return TRUE
-	// Exception for MODs
-	if(istype(worn_suit))
-		return FALSE
-	// Hide accessory if flagged to do so, taking species exceptions in account
+	. = ..()
+	if(.)
+		return
+
 	return (wearer.obscured_slots & bodypart_overlay?.slot_blocker)
 
 /datum/sprite_accessory/wings/none
@@ -74,24 +68,14 @@
 	color_src = USE_ONE_COLOR
 
 /datum/sprite_accessory/wings_open/is_hidden(mob/living/carbon/human/wearer, datum/bodypart_overlay/mutant/wings/bodypart_overlay)
-	var/obj/item/clothing/worn_suit = wearer.wear_suit
-	if(isnull(wearer.w_uniform) && isnull(worn_suit))
-		return FALSE
-	// Can hide if wearing uniform
-	if(key in wearer.try_hide_mutant_parts)
-		return TRUE
-	if(worn_suit)
-	// Exception for MODs
-		if(istype(worn_suit, /obj/item/clothing/suit/mod))
-			return FALSE
-	// Hide accessory if flagged to do so, taking species exceptions in account
-		else if((worn_suit.flags_inv & HIDEJUMPSUIT) \
-				&& (isnull(worn_suit.species_exception) \
-				|| !is_type_in_list(wearer.dna.species, worn_suit.species_exception)) \
-			)
-			return TRUE
+	. = ..()
+	if(.)
+		return
 
-	return FALSE
+	if(wearer.obscured_slots & HIDEJUMPSUIT)
+		var/obj/item/worn_suit = wearer.wear_suit
+		if(isnull(worn_suit.species_exception) || !is_type_in_list(wearer.dna.species, worn_suit.species_exception))
+			return TRUE
 
 /*
 *	MAMMAL
@@ -167,11 +151,13 @@
 	name = "Harpy"
 	icon_state = "harpy"
 	color_src = USE_ONE_COLOR
+	flags_custom_mod_icon = MOD_ACCESSORY_GAUNTLETS
 
 /datum/sprite_accessory/wings/mammal/top/harpy
 	name = "Harpy (Top)"
 	icon_state = "harpy_top"
 	color_src = USE_ONE_COLOR
+	flags_custom_mod_icon = MOD_ACCESSORY_GAUNTLETS
 
 /datum/sprite_accessory/wings/mammal/harpy/alt
 	name = "Harpy (Alt)"
@@ -422,12 +408,15 @@
 	name = "Arfel Harpy"
 	icon_state = "arfelharpy_top"
 	color_src = USE_ONE_COLOR
+	flags_custom_mod_icon = MOD_ACCESSORY_GAUNTLETS
 
 /datum/sprite_accessory/wings/mammal/harpy_fluffy
 	name = "Harpy (Fluffy)"
 	icon_state = "harpyfluffy"
 	color_src = USE_ONE_COLOR
+	flags_custom_mod_icon = MOD_ACCESSORY_GAUNTLETS
 
 /datum/sprite_accessory/wings/mammal/top/harpy_fluffy
 	name = "Harpy (Fluffy, Top)"
 	icon_state = "harpyfluffy_top"
+	flags_custom_mod_icon = MOD_ACCESSORY_GAUNTLETS

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/xeno.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/xeno.dm
@@ -3,7 +3,7 @@
 	key = FEATURE_XENODORSAL
 	color_src = USE_ONE_COLOR
 	organ_type = /obj/item/organ/xenodorsal
-	use_custom_mod_icon = TRUE
+	flags_custom_mod_icon = MOD_ACCESSORY_CHESTPLATE
 
 /datum/sprite_accessory/xenodorsal/none
 	name = SPRITE_ACCESSORY_NONE
@@ -22,17 +22,6 @@
 /datum/sprite_accessory/xenodorsal/down
 	name = "Dorsal Down"
 	icon_state = "down"
-
-/datum/sprite_accessory/xenodorsal/is_hidden(mob/living/carbon/human/wearer, datum/bodypart_overlay/mutant/bodypart_overlay)
-	var/obj/item/clothing/suit/mod/worn_suit = wearer.wear_suit
-	if(!wearer.w_uniform && isnull(worn_suit))
-		return FALSE
-	// Can hide if wearing uniform
-	if(key in wearer.try_hide_mutant_parts)
-		return TRUE
-	// Exception for MODs
-	if(istype(worn_suit))
-		return FALSE
 
 //TAILS
 /datum/sprite_accessory/tails/mammal/wagging/xeno_tail

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/MOD_sprite_accessories/mod_accessory_handler.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/MOD_sprite_accessories/mod_accessory_handler.dm
@@ -1,6 +1,6 @@
-/// Creates a masked icon for sprite accessories which have 'use_custom_mod_icon' set to TRUE
+/// Creates a masked icon for sprite accessories which have 'flags_custom_mod_icon' set to TRUE
 /datum/sprite_accessory/proc/get_custom_mod_icon(mob/living/carbon/human/owner, mutable_appearance/appearance_to_use = null)
-	if(!use_custom_mod_icon)
+	if(!flags_custom_mod_icon)
 		return null
 
 	if(!mod_overlay_active(owner))
@@ -23,43 +23,29 @@
 
 	return icon(special_icon)
 
-/// Checks that this accessory should be affected by a hardlight MOD overlay.
-/// The default behavior is to check for an active MOD and the chestplate being deployed.
+/// Checks that this accessory should be affected by a hardlight MOD overlay
 /datum/sprite_accessory/proc/mod_overlay_active(mob/living/carbon/human/wearer)
-	return has_active_mod_and_chestplate(wearer)
-
-/datum/sprite_accessory/ears/mod_overlay_active(mob/living/carbon/human/wearer)
-	return has_active_mod_and_helmet(wearer)
-
-/datum/sprite_accessory/horns/mod_overlay_active(mob/living/carbon/human/wearer)
-	return has_active_mod_and_helmet(wearer)
-
-/datum/sprite_accessory/skrell_hair/mod_overlay_active(mob/living/carbon/human/wearer)
-	return has_active_mod_and_helmet(wearer)
-
-/datum/sprite_accessory/antenna/mod_overlay_active(mob/living/carbon/human/wearer)
-	return has_active_mod_and_helmet(wearer)
-
-/datum/sprite_accessory/moth_antennae/mod_overlay_active(mob/living/carbon/human/wearer)
-	return has_active_mod_and_helmet(wearer)
-
-/datum/sprite_accessory/caps/mod_overlay_active(mob/living/carbon/human/wearer)
-	return has_active_mod_and_helmet(wearer)
-
-/datum/sprite_accessory/frills/mod_overlay_active(mob/living/carbon/human/wearer)
-	return has_active_mod_and_helmet(wearer)
-
-/datum/sprite_accessory/head_accessory/mod_overlay_active(mob/living/carbon/human/wearer)
-	return has_active_mod_and_helmet(wearer)
-
-/datum/sprite_accessory/neck_accessory/mod_overlay_active(mob/living/carbon/human/wearer)
-	return has_active_mod_and_helmet(wearer)
+	if((flags_custom_mod_icon & MOD_ACCESSORY_HELMET) && !has_active_mod_and_helmet(wearer))
+		return FALSE
+	if((flags_custom_mod_icon & MOD_ACCESSORY_CHESTPLATE) && !has_active_mod_and_chestplate(wearer))
+		return FALSE
+	if((flags_custom_mod_icon & MOD_ACCESSORY_GAUNTLETS) && !has_active_mod_and_gauntlets(wearer))
+		return FALSE
+	if((flags_custom_mod_icon & MOD_ACCESSORY_BOOTS) && !has_active_mod_and_boots(wearer))
+		return FALSE
+	return TRUE
 
 /datum/sprite_accessory/proc/has_active_mod_and_helmet(mob/living/carbon/human/wearer)
-	return (wearing_active_mod(wearer) && wearing_mod_helmet(wearer))
+	return (wearing_active_mod(wearer) && istype(wearer?.head, /obj/item/clothing/head/mod))
 
 /datum/sprite_accessory/proc/has_active_mod_and_chestplate(mob/living/carbon/human/wearer)
-	return (wearing_active_mod(wearer) && wearing_mod_chestplate(wearer))
+	return (wearing_active_mod(wearer) && istype(wearer?.wear_suit, /obj/item/clothing/suit/mod))
+
+/datum/sprite_accessory/proc/has_active_mod_and_gauntlets(mob/living/carbon/human/wearer)
+	return (wearing_active_mod(wearer) && istype(wearer?.gloves, /obj/item/clothing/gloves/mod))
+
+/datum/sprite_accessory/proc/has_active_mod_and_boots(mob/living/carbon/human/wearer)
+	return (wearing_active_mod(wearer) && istype(wearer?.shoes, /obj/item/clothing/shoes/mod))
 
 /// Checks that a MOD control unit on the wearer is active or activating and has a hardlight theme
 /datum/sprite_accessory/proc/wearing_active_mod(mob/living/carbon/human/wearer)

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/MOD_sprite_accessories/mod_accessory_handler.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/MOD_sprite_accessories/mod_accessory_handler.dm
@@ -23,14 +23,56 @@
 
 	return icon(special_icon)
 
-/// Is this accessory currently under an active hardlight MOD overlay? Used for determining if we should apply a mod overlay to a bodypart
+/// Checks that this accessory should be affected by a hardlight MOD overlay.
+/// The default behavior is to check for an active MOD and the chestplate being deployed.
 /datum/sprite_accessory/proc/mod_overlay_active(mob/living/carbon/human/wearer)
-	if(!istype(wearer?.wear_suit, /obj/item/clothing/suit/mod))
-		return FALSE
-	var/obj/item/mod/control/modsuit_control = wearer.back
+	return has_active_mod_and_chestplate(wearer)
+
+/datum/sprite_accessory/ears/mod_overlay_active(mob/living/carbon/human/wearer)
+	return has_active_mod_and_helmet(wearer)
+
+/datum/sprite_accessory/horns/mod_overlay_active(mob/living/carbon/human/wearer)
+	return has_active_mod_and_helmet(wearer)
+
+/datum/sprite_accessory/skrell_hair/mod_overlay_active(mob/living/carbon/human/wearer)
+	return has_active_mod_and_helmet(wearer)
+
+/datum/sprite_accessory/antenna/mod_overlay_active(mob/living/carbon/human/wearer)
+	return has_active_mod_and_helmet(wearer)
+
+/datum/sprite_accessory/moth_antennae/mod_overlay_active(mob/living/carbon/human/wearer)
+	return has_active_mod_and_helmet(wearer)
+
+/datum/sprite_accessory/caps/mod_overlay_active(mob/living/carbon/human/wearer)
+	return has_active_mod_and_helmet(wearer)
+
+/datum/sprite_accessory/frills/mod_overlay_active(mob/living/carbon/human/wearer)
+	return has_active_mod_and_helmet(wearer)
+
+/datum/sprite_accessory/head_accessory/mod_overlay_active(mob/living/carbon/human/wearer)
+	return has_active_mod_and_helmet(wearer)
+
+/datum/sprite_accessory/neck_accessory/mod_overlay_active(mob/living/carbon/human/wearer)
+	return has_active_mod_and_helmet(wearer)
+
+/datum/sprite_accessory/proc/has_active_mod_and_helmet(mob/living/carbon/human/wearer)
+	return (wearing_active_mod(wearer) && wearing_mod_helmet(wearer))
+
+/datum/sprite_accessory/proc/has_active_mod_and_chestplate(mob/living/carbon/human/wearer)
+	return (wearing_active_mod(wearer) && wearing_mod_chestplate(wearer))
+
+/// Checks that a MOD control unit on the wearer is active or activating and has a hardlight theme
+/datum/sprite_accessory/proc/wearing_active_mod(mob/living/carbon/human/wearer)
+	var/obj/item/mod/control/modsuit_control = wearer?.back
 	if(!istype(modsuit_control))
 		return FALSE
 	return (modsuit_control.active || modsuit_control.activating) && modsuit_control.theme?.hardlight
+
+/datum/sprite_accessory/proc/wearing_mod_chestplate(mob/living/carbon/human/wearer)
+	return (istype(wearer?.wear_suit, /obj/item/clothing/suit/mod))
+
+/datum/sprite_accessory/proc/wearing_mod_helmet(mob/living/carbon/human/wearer)
+	return (istype(wearer?.head, /obj/item/clothing/head/mod))
 
 /// The hardlight theme string, for use in the render cache key - so we don't get any color collisions
 /datum/sprite_accessory/proc/get_hardlight_theme_key(mob/living/carbon/human/wearer)

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/MOD_sprite_accessories/mod_accessory_handler.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/MOD_sprite_accessories/mod_accessory_handler.dm
@@ -25,27 +25,17 @@
 
 /// Checks that this accessory should be affected by a hardlight MOD overlay
 /datum/sprite_accessory/proc/mod_overlay_active(mob/living/carbon/human/wearer)
-	if((flags_custom_mod_icon & MOD_ACCESSORY_HELMET) && !has_active_mod_and_helmet(wearer))
+	if(!wearing_active_mod(wearer))
 		return FALSE
-	if((flags_custom_mod_icon & MOD_ACCESSORY_CHESTPLATE) && !has_active_mod_and_chestplate(wearer))
+	if((flags_custom_mod_icon & MOD_ACCESSORY_HELMET) && !istype(wearer.head, /obj/item/clothing/head/mod))
 		return FALSE
-	if((flags_custom_mod_icon & MOD_ACCESSORY_GAUNTLETS) && !has_active_mod_and_gauntlets(wearer))
+	if((flags_custom_mod_icon & MOD_ACCESSORY_CHESTPLATE) && !istype(wearer.wear_suit, /obj/item/clothing/suit/mod))
 		return FALSE
-	if((flags_custom_mod_icon & MOD_ACCESSORY_BOOTS) && !has_active_mod_and_boots(wearer))
+	if((flags_custom_mod_icon & MOD_ACCESSORY_GAUNTLETS) && !istype(wearer.gloves, /obj/item/clothing/gloves/mod))
+		return FALSE
+	if((flags_custom_mod_icon & MOD_ACCESSORY_BOOTS) && !istype(wearer.shoes, /obj/item/clothing/shoes/mod))
 		return FALSE
 	return TRUE
-
-/datum/sprite_accessory/proc/has_active_mod_and_helmet(mob/living/carbon/human/wearer)
-	return (wearing_active_mod(wearer) && istype(wearer?.head, /obj/item/clothing/head/mod))
-
-/datum/sprite_accessory/proc/has_active_mod_and_chestplate(mob/living/carbon/human/wearer)
-	return (wearing_active_mod(wearer) && istype(wearer?.wear_suit, /obj/item/clothing/suit/mod))
-
-/datum/sprite_accessory/proc/has_active_mod_and_gauntlets(mob/living/carbon/human/wearer)
-	return (wearing_active_mod(wearer) && istype(wearer?.gloves, /obj/item/clothing/gloves/mod))
-
-/datum/sprite_accessory/proc/has_active_mod_and_boots(mob/living/carbon/human/wearer)
-	return (wearing_active_mod(wearer) && istype(wearer?.shoes, /obj/item/clothing/shoes/mod))
 
 /// Checks that a MOD control unit on the wearer is active or activating and has a hardlight theme
 /datum/sprite_accessory/proc/wearing_active_mod(mob/living/carbon/human/wearer)
@@ -53,12 +43,6 @@
 	if(!istype(modsuit_control))
 		return FALSE
 	return (modsuit_control.active || modsuit_control.activating) && modsuit_control.theme?.hardlight
-
-/datum/sprite_accessory/proc/wearing_mod_chestplate(mob/living/carbon/human/wearer)
-	return (istype(wearer?.wear_suit, /obj/item/clothing/suit/mod))
-
-/datum/sprite_accessory/proc/wearing_mod_helmet(mob/living/carbon/human/wearer)
-	return (istype(wearer?.head, /obj/item/clothing/head/mod))
 
 /// The hardlight theme string, for use in the render cache key - so we don't get any color collisions
 /datum/sprite_accessory/proc/get_hardlight_theme_key(mob/living/carbon/human/wearer)


### PR DESCRIPTION
## About The Pull Request

### Problems
1. MOD hardlight overlays would clash with the mesh bodypart textures recently added upstream.
2. MOD hardlight overlays would appear on your ears or antennae when the only active part is the chestplate.
3. `/datum/sprite_accessory/proc/is_hidden` was overridden with a lot of copypasta for controlling visibility based on being manually hidden and forcing visibility if a MOD part is on.

### Solutions
1. Just commenting out the `AddElement` calls that give MOD chestplates/helmets the texture elements.
2. Refactoring how sprite accessories decide when to be covered by hardlight overlays to use flags.
3. Refactoring `is_hidden` to call parent and return if it's true, and moving the most copy pasted code to the base implementation. `is_hidden` overrides are reserved for hiding accessories when slots are obscured.

### Additional things that are now possible
- You can require multiple MOD parts to be deployed for a hardlight overlay to be rendered.
- You can do something silly and make Harpy wings render their hardlight overlays when MOD gauntlets are deployed rather than the chestplates (what the base wings expect), without having to override `is_hidden` a lot. ~~I should repath all the sprite accessories we have that are pathed like this...~~
- You can do something even sillier and make spines require both a chestplate and helmet to be deployed to render a hardlight overlay, also without having to override `is_hidden` as much.

These should definitely just use bodypart textures one day, but that's a less trivial refactor than the one in this PR...
## How This Contributes To The Nova Sector Roleplay Experience
Interesting new code, and a regression fix that aggravated me.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="331" height="314" alt="Screenshot_3795" src="https://github.com/user-attachments/assets/2f06bb28-c692-4840-b67a-ceb568ddb2dd" />
<img width="360" height="321" alt="Screenshot_3796" src="https://github.com/user-attachments/assets/c26397db-349a-47e4-8a5f-cc7a0ec9dd63" />

<img width="306" height="96" alt="Screenshot_3800" src="https://github.com/user-attachments/assets/f440b499-ac77-4363-80bc-2aba2b6f1f59" />

</details>

## Changelog
:cl:
fix: [NOVA] MOD hardlight overlays would be applied to ears, antennae or other sprite accessories on the head when the helmet wasn't deployed or active.
fix: [NOVA] MOD hardlight overlays would clash with the mesh bodypart textures recently added upstream.
/:cl:
