### PR TITLE
[QoL] Reduce Departamental Order Times & Adds Materials to BS Miner Crate

### DIFF
--- a/code/__DEFINES/cargo.dm
+++ b/code/__DEFINES/cargo.dm
@@ -84,7 +84,7 @@
 /// Multiplies the logarithmic value calculating the free crate cooldown
 #define DEPARTMENTAL_ORDER_COOLDOWN_COEFFICIENT 60
 /// Used for the power of the logarithmic value for the free crate cooldown
-#define DEPARTMENTAL_ORDER_COOLDOWN_EXPONENT 2.2
+#define DEPARTMENTAL_ORDER_COOLDOWN_EXPONENT 2 // NOVA EDIT CHANGE - ORIGINAL : 2.2
 
 //At 320 it's 475 credits, at 1400 it's 669 credits,  at 3000 (around gun crates) its 778, at 8000 (hat crate) it's 925 credits, at 9000 (expensive atmos cans) it's 943 credits, and at the 20k crate it's 1070 credits.
 

--- a/modular_nova/modules/bluespace_miner/code/bluespace_miner.dm
+++ b/modular_nova/modules/bluespace_miner/code/bluespace_miner.dm
@@ -242,7 +242,15 @@
 	name = "Bluespace Miner"
 	desc = "Nanotrasen has revolutionized the procuring of materials with bluespace-- featuring the Bluespace Miner!"
 	cost = CARGO_CRATE_VALUE * 50 // 10,000
-	contains = list(/obj/item/circuitboard/machine/bluespace_miner)
+	contains = list(/obj/item/circuitboard/machine/bluespace_miner = 1,
+					/obj/item/stack/sheet/glass = 1,
+					/obj/item/stack/sheet/iron/five = 1,
+					/obj/item/stack/ore/bluespace_crystal/refined = 1,
+					/obj/item/stock_parts/servo = 2,
+					/obj/item/stock_parts/matter_bin = 2,
+					/obj/item/stock_parts/micro_laser = 2,
+					/obj/item/stack/cable_coil/five = 1,
+					)
 	crate_name = "Bluespace Miner Circuitboard Crate"
 	crate_type = /obj/structure/closet/crate
 


### PR DESCRIPTION

## About The Pull Request
Reduces the exponent of the Departamental Orders from 2.2 to 2, This makes the shortest order go from 7.5 min to 6.75 min and the longest from 20 min to 16 min.

Makes it so the Bluespace miner crate comes with all the parts it needs to be built with, this should make it so people dont have to canibalize the teleporter to use it.

## How This Contributes To The Nova Sector Roleplay Experience
Makes the departamental order less of a commitment, while also being meaningful, as the adjustment is light.

The BS crate having the materials is mostly so the intended purpose, to makeup for mining during emergencies, is actually relevant, and you dont need arcane knowledge of the game to use it, more than you already need to.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="616" height="586" alt="image" src="https://github.com/user-attachments/assets/e51251ad-95b6-4251-8700-0d2332fc353e" />

<img width="950" height="801" alt="image" src="https://github.com/user-attachments/assets/bc47a430-87a5-47ae-82f9-4767c323fc42" />

<img width="950" height="801" alt="image" src="https://github.com/user-attachments/assets/77d4241e-968c-456d-a6ab-ac1a1e1b8d64" />
  
</details>

## Changelog
:cl:
balance: Reduces the exponent of the Departamental Orders from 2.2 to 2, This makes the shortest order go from 7.5 min to 6.75 min and the longest from 20 min to 16 min.
qol: Makes it so the Bluespace miner crate comes with all the parts it needs to be built with, this should make it so people dont have to canibalize the teleporter to use it.
/:cl:
