### PR TITLE
Fixes Green Pins

### DIFF
--- a/modular_nova/master_files/code/modules/client/playtime.dm
+++ b/modular_nova/master_files/code/modules/client/playtime.dm
@@ -46,3 +46,10 @@
 		return FALSE
 
 	return !parent?.has_playtime_data() || parent.is_green()
+
+// Mock clients for CI.
+/datum/client_interface/proc/has_playtime_data()
+	return FALSE
+
+/datum/client_interface/proc/is_green()
+	return FALSE

--- a/modular_nova/master_files/code/modules/client/playtime.dm
+++ b/modular_nova/master_files/code/modules/client/playtime.dm
@@ -3,28 +3,46 @@
 	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "green_pin"
+	default_value = FALSE
+	can_randomize = FALSE
 
-// If is_green is TRUE, you may access the toggle
 /datum/preference/toggle/green_pin/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))
 		return FALSE
 
 	return preferences?.parent?.is_green()
 
-// If is_green is TRUE, the toggle is set to TRUE
-// This is just to make sure non-noobs don't get their toggle to TRUE without having access to it
-/datum/preference/toggle/green_pin/create_default_value(datum/preferences/preferences)
-	if (!..(preferences))
-		return FALSE
+/datum/preference/toggle/green_pin/create_informed_default_value(datum/preferences/preferences)
+	var/client/owner = preferences?.parent
+	return owner?.has_playtime_data() && owner.is_green()
 
-	return preferences?.parent?.is_green()
+/datum/preference/toggle/green_pin/apply_to_human(mob/living/carbon/human/wearer, value, datum/preferences/preferences)
+	if(!value)
+		return
 
-/datum/preference/toggle/green_pin/apply_to_human(mob/living/carbon/human/wearer, value)
-	if(value && wearer.client && !wearer.client?.is_green())
-		// This way, it doesn't stick for those that had it set to TRUE before they got their 100 hours in.
-		wearer.client?.prefs?.write_preference(GLOB.preference_entries[/datum/preference/toggle/green_pin], FALSE)
+	// apply_prefs_to() runs before the key is moved onto the new mob on both the roundstart and the
+	// latejoin path, so wearer.client is usually null here. Ask the preferences datum instead.
+	var/datum/preferences/owner_prefs = preferences || wearer.client?.prefs
+	var/client/owner = owner_prefs?.parent
+	if(isnull(owner))
+		return
+	if(!owner.has_playtime_data() || owner.is_green())
+		return
 
-	return
+	owner_prefs.write_preference(GLOB.preference_entries[/datum/preference/toggle/green_pin], FALSE)
+
+	if(owner_prefs.savefile)
+		owner_prefs.save_preferences()
+
+/client/proc/has_playtime_data()
+	return length(prefs?.exp) > 0
 
 /client/proc/is_green()
 	return get_exp_living(pure_numeric = TRUE) <= PLAYTIME_GREEN
+
+/// Whether this character should actually be handed a green pin on spawn.
+/datum/preferences/proc/should_get_green_pin()
+	if(!read_preference(/datum/preference/toggle/green_pin))
+		return FALSE
+
+	return !parent?.has_playtime_data() || parent.is_green()

--- a/modular_nova/modules/loadouts/loadout_ui/loadout_outfit_helpers.dm
+++ b/modular_nova/modules/loadouts/loadout_ui/loadout_outfit_helpers.dm
@@ -110,7 +110,7 @@
 			visuals_only = visuals_only,
 		)
 
-	if(preference_source?.read_preference(/datum/preference/toggle/green_pin))
+	if(preference_source?.should_get_green_pin())
 		var/obj/item/clothing/under/uniform = w_uniform
 		uniform?.attach_accessory(new /obj/item/clothing/accessory/green_pin(), src, FALSE)
 


### PR DESCRIPTION

## About The Pull Request

Fixes green pins showing on players who have >100h of playtime. Probably.

## How This Contributes To The Nova Sector Roleplay Experience

Less manual save editing that I have to do.

## Proof of Testing

Trust, I suppose.
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl:
fix: green pins should no longer erroneously equip on players with more than 100h of playtime (unless you add it via loadout)
/:cl:

