### PR TITLE
FIX for - Mid round antagonist consent please!

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -1116,8 +1116,10 @@
 	max_antag_cap = 1
 	repeatable = TRUE
 
+/* // NOVA EDIT - Mid-Round Antag Consent - `modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm`
 /datum/dynamic_ruleset/midround/from_living/collect_candidates()
 	return GLOB.alive_player_list
+*/ // NOVA EDIT END
 
 /datum/dynamic_ruleset/midround/from_living/is_valid_candidate(mob/candidate, client/candidate_client)
 	if(candidate.stat == DEAD || isnull(candidate.mind))

--- a/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
+++ b/modular_nova/master_files/code/controllers/subsystem/dynamic_rulesets_midround.dm
@@ -26,7 +26,7 @@
 
 
 /datum/dynamic_ruleset/midround/from_living/collect_candidates()
-	var/list/candidates = ..()
+	var/list/candidates = GLOB.alive_player_list
 	candidates = shuffle(trim_candidates(candidates))
 	return poll_candidates(candidates)
 


### PR DESCRIPTION

## About The Pull Request

This PR fixes #7833

The issue is that our mid-round antag logic gets triggered twice by the main code and the modular code which causes it to be skipped.
## How This Contributes To The Nova Sector Roleplay Experience
Bug Fix

## Proof of Testing

Unable to test it.
## Changelog
:cl: Richard Blonski
fix: Fixed Mid-Round antagonist consent not working.
/:cl:
