### PR TITLE
Add an Admin verb to reload photocopier paper blank templates without restarts

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -756,6 +756,13 @@ ADMIN_VERB(reload_configuration, R_DEBUG, "Reload Configuration", "Reloads the c
 		return
 	config.admin_reload()
 
+// NOVA EDIT ADDITION BEGIN - Reload photocopier blanks without a full server restart
+ADMIN_VERB(reload_paper_blanks, R_DEBUG, "Reload Paper Blanks", "Reloads photocopier paper blank templates (config/blanks.json and config/nova/blanks.json) from disk without restarting the server.", ADMIN_CATEGORY_DEBUG)
+	GLOB.paper_blanks = init_paper_blanks_nova()
+	message_admins("[key_name_admin(user)] reloaded the photocopier paper blank templates.")
+	log_admin("[key_name(user)] reloaded the photocopier paper blank templates.")
+// NOVA EDIT ADDITION END
+
 ADMIN_VERB(check_timer_sources, R_DEBUG, "Check Timer Sources", "Checks the sources of running timers.", ADMIN_CATEGORY_DEBUG)
 	var/bucket_list_output = generate_timer_source_output(SStimer.bucket_list)
 	var/second_queue = generate_timer_source_output(SStimer.second_queue)


### PR DESCRIPTION

## About The Pull Request
This pull request seeks to allow staff to reload the photocopier templates without restarting the server.

I've noticed ever since I've added #7448 that the custom templates haven't been updated and are still missing from the photocopier.

In theory the templates should be pulled from the disk when the server restarts, but for some reason it doesn't, so adding a debug verb might be a good way to see if it fixes it.

## How This Contributes To The Nova Sector Roleplay Experience
Debug tool to reload photocopier templates.

## Proof of Testing
No testing, should be tested on the server itself and see if it fixes the issue with the photocopier templates, by checking the photocopier afterward and see if #7448 was added.

## Changelog
:cl: Richard Blonski
server: Added a debug command to reload photocopier templates without restarting the server.
/:cl:
