### PR TITLE
Generalize Mid-Round Antagonist Consent

### DIFF
--- a/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
+++ b/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
@@ -41,10 +41,12 @@
  */
 /datum/dynamic_ruleset/midround/from_living/proc/poll_candidates(list/candidates)
 	message_admins("MID-ROUND ANTAG: attempting to poll [length(candidates)] people individually to become [name].")
+	log_dynamic("MID-ROUND ANTAG: attempting to poll [length(candidates)] people individually to become [name].")
 	var/list/potential_candidates = shuffle(candidates)
 	var/list/yes_candidate = list()
 	for(var/mob/living/candidate in potential_candidates)
 		potential_candidates -= candidate
+		log_dynamic("MID-ROUND ANTAG: polling [key_name(candidate)] to become [name].")
 		yes_candidate += SSpolling.poll_candidates(
 			question = midround_ask_question || "Do you want to become [name]?.",
 			group = list(candidate),
@@ -65,8 +67,10 @@
 		if(length(yes_candidate))
 			break
 		message_admins("Candidate [key_name(candidate)] has declined to become [name].")
+		log_dynamic("MID-ROUND ANTAG: Candidate [key_name(candidate)] has declined to become [name].")
 	if(!length(yes_candidate))
-		message_admins("Nobody accepted the offer to become [name] - the ruleset will not execute this time.")
+		message_admins("MID-ROUND ANTAG: Nobody accepted the offer to become [name] - the ruleset will not execute this time.")
+		log_dynamic("MID-ROUND ANTAG: Nobody accepted the offer to become [name] - the ruleset will not execute this time.")
 	return yes_candidate
 
 /*

--- a/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
+++ b/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
@@ -68,7 +68,6 @@
 	if(!length(yes_candidate))
 		message_admins("Nobody accepted the offer to become [name] - the ruleset will not execute this time.")
 	return yes_candidate
-	// NOVA EDIT ADDITION END
 
 /*
  * Midround_ask_question and midround_ask_alert_pic - definations.

--- a/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
+++ b/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
@@ -24,51 +24,65 @@
 			player.playsound_local(player, 'sound/machines/terminal/terminal_prompt_deny.ogg', 50, FALSE)
 
 
-/datum/dynamic_ruleset/midround/from_living/traitor
-	var/static/list/sleeper_current_polling = list()
-	var/static/list/rejected_traitor = list()
 
-/datum/dynamic_ruleset/midround/from_living/traitor/collect_candidates()
+/datum/dynamic_ruleset/midround/from_living/collect_candidates()
 	var/list/candidates = ..()
 	candidates = shuffle(trim_candidates(candidates))
-	return poll_candidates_for_one(candidates)
+	return poll_candidates(candidates)
+
+/datum/dynamic_ruleset/midround/from_living
+	var/midround_ask_question // Optional question asked to candidates for consent before rolling them into a midround antagonist.
+	var/midround_ask_alert_pic // Optional alert icon shown alongside the consent poll.
+	var/list/midround_custom_response_messages // Optional custom response messages for the consent poll.
 
 /**
- * Polls a group of candidates to see if they want to be a sleeper agent.
- *
- * @param candidates a list containing a candidate mobs
+ * Individually asks each candidate in the list if they want to become this antagonist,
+ * stopping and returning as soon as one accepts.
  */
-/datum/dynamic_ruleset/midround/from_living/traitor/proc/poll_candidates_for_one(candidates)
-	message_admins("Attempting to poll [length(candidates)] people individually to become a Sleeper Agent...first one to say yes gets chosen.")
+/datum/dynamic_ruleset/midround/from_living/proc/poll_candidates(list/candidates)
+	message_admins("MID-ROUND ANTAG: attempting to poll [length(candidates)] people individually to become [name].")
 	var/list/potential_candidates = shuffle(candidates)
 	var/list/yes_candidate = list()
 	for(var/mob/living/candidate in potential_candidates)
 		potential_candidates -= candidate
-		sleeper_current_polling += candidate
 		yes_candidate += SSpolling.poll_candidates(
-		question = "Do you want to be a syndicate sleeper agent? If you ignore this, you will be considered to have declined and will be inelegible for all future rolls this round.",
-		group = list(candidate),
-		poll_time = 15 SECONDS,
-		flash_window = TRUE,
-		start_signed_up = FALSE,
-		announce_chosen = FALSE,
-		role_name_text = "Sleeper Agent",
-		alert_pic = /obj/structure/sign/poster/contraband/gorlex_recruitment,
-		custom_response_messages = list(
-			POLL_RESPONSE_SIGNUP = "You have signed up to be a traitor!",
-			POLL_RESPONSE_ALREADY_SIGNED = "You are already signed up to be a traitor.",
-			POLL_RESPONSE_NOT_SIGNED = "You aren't signed up to be a traitor.",
-			POLL_RESPONSE_TOO_LATE_TO_UNREGISTER = "It's too late to decide against being a traitor.",
-			POLL_RESPONSE_UNREGISTERED = "You decide against being a traitor.",
-		),
-		chat_text_border_icon = /obj/structure/sign/poster/contraband/gorlex_recruitment,
-	)
+			question = midround_ask_question || "Do you want to become [name]? If you ignore this, you will be considered to have declined and will be ineligible for all future rolls this round.",
+			group = list(candidate),
+			poll_time = 60 SECONDS,
+			flash_window = TRUE,
+			start_signed_up = FALSE,
+			announce_chosen = FALSE,
+			role_name_text = name,
+			alert_pic = midround_ask_alert_pic,
+			custom_response_messages = midround_custom_response_messages || list(
+				POLL_RESPONSE_SIGNUP = "You have signed up to be a [name]!",
+				POLL_RESPONSE_ALREADY_SIGNED = "You are already signed up to be a [name].",
+				POLL_RESPONSE_NOT_SIGNED = "You aren't signed up to be a [name].",
+				POLL_RESPONSE_TOO_LATE_TO_UNREGISTER = "It's too late to decide against being a [name].",
+				POLL_RESPONSE_UNREGISTERED = "You decide against being a [name].",
+			),
+		)
 		if(length(yes_candidate))
-			sleeper_current_polling -= candidate
 			break
-		else
-			message_admins("Candidate [candidate] has declined to be a sleeper agent.")
-			rejected_traitor += candidate
-			sleeper_current_polling -= candidate
-
+		message_admins("Candidate [candidate] has declined to become [name].")
+	if(!length(yes_candidate))
+		message_admins("Nobody accepted the offer to become [name] - the ruleset will not execute this time.")
 	return yes_candidate
+	// NOVA EDIT ADDITION END
+
+/*
+ * Midround_ask_question and midround_ask_alert_pic - definations.
+*/
+/datum/dynamic_ruleset/midround/from_living/malf_ai
+	midround_ask_question = "Do you want to become a malfunctioning AI and turn against your Asimov laws? If you ignore this, you will be considered to have declined and will be ineligible for all future rolls this round."
+
+/datum/dynamic_ruleset/midround/from_living/blob
+	midround_ask_question = "Do you want to become infected and turn into a blob host? If you ignore this, you will be considered to have declined and will be ineligible for all future rolls this round."
+	midround_ask_alert_pic = /obj/structure/blob/normal
+
+/datum/dynamic_ruleset/midround/from_living/obsesed
+	midround_ask_question = "Do you want to become obsessed with another crew member? If you ignore this, you will be considered to have declined and will be ineligible for all future rolls this round."
+
+/datum/dynamic_ruleset/midround/from_living/traitor/
+	midround_ask_question = "Do you want to be a syndicate sleeper agent? If you ignore this, you will be considered to have declined and will be inelegible for all future rolls this round."
+	midround_ask_alert_pic = /obj/structure/sign/poster/contraband/gorlex_recruitment

--- a/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
+++ b/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
@@ -46,7 +46,7 @@
 	for(var/mob/living/candidate in potential_candidates)
 		potential_candidates -= candidate
 		yes_candidate += SSpolling.poll_candidates(
-			question = midround_ask_question || "Do you want to become [name]? If you ignore this, you will be considered to have declined and will be ineligible for all future rolls this round.",
+			question = midround_ask_question || "Do you want to become [name]?.",
 			group = list(candidate),
 			poll_time = 60 SECONDS,
 			flash_window = TRUE,
@@ -74,15 +74,15 @@
  * Midround_ask_question and midround_ask_alert_pic - definations.
 */
 /datum/dynamic_ruleset/midround/from_living/malf_ai
-	midround_ask_question = "Do you want to become a malfunctioning AI and turn against your Asimov laws? If you ignore this, you will be considered to have declined and will be ineligible for all future rolls this round."
+	midround_ask_question = "Do you want to become a malfunctioning AI and turn against your Asimov laws?."
 
 /datum/dynamic_ruleset/midround/from_living/blob
-	midround_ask_question = "Do you want to become infected and turn into a blob host? If you ignore this, you will be considered to have declined and will be ineligible for all future rolls this round."
+	midround_ask_question = "Do you want to become infected and turn into a blob host?."
 	midround_ask_alert_pic = /obj/structure/blob/normal
 
 /datum/dynamic_ruleset/midround/from_living/obsesed
-	midround_ask_question = "Do you want to become obsessed with another crew member? If you ignore this, you will be considered to have declined and will be ineligible for all future rolls this round."
+	midround_ask_question = "Do you want to become obsessed with another crew member?."
 
 /datum/dynamic_ruleset/midround/from_living/traitor/
-	midround_ask_question = "Do you want to be a syndicate sleeper agent? If you ignore this, you will be considered to have declined and will be inelegible for all future rolls this round."
+	midround_ask_question = "Do you want to be a syndicate sleeper agent?."
 	midround_ask_alert_pic = /obj/structure/sign/poster/contraband/gorlex_recruitment

--- a/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
+++ b/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
@@ -64,7 +64,7 @@
 		)
 		if(length(yes_candidate))
 			break
-		message_admins("Candidate [candidate] has declined to become [name].")
+		message_admins("Candidate [key_name(candidate)] has declined to become [name].")
 	if(!length(yes_candidate))
 		message_admins("Nobody accepted the offer to become [name] - the ruleset will not execute this time.")
 	return yes_candidate


### PR DESCRIPTION

## About The Pull Request
This Pull Request edits the modular file `modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm`, making to be more generalized for all mid-round antagonists.
In addition, it also removes the ability to become ineligible for future polls on the specific role for code simplification.

This means in simple terms that you won't get forced into a mid-round antagonist without a prompt. Asking you whether you wish to become one.

I've also increased the poll time from 15 seconds to --> 60 seconds, as I think 15 seconds is too short. 

## How This Contributes To The Nova Sector Roleplay Experience
A complaint I've heard regarding mid-round antagonist roles is that people **dislike** being forced into a mid-round antagonist role without being alerted whether they actually want it or not.

Until this pull request, only the **mid-round traitor** had this option that asks you whether you actually want to be a mid-round traitor or not, as a result, this caused common complaints of people being forced into being obsessed mid-round when they don't want to be an antagonist for whatever reason.

## Proof of Testing
I've tried to test this in the dev environment, but I've failed to proply get it to work.

### If you wish to merge this, please test merge this first to see if it functions at all.

## Changelog
:cl: Richard Blonski
del: Mid-round antagonist candidates won't be ineligible for future mid-round polls. 
qol: All mid-round antagonist candidates will now be polled on whether they actually wish to play as an antagonist.
qol: Mid-round antagonist polls have been increased from 15 seconds to --> 60 seconds.
/:cl:
