### PR TITLE
Possible fix for taur cropping issues.

### DIFF
--- a/modular_nova/master_files/code/modules/clothing/base_clothes.dm
+++ b/modular_nova/master_files/code/modules/clothing/base_clothes.dm
@@ -53,7 +53,7 @@
 	var/list/species_clothing_color_coords[3]
 
 	/// Does this item's sprite get cropped on taurs when worn?
-	var/gets_cropped_on_taurs = TRUE
+	var/gets_cropped_on_taurs = FALSE
 
 /obj/item/clothing/head
 	supports_variations_flags = CLOTHING_SNOUTED_VARIATION
@@ -67,15 +67,14 @@
 /obj/item/clothing/under
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION | CLOTHING_BIG_LEGS_MASK
 	bodyshapes_with_variations = BODYSHAPE_DIGITIGRADE
+	gets_cropped_on_taurs = TRUE
 
 /obj/item/clothing/suit
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
+	gets_cropped_on_taurs = TRUE
 
 /obj/item/clothing/shoes
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
 
 /obj/item/changeling
 	supports_variations_flags = NONE
-
-/obj/item/clothing/neck
-	gets_cropped_on_taurs = FALSE


### PR DESCRIPTION

## About The Pull Request

Taur cropping was defaulted to true for everything. This, I think, was causing runtimes for icon generation and causing some very weird rsc issues. 
## How This Contributes To The Nova Sector Roleplay Experience

As funny as it is, this...

<img width="177" height="165" alt="image" src="https://github.com/user-attachments/assets/f3dd6cbf-50cb-45cd-8298-621ecbd18a1d" />

...is not a very good sprite for a belt.
## Proof of Testing
## Changelog
:cl:
fix: icons should crop against taurs properly now
/:cl:
