### PR TITLE
Fixes not being able to turn while buckled.

### DIFF
--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -166,6 +166,6 @@
 	return ..()
 
 /mob/living/keybind_face_direction(direction)
-	if(!(mobility_flags & MOBILITY_MOVE))
+	if(IS_UNCONSCIOUS(src) || HAS_TRAIT(src, TRAIT_STASIS)) // NOVA EDIT CHANGE - ORIGINAL: if(!(mobility_flags & MOBILITY_MOVE))
 		return
 	return ..()


### PR DESCRIPTION

## About The Pull Request
See title. TG change made it so you can't wiggle while time-stopped but the change is a bit broader than the intent.

## How This Contributes To The Nova Sector Roleplay Experience
Just because my legs don't work doesn't mean my neck doesn't work, too.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl:
fix: buckled people can look around again.
/:cl:

